### PR TITLE
sinon.test: use try/finally instead of catch and throw.

### DIFF
--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -43,14 +43,8 @@
 
             try {
                 result = callback.apply(this, args);
-            } catch (e) {
-                exception = e;
-            }
-
-            sandbox.verifyAndRestore();
-
-            if (exception) {
-                throw exception;
+            } finally {
+                sandbox.verifyAndRestore();
             }
 
             return result;


### PR DESCRIPTION
Catch-and-throw obscures where the exception originated.  Before, chrome's inspector only was able to tell me there was being an exception being caught and thrown here, but not where it originated in the code under test.

This way the debugger is able to show me the traceback starting where the error actually occurred in my code, instead of sinon.test being the lowest stack frame.
