### PR TITLE
XMLHttpRequest#response

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -180,15 +180,6 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
         }
     }
 
-    function verifyResponseBodyType(body) {
-        if (typeof body != "string" && !Array.isArray(body)) {
-            var error = new Error("Attempted to respond to fake XMLHttpRequest with " +
-                                 body + ", which is neither a string nor an array.");
-            error.name = "InvalidBodyException";
-            throw error;
-        }
-    }
-
     sinon.extend(FakeXMLHttpRequest.prototype, sinon.EventTarget, {
         async: true,
 
@@ -348,33 +339,52 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
         // Sets the response body.
         //
         // If #response is:
-        // - "" or "text" or "json": body has to be a String
-        // - "arraybuffer": body has an array of usigned bytes (ints between 0 and 255) to put in the array buffer
-        // - "blob": body can be anything that you can put in a Blob
+        // - "" or "text": body has to be a String
+        // - "json": body has to be a JSON String or an Object, that can be stringified to JSON
+        // - "arraybuffer": body has to be an array of usigned bytes (ints between 0 and 255) to put in the array buffer
+        //   or an ArrayBuffer
+        // - "blob": body can be anything that you can put in a Blob or a Blob
         setResponseBody: function setResponseBody(body) {
             verifyRequestSent(this);
             verifyHeadersReceived(this);
-            verifyResponseBodyType(body);
 
             switch (this.responseType) {
                 case "": // The empty string should fall through
                 case "text":
+                    if (typeof body != "string") {
+                        var error = new Error();
+                        error.name = "InvalidBodyException";
+                        throw error;
+                    }
+
                     this.loadResponseText(body)
                     this.response = this.responseText
                     break;
                 case "json":
-                    this.response = JSON.parse(body);
+                    if (typeof body == "object") {
+                        this.response = body;
+                    } else {
+                        this.response = JSON.parse(body);
+                    }
                     break;
                 case "arraybuffer":
-                    this.response = new ArrayBuffer(body.length);
+                    if (body instanceof ArrayBuffer) {
+                        this.response = body;
+                    } else {
+                        this.response = new ArrayBuffer(body.length);
 
-                    var arrayView = new Uint8Array(this.response);
-                    for (var i = 0, length = body.length; i < length; i++) {
-                        arrayView[i] = body[i];
+                        var arrayView = new Uint8Array(this.response);
+                        for (var i = 0, length = body.length; i < length; i++) {
+                            arrayView[i] = body[i];
+                        }
                     }
                     break;
                 case "blob":
-                    this.response = new Blob(body);
+                    if (body instanceof Blob) {
+                        this.response = body;
+                    } else {
+                        this.response = new Blob(body);
+                    }
                     break;
             }
 

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -447,6 +447,95 @@
             }
         },
 
+        "setResponseBody": {
+            setUp: function () {
+                this.xhr = new sinon.FakeXMLHttpRequest();
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+                this.xhr.setResponseHeaders({});
+            },
+
+            "when the responseType is 'text'": {
+                setUp: function () {
+                    this.xhr.responseType = "text";
+                },
+
+                "sets the responseText": function () {
+                    this.xhr.setResponseBody("ABCDEFG");
+
+                    assert.equals(this.xhr.responseText, "ABCDEFG");
+                },
+
+                "sets the response": function () {
+                    this.xhr.setResponseBody("ABCDEFG");
+
+                    assert.equals(this.xhr.response, "ABCDEFG");
+                }
+            },
+
+            "when the responseType is 'json'": {
+                setUp: function () {
+                    this.xhr.responseType = "json";
+                },
+
+                "it parses a JSON string": function () {
+                    this.xhr.setResponseBody('{"t": 1}');
+
+                    assert.equals(this.xhr.response, {t: 1});
+                },
+
+                "it passes a JS object right through": function () {
+                    this.xhr.setResponseBody({x: {d: 5}});
+
+                    assert.equals(this.xhr.response, {x: {d: 5}});
+                }
+            },
+
+            "when the responseType is 'arraybuffer'": {
+                setUp: function () {
+                    this.xhr.responseType = "arraybuffer";
+                },
+
+                "it puts an array of bytes into an ArrayBuffer": function () {
+                    this.xhr.setResponseBody([65, 66, 67]);
+
+                    var array = new Uint8Array(this.xhr.response);
+
+                    assert.equals(array[0], 65);
+                    assert.equals(array[1], 66);
+                    assert.equals(array[2], 67);
+                },
+
+                "it passes an ArrayBuffer right through": function () {
+                    var buffer = new ArrayBuffer(5);
+
+                    this.xhr.setResponseBody(buffer);
+
+                    assert.same(this.xhr.response, buffer);
+                }
+            },
+
+            "when the responseType is 'blob'": {
+                setUp: function () {
+                    this.xhr.responseType = "blob";
+                },
+
+                "it puts the body into a Blob": function () {
+                    this.xhr.setResponseBody(["test"]);
+
+                    assert.hasPrototype(this.xhr.response, Blob.prototype);
+                },
+
+                "it passes a Blob right through": function () {
+                    var blob = new Blob(["test"]);
+
+                    this.xhr.setResponseBody(blob);
+
+                    assert.same(this.xhr.response, blob);
+                }
+            }
+        },
+
         "setResponseBodyAsync": {
             setUp: function () {
                 this.xhr = new sinon.FakeXMLHttpRequest();


### PR DESCRIPTION
Implement XMLHttpRequest#response and #responseType for some more advanced usages like responding with an ArrayBuffer.

I tried to implement http://www.w3.org/TR/XMLHttpRequest/#the-responsetype-attribute and http://www.w3.org/TR/XMLHttpRequest/#the-response-attribute as closely as possible.

We could implement it even better, if we used getters and setters (https://developer.mozilla.org/en-US/docs/JavaScript/Guide/Working_with_Objects#Defining_getters_and_setters), that are available since Javascript 1.5, but they are not supported in IE<9. Is this incompatibility a problem for this project?
