### PR TITLE
Retain original expectation messages, for failed mocks under sinon.test

### DIFF
--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -43,7 +43,15 @@
 
             try {
                 result = callback.apply(this, args);
-            } finally {
+            } catch (e) {
+                exception = e;
+            }
+
+            if (typeof exception !== "undefined") {
+                sandbox.restore();
+                throw exception;
+            }
+            else {
                 sandbox.verifyAndRestore();
             }
 

--- a/test/sinon/test_test.js
+++ b/test/sinon/test_test.js
@@ -129,13 +129,21 @@ buster.testCase("sinon.test", {
     "verifies mocks": function () {
         var method = function () {};
         var object = { method: method };
+        var exception;
 
-        assert.exception(function () {
+        try {
             sinon.test(function () {
-                this.mock(object).expects("method");
+                this.mock(object).expects("method").withExactArgs(1).once();
+                object.method(42);
             }).call({});
-        }, "ExpectationError");
+        } catch (e) {
+          exception = e;
+        }
 
+        assert.same(exception.name, "ExpectationError");
+        assert.equals(exception.message,
+                      "Unexpected call: method(42)\n" +
+                      "    Expected method(1) once (never called)");
         assert.same(object.method, method);
     },
 


### PR DESCRIPTION
Dear all,

Under **sinon.test**, the expectation errors for failed mocks didn't provide the original error message.

In order to resolve this, when **invokeMethod** throws an ExpectationError instead of **verifyAndRestore** (which will send another exception, overwriting the first one), we just restore the sandbox and propagate the original exception.

There might be a more elegant way to resolve this issue, so I'm really waiting for your feedback.

Good night,

Giorgos
