### PR TITLE
add volo section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "http-server": "*"
     },
     "main": "./lib/sinon.js",
-    "engines": { "node": ">=0.1.103" }
+    "engines": { "node": ">=0.1.103" },
     "volo": {
         "url": "http://sinonjs.org/releases/sinon-{version}.js"
     }


### PR DESCRIPTION
Hey there -

This makes it so that we can more easily pull in Sinon via the volo client-side package manager ( http://volojs.org/ )

Some detail here: https://github.com/volojs/volo/wiki/add-dependency-rules#wiki-resolution

> "If the package.json does not exist for that user/repo/tag combination, or if it does not
> contain a "volo" property, then the volojs/repos repo is consulted to see if there is an
> "override" for that project.

FWIW, the [override](https://github.com/volojs/repos/blob/master/cjohansen/Sinon.JS/package.json) has been working great - so hopefully this change just makes it more official / reliable over time. Assuming Sinon's release process is fairly stable, I don't expect this to add much if any maintenance overhead as it simply piggy-backs on the version field in package.json.

Thanks for such a great lib!
-matt
