### PR TITLE
Added invokeCallback to spy API as an alias for yield

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -273,6 +273,8 @@
         delegateToCalls(spyApi, "yield", false, "yield", function () {
             throw new Error(this.toString() + " cannot yield since it was not yet invoked.");
         });
+        // "invokeCallback" is an alias for "yield" since "yield" is invalid in strict mode.
+        spyApi.invokeCallback = spyApi.yield;
         delegateToCalls(spyApi, "yieldTo", false, "yieldTo", function (property) {
             throw new Error(this.toString() + " cannot yield to '" + property +
                 "' since it was not yet invoked.");

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -1494,6 +1494,16 @@ if (typeof require == "function" && typeof testCase == "undefined") {
 
     });
 
+    testCase("SpyInvokeCallbackTest", {
+
+        "should be alias for yield": function () {
+            var spy = sinon.spy();
+
+            assertSame(spy.yield, spy.invokeCallback);
+        }
+
+    });
+
     testCase("SpyYieldToTest", {
 
         "should be function": function () {


### PR DESCRIPTION
Since `yield` is invalid in strict mode, I’ve added `invokeCallback` as an alias for those who lint their unit tests or use strict mode. See discussion following pull request #48.
