### PR TITLE
Add 'invokeCallback' alias for 'yield' on calls

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -366,7 +366,7 @@
             throw new Error(msg);
         }
 
-        return {
+        var callApi = {
             create: function create(spy, thisValue, args, returnValue, exception, id) {
                 var proxyCall = sinon.create(spyCall);
                 delete proxyCall.create;
@@ -506,6 +506,8 @@
                 return callStr;
             }
         };
+        callApi.invokeCallback = callApi.yield;
+        return callApi;
     }());
 
     spy.spyCall = spyCall;

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -2074,6 +2074,16 @@ if (typeof require === "function" && typeof module === "object") {
             }
         },
 
+        "call.invokeCallback": {
+
+            "is alias for yield": function () {
+                var call = sinon.spy.spyCall.create(function () {});
+
+                assert.same(call.yield, call.invokeCallback);
+            }
+
+        },
+
         "call.yieldTo": {
             setUp: spyCallCallSetup,
 


### PR DESCRIPTION
`invokeCallback` was introduces on the spy object as an alias for `yield`, but it was never added to calls.
