### PR TITLE
clock.tick returns clock.now

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -157,6 +157,8 @@ if (typeof sinon == "undefined") {
             if (firstException) {
               throw firstException;
             }
+
+            return this.now;
         },
 
         firstTimerInRange: function (from, to) {

--- a/test/sinon/util/fake_timers_test.js
+++ b/test/sinon/util/fake_timers_test.js
@@ -398,6 +398,12 @@ buster.testCase("sinon.clock", {
             assert.exception(function() {
                 clock.tick(1000);
             });
+        },
+
+        "returns the current now value": function () {
+            var clock = this.clock;
+            var value = clock.tick(200);
+            assert.equals(clock.now, value);
         }
     },
 


### PR DESCRIPTION
It is useful for `clock.tick()` to return the new value of now instead of `undefined`.
