### PR TITLE
fakeServer.respond drops requests (with autoRespond?)

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -150,12 +150,11 @@ sinon.fakeServer = (function () {
 
         respond: function respond() {
             var queue = this.queue || [];
+            var request;
 
-            for (var i = 0, l = queue.length; i < l; i++) {
-                this.processRequest(queue[i]);
+            while(request = queue.shift()) {
+                this.processRequest(request);
             }
-
-            this.queue = [];
         },
 
         processRequest: function processRequest(request) {


### PR DESCRIPTION
Apparently with autoRespond set to true then fakeServer.respond might drop requests from the queue even though they haven't been processed, yet:

https://github.com/cjohansen/Sinon.JS/blob/master/lib/sinon/util/fake_server.js#L92

vs

https://github.com/cjohansen/Sinon.JS/blob/master/lib/sinon/util/fake_server.js#L154-156

In line 154 it captures the length of the queue to iterate over it and process each queued request. Meanwhile new requests might be queued which then will be missed when the for loop breaks and the queue is reset to an empty array in line 158.

This seems to fix the issue:

https://github.com/svenfuchs/Sinon.JS/commit/01b9033092ed0dc2067153cbca1f9a8cc99f9586
