### PR TITLE
Easier stubbed fluent interfaces: stub.returnsThis()

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -132,6 +132,9 @@
         return {
             create: function create() {
                 var functionStub = function () {
+
+                    callCallback(functionStub, arguments);
+
                     if (functionStub.exception) {
                         throw functionStub.exception;
                     } else if (typeof functionStub.returnArgAt == 'number') {
@@ -139,9 +142,6 @@
                     } else if (functionStub.returnThis) {
                         return this;
                     }
-
-                    callCallback(functionStub, arguments);
-
                     return functionStub.returnValue;
                 };
 

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -690,6 +690,38 @@ buster.testCase("sinon.stub", {
             assert.exception(function () {
                 stub(callback);
             });
+        },
+
+        "plays nice with throws": function () {
+            var stub = sinon.stub().throws().yields();
+            var spy = sinon.spy();
+            assert.exception(function () {
+                stub(spy);
+            })
+            assert(spy.calledOnce);
+        },
+
+        "plays nice with returns": function () {
+            var obj = {};
+            var stub = sinon.stub().returns(obj).yields();
+            var spy = sinon.spy();
+            assert.same(stub(spy), obj);
+            assert(spy.calledOnce);
+        },
+
+        "plays nice with returnsArg": function () {
+            var stub = sinon.stub().returnsArg(0).yields();
+            var spy = sinon.spy();
+            assert.same(stub(spy), spy);
+            assert(spy.calledOnce);
+        },
+
+        "plays nice with returnsThis": function () {
+            var obj = {};
+            var stub = sinon.stub().returnsThis().yields();
+            var spy = sinon.spy();
+            assert.same(stub.call(obj, spy), obj);
+            assert(spy.calledOnce);
         }
     },
 


### PR DESCRIPTION
See #130 - I can't seem to figure out how to attach this directly onto that.

I also couldn't figure out how to run the jslint config, so I might have missed some style things.

And finally: callbacks can be used with returnsValue, but not returnsArg. I've put returnsThis in the latter category, but I'm unsure why a distinction exists?
