### PR TITLE
Failover to property assignment in release

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -81,10 +81,14 @@ var sinon = (function (buster) {
             method.displayName = property;
 
             method.restore = function () {
-                if(owned) {
-                    object[property] = wrappedMethod;
-                } else {
+                // For prototype properties try to reset by delete first.
+                // If this fails (ex: localStorage on mobile safari) then force a reset
+                // via direct assignment.
+                if (!owned) {
                     delete object[property];
+                }
+                if (object[property] === method) {
+                    object[property] = wrappedMethod;
                 }
             };
 


### PR DESCRIPTION
Seen under iOS 5.1 some system objects such as localStorage will fail silently on delete,
leaving the mock instance in place. This resolves that issue as best possible, using
a instance reset if the delete was not successful.
