### PR TITLE
True(ish) and false(ish) support for sinon.match.like

### DIFF
--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -138,6 +138,10 @@
             return match(function (actual) {
                 return like(expectation, actual);
             }, "like(" + str.join(", ") + ")");
+        case "boolean":
+            return match(function (actual) {
+                return !!actual === expectation;
+            }, "like(" + expectation + ")");
         case "string":
             return match(function (actual) {
                 if (typeof actual !== "string") {

--- a/test/sinon/assert_test.js
+++ b/test/sinon/assert_test.js
@@ -1073,6 +1073,15 @@ if (typeof require == "function" && typeof testCase == "undefined") {
                          sinon.match.like({ some: "value", and: 123 })));
         },
 
+        "assert.calledWith match.like boolean exception message": function () {
+            this.obj.doSomething();
+
+            assertEquals("expected doSomething to be called with arguments " +
+                         "like(true)\n    doSomething()",
+                         this.message("calledWith", this.obj.doSomething,
+                         sinon.match.like(true)));
+        },
+
         "assert.calledWith match.like string exception message": function () {
             this.obj.doSomething();
 

--- a/test/sinon/match_test.js
+++ b/test/sinon/match_test.js
@@ -297,6 +297,38 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             assertFalse(like.test(null));
             assertFalse(like.test(123));
             assertFalse(like.test({}));
+        },
+
+        "should return true for boolean true(ish) match": function () {
+            var like = sinon.match.like(true);
+
+            assert(like.test(true));
+            assert(like.test(1));
+            assert(like.test("indeed"));
+        },
+
+        "should return true for boolean false(ish) match": function () {
+            var like = sinon.match.like(false);
+
+            assert(like.test(false));
+            assert(like.test(0));
+            assert(like.test(""));
+        },
+
+        "should return false for boolean true(ish) mismatch": function () {
+            var like = sinon.match.like(true);
+
+            assertFalse(like.test(false));
+            assertFalse(like.test(0));
+            assertFalse(like.test(""));
+        },
+
+        "should return false for boolean false(ish) mismatch": function () {
+            var like = sinon.match.like(false);
+
+            assertFalse(like.test(true));
+            assertFalse(like.test(1));
+            assertFalse(like.test("nope"));
         }
     });
 


### PR DESCRIPTION
Added support for `sinon.match.like(true)` and `sinon.match.like(false)`.
