### PR TITLE
fake server should not respond to requests queued after respond() (eg from callbacks)

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -167,9 +167,10 @@ sinon.fakeServer = (function () {
         respond: function respond() {
             if (arguments.length > 0) this.respondWith.apply(this, arguments);
             var queue = this.queue || [];
+            var requests = queue.splice(0);
             var request;
 
-            while(request = queue.shift()) {
+            while(request = requests.shift()) {
                 this.processRequest(request);
             }
         },

--- a/test/sinon/util/fake_server_test.js
+++ b/test/sinon/util/fake_server_test.js
@@ -158,6 +158,28 @@ buster.testCase("sinon.fakeServer", {
             assert(this.getPathAsync.respond.called);
         },
 
+        "does not respond to requests queued after respond() (eg from callbacks)": function () {
+            var xhr;
+            this.getRootAsync.addEventListener("load", function() {
+              xhr = new sinon.FakeXMLHttpRequest();
+              xhr.open("GET", "/", true);
+              xhr.send();
+              sinon.spy(xhr, "respond");
+            });
+
+            this.server.respondWith("Oh yeah! Duffman!");
+
+            this.server.respond();
+
+            assert(this.getRootAsync.respond.called);
+            assert(this.getPathAsync.respond.called);
+            assert(!xhr.respond.called);
+
+            this.server.respond();
+
+            assert(xhr.respond.called);
+        },
+
         "responds with status, headers, and body": function () {
             var headers = { "Content-Type": "X-test" };
             this.server.respondWith([201, headers, "Oh yeah!"]);


### PR DESCRIPTION
Otherwise there would not be way to inspect (test against) the intermediate state between the original queue of requests and further ones added by callbacks on these requests.
