### PR TITLE
Fixing `clearTimeout` to not throw when called for nonexistant IDs.

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -118,7 +118,9 @@ if (typeof sinon == "undefined") {
                 this.timeouts = [];
             }
 
-            delete this.timeouts[timerId];
+            if (timerId in this.timeouts) {
+                delete this.timeouts[timerId];
+            }
         },
 
         setInterval: function setInterval(callback, timeout) {


### PR DESCRIPTION
Since sinon is in strict mode, `delete` throws when used on a non-existent property, causing `clearTimeout` to throw. This breaks the contract of `clearTimeout`.
