### PR TITLE
Fix for #189

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -38,7 +38,7 @@ var sinon = (function (buster) {
     }
 
     function isFunction(obj) {
-        return !!(obj && obj.constructor && obj.call && obj.apply);
+        return typeof obj === "function" || !!(obj && obj.constructor && obj.call && obj.apply);
     }
 
     function mirrorProperties(target, source) {


### PR DESCRIPTION
This fixes #189. Ensure `window.Image` can be stubbed.
