### PR TITLE
Fixing fake `setTimeout` to return ids greater than 0.

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -24,7 +24,7 @@ if (typeof sinon == "undefined") {
 }
 
 sinon.clock = (function () {
-    var id = 0;
+    var id = 1;
 
     function addTimer(args, recurring) {
         if (args.length === 0) {


### PR DESCRIPTION
As per the spec at http://www.whatwg.org/specs/web-apps/current-work/multipage/timers.html#timers, `setTimeout` et al. must return an id _greater than 0_.
