### PR TITLE
Avoid readystatechange -> DONE on abort() when already in DONE state.

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -272,7 +272,8 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
             this.errorFlag = true;
             this.requestHeaders = {};
 
-            if (this.readyState > sinon.FakeXMLHttpRequest.UNSENT && this.sendFlag) {
+            if (this.readyState < sinon.FakeXMLHttpRequest.DONE &&
+                this.readyState > sinon.FakeXMLHttpRequest.UNSENT && this.sendFlag) {
                 this.readyStateChange(sinon.FakeXMLHttpRequest.DONE);
                 this.sendFlag = false;
             }


### PR DESCRIPTION
This was failing when used with YUI 3.5.0 Y.IO transport where the success callback was issued twice as YUI issues a call to abort() as a part of its IE7/8 request cleanup.
