### PR TITLE
callArg, callArgWith, yield and yieldTo for spy calls

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -290,6 +290,16 @@
     }()));
 
     spyCall = (function () {
+        var slice = Array.prototype.slice;
+
+        function throwYieldError(proxy, text, args) {
+            var msg = sinon.functionName(proxy) + text;
+            if (args.length) {
+                msg += " Received [" + slice.call(args).join(", ") + "]";
+            }
+            throw new Error(msg);
+        }
+
         return {
             create: function create(spy, thisValue, args, returnValue, exception, id) {
                 var proxyCall = sinon.create(spyCall);
@@ -358,6 +368,38 @@
 
             calledAfter: function (other) {
                 return this.callId > other.callId;
+            },
+
+            callArg: function (pos) {
+                this.args[pos]();
+            },
+
+            callArgWith: function (pos) {
+                var args = slice.call(arguments, 1);
+                this.args[pos].apply(null, args);
+            },
+
+            yield: function () {
+                var args = this.args;
+                for (var i = 0, l = args.length; i < l; ++i) {
+                    if (typeof args[i] === "function") {
+                        args[i].apply(null, slice.call(arguments));
+                        return;
+                    }
+                }
+                throwYieldError(this.proxy, " cannot yield since no callback was passed.", args);
+            },
+
+            yieldTo: function (prop) {
+                var args = this.args;
+                for (var i = 0, l = args.length; i < l; ++i) {
+                    if (args[i] && typeof args[i][prop] === "function") {
+                        args[i][prop].apply(null, slice.call(arguments, 1));
+                        return;
+                    }
+                }
+                throwYieldError(this.proxy, " cannot yield to '" + prop +
+                    "' since no callback was passed.", args);
             },
 
             toString: function () {


### PR DESCRIPTION
I sometimes find myself writing something like this:

``` javascript
var stub = sinon.stub(object, "methodThatTakesCallback");
```

Test execution then invokes `methodThatTakesCallback` and might do something else afterwards. Since the callback would normally get invoked asynchronously, I need to call it myself (instead of using a stub with yields):

``` javascript
stub.getCall(0).args[2]("abc", 123); // ouch!
```

I would prefer something more convenient:

``` javascript
stub.getCall(0).yield("abc", 123);
```

One question though: would it make sense to even skip the `getCall(n)` part and always use the last call by default?

``` javascript
stub.yield("abc", 123); // not yet possible
```

Not sure whether this could be confusing :-/
