### PR TITLE
Add onInvocation helper that fires on spy invocation

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -109,6 +109,11 @@ var sinon = (function (buster) {
                         target[prop] = arguments[i][prop];
                     }
 
+                    var pd = Object.getOwnPropertyDescriptor(arguments[i], prop);
+                    if (pd) {
+                        Object.defineProperty(target, prop, pd);
+                    }
+
                     // DONT ENUM bug, only care about toString
                     if (arguments[i].hasOwnProperty("toString") &&
                         arguments[i].toString != target.toString) {
@@ -316,6 +321,26 @@ var sinon = (function (buster) {
             else if (isRestorable(object)) {
                 object.restore();
             }
+        },
+
+        onInvocation: function (object, callback) {
+            if (typeof callback !== "function") {
+                throw new TypeError("The callback should be a function.");
+            }
+            var pd = Object.getOwnPropertyDescriptor(object, "callCount");
+            if (!pd) {
+                throw new TypeError("Object is not an instance of spy.");
+            }
+
+            Object.defineProperty(object, "callCount", {
+                get: pd.get.bind(object),
+                set: function(value) {
+                    pd.set.apply(this, arguments);
+                    callback.apply(object);
+                },
+                enumerable: true,
+                configurable: true
+            });
         }
     };
 

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -114,6 +114,14 @@
             }
         },
 
+        get callCount() {
+            return this.$callCount || 0;
+        },
+
+        set callCount(value) {
+            this.$callCount = value;
+        },
+
         create: function create(func) {
             var name;
 

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -549,5 +549,52 @@ buster.testCase("sinon", {
 
             assert.same(obj.method, method);
         }
+    },
+
+    ".onInvocation": {
+        "calls when a spy is being called": function (next) {
+            var obj = sinon.spy();
+
+            sinon.onInvocation(obj, function() {
+                assert.same(obj.callCount, 1);
+                next();
+            });
+
+            obj();
+        },
+
+        "calls when a stub is being called": function (next) {
+            var obj = sinon.stub();
+
+            sinon.onInvocation(obj, function() {
+                assert.same(obj.callCount, 1);
+                next();
+            });
+
+            obj();
+        },
+
+        "context of callback is the spy": function (next) {
+            var obj = sinon.stub();
+
+            sinon.onInvocation(obj, function() {
+                assert.same(this, obj);
+                next();
+            });
+
+            obj();
+        },
+
+        "throws exception for non function callback": function () {
+            assert.exception(function() {
+                sinon.onInvocation(sinon.stub(), null);
+            });
+        },
+
+        "throws exception for non spy object": function () {
+            assert.exception(function() {
+                sinon.onInvocation({}, function() {});
+            });
+        }
     }
 });


### PR DESCRIPTION
This is a usecase when testing web workers. Because of their nature it's only possible to communicate through `postMessage` calls and `onmessage` handlers. This creates an asynchronous workflow that is currently not being covered by sinon. For example: I'm testing the worker, which will send a message back after running to completion. The action is kicked off via a `postMessage`. Currently you'd write code like this:

``` javascript
var worker = /* bla */;
worker.onmessage = sinon.stub();
worker.postMessage('something');
var iv = setInterval(function() {
  if (worker.onmessage.called) {
    clearInterval(iv);
    // do assertions
  }
}, 20);
```

A nice addition would be to have a callback fire when a method gets invoked.

In this PR I have changed the `callCount` field on spy into a ES5 get/set method, then adding a helper method on the `sinon` object that can hook into the setter to fire a callback function whenever the callCount of this object changes. This way the code doesn't need to rely on setInterval, but can be written like:

``` javascript
var worker = /* bla */;
worker.onmessage = sinon.stub();
worker.postMessage('something');
sinon.onInvocation(worker.onmessage, function() {
  // do assertions
});
```

_I'm aware this breaks in some browsers at the moment, but I first want to hear a yay/nay before putting more work into it_
