### PR TITLE
Fixed work with sinon.useFakeTImers() and Rhino.js 1.7R3

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -324,7 +324,7 @@ if (typeof sinon == "undefined") {
 
         return clock;
     };
-}(typeof global != "undefined" ? global : this));
+}(typeof global != "undefined" && typeof global !== "function" ? global : this));
 
 sinon.timers = {
     setTimeout: setTimeout,


### PR DESCRIPTION
This is fix for my blog post about Sinon.js and Fake timers: [Headless JavaScript testing, Sinon.js, Fake Timers and Rhino](http://djangoandother.blogspot.com/2012/02/headless-javascript-testing-sinonjs.html).

As promised, I've made environment with Rhino and Sinon.js where test for Fake Timers is not work properly ([download](http://dl.dropbox.com/u/28023777/sinon-rhino.tar.bz2)). To execute tests use `./runtests.sh`.

The main reason of issue is that Rhino.js use global object called `global` which cause conflict with Sinon.js `global` object recognition.

I've not wrote regression tests because most of the tests are failed within Rhino.js.
