### PR TITLE
Format arguments output when mock expectation is not met

### DIFF
--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -300,24 +300,24 @@
 
                 if (!args) {
                     sinon.expectation.fail(this.method + " received no arguments, expected " +
-                        this.expectedArguments.join());
+                        sinon.format(this.expectedArguments));
                 }
 
                 if (args.length < this.expectedArguments.length) {
-                    sinon.expectation.fail(this.method + " received too few arguments (" + args.join() +
-                        "), expected " + this.expectedArguments.join());
+                    sinon.expectation.fail(this.method + " received too few arguments (" + sinon.format(args) +
+                        "), expected " + sinon.format(this.expectedArguments));
                 }
 
                 if (this.expectsExactArgCount &&
                     args.length != this.expectedArguments.length) {
-                    sinon.expectation.fail(this.method + " received too many arguments (" + args.join() +
-                        "), expected " + this.expectedArguments.join());
+                    sinon.expectation.fail(this.method + " received too many arguments (" + sinon.format(args) +
+                        "), expected " + sinon.format(this.expectedArguments));
                 }
 
                 for (var i = 0, l = this.expectedArguments.length; i < l; i += 1) {
                     if (!sinon.deepEqual(this.expectedArguments[i], args[i])) {
-                        sinon.expectation.fail(this.method + " received wrong arguments (" + args.join() +
-                            "), expected " + this.expectedArguments.join());
+                        sinon.expectation.fail(this.method + " received wrong arguments " + sinon.format(args) +
+                            ", expected " + sinon.format(this.expectedArguments));
                     }
                 }
             },


### PR DESCRIPTION
Hi, 

I've used sinon.format function to format arguments in verify output when expectation is not met. 

So now we'll get the output like : 

```
Anonymous mock received wrong arguments [{ status: true }], expected [{ status: false }]
```

Instead of 

```
Anonymous mock received wrong arguments ([object Object]), expected [object Object]
```

This fixes #191
