### PR TITLE
Improvements for npm publishing. Fixes #232.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+/.npmignore
+/.travis.yml
+/AUTHORS
+/build
+/Changelog.txt
+/jsl.conf
+/release.sh
+
+/pkg
+!/pkg/sinon.js
+!/pkg/sinon-ie.js

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         }
     ],
     "scripts": {
-        "test": "node test/node/run.js"
+        "test": "node test/node/run.js",
+        "prepublish": "./build"
     },
     "dependencies": {
         "buster-format": "~0.5"


### PR DESCRIPTION
- Published package no longer includes lots of dev-only stuff.
- Published package now _does_ include pkg/sinon.js and pkg/sinon-ie.js, since no longer is .gitignore being used as .npmignore
- Add a prepublish script to run the build script, to ensure that pkg/sinon.js and pkg/sinon-ie.js are present and up-to-date for publishing.
