### PR TITLE
Allow mocks to use .withArgs and .withExactArgs with no arguments

### DIFF
--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -298,7 +298,7 @@
                     return;
                 }
 
-                if (!args || args.length === 0) {
+                if (!args) {
                     sinon.expectation.fail(this.method + " received no arguments, expected " +
                         this.expectedArguments.join());
                 }

--- a/test/sinon/mock_test.js
+++ b/test/sinon/mock_test.js
@@ -517,6 +517,22 @@ if (typeof require == "function" && typeof testCase == "undefined") {
             assertNoException(function () {
                 expectation(1, 2, 3, 4);
             });
+        },
+
+        "should call accept with no args": function () {
+            this.expectation.withArgs();
+            this.expectation();
+
+            assert(this.expectation.met());
+        },
+
+        "should allow no args called with excessive args": function () {
+            var expectation = this.expectation;
+            expectation.withArgs();
+
+            assertNoException(function () {
+                expectation(1, 2, 3);
+            });
         }
     });
 
@@ -571,6 +587,22 @@ if (typeof require == "function" && typeof testCase == "undefined") {
 
             assertException(function () {
                 expectation(1, 2, 3, 4);
+            }, "ExpectationError");
+        },
+
+        "should accept call with no expected args": function () {
+            this.expectation.withExactArgs();
+            this.expectation();
+
+            assert(this.expectation.met());
+        },
+
+        "should not allow excessive args with no expected args": function () {
+            var expectation = this.expectation;
+            expectation.withExactArgs();
+
+            assertException(function () {
+                expectation(1, 2, 3);
             }, "ExpectationError");
         }
     });


### PR DESCRIPTION
Currently, if I write a test using .withArgs() or .withExactArgs() passing no arguments, it fails regardless of how many parameters are passed to the method under test (a bit useless if you ask me).  I would expect that if I write a test using .withExactArgs() that I am saying I expect exactly zero arguments to be passed - no more or no less.  Currently, the framework fails the test with "hide received no arguments, expected" (note that nothing follows "expected").

This change allows passing of empty arguments to .withArgs & .withExactArgs, and using .withExactArgs to specify that the method is called with no arguments.  Using .withArgs with no arguments after this change does not cause the test to fail, but it is implying the method is called with zero or more arguments, so it will never fail a test.
