### PR TITLE
Better error message when juicer cannot be found

### DIFF
--- a/build
+++ b/build
@@ -3,6 +3,9 @@ begin
   require "juicer/merger/javascript_merger"
 rescue LoadError => err
   puts "Install juicer to build Sinon.JS"
+  if !defined?(Gem)
+    puts "RubyGems isn't loaded. Perhaps that's why juicer can't be found?"
+  end
   exit
 end
 


### PR DESCRIPTION
When juicer cannot be found, an additional check is prerformed to see if rubygems is around.

I tried to run the script with "ruby build", but it errored with a message about having to install the juicer gem. I had juicer installed, so I was confused. The problem was that rubygems wasn't around, and I had to do "ruby -rrubygems build" instead.

This error message might make it easier for people in a similar situation. Feel free to discard if you don't like it, of course ;)
