### PR TITLE
Changed reference to buster file in build.

### DIFF
--- a/build
+++ b/build
@@ -49,7 +49,7 @@ buster-format not found, skipping. To build with buster-format support:
 
   File.open(file, "w") do |f|
     f.puts("var sinon = (function () {")
-    f.puts(File.read("./node_modules/buster-format/node_modules/buster-core/lib/buster-core.js"))
+    f.puts(File.read("./node_modules/buster-core/lib/buster-core.js"))
     f.puts(File.read("./node_modules/buster-format/lib/buster-format.js").gsub("var buster = this.buster || {};", ""))
     f.puts(contents)
     f.puts("return sinon;}.call(typeof window != 'undefined' && window || {}));")


### PR DESCRIPTION
This is in response to this error I was getting:

./build:52:in `read': No such file or directory - ./node_modules/buster-format/node_modules/buster-core/lib/buster-core.js (Errno::ENOENT)
    from ./build:52:in`block in add_buster_format'
    from ./build:50:in `open'
    from ./build:50:in`add_buster_format'
    from ./build:71:in `block in <main>'
    from ./build:61:in`chdir'
    from ./build:61:in `<main>'

I guess at one point buster-core was a dependency of buster-format? Either way buster-core is already in your dev-dependencies, so I just changed the reference.
