### PR TITLE
Spys created using 'withArgs' should get initialized

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -83,6 +83,21 @@
             }
         }
 
+        function incrementCallCount() {
+            this.called = true;
+            this.callCount += 1;
+            this.calledOnce = this.callCount == 1;
+            this.calledTwice = this.callCount == 2;
+            this.calledThrice = this.callCount == 3;
+        }
+
+        function createCallProperties() {
+            this.firstCall = this.getCall(0);
+            this.secondCall = this.getCall(1);
+            this.thirdCall = this.getCall(2);
+            this.lastCall = this.getCall(this.callCount - 1);
+        }
+
         var uuid = 0;
 
         // Public API
@@ -134,11 +149,8 @@
             invoke: function invoke(func, thisValue, args) {
                 var matching = matchingFake(this.fakes, args);
                 var exception, returnValue;
-                this.called = true;
-                this.callCount += 1;
-                this.calledOnce = this.callCount == 1;
-                this.calledTwice = this.callCount == 2;
-                this.calledThrice = this.callCount == 3;
+
+                incrementCallCount.call(this);
                 push.call(this.thisValues, thisValue);
                 push.call(this.args, args);
                 push.call(this.callIds, callId++);
@@ -159,10 +171,7 @@
 
                 push.call(this.returnValues, returnValue);
 
-                this.firstCall = this.getCall(0);
-                this.secondCall = this.getCall(1);
-                this.thirdCall = this.getCall(2);
-                this.lastCall = this.getCall(this.callCount - 1);
+                createCallProperties.call(this);
 
                 return returnValue;
             },
@@ -218,6 +227,18 @@
                 fake.withArgs = function () {
                     return original.withArgs.apply(original, arguments);
                 };
+
+                for (var i = 0; i < this.args.length; i++) {
+                    if (fake.matches(this.args[i])) {
+                        incrementCallCount.call(fake);
+                        push.call(fake.thisValues, this.thisValues[i]);
+                        push.call(fake.args, this.args[i]);
+                        push.call(fake.returnValues, this.returnValues[i]);
+                        push.call(fake.exceptions, this.exceptions[i]);
+                        push.call(fake.callIds, this.callIds[i]);
+                    }
+                }
+                createCallProperties.call(fake);
 
                 return fake;
             },

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -2271,6 +2271,131 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             assertEquals(3, spy.callCount);
             assertEquals(1, numArgSpy.callCount);
             assertEquals(1, spy.withArgs({}, []).callCount);
+        },
+
+        "should initialize filtered spy with callCount": function () {
+            var spy = sinon.spy();
+            spy("a");
+            spy("b");
+            spy("b");
+            spy("c");
+            spy("c");
+            spy("c");
+
+            var argSpy1 = spy.withArgs("a");
+            var argSpy2 = spy.withArgs("b");
+            var argSpy3 = spy.withArgs("c");
+
+            assertEquals(1, argSpy1.callCount);
+            assertEquals(2, argSpy2.callCount);
+            assertEquals(3, argSpy3.callCount);
+            assert(argSpy1.called);
+            assert(argSpy2.called);
+            assert(argSpy3.called);
+            assert(argSpy1.calledOnce);
+            assert(argSpy2.calledTwice);
+            assert(argSpy3.calledThrice);
+        },
+
+        "should initialize filtered spy with first, second, third and last call": function () {
+            var spy = sinon.spy();
+            spy("a", 1);
+            spy("b", 2);
+            spy("b", 3);
+            spy("b", 4);
+
+            var argSpy1 = spy.withArgs("a");
+            var argSpy2 = spy.withArgs("b");
+
+            assert(argSpy1.firstCall.calledWithExactly("a", 1));
+            assert(argSpy1.lastCall.calledWithExactly("a", 1));
+            assert(argSpy2.firstCall.calledWithExactly("b", 2));
+            assert(argSpy2.secondCall.calledWithExactly("b", 3));
+            assert(argSpy2.thirdCall.calledWithExactly("b", 4));
+            assert(argSpy2.lastCall.calledWithExactly("b", 4));
+        },
+
+        "should initialize filtered spy with arguments": function () {
+            var spy = sinon.spy();
+            spy("a");
+            spy("b");
+            spy("b", "c", "d");
+
+            var argSpy1 = spy.withArgs("a");
+            var argSpy2 = spy.withArgs("b");
+
+            assert(argSpy1.getCall(0).calledWithExactly("a"));
+            assert(argSpy2.getCall(0).calledWithExactly("b"));
+            assert(argSpy2.getCall(1).calledWithExactly("b", "c", "d"));
+        },
+
+        "should initialize filtered spy with thisValues": function () {
+            var spy = sinon.spy();
+            var thisValue1 = {};
+            var thisValue2 = {};
+            var thisValue3 = {};
+            spy.call(thisValue1, "a");
+            spy.call(thisValue2, "b");
+            spy.call(thisValue3, "b");
+
+            var argSpy1 = spy.withArgs("a");
+            var argSpy2 = spy.withArgs("b");
+
+            assert(argSpy1.getCall(0).calledOn(thisValue1));
+            assert(argSpy2.getCall(0).calledOn(thisValue2));
+            assert(argSpy2.getCall(1).calledOn(thisValue3));
+        },
+
+        "should initialize filtered spy with return values": function () {
+            var spy = sinon.spy(function (value) { return value; });
+            spy("a");
+            spy("b");
+            spy("b");
+
+            var argSpy1 = spy.withArgs("a");
+            var argSpy2 = spy.withArgs("b");
+
+            assert(argSpy1.getCall(0).returned("a"));
+            assert(argSpy2.getCall(0).returned("b"));
+            assert(argSpy2.getCall(1).returned("b"));
+        },
+
+        "should initialize filtered spy with call order": function () {
+            var spy = sinon.spy();
+            spy("a");
+            spy("b");
+            spy("b");
+
+            var argSpy1 = spy.withArgs("a");
+            var argSpy2 = spy.withArgs("b");
+
+            assert(argSpy2.getCall(0).calledAfter(argSpy1.getCall(0)));
+            assert(argSpy2.getCall(1).calledAfter(argSpy1.getCall(0)));
+        },
+
+        "should initialize filtered spy with exceptions": function () {
+            var spy = sinon.spy(function (x, y) {
+                var error = new Error();
+                error.name = y;
+                throw error;
+            });
+            try {
+                spy("a", "1");
+            } catch (ignored) {}
+            try {
+                spy("b", "2");
+            } catch (ignored) {}
+            try {
+                spy("b", "3");
+            } catch (ignored) {}
+
+            var argSpy1 = spy.withArgs("a");
+            var argSpy2 = spy.withArgs("b");
+
+            assert(argSpy1.getCall(0).threw("1"));
+            assert(argSpy2.getCall(0).threw("2"));
+            assert(argSpy2.getCall(1).threw("3"));
         }
+
     });
 }());


### PR DESCRIPTION
This allows things like

``` javascript
assert(spy.withArgs("foo").threw());
```

``` javascript
spy.withArgs("foo").yield();
```

``` javascript
assert(spy.withArgs("foo").calledBefore(spy.withArgs("bar")));
```
