### PR TITLE
Add `thenYields` for sequential yielding. Closes #157.

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -55,34 +55,46 @@
         return sinon.wrapMethod(object, property, wrapper);
     }
 
+    function getChangingValue(stub, property) {
+        var index = stub.callCount - 1;
+        var prop = index in stub[property] ? stub[property][index] : stub[property + "Last"];
+        stub[property + "Last"] = prop;
+
+        return prop;
+    }
+
     function getCallback(stub, args) {
-        if (stub.callArgAt < 0) {
+        var callArgAt = getChangingValue(stub, "callArgAts");
+
+        if (callArgAt < 0) {
+            var callArgProp = getChangingValue(stub, "callArgProps");
+
             for (var i = 0, l = args.length; i < l; ++i) {
-                if (!stub.callArgProp && typeof args[i] == "function") {
+                if (!callArgProp && typeof args[i] == "function") {
                     return args[i];
                 }
 
-                if (stub.callArgProp && args[i] &&
-                    typeof args[i][stub.callArgProp] == "function") {
-                    return args[i][stub.callArgProp];
+                if (callArgProp && args[i] &&
+                    typeof args[i][callArgProp] == "function") {
+                    return args[i][callArgProp];
                 }
             }
 
             return null;
         }
 
-        return args[stub.callArgAt];
+        return args[callArgAt];
     }
 
     var join = Array.prototype.join;
 
     function getCallbackError(stub, func, args) {
-        if (stub.callArgAt < 0) {
+        if (stub.callArgAtsLast < 0) {
             var msg;
 
-            if (stub.callArgProp) {
+            if (stub.callArgPropsLast) {
                 msg = sinon.functionName(stub) +
-                    " expected to yield to '" + stub.callArgProp +
+                    " expected to yield to '" + stub.callArgPropsLast +
                     "', but no object with such a property was passed."
             } else {
                 msg = sinon.functionName(stub) +
@@ -96,7 +108,7 @@
             return msg;
         }
 
-        return "argument at index " + stub.callArgAt + " is not a function: " + func;
+        return "argument at index " + stub.callArgAtsLast + " is not a function: " + func;
     }
 
     var nextTick = (function () {
@@ -114,19 +126,24 @@
     })();
 
     function callCallback(stub, args) {
-        if (typeof stub.callArgAt == "number") {
+        if (stub.callArgAts.length > 0) {
             var func = getCallback(stub, args);
 
             if (typeof func != "function") {
                 throw new TypeError(getCallbackError(stub, func, args));
             }
 
+            var index = stub.callCount - 1;
+
+            var callbackArguments = getChangingValue(stub, "callbackArguments");
+            var callbackContext = getChangingValue(stub, "callbackContexts");
+
             if (stub.callbackAsync) {
                 nextTick(function() {
-                    func.apply(stub.callbackContext, stub.callbackArguments);
+                    func.apply(callbackContext, callbackArguments);
                 });
             } else {
-                func.apply(stub.callbackContext, stub.callbackArguments);
+                func.apply(callbackContext, callbackArguments);
             }
         }
     }
@@ -170,6 +187,11 @@
                 functionStub = sinon.spy.create(functionStub);
                 functionStub.func = orig;
 
+                functionStub.callArgAts = [];
+                functionStub.callbackArguments = [];
+                functionStub.callbackContexts = [];
+                functionStub.callArgProps = [];
+
                 sinon.extend(functionStub, stub);
                 functionStub._create = sinon.stub.create;
                 functionStub.displayName = "stub";
@@ -208,8 +230,10 @@
                     throw new TypeError("argument index is not number");
                 }
 
-                this.callArgAt = pos;
-                this.callbackArguments = [];
+                this.callArgAts.push(pos);
+                this.callbackArguments.push([]);
+                this.callbackContexts.push(undefined);
+                this.callArgProps.push(undefined);
 
                 return this;
             },
@@ -222,9 +246,10 @@
                     throw new TypeError("argument context is not an object");
                 }
 
-                this.callArgAt = pos;
-                this.callbackArguments = [];
-                this.callbackContext = context;
+                this.callArgAts.push(pos);
+                this.callbackArguments.push([]);
+                this.callbackContexts.push(context);
+                this.callArgProps.push(undefined);
 
                 return this;
             },
@@ -234,8 +259,10 @@
                     throw new TypeError("argument index is not number");
                 }
 
-                this.callArgAt = pos;
-                this.callbackArguments = slice.call(arguments, 1);
+                this.callArgAts.push(pos);
+                this.callbackArguments.push(slice.call(arguments, 1));
+                this.callbackContexts.push(undefined);
+                this.callArgProps.push(undefined);
 
                 return this;
             },
@@ -248,16 +275,19 @@
                     throw new TypeError("argument context is not an object");
                 }
 
-                this.callArgAt = pos;
-                this.callbackArguments = slice.call(arguments, 2);
-                this.callbackContext = context;
+                this.callArgAts.push(pos);
+                this.callbackArguments.push(slice.call(arguments, 2));
+                this.callbackContexts.push(context);
+                this.callArgProps.push(undefined);
 
                 return this;
             },
 
             yields: function () {
-                this.callArgAt = -1;
-                this.callbackArguments = slice.call(arguments, 0);
+                this.callArgAts.push(-1);
+                this.callbackArguments.push(slice.call(arguments, 0));
+                this.callbackContexts.push(undefined);
+                this.callArgProps.push(undefined);
 
                 return this;
             },
@@ -267,17 +297,19 @@
                     throw new TypeError("argument context is not an object");
                 }
 
-                this.callArgAt = -1;
-                this.callbackArguments = slice.call(arguments, 1);
-                this.callbackContext = context;
+                this.callArgAts.push(-1);
+                this.callbackArguments.push(slice.call(arguments, 1));
+                this.callbackContexts.push(context);
+                this.callArgProps.push(undefined);
 
                 return this;
             },
 
             yieldsTo: function (prop) {
-                this.callArgAt = -1;
-                this.callArgProp = prop;
-                this.callbackArguments = slice.call(arguments, 1);
+                this.callArgAts.push(-1);
+                this.callbackArguments.push(slice.call(arguments, 1));
+                this.callbackContexts.push(undefined);
+                this.callArgProps.push(prop);
 
                 return this;
             },
@@ -287,10 +319,10 @@
                     throw new TypeError("argument context is not an object");
                 }
 
-                this.callArgAt = -1;
-                this.callArgProp = prop;
-                this.callbackArguments = slice.call(arguments, 2);
-                this.callbackContext = context;
+                this.callArgAts.push(-1);
+                this.callbackArguments.push(slice.call(arguments, 2));
+                this.callbackContexts.push(context);
+                this.callArgProps.push(prop);
 
                 return this;
             }
@@ -299,7 +331,8 @@
         // create asynchronous versions of callsArg* and yields* methods
         for (var method in proto) {
             // need to avoid creating anotherasync versions of the newly added async methods
-            if (proto.hasOwnProperty(method) && method.match(/^(callsArg|yields)/) &&
+            if (proto.hasOwnProperty(method) &&
+                method.match(/^(callsArg|yields|thenYields$)/) &&
                 !method.match(/Async/)) {
                 proto[method + 'Async'] = (function (syncFnName) {
                     return function () {
@@ -309,9 +342,9 @@
                 })(method);
             }
         }
-        
+
         return proto;
-        
+
     }()));
 
     if (commonJSModule) {

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -22,14 +22,14 @@ buster.testCase("sinon.stub", {
         assert.isFunction(stub.calledOn);
     },
 
-    "should contain asynchronous versions of callsArg* or yields* methods": function() {
+    "should contain asynchronous versions of callsArg*, yields*, and thenYields methods": function() {
         var stub = sinon.stub.create();
 
         var syncVersions = 0;
         var asyncVersions = 0;
 
         for (var method in stub) {
-            if (stub.hasOwnProperty(method) && method.match(/^(callsArg|yields)/)) {
+            if (stub.hasOwnProperty(method) && method.match(/^(callsArg|yields|thenYields$)/)) {
                 if (!method.match(/Async/)) {
                     syncVersions++;
                 } else if (method.match(/Async/)) {
@@ -742,7 +742,7 @@ buster.testCase("sinon.stub", {
             var spy = sinon.spy();
             assert.same(stub.call(obj, spy), obj);
             assert(spy.calledOnce);
-        }
+        },
     },
 
     "yieldsOn": {
@@ -1069,13 +1069,13 @@ buster.testCase("sinon.stub", {
         setUp: function () {
             this.stub = sinon.stub.create();
         },
-        
+
         "passes call to callsArgWith": function () {
             var object = {};
             sinon.spy(this.stub, "callsArgWith");
-            
+
             this.stub.callsArgWithAsync(1, object);
-            
+
             assert(this.stub.callsArgWith.calledWith(1, object));
         },
 
@@ -1083,7 +1083,7 @@ buster.testCase("sinon.stub", {
             var object = {};
             var array = [];
             this.stub.callsArgWithAsync(1, object, array);
-            
+
             var callback = sinon.spy(done(function () {
                 assert(callback.calledWith(object, array));
             }));
@@ -1101,7 +1101,7 @@ buster.testCase("sinon.stub", {
                 foo: "bar"
             };
         },
-        
+
         "passes call to callsArgOn": function () {
             sinon.spy(this.stub, "callsArgOn");
 
@@ -1113,13 +1113,13 @@ buster.testCase("sinon.stub", {
         "asynchronously calls argument at specified index with specified context": function (done) {
             var context = this.fakeContext;
             this.stub.callsArgOnAsync(2, context);
-            
+
             var callback = sinon.spy(done(function () {
                 assert(callback.calledOn(context));
             }));
 
             this.stub(1, 2, callback);
-            
+
             assert(!callback.called);
         }
     },
@@ -1129,7 +1129,7 @@ buster.testCase("sinon.stub", {
             this.stub = sinon.stub.create();
             this.fakeContext = { foo: "bar" };
         },
-        
+
         "passes call to callsArgOnWith": function () {
             var object = {};
             sinon.spy(this.stub, "callsArgOnWith");
@@ -1143,14 +1143,14 @@ buster.testCase("sinon.stub", {
             var object = {};
             var context = this.fakeContext;
             this.stub.callsArgOnWithAsync(1, context, object);
-            
+
             var callback = sinon.spy(done(function () {
                 assert(callback.calledOn(context))
                 assert(callback.calledWith(object));
             }));
 
             this.stub(1, callback);
-            
+
             assert(!callback.called);
         }
     },
@@ -1169,7 +1169,7 @@ buster.testCase("sinon.stub", {
             var stub = sinon.stub().yieldsAsync();
 
             var spy = sinon.spy(done);
-            
+
             stub(spy);
 
             assert(!spy.called);
@@ -1200,9 +1200,9 @@ buster.testCase("sinon.stub", {
                 assert(spy.calledOn(context));
                 assert.equals(spy.args[0].length, 0);
             }));
-            
+
             this.stub(spy);
-            
+
             assert(!spy.called);
         }
     },
@@ -1216,7 +1216,7 @@ buster.testCase("sinon.stub", {
 
             assert(stub.yieldsTo.calledWith("success"));
         },
-        
+
         "asynchronously yields to property of object argument": function (done) {
             var stub = sinon.stub().yieldsToAsync("success");
 
@@ -1249,7 +1249,7 @@ buster.testCase("sinon.stub", {
         "asynchronously yields to property of object argument with given context": function (done) {
             var context = this.fakeContext;
             this.stub.yieldsToOnAsync("success", context);
-            
+
             var callback = sinon.spy(done(function () {
                 assert(callback.calledOnce);
                 assert(callback.calledOn(context));
@@ -1260,5 +1260,121 @@ buster.testCase("sinon.stub", {
 
             assert(!callback.called);
         }
+    },
+
+    "yields* calls should be chainable to produce a sequence": function () {
+        var context = { foo: "bar" };
+        var obj = { method1: sinon.spy(), method2: sinon.spy() };
+        var obj2 = { method2: sinon.spy() };
+        var stub = sinon.stub().yields(1, 2)
+                               .yieldsOn(context, 3, 4)
+                               .yieldsTo("method1", 5, 6)
+                               .yieldsToOn("method2", context, 7, 8);
+
+        var spy1 = sinon.spy();
+        var spy2 = sinon.spy();
+
+        stub(spy1);
+        stub(spy2);
+        stub(obj);
+        stub(obj);
+        stub(obj2); // should continue doing the last thing
+
+        assert(spy1.calledOnce);
+        assert(spy1.calledWithExactly(1, 2));
+
+        assert(spy2.calledOnce);
+        assert(spy2.calledAfter(spy1));
+        assert(spy2.calledOn(context));
+        assert(spy2.calledWithExactly(3, 4));
+
+        assert(obj.method1.calledOnce);
+        assert(obj.method1.calledAfter(spy2));
+        assert(obj.method1.calledWithExactly(5, 6));
+
+        assert(obj.method2.calledOnce);
+        assert(obj.method2.calledAfter(obj.method1));
+        assert(obj.method2.calledOn(context));
+        assert(obj.method2.calledWithExactly(7, 8));
+
+        assert(obj2.method2.calledOnce);
+        assert(obj2.method2.calledAfter(obj.method2));
+        assert(obj2.method2.calledOn(context));
+        assert(obj2.method2.calledWithExactly(7, 8));
+    },
+
+    "callsArg* calls should be chainable to produce a sequence": function () {
+        var spy1 = sinon.spy();
+        var spy2 = sinon.spy();
+        var spy3 = sinon.spy();
+        var spy4 = sinon.spy();
+        var spy5 = sinon.spy();
+        var decoy = sinon.spy();
+        var context = { foo: "bar" };
+
+        var stub = sinon.stub().callsArg(0)
+                               .callsArgWith(1, "a", "b")
+                               .callsArgOn(2, context)
+                               .callsArgOnWith(3, context, "c", "d");
+
+        stub(spy1);
+        stub(decoy, spy2);
+        stub(decoy, decoy, spy3);
+        stub(decoy, decoy, decoy, spy4);
+        stub(decoy, decoy, decoy, spy5); // should continue doing last thing
+
+        assert(spy1.calledOnce);
+
+        assert(spy2.calledOnce);
+        assert(spy2.calledAfter(spy1));
+        assert(spy2.calledWithExactly("a", "b"));
+
+        assert(spy3.calledOnce);
+        assert(spy3.calledAfter(spy2));
+        assert(spy3.calledOn(context));
+
+        assert(spy4.calledOnce);
+        assert(spy4.calledAfter(spy3));
+        assert(spy4.calledOn(context));
+        assert(spy4.calledWithExactly("c", "d"));
+
+        assert(spy5.calledOnce);
+        assert(spy5.calledAfter(spy4));
+        assert(spy5.calledOn(context));
+        assert(spy5.calledWithExactly("c", "d"));
+
+        assert(decoy.notCalled);
+    },
+
+    "yields* calls and callsArg* in combination should be chainable to produce a sequence": function () {
+        var stub = sinon.stub().yields(1, 2)
+                               .callsArg(1)
+                               .yieldsTo("method")
+                               .callsArgWith(2, "a", "b");
+
+        var obj = { method: sinon.spy() };
+        var spy1 = sinon.spy();
+        var spy2 = sinon.spy();
+        var spy3 = sinon.spy();
+        var decoy = sinon.spy();
+
+        stub(spy1);
+        stub(decoy, spy2);
+        stub(obj);
+        stub(decoy, decoy, spy3);
+
+        assert(spy1.calledOnce);
+
+        assert(spy2.calledOnce);
+        assert(spy2.calledAfter(spy1));
+
+        assert(obj.method.calledOnce);
+        assert(obj.method.calledAfter(spy2));
+
+        assert(spy3.calledOnce);
+        assert(spy3.calledAfter(obj.method));
+        assert(spy3.calledWithExactly("a", "b"));
+
+        assert(decoy.notCalled);
     }
 });


### PR DESCRIPTION
Let me know what you think. I didn't add too many tests, or variations (`thenYieldsOn`, etc.), or even `thenYieldsAsync`. But it's a nice little extra feature that I'm happy to expand on if you think it'd be valuable.
