### PR TITLE
Call pass when verify succeeds

### DIFF
--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -115,6 +115,8 @@
 
                 if (messages.length > 0) {
                     sinon.expectation.fail(messages.concat(met).join("\n"));
+                } else {
+                    sinon.expectation.pass(messages.concat(met).join("\n"));
                 }
 
                 return true;
@@ -385,11 +387,16 @@
             verify: function verify() {
                 if (!this.met()) {
                     sinon.expectation.fail(this.toString());
+                } else {
+                    sinon.expectation.pass(this.toString());
                 }
 
                 return true;
             },
 
+            pass: function(message) {
+              sinon.assert.pass(message);
+            },
             fail: function (message) {
                 var exception = new Error(message);
                 exception.name = "ExpectationError";

--- a/test/sinon/mock_test.js
+++ b/test/sinon/mock_test.js
@@ -593,6 +593,17 @@ if (typeof require == "function" && typeof testCase == "undefined") {
     testCase("MockExpectationVerifyTest", {
         setUp: expectationSetUp,
 
+        "should pass if met": function () {
+            sinon.stub(sinon.expectation, "pass");
+            var expectation = this.expectation;
+
+            expectation();
+            expectation.verify();
+
+            assertEquals(1, sinon.expectation.pass.callCount);
+            sinon.expectation.pass.restore();
+        },
+
         "should throw if not called enough times": function () {
             var expectation = this.expectation;
 
@@ -622,6 +633,17 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             this.mock.verify();
 
             assertSame(this.method, this.object.method);
+        },
+
+        "should pass verified mocks": function () {
+            sinon.stub(sinon.expectation, "pass");
+
+            this.mock.expects("method").once();
+            this.object.method();
+            this.mock.verify();
+
+            assertEquals(1, sinon.expectation.pass.callCount);
+            sinon.expectation.pass.restore();
         },
 
         "should restore if not met": function () {


### PR DESCRIPTION
Fixes errors seen in qunit when tests are using expectations only.
