### PR TITLE
Fix: Fake timers were swallowing exceptions

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -130,10 +130,15 @@ sinon.clock = (function () {
             var tickFrom = this.now, tickTo = this.now + ms, previous = this.now;
             var timer = this.firstTimerInRange(tickFrom, tickTo);
 
+            var firstException;
             while (timer && tickFrom <= tickTo) {
                 if (this.timeouts[timer.id]) {
                     tickFrom = this.now = timer.callAt;
-                    this.callTimer(timer);
+                    try {
+                      this.callTimer(timer);
+                    } catch (e) {
+                      firstException = firstException || e;
+                    }
                 }
 
                 timer = this.firstTimerInRange(previous, tickTo);
@@ -141,6 +146,10 @@ sinon.clock = (function () {
             }
 
             this.now = tickTo;
+
+            if (firstException) {
+              throw firstException;
+            }
         },
 
         firstTimerInRange: function (from, to) {
@@ -176,9 +185,14 @@ sinon.clock = (function () {
                 } else {
                     eval(timer.func);
                 }
-            } catch (e) {}
+            } catch (e) {
+              var exception = e;
+            }
 
             if (!this.timeouts[timer.id]) {
+                if (exception) {
+                  throw exception;
+                }
                 return;
             }
 
@@ -186,6 +200,10 @@ sinon.clock = (function () {
                 this.timeouts[timer.id].callAt += timer.interval;
             } else {
                 delete this.timeouts[timer.id];
+            }
+
+            if (exception) {
+              throw exception;
             }
         },
 

--- a/test/sinon/util/fake_timers_test.js
+++ b/test/sinon/util/fake_timers_test.js
@@ -181,20 +181,28 @@ if (typeof require == "function" && typeof testCase == "undefined") {
         },
 
         "should trigger even when some throw": function () {
+            var clock = this.clock;
             var stubs = [sinon.stub.create().throws(), sinon.stub.create()];
-            this.clock.setTimeout(stubs[0], 100);
-            this.clock.setTimeout(stubs[1], 120);
 
-            this.clock.tick(120);
+            clock.setTimeout(stubs[0], 100);
+            clock.setTimeout(stubs[1], 120);
+
+            assertException(function() {
+              clock.tick(120);
+            });
 
             assert(stubs[0].called);
             assert(stubs[1].called);
         },
 
         "should call function with global object or null (strict mode) as this": function () {
+            var clock = this.clock;
             var stub = sinon.stub.create().throws();
-            this.clock.setTimeout(stub, 100);
-            this.clock.tick(100);
+            clock.setTimeout(stub, 100);
+
+            assertException(function() {
+              clock.tick(100);
+            });
 
             assert(stub.calledOn(global) || stub.calledOn(null));
         },
@@ -375,6 +383,18 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             clock.tick(1000);
 
             assertEquals(11, i);
+        },
+
+        "should not silently catch exceptions": function () {
+          var clock = this.clock;
+
+          clock.setTimeout(function() {
+            throw new Exception('oh no!');
+          }, 1000);
+
+          assertException(function() {
+            clock.tick(1000);
+          });
         }
     });
 


### PR DESCRIPTION
I promised to submit a patch for this a long time ago ... but now that we have met here at oredev, and I can no longer hide behind the internetz, I figured I should finally live up to my promise : ).

Let me know if the patch looks good to you - all tests of the node suite are passing when running them.

Currently clock.tick() was executing fake timer callbacks inside a
try...catch block which would silently swallow any exceptions which
may occur in the callback.

This patch changes this behavior to re-throw any exception that might
occur. If there are multiple timer callbacks to be executed, and there
are multiple exceptions, only the first one will be thrown, but all
timers will be executed.

Fixes #27
