### PR TITLE
Allows dirty access to fakeServer

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -17,7 +17,7 @@
 "use strict";
 
 if (typeof sinon == "undefined") {
-    var sinon = {};
+    this.sinon = {};
 }
 
 sinon.fakeServer = (function () {


### PR DESCRIPTION
This is the only obstacle on way to using `fakeServer` in Mocha tests run from commandline. The usage is still pretty ugly, but works :).
