### PR TITLE
Case-Insensitive ActiveXObject for enabling fakeXHR.

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -341,7 +341,7 @@ sinon.FakeXMLHttpRequest = (function () {
 
         if (supportsActiveX) {
             global.ActiveXObject = function ActiveXObject(objId) {
-                if (objId == "Microsoft.XMLHTTP" || /^Msxml2\.XMLHTTP/.test(objId)) {
+                if (objId == "Microsoft.XMLHTTP" || /^Msxml2\.XMLHTTP/i.test(objId)) {
                     return new sinon.FakeXMLHttpRequest();
                 }
 


### PR DESCRIPTION
Making the test in ActiveXObject case-insensitive. Fixes MooTools which uses `'MSXML2.XMLHTTP'`, as objectId.
