### PR TITLE
Remove sudo from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Standalone and test framework agnostic JavaScript test spies, stubs and mocks.
 
 via [npm (node package manager)](http://github.com/isaacs/npm)
 
-    $ sudo npm install sinon
+    $ npm install sinon
 
 or install via git by cloning the repository and including sinon.js 
 in your project, as you would any other third party library.


### PR DESCRIPTION
Sudo is not needed / recommended when installing npm modules locally.
