### PR TITLE
sinon.deepEqual(new Date(0), new Date()) returns true

### DIFF
--- a/test/sinon/match_test.js
+++ b/test/sinon/match_test.js
@@ -140,18 +140,6 @@ buster.testCase("sinon.match", {
         assert(match.test({ one : new Number(1) }));
     },
 
-    "returns true if date objects are equal": function () {
-        var match = sinon.match(new Date(2012, 3, 5));
-
-        assert(match.test(new Date(2012, 3, 5)));
-    },
-
-    "returns false if date objects are not equal": function () {
-        var match = sinon.match(new Date(2013, 3, 5));
-
-        assert.isFalse(match.test(new Date(2012, 3, 5)));
-    },
-
     "returns true if test matches": function () {
         var match = sinon.match({ prop: sinon.match.typeOf("boolean") });
 

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -238,6 +238,20 @@ buster.testCase("sinon", {
             assert(sinon.deepEqual(obj1, obj2));
         },
 
+        "passes equal dates": function () {
+            var date1 = new Date(2012, 3, 5);
+            var date2 = new Date(2012, 3, 5);
+
+            assert(sinon.deepEqual(date1, date2));
+        },
+
+        "fails different dates": function () {
+            var date1 = new Date(2012, 3, 5);
+            var date2 = new Date(2013, 3, 5);
+
+            assert.isFalse(sinon.deepEqual(date1, date2));
+        },
+
         "in browsers": {
             requiresSupportFor: {
                 "document object": typeof document !== "undefined"


### PR DESCRIPTION
Hopefully fixes ![issue](https://github.com/cjohansen/Sinon.JS/issues/200) with datetime values not being compared correctly. Hope I didn't miss the right place for tests.
