### PR TITLE
Fix for restoring a non-owned method

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -61,11 +61,16 @@ var sinon = (function () {
                 throw new TypeError("Attempted to wrap " + property + " which is already " + verb);
             }
 
+            var owned = object.hasOwnProperty(property);
             object[property] = method;
             method.displayName = property;
 
             method.restore = function () {
-                object[property] = wrappedMethod;
+                if(owned) {
+                    object[property] = wrappedMethod;
+                } else {
+                    delete object[property];
+                }
             };
 
             method.restore.sinon = true;

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -132,6 +132,29 @@ if (typeof require == "function" && typeof testCase == "undefined") {
         }
     });
 
+    testCase("WrappedPrototypeMethodTest", {
+        setUp: function () {
+            this.type = function () {};
+            this.type.prototype.method = function () {};
+            this.object = new this.type();
+        },
+
+        "wrap should add owned property": function () {
+            var wrapper = sinon.wrapMethod(this.object, "method", function () {});
+
+            assertSame(wrapper, this.object.method);
+            assertTrue(this.object.hasOwnProperty("method"));
+        },
+
+        "restore should remove owned property": function () {
+            sinon.wrapMethod(this.object, "method", function () {});
+            this.object.method.restore();
+
+            assertSame(this.type.prototype.method, this.object.method);
+            assertFalse(this.object.hasOwnProperty("method"));
+        }
+    });
+
     testCase("SinonDeepEqualTest", {
         "should pass primitives": function () {
             assert(sinon.deepEqual(1, 1));


### PR DESCRIPTION
When restoring, the wrapped method is replaced by the original method, which is fine if the object owned the original method. However, if the the original method is actually defined higher in the prototype chain, this can cause subtle bugs, particularly if the object is a singleton. This commit is a simple change that checks for this case and removes the wrapped method instead of replacing it.
