### PR TITLE
Patch for Issue #7

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -33,7 +33,7 @@ var sinon = (function () {
     }
 
     return {
-        wrapMethod: function wrapMethod(object, property, method) {
+        "wrapMethod": function(object, property, method) {
             if (!object) {
                 throw new TypeError("Should wrap property of object");
             }
@@ -71,7 +71,7 @@ var sinon = (function () {
             return method;
         },
 
-        extend: function extend(target) {
+        "extend": function(target) {
             for (var i = 1, l = arguments.length; i < l; i += 1) {
                 for (var prop in arguments[i]) {
                     if (arguments[i].hasOwnProperty(prop)) {
@@ -83,7 +83,7 @@ var sinon = (function () {
             return target;
         },
 
-        create: function create(proto) {
+        "create": function(proto) {
             if (Object.create) {
                 return Object.create(proto);
             } else {
@@ -93,7 +93,7 @@ var sinon = (function () {
             }
         },
 
-        deepEqual: function deepEqual(a, b) {
+        "deepEqual": function(a, b) {
             if (typeof a != "object" || typeof b != "object") {
                 return a === b;
             }
@@ -141,7 +141,7 @@ var sinon = (function () {
             return true;
         },
 
-        keys: function keys(object) {
+        "keys": function(object) {
             var objectKeys = [];
 
             for (var prop in object) {
@@ -153,7 +153,7 @@ var sinon = (function () {
             return objectKeys.sort();
         },
 
-        functionName: function functionName(func) {
+        "functionName": function(func) {
             var name = func.displayName || func.name;
 
             // Use function decomposition as a last resort to get function
@@ -168,7 +168,7 @@ var sinon = (function () {
             return name;
         },
 
-        functionToString: function toString() {
+        "functionToString": function() { // toString
             if (this.getCall && this.callCount) {
                 var thisValue, prop, i = this.callCount;
 
@@ -186,7 +186,7 @@ var sinon = (function () {
             return this.displayName || "sinon fake";
         },
 
-        getConfig: function (custom) {
+        "getConfig": function(custom) {
             var config = {};
             custom = custom || {};
             var defaults = sinon.defaultConfig;
@@ -200,12 +200,12 @@ var sinon = (function () {
             return config;
         },
 
-        defaultConfig: {
-            injectIntoThis: true,
-            injectInto: null,
-            properties: ["spy", "stub", "mock", "clock", "server", "requests"],
-            useFakeTimers: true,
-            useFakeServer: true
+        "defaultConfig": {
+            "injectIntoThis": true,
+            "injectInto": null,
+            "properties": ["spy", "stub", "mock", "clock", "server", "requests"],
+            "useFakeTimers": true,
+            "useFakeServer": true
         }
     };
 }());

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -75,18 +75,18 @@
     }
 
     assert = {
-        failException: "AssertError",
+        "failException": "AssertError",
 
-        fail: function fail(message) {
+        "fail": function(message) {
             var error = new Error(message);
             error.name = this.failException || assert.failException;
 
             throw error;
         },
 
-        pass: function pass(assertion) {},
+        "pass": function(assertion) {},
 
-        called: function assertCalled(method) {
+        "called": function(method) { // assertCalled
             verifyIsStub(method);
 
             if (!method.called) {
@@ -97,7 +97,7 @@
             }
         },
 
-        notCalled: function assertNotCalled(method) {
+        "notCalled": function(method) { // assertNotCalled
             verifyIsStub(method);
 
             if (method.called) {
@@ -108,7 +108,7 @@
             }
         },
 
-        callOrder: function assertCallOrder() {
+        "callOrder": function() { // assertCallOrder
             verifyIsStub(arguments[0]);
             var expected = [];
             var actual = [];
@@ -147,7 +147,7 @@
             }
         },
 
-        callCount: function assertCallCount(method, count) {
+        "callCount": function(method, count) { // assertCallCount
             verifyIsStub(method);
 
             if (method.callCount != count) {
@@ -158,7 +158,7 @@
             }
         },
 
-        expose: function expose(target, options) {
+        "expose": function(target, options) {
             if (!target) {
                 throw new TypeError("target is null or undefined");
             }

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -43,15 +43,15 @@
     }
 
     var collection = {
-        verify: function resolve() {
+        "verify": function() { // resolve
             each(this, "verify");
         },
 
-        restore: function restore() {
+        "restore": function() {
             each(this, "restore");
         },
 
-        verifyAndRestore: function verifyAndRestore() {
+        "verifyAndRestore": function() {
             var exception;
 
             try {
@@ -67,25 +67,25 @@
             }
         },
 
-        add: function add(fake) {
+        "add": function(fake) {
             getFakes(this).push(fake);
 
             return fake;
         },
 
-        spy: function spy() {
+        "spy": function() {
             return this.add(sinon.spy.apply(sinon, arguments));
         },
 
-        stub: function stub() {
+        "stub": function() {
             return this.add(sinon.stub.apply(sinon, arguments));
         },
 
-        mock: function mock() {
+        "mock": function() {
             return this.add(sinon.mock.apply(sinon, arguments));
         },
 
-        inject: function inject(obj) {
+        "inject": function(obj) {
             var col = this;
 
             obj.spy = function () {

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -45,7 +45,7 @@
         }
 
         return {
-            create: function create(object) {
+            "create": function(object) {
                 if (!object) {
                     throw new TypeError("object is null");
                 }
@@ -57,7 +57,7 @@
                 return mockObject;
             },
 
-            expects: function expects(method) {
+            "expects": function(method) {
                 if (!method) {
                     throw new TypeError("method is falsy");
                 }
@@ -84,7 +84,7 @@
                 return expectation;
             },
 
-            restore: function restore() {
+            "restore": function() {
                 var object = this.object;
 
                 each(this.proxies, function (proxy) {
@@ -94,7 +94,7 @@
                 });
             },
 
-            verify: function verify() {
+            "verify": function() {
                 var expectations = this.expectations || {};
                 var exception;
 
@@ -117,7 +117,7 @@
                 return true;
             },
 
-            invokeMethod: function invokeMethod(method, thisValue, args) {
+            "invokeMethod": function(method, thisValue, args) {
                 var expectations = this.expectations && this.expectations[method];
                 var length = expectations && expectations.length || 0;
 
@@ -169,10 +169,10 @@
         }
 
         return {
-            minCalls: 1,
-            maxCalls: 1,
+            "minCalls": 1,
+            "maxCalls": 1,
 
-            create: function create(methodName) {
+            "create": function(methodName) {
                 var expectation = sinon.extend(sinon.stub.create(), sinon.expectation);
                 delete expectation.create;
                 expectation.method = methodName;
@@ -180,13 +180,13 @@
                 return expectation;
             },
 
-            invoke: function invoke(func, thisValue, args) {
+            "invoke": function(func, thisValue, args) {
                 this.verifyCallAllowed(thisValue, args);
 
                 return _invoke.apply(this, arguments);
             },
 
-            atLeast: function atLeast(num) {
+            "atLeast": function(num) {
                 if (typeof num != "number") {
                     throw new TypeError("'" + num + "' is not number");
                 }
@@ -201,7 +201,7 @@
                 return this;
             },
 
-            atMost: function atMost(num) {
+            "atMost": function(num) {
                 if (typeof num != "number") {
                     throw new TypeError("'" + num + "' is not number");
                 }
@@ -216,23 +216,23 @@
                 return this;
             },
 
-            never: function never() {
+            "never": function() {
                 return this.exactly(0);
             },
 
-            once: function once() {
+            "once": function() {
                 return this.exactly(1);
             },
 
-            twice: function twice() {
+            "twice": function() {
                 return this.exactly(2);
             },
 
-            thrice: function thrice() {
+            "thrice": function() {
                 return this.exactly(3);
             },
 
-            exactly: function exactly(num) {
+            "exactly": function(num) {
                 if (typeof num != "number") {
                     throw new TypeError("'" + num + "' is not a number");
                 }
@@ -241,11 +241,11 @@
                 return this.atMost(num);
             },
 
-            met: function met() {
+            "met": function() {
                 return !this.failed && receivedMinCalls(this);
             },
 
-            verifyCallAllowed: function verifyCallAllowed(thisValue, args) {
+            "verifyCallAllowed": function(thisValue, args) {
                 if (receivedMaxCalls(this)) {
                     this.failed = true;
                     err(this.method + " already called " + timesInWords(this.maxCalls));
@@ -284,23 +284,23 @@
                 }
             },
 
-            withArgs: function withArgs() {
+            "withArgs": function() {
                 this.expectedArguments = slice.call(arguments);
                 return this;
             },
 
-            withExactArgs: function withExactArgs() {
+            "withExactArgs": function() {
                 this.withArgs.apply(this, arguments);
                 this.expectsExactArgCount = true;
                 return this;
             },
 
-            on: function on(thisValue) {
+            "on": function(thisValue) {
                 this.expectedThis = thisValue;
                 return this;
             },
 
-            verify: function verify() {
+            "verify": function() {
                 if (!this.met()) {
                     err(this.method + " expected to be called " + timesInWords(this.minCalls) +
                         ", but was called " + timesInWords(this.callCount));

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -56,21 +56,21 @@ if (typeof require == "function") {
     }
 
     sinon.sandbox = sinon.extend(sinon.create(sinon.collection), {
-        useFakeTimers: function useFakeTimers() {
+        "useFakeTimers": function() {
             this.clock = sinon.useFakeTimers.apply(sinon, arguments);
 
             return this.add(this.clock);
         },
 
-        serverPrototype: sinon.fakeServer,
+        "serverPrototype": sinon.fakeServer,
 
-        useFakeServer: function useFakeServer() {
+        "useFakeServer": function() {
             this.server = (this.serverPrototype || sinon.fakeServer).create();
 
             return this.add(this.server);
         },
 
-        inject: function (obj) {
+        "inject": function(obj) {
             sinon.collection.inject.call(this, obj);
 
             if (this.clock) {
@@ -85,7 +85,7 @@ if (typeof require == "function") {
             return obj;
         },
 
-        create: function (config) {
+        "create": function(config) {
             if (!config) {
                 return sinon.create(sinon.sandbox);
             }

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -65,13 +65,13 @@
 
         // Public API
         var spyApi = {
-            called: false,
-            calledOnce: false,
-            calledTwice: false,
-            calledThrice: false,
-            callCount: 0,
+            "called": false,
+            "calledOnce": false,
+            "calledTwice": false,
+            "calledThrice": false,
+            "callCount": 0,
 
-            create: function create(func) {
+            "create": function(func) {
                 var name;
 
                 if (typeof func != "function") {
@@ -100,7 +100,7 @@
                 return proxy;
             },
 
-            invoke: function invoke(func, thisValue, args) {
+            "invoke": function(func, thisValue, args) {
                 var exception, returnValue;
                 this.called = true;
                 this.callCount += 1;
@@ -126,7 +126,7 @@
                 return returnValue;
             },
 
-            getCall: function getCall(i) {
+            "getCall": function(i) {
                 if (i < 0 || i >= this.callCount) {
                     return null;
                 }
@@ -136,7 +136,7 @@
                                       this.callIds[i]);
             },
 
-            calledBefore: function calledBefore(spyFn) {
+            "calledBefore": function(spyFn) {
                 if (!this.called) {
                     return false;
                 }
@@ -148,7 +148,7 @@
                 return this.callIds[0] < spyFn.callIds[0];
             },
 
-            calledAfter: function calledAfter(spyFn) {
+            "calledAfter": function(spyFn) {
                 if (!this.called || !spyFn.called) {
                     return false;
                 }
@@ -173,7 +173,7 @@
 
     spyCall = (function () {
         return {
-            create: function create(thisValue, args, returnValue, exception, id) {
+            "create": function(thisValue, args, returnValue, exception, id) {
                 var proxyCall = sinon.create(spyCall);
                 delete proxyCall.create;
                 proxyCall.thisValue = thisValue;
@@ -185,11 +185,11 @@
                 return proxyCall;
             },
 
-            calledOn: function calledOn(thisValue) {
+            "calledOn": function(thisValue) {
                 return this.thisValue === thisValue;
             },
 
-            calledWith: function calledWith() {
+            "calledWith": function() {
                 for (var i = 0, l = arguments.length; i < l; i += 1) {
                     if (!sinon.deepEqual(arguments[i], this.args[i])) {
                         return false;
@@ -199,16 +199,16 @@
                 return true;
             },
 
-            calledWithExactly: function calledWithExactly() {
+            "calledWithExactly": function() {
                 return arguments.length == this.args.length &&
                     this.calledWith.apply(this, arguments);
             },
 
-            returned: function returned(value) {
+            "returned": function(value) {
                 return this.returnValue === value;
             },
 
-            threw: function threw(error) {
+            "threw": function(error) {
                 if (typeof error == "undefined" || !this.exception) {
                     return !!this.exception;
                 }
@@ -220,11 +220,11 @@
                 return this.exception === error;
             },
 
-            calledBefore: function (other) {
+            "calledBefore": function(other) {
                 return this.callId < other.callId;
             },
 
-            calledAfter: function (other) {
+            "calledAfter": function(other) {
                 return this.callId > other.callId;
             }
         };

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -113,7 +113,7 @@
         var slice = Array.prototype.slice;
 
         return {
-            create: function create() {
+            "create": function() {
                 var functionStub = function () {
                     if (functionStub.exception) {
                         throw functionStub.exception;
@@ -135,7 +135,7 @@
                 return functionStub;
             },
 
-            returns: function returns(value) {
+            "returns": function(value) {
                 this.returnValue = value;
 
                 return this;
@@ -154,7 +154,7 @@
                 return this;
             },
 
-            callsArg: function callsArg(pos) {
+            "callsArg": function(pos) {
                 if (typeof pos != "number") {
                     throw new TypeError("argument index is not number");
                 }
@@ -165,7 +165,7 @@
                 return this;
             },
 
-            callsArgWith: function callsArgWith(pos) {
+            "callsArgWith": function(pos) {
                 if (typeof pos != "number") {
                     throw new TypeError("argument index is not number");
                 }
@@ -176,14 +176,14 @@
                 return this;
             },
 
-            yields: function () {
+            "yields": function() {
                 this.callArgAt = -1;
                 this.callbackArguments = slice.call(arguments, 0);
 
                 return this;
             },
 
-            yieldsTo: function (prop) {
+            "yieldsTo": function(prop) {
                 this.callArgAt = -1;
                 this.callArgProp = prop;
                 this.callbackArguments = slice.call(arguments, 1);

--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -56,11 +56,11 @@
     }
 
     test.config = {
-        injectIntoThis: true,
-        injectInto: null,
-        properties: ["spy", "stub", "mock", "clock", "server", "requests"],
-        useFakeTimers: true,
-        useFakeServer: true
+        "injectIntoThis": true,
+        "injectInto": null,
+        "properties": ["spy", "stub", "mock", "clock", "server", "requests"],
+        "useFakeTimers": true,
+        "useFakeServer": true
     };
 
     if (commonJSModule) {

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -68,7 +68,7 @@ sinon.fakeServer = (function () {
     }
 
     return {
-        create: function () {
+        "create": function() {
             var server = create(this);
             this.xhr = sinon.useFakeXMLHttpRequest();
             server.requests = [];
@@ -80,7 +80,7 @@ sinon.fakeServer = (function () {
             return server;
         },
 
-        addRequest: function addRequest(xhrObj) {
+        "addRequest": function(xhrObj) {
             var server = this;
             this.requests.push(xhrObj);
 
@@ -89,7 +89,7 @@ sinon.fakeServer = (function () {
             };
         },
 
-        getHTTPMethod: function getHTTPMethod(request) {
+        "getHTTPMethod": function(request) {
             if (this.fakeHTTPMethods && /post/i.test(request.method)) {
                 var matches = request.requestBody.match(/_method=([^\b;]+)/);
                 return !!matches ? matches[1] : request.method;
@@ -98,7 +98,7 @@ sinon.fakeServer = (function () {
             return request.method;
         },
 
-        handleRequest: function handleRequest(xhr) {
+        "handleRequest": function(xhr) {
             if (xhr.async) {
                 if (!this.queue) {
                     this.queue = [];
@@ -110,7 +110,7 @@ sinon.fakeServer = (function () {
             }
         },
 
-        respondWith: function respondWith(method, url, body) {
+        "respondWith": function(method, url, body) {
             if (arguments.length == 1) {
                 this.response = responseArray(method);
             } else {
@@ -125,14 +125,14 @@ sinon.fakeServer = (function () {
                 }
 
                 this.responses.push({
-                    method: method,
-                    url: url,
-                    response: responseArray(body)
+                    "method": method,
+                    "url": url,
+                    "response": responseArray(body)
                 });
             }
         },
 
-        respond: function respond() {
+        "respond": function() {
             var queue = this.queue || [];
 
             for (var i = 0, l = queue.length; i < l; i++) {
@@ -142,7 +142,7 @@ sinon.fakeServer = (function () {
             this.queue = [];
         },
 
-        processRequest: function processRequest(request) {
+        "processRequest": function(request) {
             try {
                 if (request.aborted) {
                     return;
@@ -163,7 +163,7 @@ sinon.fakeServer = (function () {
             } catch (e) {}
         },
 
-        restore: function restore() {
+        "restore": function() {
             return this.xhr.restore && this.xhr.restore.apply(this.xhr, arguments);
         }
     };

--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -37,9 +37,9 @@ sinon.clock = (function () {
         }
 
         this.timeouts[toId] = {
-            id: toId,
-            func: args[0],
-            callAt: this.now + delay
+            "id": toId,
+            "func": args[0],
+            "callAt": this.now + delay
         };
 
         if (recurring === true) {
@@ -91,9 +91,9 @@ sinon.clock = (function () {
     }
 
     return {
-        now: 0,
+        "now": 0,
 
-        create: function create(now) {
+        "create": function(now) {
             var clock = createObject(this);
 
             if (typeof now == "number") {
@@ -103,11 +103,11 @@ sinon.clock = (function () {
             return clock;
         },
 
-        setTimeout: function setTimeout(callback, timeout) {
+        "setTimeout": function(callback, timeout) {
             return addTimer.call(this, arguments, false);
         },
 
-        clearTimeout: function clearTimeout(timerId) {
+        "clearTimeout": function(timerId) {
             if (!this.timeouts) {
                 this.timeouts = [];
             }
@@ -115,15 +115,15 @@ sinon.clock = (function () {
             delete this.timeouts[timerId];
         },
 
-        setInterval: function setInterval(callback, timeout) {
+        "setInterval": function(callback, timeout) {
             return addTimer.call(this, arguments, true);
         },
 
-        clearInterval: function clearInterval(timerId) {
+        "clearInterval": function(timerId) {
             this.clearTimeout(timerId);
         },
 
-        tick: function tick(ms) {
+        "tick": function(ms) {
             ms = typeof ms == "number" ? ms : parseTime(ms);
             var tickFrom = this.now, tickTo = this.now + ms, previous = this.now;
             var timer = this.firstTimerInRange(tickFrom, tickTo);
@@ -141,7 +141,7 @@ sinon.clock = (function () {
             this.now = tickTo;
         },
 
-        firstTimerInRange: function (from, to) {
+        "firstTimerInRange": function(from, to) {
             var timer, smallest, originalTimer;
 
             for (var id in this.timeouts) {
@@ -153,21 +153,21 @@ sinon.clock = (function () {
                     if (!smallest || this.timeouts[id].callAt < smallest) {
                         originalTimer = this.timeouts[id];
                         smallest = this.timeouts[id].callAt;
-                        
+
                         timer = {
-                            func: this.timeouts[id].func,
-                            callAt: this.timeouts[id].callAt,
-                            interval: this.timeouts[id].interval,
-                            id: this.timeouts[id].id
+                            "func": this.timeouts[id].func,
+                            "callAt": this.timeouts[id].callAt,
+                            "interval": this.timeouts[id].interval,
+                            "id": this.timeouts[id].id
                         };
                     }
                 }
             }
-            
+
             return timer || null;
         },
 
-        callTimer: function (timer) {
+        "callTimer": function(timer) {
             try {
                 if (typeof timer.func == "function") {
                     timer.func.call(null);
@@ -187,11 +187,11 @@ sinon.clock = (function () {
             }
         },
 
-        reset: function reset() {
+        "reset": function() {
             this.timeouts = {};
         },
 
-        Date: (function () {
+        "Date": (function () {
             var NativeDate = Date;
 
             function ClockDate(year, month, date, hour, minute, second, ms) {
@@ -243,11 +243,11 @@ sinon.clock = (function () {
 }());
 
 sinon.timers = {
-    setTimeout: setTimeout,
-    clearTimeout: clearTimeout,
-    setInterval: setInterval,
-    clearInterval: clearInterval,
-    Date: Date
+    "setTimeout": setTimeout,
+    "clearTimeout": clearTimeout,
+    "setInterval": setInterval,
+    "clearInterval": clearInterval,
+    "Date": Date
 };
 
 sinon.useFakeTimers = (function () {

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -12,7 +12,7 @@ if (typeof sinon == "undefined") {
     this.sinon = {};
 }
 
-sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
+sinon.xhr = { "XMLHttpRequest": this.XMLHttpRequest };
 
 sinon.FakeXMLHttpRequest = (function () {
     /*jsl:ignore*/
@@ -61,9 +61,9 @@ sinon.FakeXMLHttpRequest = (function () {
     }
 
     sinon.extend(FakeXMLHttpRequest.prototype, {
-        async: true,
+        "async": true,
 
-        open: function open(method, url, async, username, password) {
+        "open": function(method, url, async, username, password) {
             this.method = method;
             this.url = url;
             this.async = typeof async == "boolean" ? async : true;
@@ -76,7 +76,7 @@ sinon.FakeXMLHttpRequest = (function () {
             this.readyStateChange(FakeXMLHttpRequest.OPENED);
         },
 
-        readyStateChange: function readyStateChange(state) {
+        "readyStateChange": function(state) {
             this.readyState = state;
 
             if (typeof this.onreadystatechange == "function") {
@@ -84,7 +84,7 @@ sinon.FakeXMLHttpRequest = (function () {
             }
         },
 
-        setRequestHeader: function setRequestHeader(header, value) {
+        "setRequestHeader": function(header, value) {
             verifyState(this);
 
             if (unsafeHeaders[header] || /^(Sec-|Proxy-)/.test(header)) {
@@ -92,14 +92,14 @@ sinon.FakeXMLHttpRequest = (function () {
             }
 
             if (this.requestHeaders[header]) {
-                this.requestHeaders[header] += "," + value; 
+                this.requestHeaders[header] += "," + value;
             } else {
                 this.requestHeaders[header] = value;
             }
         },
 
         // Helps testing
-        setResponseHeaders: function setResponseHeaders(headers) {
+        "setResponseHeaders": function(headers) {
             this.responseHeaders = {};
 
             for (var header in headers) {
@@ -114,7 +114,7 @@ sinon.FakeXMLHttpRequest = (function () {
         },
 
         // Currently treats ALL data as a DOMString (i.e. no Document)
-        send: function send(data) {
+        "send": function(data) {
             verifyState(this);
 
             if (!/^(get|head)$/i.test(this.method)) {
@@ -137,7 +137,7 @@ sinon.FakeXMLHttpRequest = (function () {
             }
         },
 
-        abort: function abort() {
+        "abort": function() {
             this.aborted = true;
             this.responseText = null;
             this.errorFlag = true;
@@ -151,7 +151,7 @@ sinon.FakeXMLHttpRequest = (function () {
             this.readyState = sinon.FakeXMLHttpRequest.UNSENT;
         },
 
-        getResponseHeader: function getResponseHeader(header) {
+        "getResponseHeader": function(header) {
             if (this.readyState < FakeXMLHttpRequest.HEADERS_RECEIVED) {
                 return null;
             }
@@ -171,7 +171,7 @@ sinon.FakeXMLHttpRequest = (function () {
             return null;
         },
 
-        getAllResponseHeaders: function getAllResponseHeaders() {
+        "getAllResponseHeaders": function() {
             if (this.readyState < FakeXMLHttpRequest.HEADERS_RECEIVED) {
                 return "";
             }
@@ -188,7 +188,7 @@ sinon.FakeXMLHttpRequest = (function () {
             return headers;
         },
 
-        setResponseBody: function setResponseBody(body) {
+        "setResponseBody": function(body) {
             if (this.readyState == FakeXMLHttpRequest.DONE) {
                 throw new Error("Request done");
             }
@@ -224,7 +224,7 @@ sinon.FakeXMLHttpRequest = (function () {
             }
         },
 
-        respond: function respond(status, headers, body) {
+        "respond": function(status, headers, body) {
             this.setResponseHeaders(headers || {});
             this.status = typeof status == "number" ? status : 200;
             this.statusText = FakeXMLHttpRequest.statusCodes[this.status];
@@ -233,11 +233,11 @@ sinon.FakeXMLHttpRequest = (function () {
     });
 
     sinon.extend(FakeXMLHttpRequest, {
-        UNSENT: 0,
-        OPENED: 1,
-        HEADERS_RECEIVED: 2,
-        LOADING: 3,
-        DONE: 4
+        "UNSENT": 0,
+        "OPENED": 1,
+        "HEADERS_RECEIVED": 2,
+        "LOADING": 3,
+        "DONE": 4
     });
 
     // Borrowed from JSpec


### PR DESCRIPTION
This patch addresses Issue #7 by following the JSON declarative style for object member declarations.

Strictly speaking, it is not required to follow this style when declaring objects in native JavaScript code. However, following this style does prevent possible reserved keyword collisions which may arise in specific environments. Notably, Rhino fails if "throws" is defined as an object key without being declared using the string variant, as "throws" is a reserved keyword in that environment.

Summary of changes:
- All object keys changed to follow "name-is-a-string" convention. For example, `injectIntoThis: true` became `"injectIntoThis": true`
- Removed unneeded function names when declaring a function as the value of an object key -- the effective function name is derived from the value's key name within the object. For example, `throws: function throws(error, message) {` became `"throws": function(error, message) {`
- In cases where the object key name differed from the value's function name, the original value's function name has been added to the end of the line as a comment. For example `called: function assertCalled() {` became `"called": function() { // assertCalled`

Relevant passage from RFC4627: "An object is an unordered collection of zero or more name/value pairs, where a name is a string and a value is a string, number, boolean, null, object, or array."

Cheers,

Ben Loveridge
