### PR TITLE
Adds logging to the FakeServer

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -192,9 +192,7 @@ sinon.fakeServer = (function () {
                 }
 
                 if (request.readyState != 4) {
-                    if (this.enableResponseLogging) {
-                        log(response, request);
-                    }
+                    log(response, request);
 
                     request.respond(response[0], response[1], response[2]);
                 }


### PR DESCRIPTION
To enable (in node or a modern browser):
server.enableResponseLogging = true;
sinon.log = console.log;

This adds to the fake server the capability of logging responded
requests. This feature is opt in. What will be printed is a beautified
stringify of the request and response objects.

If the current environment does not support JSON.stringify the logging
fails silently.

PS: If you think this a worthy thing to have in Sinon I will also write some tests.
