### PR TITLE
Fix for "ReferenceError: window is not defined" in node.js

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -44,7 +44,7 @@ sinon.fakeServer = (function () {
         return response;
     }
 
-    var wloc = window.location;
+    var wloc = (typeof window !== 'undefined') ? window.location : '';
     var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
     function matchOne(response, reqMethod, reqUrl) {


### PR DESCRIPTION
I was encountering this error loading sinon.js in node with requirejs (for tests that run both in browser and node). Changing the config to not use a fake server by default did not help.

```
var wloc = window.location;
           ^
```

ReferenceError: window is not defined
