### PR TITLE
sinon.js can catch itself in endless loop while filling stub prototype with asynch methods

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -295,10 +295,12 @@
                 return this;
             }
         };
-        
+
         // create asynchronous versions of callsArg* and yields* methods
         for (var method in proto) {
-            if (proto.hasOwnProperty(method) && method.match(/^(callsArg|yields)/)) {
+            // need to avoid creating anotherasync versions of the newly added async methods
+            if (proto.hasOwnProperty(method) && method.match(/^(callsArg|yields)/) &&
+                !method.match(/Async/)) {
                 proto[method + 'Async'] = (function (syncFnName) {
                     return function () {
                         this.callbackAsync = true;

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -22,6 +22,26 @@ buster.testCase("sinon.stub", {
         assert.isFunction(stub.calledOn);
     },
 
+    "should contain asynchronous versions of callsArg* or yields* methods": function() {
+        var stub = sinon.stub.create();
+
+        var syncVersions = 0;
+        var asyncVersions = 0;
+
+        for (var method in stub) {
+            if (stub.hasOwnProperty(method) && method.match(/^(callsArg|yields)/)) {
+                if (!method.match(/Async/)) {
+                    syncVersions++;
+                } else if (method.match(/Async/)) {
+                    asyncVersions++;
+                }
+            }
+        }
+
+        assert.same(syncVersions, asyncVersions,
+            "Stub prototype should contain same amount of synchronous and asynchronous methods");
+    },
+
     "returns": {
         "returns specified value": function () {
             var stub = sinon.stub.create();


### PR DESCRIPTION
Browser can loop endlessly due to this code:

// create asynchronous versions of callsArg\* and yields\* methods
        for (var method in proto) {
            if (proto.hasOwnProperty(method) && method.match(/^(callsArg|yields)/)  {
                proto[method + 'Async'] = (function (syncFnName) {
                    return function () {
                        this.callbackAsync = true;
                        return this[syncFnName].apply(this, arguments);
                    };
                })(method);
            }
        }

Here, a new method with name  'methodAsync' is added to the prototype every time a good match is found, causing the for loop to loop forever.
