### PR TITLE
Web Workers support.

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -180,4 +180,4 @@
     } else {
         sinon.assert = assert;
     }
-}(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : global));
+}(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global));


### PR DESCRIPTION
The environment in Web Workers is slightly different from the standard browser environment. `document` is not defined, the global object is `self` not `window`, and some extra APIs are available, such as `FileReaderSync`. Given these differences, it is desirable to be able to run test suites in a Web Worker environment.

This tiny change fixes an exception that was raised when importing sinon.js in a Web Worker context using `importScripts`.

I hope that you will consider merging this PR, and I'll be happy to make any changes based on your feedback. Thank you!
