### PR TITLE
fix fakeXHR when response is function handler and url contains RegExp characters

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -67,7 +67,7 @@ sinon.fakeServer = (function () {
         if (matchOne(response, this.getHTTPMethod(request), requestUrl)) {
             if (typeof response.response == "function") {
                 var ru = response.url;
-                var args = [request].concat(!ru ? [] : requestUrl.match(ru).slice(1));
+                var args = [request].concat(ru && typeof ru.exec == "function" ? ru.exec(requestUrl).slice(1) : []);
                 return response.response.apply(response, args);
             }
 

--- a/test/sinon/util/fake_server_test.js
+++ b/test/sinon/util/fake_server_test.js
@@ -438,6 +438,18 @@ buster.testCase("sinon.fakeServer", {
             assert(handler.calledOnce);
         },
 
+        "yields response to request function handler when url contains RegExp characters": function () {
+            var handler = sinon.spy();
+            this.server.respondWith("GET", "/hello?world", handler);
+            var xhr = new sinon.FakeXMLHttpRequest();
+            xhr.open("GET", "/hello?world");
+            xhr.send();
+
+            this.server.respond();
+
+            assert(handler.calledOnce);
+        },
+
         "does not yield response to request function handler when method does not match": function () {
             var handler = sinon.spy();
             this.server.respondWith("GET", "/hello", handler);


### PR DESCRIPTION
The problem here was that String.exec accepts RegExp or string, in the latter case compiles the string into RegExp using `new RegExp(string)`. This might not match in case we ended up here because fake_server.js#L54 matched by string equality.
