### PR TITLE
Implemented stubbing of constructors

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -42,14 +42,18 @@
             return sinon.stub.create();
         }
 
-        if (!property && !!object && typeof object == "object") {
-            for (var prop in object) {
-                if (typeof object[prop] === "function") {
-                    stub(object, prop);
+        if (!property && !!object) {
+            if (typeof object == "object") {
+                for (var prop in object) {
+                    if (typeof object[prop] === "function") {
+                        stub(object, prop);
+                    }
                 }
+                return object;
+            } else if (typeof object == "function") {
+                object = Object.create(object.prototype);
+                return stub(object);
             }
-
-            return object;
         }
 
         return sinon.wrapMethod(object, property, wrapper);

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -566,11 +566,20 @@ buster.testCase("sinon.stub", {
             assert.equals(obj.someProp, 42);
         },
 
-        "does not stub function object": function () {
-            assert.exception(function () {
-                sinon.stub(function () {});
-            });
-        }
+        "wraps prototype if a constructor is given": function() {
+            var stub,
+                TestConstructor = sinon.spy();
+
+            TestConstructor.prototype.foo = function() {};
+
+            stub = sinon.stub(TestConstructor);
+
+            assert(stub instanceof TestConstructor);
+            assert(!TestConstructor.called);
+
+            assert.isFunction(stub.foo.returns);
+            assert.isFunction(stub.foo.throws);
+        },
     },
 
     "everything": {


### PR DESCRIPTION
On projects with the dependency injection pattern, it may be very useful to be able to stub complete prototypes of constructors. In this cases we need to inject an instance of the required constructor with all its prototype functions, but not to execute its constructor.

Usage example:

```
test('calling log fomats the input and passes it to writer', function() {
    var writer    = sinon.stub(Example.Logger.Writer),
        formatter = sinon.stub(Example.Logger.Formatter),
        logger = new Example.Logger(writer, formatter);

    formatter.format.returns('formatted text');

    logger.log('test text');

    assert.ok(formatter.format.calledOnce);
    assert.equal(formatter.format.firstCall.args[0], 'test text');
    assert.ok(writer.write.calledOnce);
    assert.equal(writer.write.firstCall.args[0], 'formatted text');
})
```
