### PR TITLE
Format args when doing `spy.printf("%*")`

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -341,7 +341,13 @@
             },
 
             "*": function (spy, args) {
-                return args.join(", ");
+                var formatted = [];
+
+                for (var i = 0, l = args.length; i < l; ++i) {
+                    push.call(formatted, sinon.format(args[i]));
+                }
+
+                return formatted.join(", ");
             }
         };
 


### PR DESCRIPTION
This makes assertions say "expected to have been called with { foo: 'bar' }" instead of "expected to have been called with [object Object]".
