### PR TITLE
use JSON.stringify() instead of args.join(", ")

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -329,7 +329,7 @@
             },
 
             "*": function (spy, args) {
-                return args.join(", ");
+                return JSON.stringify(args);
             }
         };
 


### PR DESCRIPTION
use JSON.stringify() instead of args.join(", ") to show the expected arguments when using "calledWith" asserts.
without this, it returns something like this:

  AssertError: expected method to be called with [Object]

which isn't very helpful.
