### PR TITLE
Fix for timer callbacks that contain a clock.tick, issue #109

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -187,6 +187,12 @@ if (typeof sinon == "undefined") {
         },
 
         callTimer: function (timer) {
+            if (typeof timer.interval == "number") {
+                this.timeouts[timer.id].callAt += timer.interval;
+            } else {
+                delete this.timeouts[timer.id];
+            }
+
             try {
                 if (typeof timer.func == "function") {
                     timer.func.apply(null, timer.invokeArgs);
@@ -202,12 +208,6 @@ if (typeof sinon == "undefined") {
                   throw exception;
                 }
                 return;
-            }
-
-            if (typeof timer.interval == "number") {
-                this.timeouts[timer.id].callAt += timer.interval;
-            } else {
-                delete this.timeouts[timer.id];
             }
 
             if (exception) {

--- a/test/sinon/util/fake_timers_test.js
+++ b/test/sinon/util/fake_timers_test.js
@@ -97,7 +97,21 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             clock.tick(3);
 
             assertEquals(true, stub.calledWithExactly('the first', 'the second'));
-        }
+        },
+
+		"should call correct timeout on recursive tick": function() {
+			var clock = sinon.clock.create(),
+				stub = sinon.stub.create(),
+				recurseCallback = function(){
+					clock.tick(100);
+				};
+
+			clock.setTimeout(recurseCallback, 50);
+			clock.setTimeout(stub, 100);
+
+			clock.tick(50);
+			assert(stub.called);
+		}
     });
 
     testCase("ClockTickTest", {


### PR DESCRIPTION
Issue #109

Timers aren't removed from the timeouts array until after they have been called. This means that if a timer's callback contains a clock.tick, that tick will pull the same timeout out of the array and recurses into itself. This blows the stack; a 'too much recursion' exception.
