### PR TITLE
Added spec functionality.

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -312,6 +312,7 @@ var sinon = (function (buster) {
         module.exports.testCase = require("./sinon/test_case");
         module.exports.assert = require("./sinon/assert");
         module.exports.match = require("./sinon/match");
+        module.exports.spec = require("./sinon/spec");
     }
 
     if (buster) {

--- a/lib/sinon/spec.js
+++ b/lib/sinon/spec.js
@@ -1,0 +1,46 @@
+/**
+ * @depend ../sinon.js
+ * @depend spy.js
+ */
+/*jslint eqeqeq: false, onevar: false, plusplus: false*/
+/*global module, require, sinon*/
+/**
+ * Spy functions
+ *
+ * @author Shawn Krisman
+ * @license BSD
+ *
+ * Copyright (c) 2012 Shawn Krisman
+ */
+"use strict";
+
+(function (sinon) {
+    var commonJSModule = typeof module == "object" && typeof require == "function";
+
+    if (!sinon && commonJSModule) {
+        sinon = require("../sinon");
+    }
+
+    if (!sinon) {
+        return;
+    }
+
+    function spec(speccable) {
+	var model = typeof speccable === "function" ? new speccable : speccable;
+	var SpecClass = function () {};
+	SpecClass.prototype = model;
+	var specObj = new SpecClass();
+	for (var prop in model) {
+	    if (typeof specObj[prop] === "function") {
+		specObj[prop] = sinon.spy();
+	    }
+	}
+	return specObj;
+    }
+
+    if (commonJSModule) {
+        module.exports = spec;
+    } else {
+        sinon.spec = spec;
+    }
+}(typeof sinon == "object" && sinon || null));

--- a/test/node/run.js
+++ b/test/node/run.js
@@ -9,6 +9,7 @@ require("../sinon/assert_test.js");
 require("../sinon/test_test.js");
 require("../sinon/test_case_test.js");
 require("../sinon/match_test.js");
+require("../sinon/spec_test.js");
 var buster = require("../runner");
 
 buster.testRunner.onCreate(function (runner) {

--- a/test/sinon.html
+++ b/test/sinon.html
@@ -33,6 +33,7 @@
     <script src="../lib/sinon/spy.js"></script>
     <script src="../lib/sinon/stub.js"></script>
     <script src="../lib/sinon/mock.js"></script>
+    <script src="../lib/sinon/spec.js"></script>
     <script src="../lib/sinon/assert.js"></script>
     <script src="../lib/sinon/util/event.js"></script>
     <script src="../lib/sinon/util/fake_xml_http_request.js"></script>
@@ -50,6 +51,7 @@
     <script src="sinon/spy_test.js"></script>
     <script src="sinon/stub_test.js"></script>
     <script src="sinon/mock_test.js"></script>
+    <script src="sinon/spec_test.js"></script>
     <script src="sinon/match_test.js"></script>
     <script src="sinon/assert_test.js"></script>
     <script src="sinon/collection_test.js"></script>

--- a/test/sinon/spec_test.js
+++ b/test/sinon/spec_test.js
@@ -1,0 +1,52 @@
+/*jslint onevar: false, eqeqeq: false*/
+/*globals window sinon buster*/
+/**
+ * @author Shawn Krisman
+ * @license BSD
+ *
+ * Copyright (c) 2012 Shawn Krisman
+ */
+"use strict";
+
+if (typeof require === "function" && typeof module === "object") {
+    var buster = require("../runner");
+    var sinon = require("../../lib/sinon");
+}
+
+(function () {
+    buster.testCase("sinon.spec", {
+        "throws an exception for a bad method call": function () {
+	    var obj = {'realMethod': function() {}};
+	    var spec = sinon.spec(obj);
+	    assert.exception(function() {
+		spec.fakeMethod();
+	    });
+	},
+	"normal methods are just spies": function () {
+	    var obj = {'realMethod': function() {}};
+	    var spec = sinon.spec(obj);
+	    spec.realMethod(3, 4);
+	    assert(spec.realMethod.calledWith(3, 4));
+	},
+	"can make specs from new-able constructors": function () {
+	    var Class = function(a, b, c) {
+		this.a = a;
+		this.b = b;
+		this.c = c;
+	    };
+	    Class.prototype.method = function () {};
+
+	    var spec = sinon.spec(Class);
+	    refute.exception(spec.method);
+	},
+	"non-function properties on the class exist on the spec": function() {
+	    var CONSTANT = "some constant";
+	    var Class = function() {
+		this.constant = CONSTANT;
+	    };
+
+	    var spec = sinon.spec(Class);
+	    assert.equals(CONSTANT, spec.constant);
+	},
+    });
+}());


### PR DESCRIPTION
Right now when writing sinon tests a very common pattern is to do something like this: 

``` javascript
var obj = {'foo': function() {}};
var spy = sinon.spy(obj, 'foo');
obj.foo(3);
sinon.assertCalledWith(spy, e); 
```

The problem comes when you change the definition of the class of "obj." When you get rid of the "foo" method, or simply rename it, your unit tests pass, but your code is totally broken! This starts to become an increasingly big issue in large codebases because you can no longer depend on your tests to fail when regressions happen.

Here is the feature I've added:

``` javascript
var spec = sinon.spec(ObjConstructor);
spec.foo(3); // this throws an exception if foo isn't defined.
sinon.assertCalledWith(spec.foo, 3); // all spec methods are just spies.
```

The idea was mostly inspired by the autospec feature of python's mock library, and mockitos "mock" feature. 
