### PR TITLE
Make spy formatter `%C` have empty lines

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -340,7 +340,11 @@
                 var calls = [];
 
                 for (var i = 0, l = spy.callCount; i < l; ++i) {
-                    push.call(calls, "    " + spy.getCall(i).toString());
+                    var stringifiedCall = "    " + spy.getCall(i).toString();
+                    if (/\n/.test(calls[i - 1])) {
+                        stringifiedCall = "\n" + stringifiedCall;
+                    }
+                    push.call(calls, stringifiedCall);
                 }
 
                 return calls.length > 0 ? "\n" + calls.join("\n") : "";

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -2697,8 +2697,19 @@ if (typeof require === "function" && typeof module === "object") {
 
                     assert.equals(spy.printf('%C'), 
                         '\n    spy(' + str + ')' +
+                        '\n\n    spy(' + str + ')' +
+                        '\n\n    spy(' + str + ')');
+
+                    spy.reset();
+
+                    spy('test');
+                    spy('spy\ntest');
+                    spy('spy\ntest');
+
+                    assert.equals(spy.printf('%C'),
+                        '\n    spy(test)' +
                         '\n    spy(' + str + ')' +
-                        '\n    spy(' + str + ')');
+                        '\n\n    spy(' + str + ')');
                 }
             },
             "thisValues" : function () {


### PR DESCRIPTION
This really makes life easier.
