### PR TITLE
Pass test.config to sinon.getConfig

### DIFF
--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -35,7 +35,7 @@
         }
 
         return function () {
-            var config = sinon.getConfig(sinon.config);
+            var config = sinon.getConfig(test.config);
             config.injectInto = config.injectIntoThis && this || config.injectInto;
             var sandbox = sinon.sandbox.create(config);
             var exception, result;


### PR DESCRIPTION
Doesn't seem to make sense to pass sinon.config, which as far as I can tell,
is never defined.
