### PR TITLE
has and hasOwn matchers

### DIFF
--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -120,6 +120,32 @@
         }, "like(" + str.join(", ") + ")");
     };
 
+    function createPropertyMatcher(propertyTest, messagePrefix) {
+        return function (property, value) {
+            assertType(property, "string", "property");
+            var onlyProperty = arguments.length === 1;
+            var message = messagePrefix + "(\"" + property + "\"";
+            if (!onlyProperty) {
+                message += ", " + value;
+            }
+            message += ")";
+            return match(function (actual) {
+                if (sinon.typeOf(actual) !== "object" || !propertyTest(actual, property)) {
+                    return false;
+                }
+                return onlyProperty || sinon.deepEqual(value, actual[property]);
+            }, message);
+        };
+    }
+
+    match.has = createPropertyMatcher(function (actual, property) {
+        return property in actual;
+    }, "has");
+
+    match.hasOwn = createPropertyMatcher(function (actual, property) {
+        return actual.hasOwnProperty(property);
+    }, "hasOwn");
+
     match.bool = match.typeOf("boolean");
     match.number = match.typeOf("number");
     match.string = match.typeOf("string");

--- a/test/sinon/match_test.js
+++ b/test/sinon/match_test.js
@@ -274,6 +274,114 @@ if (typeof require == "function" && typeof testCase == "undefined") {
         }
     });
 
+    function propertyMatcherTests(matcher) {
+        return {
+            "should return matcher": function () {
+                var has = matcher("foo");
+
+                assert(sinon.match.isMatcher(has));
+            },
+
+            "should throw if first argument is not string": function () {
+                assertException(function () {
+                    matcher();
+                }, "TypeError");
+                assertException(function () {
+                    matcher(123);
+                }, "TypeError");
+            },
+
+            "should return false if value is not object": function () {
+                var has = matcher("foo");
+
+                assertFalse(has.test());
+                assertFalse(has.test(null));
+                assertFalse(has.test(123));
+                assertFalse(has.test("test"));
+            },
+
+            "should return true if object has property": function () {
+                var has = matcher("foo");
+
+                assert(has.test({ foo: null }));
+            },
+
+            "should return false if object value is not equal to given value": function () {
+                var has = matcher("foo", 1);
+
+                assertFalse(has.test({ foo: null }));
+            },
+
+            "should return true if object value is equal to given value": function () {
+                var has = matcher("foo", 1);
+
+                assert(has.test({ foo: 1 }));
+            },
+
+            "should allow to expect undefined": function () {
+                var has = matcher("foo", undefined);
+
+                assertFalse(has.test({ foo: 1 }));
+            },
+
+            "should compare value deeply": function () {
+                var has = matcher("foo", { bar: "doo", test: 42 });
+
+                assert(has.test({ foo: { bar: "doo", test: 42 } }));
+            },
+
+            "should compare with matcher": function () {
+                var has = matcher("callback", sinon.match.typeOf("function"));
+
+                assert(has.test({ callback: function () {} }));
+            }
+        };
+    }
+
+    testCase("MatchHasTest", propertyMatcherTests(sinon.match.has));
+
+    testCase("MatchHasOwnTest", propertyMatcherTests(sinon.match.hasOwn));
+
+    testCase("MatchHasSpecialTest", {
+        "should return true if object has inherited property": function () {
+            var has = sinon.match.has("toString");
+
+            assert(has.test({}));
+        },
+
+        "should only include property in message": function () {
+            var has = sinon.match.has("test");
+
+            assertEquals("has(\"test\")", has.toString());
+        },
+
+        "should include property and value in message": function () {
+            var has = sinon.match.has("test", undefined);
+
+            assertEquals("has(\"test\", undefined)", has.toString());
+        }
+    });
+
+    testCase("MatchHasOwnSpecialTest", {
+        "should return false if object has inherited property": function () {
+          var hasOwn = sinon.match.hasOwn("toString");
+
+          assertFalse(hasOwn.test({}));
+        },
+
+        "should only include property in message": function () {
+            var hasOwn = sinon.match.hasOwn("test");
+
+            assertEquals("hasOwn(\"test\")", hasOwn.toString());
+        },
+
+        "should include property and value in message": function () {
+            var hasOwn = sinon.match.hasOwn("test", undefined);
+
+            assertEquals("hasOwn(\"test\", undefined)", hasOwn.toString());
+        }
+    });
+
     testCase("MatchBoolTest", {
         "should be typeOf boolean matcher": function () {
             var bool = sinon.match.bool;


### PR DESCRIPTION
A small addition to the new matchers.
- `sinon.match.has(property)` requires the value to be an object and have the given property defined.
- `sinon.match.has(property, expectation)` additionally compares with the given expectation. Can be another matcher.
- `sinon.match.hasOwn(property)` requires the value to be an object and have the given _own_ property defined.
- `sinon.match.hasOwn(property, expectation)` well ...

I think this is particularly useful if testing APIs with config objects or large JSON messages.
