### PR TITLE
Allow stubs to call through to other functions (original or new)

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -95,6 +95,7 @@ var sinon = (function (buster) {
                     object[property] = wrappedMethod;
                 }
             };
+            method.original = wrappedMethod;
 
             method.restore.sinon = true;
             mirrorProperties(method, wrappedMethod);

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -145,6 +145,24 @@
         }
     }
 
+    function callThrough(stub, thisValue, args) {
+        var func = stub._callback;
+        return func.apply(stub.callbackContext || thisValue, args);
+    }
+
+    function callOriginal(stub, thisValue, args) {
+        var func = stub.original;
+        return func.apply(thisValue, args);
+    }
+
+    function passLastCallThrough(stub, func, ctx) {
+        var calls = stub.callCount;
+        var args = stub.args[calls - 1];
+        var thisValue = stub.thisValues[calls - 1];
+
+        return (func || stub.original).apply(ctx || thisValue, args);
+    }
+
     var uuid = 0;
 
     sinon.extend(stub, (function () {
@@ -175,6 +193,10 @@
                         return arguments[functionStub.returnArgAt];
                     } else if (functionStub.returnThis) {
                         return this;
+                    } else if (functionStub._callback) {
+                        return callThrough(functionStub, this, arguments);
+                    } else if (functionStub._callOriginal) {
+                        return callOriginal(functionStub, this, arguments);
                     }
                     return functionStub.returnValue;
                 };
@@ -240,6 +262,42 @@
 
             "throws": throwsException,
             throwsException: throwsException,
+
+            callFake: function callFake(func) {
+                return passLastCallThrough(this, func);
+            },
+
+            callFakeOn: function callFakeOn(func, context) {
+                return passLastCallThrough(this, func, context);
+            },
+
+            callOriginal: function callOriginal() {
+                return passLastCallThrough(this);
+            },
+
+            callsFake: function callsFake(callback) {
+                this._callback = callback;
+                this.callbackArguments = [];
+                this.callbackContext = null;
+
+                return this;
+            },
+
+            callsFakeOn: function callsFakeOn(callback, context) {
+                this._callback = callback;
+                this.callbackContext = context;
+                this.callbackArguments = [];
+
+                return this;
+            },
+
+            callsOriginal: function callsOriginal() {
+                this.func = null;
+                this._callOriginal = true;
+                this._callback = null;
+
+                return this;
+            },
 
             callsArg: function callsArg(pos) {
                 if (typeof pos != "number") {

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -199,6 +199,268 @@ buster.testCase("sinon.stub", {
         }
     },
 
+    "callFake": {
+        setUp: function () {
+            this.stub = sinon.stub.create();
+        },
+
+        "calls the specified function": function() {
+            var callback = sinon.stub.create();
+
+            this.stub(1, 2);
+
+            this.stub.callFake(callback);
+
+            assert(callback.calledWith(1, 2));
+        },
+
+        "returns the result of the function": function() {
+            var callback = function() { return 3; }
+            this.stub();
+
+            var result = this.stub.callFake(callback);
+
+            assert.equals(result, 3);
+        },
+
+        "uses the current context": function() {
+            var o = { stub: this.stub };
+            var callback = sinon.stub.create();
+
+            o.stub();
+
+            o.stub.callFake(callback);
+
+            assert(callback.calledOn(o));
+        }
+    },
+
+    "callFakeOn": {
+        setUp: function () {
+            this.stub = sinon.stub.create();
+            this.fakeContext = {};
+        },
+
+        "calls the specified function": function() {
+            var callback = sinon.stub.create();
+            this.stub(1, 2);
+
+            this.stub.callFakeOn(callback, this.fakeContext);
+
+            assert(callback.calledWith(1, 2));
+        },
+
+        "returns the result of the function": function() {
+            var callback = function() { return 3; }
+            this.stub();
+
+            var result = this.stub.callFakeOn(callback, this.fakeContext);
+
+            assert.equals(result, 3);
+        },
+
+        "uses the specified current context": function() {
+            var o = { stub: this.stub };
+            var callback = sinon.stub.create();
+            o.stub();
+
+            o.stub.callFakeOn(callback, this.fakeContext);
+
+            assert(callback.calledOn(this.fakeContext));
+        }
+    },
+
+    "callOriginal": {
+        setUp: function () {
+            var orgFunc = this.originalFunction = sinon.stub.create();
+            this.object = {
+                func: function() {
+                    return orgFunc.apply(this, arguments);
+                }
+            };
+
+            this.stub = sinon.stub(this.object, 'func');
+        },
+
+        "calls the original function": function() {
+            this.object.func(1, 2);
+
+            this.stub.callOriginal();
+
+            assert(this.originalFunction.calledWith(1, 2));
+        },
+
+        "returns the result of the function": function() {
+            this.originalFunction.returns(1);
+            this.object.func();
+
+            var result = this.stub.callOriginal();
+
+            assert.equals(result, 1);
+        },
+
+        "uses the original context": function() {
+            this.object.func();
+
+            this.stub.callOriginal();
+
+            assert(this.originalFunction.calledOn(this.object));
+        }
+    },
+
+    "calls": {
+        setUp: function () {
+            this.stub = sinon.stub.create();
+        },
+
+        "calls the specified function": function() {
+            var callback = sinon.stub.create();
+            this.stub.callsFake(callback);
+
+            this.stub(1, 2);
+
+            assert(callback.calledWith(1, 2));
+        },
+
+        "returns the result of the function": function() {
+            var callback = function() { return 3; }
+            this.stub.callsFake(callback);
+
+            var result = this.stub();
+
+            assert.equals(result, 3);
+        },
+
+        "uses the current context": function() {
+            var o = { stub: this.stub };
+            var callback = sinon.stub.create();
+            o.stub.callsFake(callback);
+
+            o.stub();
+
+            assert(callback.calledOn(o));
+        },
+
+        "resets the context, in case callsOn was called first": function () {
+            var callback = sinon.stub.create();
+            var context = { stub: this.stub };
+            context.stub.callsFakeOn(callback, {});
+            context.stub.callsFake(callback);
+
+            context.stub();
+
+            assert.equals(callback.callCount, 1);
+            assert(callback.calledOn(context));
+        },
+
+        "returns the stub for chaining": function () {
+            var callback = sinon.stub.create();
+
+            var result = this.stub.callsFake(callback);
+
+            assert.same(result, this.stub)
+        }
+    },
+
+    "callsFakeOn": {
+        setUp: function () {
+            this.stub = sinon.stub.create();
+            this.fakeContext = {};
+        },
+
+        "calls the specified function": function() {
+            var callback = sinon.stub.create();
+            this.stub.callsFakeOn(callback, this.fakeContext);
+
+            this.stub(1, 2);
+
+            assert(callback.calledWith(1, 2));
+        },
+
+        "returns the result of the function": function() {
+            var callback = function() { return 3; }
+            this.stub.callsFakeOn(callback, this.fakeContext);
+
+            var result = this.stub();
+
+            assert.equals(result, 3);
+        },
+
+        "uses the specified current context": function() {
+            var o = { stub: this.stub };
+            var callback = sinon.stub.create();
+            o.stub.callsFakeOn(callback, this.fakeContext);
+
+            o.stub();
+
+            assert(callback.calledOn(this.fakeContext));
+        },
+
+        "returns the stub for chaining": function () {
+            var callback = sinon.stub.create();
+
+            var result = this.stub.callsFakeOn(callback, this.fakeContext);
+
+            assert.same(result, this.stub)
+        }
+    },
+
+    "callsOriginal": {
+        setUp: function () {
+            var orgFunc = this.originalFunction = sinon.stub.create();
+            this.object = {
+                func: function() {
+                    return orgFunc.apply(this, arguments);
+                }
+            };
+
+            this.stub = sinon.stub(this.object, 'func');
+        },
+
+        "calls the original function": function() {
+            this.stub.callsOriginal();
+
+            this.object.func(1, 2);
+
+            assert(this.originalFunction.calledWith(1, 2));
+        },
+
+        "returns the result of the function": function() {
+            this.originalFunction.returns(1);
+            this.stub.callsOriginal();
+
+            var result = this.object.func();
+
+            assert.equals(result, 1);
+        },
+
+        "uses the original context": function() {
+            this.stub.callsOriginal();
+
+            this.object.func();
+
+            assert(this.originalFunction.calledOn(this.object));
+        },
+
+        "resets the context if other stub methods are called first": function () {
+            var callback = sinon.stub.create();
+            this.stub.callsFakeOn(callback, {});
+            this.stub.callsOriginal();
+
+            this.object.func();
+
+            assert.equals(callback.callCount, 0);
+            assert.equals(this.originalFunction.callCount, 1);
+            assert(this.originalFunction.calledOn(this.object));
+        },
+
+        "returns the stub for chaining": function () {
+            var result = this.stub.callsOriginal();
+
+            assert.same(result, this.stub)
+        }
+    },
+
     "callsArg": {
         setUp: function () {
             this.stub = sinon.stub.create();


### PR DESCRIPTION
Let's say that you want to stub a function, such as `fs.readFile`, for certain inputs, but most inputs are of no interest to you.

Currently, this requires you to replace the function with your own, and perform a number of comparisons in order to decide what to do.

But stubs already have a great syntax for determining calls (`withArgs`, so as a developer writing tests, I would love to utilize this.

Towards that end, I have added the following functions to the stub interface:
- `callFake(function)`: Pipes the last call through to the given function.
- `callFakeOn(function, context)`: Pipes the last call through to the given function, and force the given context.
- `callOriginal()`: Pipes the last call through to the function that was stubbed.
- `callsFake(function)`: Pipe future calls through to the given function.
- `callsFakeOn(function, context)`: Pipe future calls through to the given function, and force the given context.
- `callsOriginal()`: Pipe all future calls through to the stubbed function. This is the default behaviour of the sinon.spy() function.

In general, we would like to combine the `withArgs()` function of stubs with the ability to either call either the original or a specific fake function, thus utilizing the quite-good comparison behind that function.

Since all calls still go through the stubs, the various assert-methods also still function as expected.

Incidentally, this also renders the `sinon.spy()` function irrelevant, as it behaves the same as `sinon.stub().callsOriginal()`, except stubs have the powerful `withArgs` function.
## Scenarious where this could be useful

Replacing specific call to `fs.readFile`:

```
var fs = require('fs')
var sinon = require('sinon')
var readFileStub = sinon.stub(fs, 'readFile')

// We don't care about most files
readFileStub.callsOriginal()

// We do care about this specific file
readFileStub.withArgs('/path/to/interesting/file').yieldsAsync(ourFakeFile)
```

Overriding specific selector for `document.querySelector`:

```
var stub = sinon.stub(document, 'querySelector').callsOriginal()
stub.withArgs('.ourSpecificClass').returns(ourFakedElement)
```

Faking an ajax-response (this one might be a bit farfetched to see in practice):

```
var stub = sinon.stub(JSON, 'parse').callsOriginal()
stub.withArgs('fake-json').returns(ourFakeObject)

// This is responsible for parsing the JSON and parsing it on into the system
jsonFetched('fake-json')
```

(This potentially fixes #169, as I understood it).
