### PR TITLE
White-list XHR requests to allow through

### DIFF
--- a/jsTestDriver.conf
+++ b/jsTestDriver.conf
@@ -18,3 +18,6 @@ load:
   - test/sinon_test.js
   - test/sinon/*.js
   - test/sinon/util/*.js
+
+serve:
+  - test/resources/*

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -103,6 +103,7 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
     FakeXMLHttpRequest.addFilter = function(fn) {
         this.filters.push(fn)
     };
+    var IE6Re = /MSIE 6/;
     FakeXMLHttpRequest.defake = function(fakeXhr,xhrArgs) {
         var xhr = new sinon.xhr.workingXHR();
         each(["open","setRequestHeader","send","abort","getResponseHeader",
@@ -114,7 +115,13 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
              });
         
         var copyAttrs = function(args) { 
-            each(args, function(attr) { fakeXhr[attr] = xhr[attr] });
+            each(args, function(attr) {
+              try {
+                fakeXhr[attr] = xhr[attr]
+              } catch(e) {
+                if(!IE6Re.test(navigator.userAgent)) throw e;
+              }
+            });
         };
 
         var stateChange = function() {

--- a/test/resources/xhr_target.txt
+++ b/test/resources/xhr_target.txt
@@ -1,0 +1,1 @@
+loaded successfully

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -1028,6 +1028,43 @@
         }
     });
 
+    AsyncTestCase("DefakedXHRTest",{
+        setUp: function() {
+            sinon.FakeXMLHttpRequest.useFilters = true;
+            sinon.FakeXMLHttpRequest.filters = [];
+            sinon.useFakeXMLHttpRequest();
+            sinon.FakeXMLHttpRequest.addFilter(function() {return true;});
+        },
+        tearDown: function() {
+            sinon.FakeXMLHttpRequest.useFilters = false;
+            sinon.FakeXMLHttpRequest.restore();
+        },
+        "test loads resource asynchronously": function(q) {
+            q.call(function(callbacks) {
+                var req = new XMLHttpRequest;
+                var responseReceived = callbacks.add(function(responseText) {
+                    assertMatch(/loaded successfully/, responseText);
+                });
+                req.onreadystatechange = function() {
+                    if(this.readyState == 4) {
+                        responseReceived(this.responseText);
+                    }
+                };
+
+                setTimeout(callbacks.addErrback("timeout on ajax"),1000);
+
+                req.open("GET","/test/test/resources/xhr_target.txt",true);
+                req.send();
+            });
+        },
+        "test loads resource synchronously": function() {
+            var req = new XMLHttpRequest;
+            req.open("GET","/test/test/resources/xhr_target.txt",false);
+            req.send();
+            assertMatch(/loaded successfully/, req.responseText);
+        }
+    });
+
     if (typeof ActiveXObject == "undefined") {
         testCase("StubXHRActiveXTest", {
             setUp: fakeXhrSetUp,


### PR DESCRIPTION
Creates a white-list of URLs that Sinon's FakeXHR will ignore. Delegates all methods to real XHR object, and updates attributes of FakeXHR as they change on the real.

This is lacking documentation, but now matches Sinon's code conventions etc as per our [last chat](https://github.com/Picklive/Sinon.JS/commit/5e4e28d91fd7ca64b31ecdd114c6e9b659c0ce75#commitcomment-517271) about it (ages back, sorry ;) ). Let me know if this looks good and I'll document it!
