### PR TITLE
export sinon.sandbox in node

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -212,6 +212,7 @@ if (typeof module == "object" && typeof require == "function") {
     module.exports.mock = require("sinon/mock");
     module.exports.collection = require("sinon/collection");
     module.exports.assert = require("sinon/assert");
+    module.exports.sandbox = require("sinon/sandbox");
     module.exports.test = require("sinon/test");
     module.exports.testCase = require("sinon/test_case");
     require.paths.shift();


### PR DESCRIPTION
Hey,

I use jsUnity for our test framework and at the time of using sinon we couldn't use any of the test objects you exposed.

I moved on to use the sandbox object and it was a nice way to integrate into jsUnity and provide a fast way to setup and teardown a bunch of mocks / stubs.
