### PR TITLE
Fixes a problem with sandboxes not restoring stubs when a whole object was stubbed

### DIFF
--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -106,6 +106,19 @@
                     });
                 }
             }
+            if (!property && !!object && typeof object == "object") {
+                var stubbedObj = sinon.stub.apply(sinon, arguments);
+
+                return this.add({
+                    restore: function () {
+                        for (var prop in stubbedObj) {
+                            if (typeof stubbedObj[prop] === "function") {
+                                stubbedObj[prop].restore();
+                            }
+                        }
+                    }
+                });
+            }
 
             return this.add(sinon.stub.apply(sinon, arguments));
         },

--- a/test/sinon/test_case_test.js
+++ b/test/sinon/test_case_test.js
@@ -161,6 +161,28 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             assertSame(myMeth, myObj.meth);
         },
 
+        "should unstub all methods of an objects after test is run": function () {
+            var myMeth = function () {};
+            var myMeth2 = function () {};
+            var myObj = { meth: myMeth, meth2: myMeth2 };
+
+            var testCase = sinon.testCase({
+                testA: function () {
+                    this.stub(myObj);
+
+                    assertFunction(this.stub);
+
+                    assertNotSame(myMeth, myObj.meth);
+                    assertNotSame(myMeth2, myObj.meth2);
+                }
+            });
+
+            testCase.testA();
+
+            assertSame(myMeth, myObj.meth);
+            assertSame(myMeth2, myObj.meth2);
+        },
+
         "should unstub objects stubbed in setUp": function () {
             var myMeth = function () {};
             var myObj = { meth: myMeth };
@@ -179,6 +201,29 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             testCase.testA();
 
             assertSame(myMeth, myObj.meth);
+        },
+
+        "should unstub all methods of an objects stubbed in setUp": function () {
+            var myMeth = function () {};
+            var myMeth2 = function () {};
+            var myObj = { meth: myMeth, meth2: myMeth2 };
+
+            var testCase = sinon.testCase({
+                setUp: function () {
+                    this.stub(myObj);
+                },
+                testA: function () {
+                    assertFunction(this.stub);
+
+                    assertNotSame(myMeth, myObj.meth);
+                    assertNotSame(myMeth2, myObj.meth2);
+                }
+            });
+
+            testCase.testA();
+
+            assertSame(myMeth, myObj.meth);
+            assertSame(myMeth2, myObj.meth2);
         },
 
         "should allow the use of helper methods": function () {

--- a/test/sinon/test_test.js
+++ b/test/sinon/test_test.js
@@ -72,6 +72,19 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             assertSame(method, object.method);
         },
 
+        "should restore stubs on all object methods": function() {
+            var method = function () {};
+            var method2 = function () {};
+            var object = { method: method, method2: method2 };
+
+            sinon.test(function () {
+                this.stub(object);
+            }).call({});
+
+            assertSame(method, object.method);
+            assertSame(method2, object.method2);
+        },
+
         "should throw when method throws": function () {
             var method = function () {};
             var object = { method: method };


### PR DESCRIPTION
Hi.

I've been working with the sandboxes lately and I've found an issue with restoring the stubbed objects when the sandbox.restore() is called.
The sandbox.restore() wasn't restoring the methods when a whole object was stubbed.

Fix included in pull request.
Tests included also.

I've chosen to add a wrapper on a stubbed object in collection and leave the actual stubs restore method intact.

It seems that a better solution would be to change the stubs restore method to restore all methods.
I need a verification if it was left as something that you didn't want to implement for some reason or if it is just missing.

I will provide a patch for restore method if we agree that's the solution we should go with (I think it is).
