### PR TITLE
Remove msSetImmediate; it only existed in IE10 previews.

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -114,8 +114,6 @@
     var nextTick = (function () {
         if (typeof process === "object" && typeof process.nextTick === "function") {
             return process.nextTick;
-        } else if (typeof msSetImmediate === "function") {
-            return msSetImmediate.bind(window);
         } else if (typeof setImmediate === "function") {
             return setImmediate;
         } else {


### PR DESCRIPTION
IE10 final unprefixed it.
