### PR TITLE
Additional spy functions

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -16,7 +16,7 @@
     var spyCall;
     var callId = 0;
     var push = [].push;
-	var slice = Array.prototype.slice;
+    var slice = Array.prototype.slice;
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");
@@ -44,7 +44,10 @@
         function delegateToCalls(api, method, matchAny, actual, notCalled) {
             api[method] = function () {
                 if (!this.called) {
-                    return !!notCalled;
+                    if (notCalled) {
+                        return notCalled.apply(this, arguments);
+                    }
+                    return false;
                 }
 
                 var currentCall;
@@ -90,6 +93,10 @@
                 this.calledTwice = false;
                 this.calledThrice = false;
                 this.callCount = 0;
+                this.firstCall = null;
+                this.secondCall = null;
+                this.thirdCall = null;
+                this.lastCall = null;
                 this.args = [];
                 this.returnValues = [];
                 this.thisValues = [];
@@ -152,19 +159,10 @@
 
                 push.call(this.returnValues, returnValue);
 
-                if (!this.firstCall && this.calledOnce) {
-                    this.firstCall = this.lastCall = this.getCall(0);
-                }
-                if (!this.secondCall && this.calledTwice) {
-                    this.secondCall = this.lastCall = this.getCall(1);
-                }
-                if (!this.thirdCall && this.calledThrice) {
-                    this.thirdCall = this.lastCall = this.getCall(2);
-                }
-                if (this.callCount > 3) {
-                    this.lastCall = this.getCall(this.callCount - 1);
-                }
-
+                this.firstCall = this.getCall(0);
+                this.secondCall = this.getCall(1);
+                this.thirdCall = this.getCall(2);
+                this.lastCall = this.getCall(this.callCount - 1);
 
                 return returnValue;
             },
@@ -249,50 +247,10 @@
 
                     return "%" + specifyer;
                 });
-            },
-
-			callArg: function (pos) {
-				var l = this.args.length;
-				if (!l) {
-					var name = this.toString();
-					throw new Error(name + " cannot call arg since it was not yet invoked.");
-				}
-				var args = slice.call(arguments, 1);
-				for (var i = 0; i < l; i++) {
-					this.args[i][pos].apply(null, args);
-				}
-			},
-
-			yield: function () {
-				var l = this.callCount;
-				if (!l) {
-					var name = this.toString();
-					throw new Error(name + " cannot yield since it was not yet invoked.");
-				}
-				var args = slice.call(arguments);
-				for (var i = 0; i < l; i++) {
-					var call = this.getCall(i);
-					call.yield.apply(call, args);
-				}
-			},
-
-			yieldTo: function (property) {
-				var l = this.callCount;
-				if (!l) {
-					var name = this.toString();
-					throw new Error(name + " cannot yield to '" + property +
-                        "' since it was not yet invoked.");
-				}
-				var args = slice.call(arguments);
-				for (var i = 0; i < l; i++) {
-					var call = this.getCall(i);
-					call.yieldTo.apply(call, args);
-				}
-			}
+            }
 
         };
 
-		spyApi.callArgWith = spyApi.callArg;
 
         delegateToCalls(spyApi, "calledOn", true);
         delegateToCalls(spyApi, "alwaysCalledOn", false, "calledOn");
@@ -300,13 +258,25 @@
         delegateToCalls(spyApi, "alwaysCalledWith", false, "calledWith");
         delegateToCalls(spyApi, "calledWithExactly", true);
         delegateToCalls(spyApi, "alwaysCalledWithExactly", false, "calledWithExactly");
-        delegateToCalls(spyApi, "neverCalledWith", false, "notCalledWith", true);
+        delegateToCalls(spyApi, "neverCalledWith", false, "notCalledWith",
+            function () { return true; });
         delegateToCalls(spyApi, "threw", true);
         delegateToCalls(spyApi, "alwaysThrew", false, "threw");
         delegateToCalls(spyApi, "returned", true);
         delegateToCalls(spyApi, "alwaysReturned", false, "returned");
         delegateToCalls(spyApi, "calledWithNew", true);
         delegateToCalls(spyApi, "alwaysCalledWithNew", false, "calledWithNew");
+        delegateToCalls(spyApi, "callArg", false, "callArgWith", function () {
+            throw new Error(this.toString() + " cannot call arg since it was not yet invoked.");
+        });
+        spyApi.callArgWith = spyApi.callArg;
+        delegateToCalls(spyApi, "yield", false, "yield", function () {
+            throw new Error(this.toString() + " cannot yield since it was not yet invoked.");
+        });
+        delegateToCalls(spyApi, "yieldTo", false, "yieldTo", function (property) {
+            throw new Error(this.toString() + " cannot yield to '" + property +
+                "' since it was not yet invoked.");
+        });
 
         spyApi.formatters = {
             "c": function (spy) {

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -1212,7 +1212,7 @@ if (typeof require == "function" && typeof testCase == "undefined") {
         "should be undefined by default": function () {
             var spy = sinon.spy();
 
-            assertUndefined(spy.firstCall);
+            assertNull(spy.firstCall);
         },
 
         "should be equal to getCall(0) result after first call": function () {
@@ -1220,36 +1220,26 @@ if (typeof require == "function" && typeof testCase == "undefined") {
 
             spy();
 
-			var call0 = spy.getCall(0);
+            var call0 = spy.getCall(0);
             assertEquals(call0.callId, spy.firstCall.callId);
             assertSame(call0.spy, spy.firstCall.spy);
-        },
-
-	    "should not change on second call": function () {
-            var spy = sinon.spy();
-            spy();
-			var firstCall = spy.firstCall;
-
-			spy();
-
-            assertSame(firstCall, spy.firstCall);
         }
 
     });
 
     testCase("SpySecondCallTest", {
 
-        "should be undefined by default": function () {
+        "should be null by default": function () {
             var spy = sinon.spy();
 
-            assertUndefined(spy.secondCall);
+            assertNull(spy.secondCall);
         },
 
-        "should still be undefined after first call": function () {
+        "should still be null after first call": function () {
             var spy = sinon.spy();
             spy();
 
-            assertUndefined(spy.secondCall);
+            assertNull(spy.secondCall);
         },
 
         "should be equal to getCall(1) result after second call": function () {
@@ -1258,20 +1248,9 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             spy();
             spy();
 
-			var call1 = spy.getCall(1);
+            var call1 = spy.getCall(1);
             assertEquals(call1.callId, spy.secondCall.callId);
             assertSame(call1.spy, spy.secondCall.spy);
-        },
-
-	    "should not change on third call": function () {
-            var spy = sinon.spy();
-            spy();
-            spy();
-			var secondCall = spy.secondCall;
-
-			spy();
-
-            assertSame(secondCall, spy.secondCall);
         }
 
     });
@@ -1281,7 +1260,7 @@ if (typeof require == "function" && typeof testCase == "undefined") {
         "should be undefined by default": function () {
             var spy = sinon.spy();
 
-            assertUndefined(spy.thirdCall);
+            assertNull(spy.thirdCall);
         },
 
         "should still be undefined after second call": function () {
@@ -1289,7 +1268,7 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             spy();
             spy();
 
-            assertUndefined(spy.thirdCall);
+            assertNull(spy.thirdCall);
         },
 
         "should be equal to getCall(1) result after second call": function () {
@@ -1299,21 +1278,9 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             spy();
             spy();
 
-			var call2 = spy.getCall(2);
+            var call2 = spy.getCall(2);
             assertEquals(call2.callId, spy.thirdCall.callId);
             assertSame(call2.spy, spy.thirdCall.spy);
-        },
-
-	    "should not change on fourth call": function () {
-            var spy = sinon.spy();
-            spy();
-            spy();
-            spy();
-			var thirdCall = spy.thirdCall;
-
-			spy();
-
-            assertSame(thirdCall, spy.thirdCall);
         }
 
     });
@@ -1323,7 +1290,7 @@ if (typeof require == "function" && typeof testCase == "undefined") {
         "should be undefined by default": function () {
             var spy = sinon.spy();
 
-            assertUndefined(spy.lastCall);
+            assertNull(spy.lastCall);
         },
 
         "should be same as firstCall after first call": function () {
@@ -1331,7 +1298,8 @@ if (typeof require == "function" && typeof testCase == "undefined") {
 
             spy();
 
-            assertSame(spy.firstCall, spy.lastCall);
+            assertSame(spy.firstCall.callId, spy.lastCall.callId);
+            assertSame(spy.firstCall.spy, spy.lastCall.spy);
         },
 
         "should be same as secondCall after second call": function () {
@@ -1340,7 +1308,8 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             spy();
             spy();
 
-            assertSame(spy.secondCall, spy.lastCall);
+            assertSame(spy.secondCall.callId, spy.lastCall.callId);
+            assertSame(spy.secondCall.spy, spy.lastCall.spy);
         },
 
         "should be same as thirdCall after third call": function () {
@@ -1350,7 +1319,8 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             spy();
             spy();
 
-            assertSame(spy.thirdCall, spy.lastCall);
+            assertSame(spy.thirdCall.callId, spy.lastCall.callId);
+            assertSame(spy.thirdCall.spy, spy.lastCall.spy);
         },
 
         "should be equal to getCall(3) result after fourth call": function () {
@@ -1361,7 +1331,7 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             spy();
             spy();
 
-			var call3 = spy.getCall(3);
+            var call3 = spy.getCall(3);
             assertEquals(call3.callId, spy.lastCall.callId);
             assertSame(call3.spy, spy.lastCall.spy);
         },
@@ -1375,7 +1345,7 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             spy();
             spy();
 
-			var call4 = spy.getCall(4);
+            var call4 = spy.getCall(4);
             assertEquals(call4.callId, spy.lastCall.callId);
             assertSame(call4.spy, spy.lastCall.spy);
         }
@@ -2186,6 +2156,10 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             assertEquals(0, spy.returnValues.length);
             assertEquals(0, spy.exceptions.length);
             assertEquals(0, spy.thisValues.length);
+            assertNull(spy.firstCall);
+            assertNull(spy.secondCall);
+            assertNull(spy.thirdCall);
+            assertNull(spy.lastCall);
         },
 
         "should reset call order state": function () {


### PR DESCRIPTION
As discussed in #45 I added `callArg`, `callArgWith`, `yield` and `yieldTo` to the spy API. They are applied to all calls.

To address a specific call, there are now additional convenience properties available: `firstCall`, `secondCall`, `thirdCall` and `lastCall`.

Happy merging!
