### PR TITLE
Fix CommonJS detection to work in Component package manager

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -319,7 +319,7 @@ var sinon = (function (buster) {
         }
     };
 
-    var isNode = typeof module == "object" && typeof require == "function";
+    var isNode = typeof module !== "undefined" && module.exports;
 
     if (isNode) {
         try {

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -15,7 +15,7 @@
 "use strict";
 
 (function (sinon, global) {
-    var commonJSModule = typeof module == "object" && typeof require == "function";
+    var commonJSModule = typeof module !== "undefined" && module.exports;
     var slice = Array.prototype.slice;
     var assert;
 

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -17,7 +17,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module == "object" && typeof require == "function";
+    var commonJSModule = typeof module !== 'undefined' && module.exports;
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");
     }

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -16,7 +16,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module == "object" && typeof require == "function";
+    var commonJSModule = typeof module !== 'undefined' && module.exports;
     var push = [].push;
     var hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -12,7 +12,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module == "object" && typeof require == "function";
+    var commonJSModule = typeof module !== 'undefined' && module.exports;
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -15,7 +15,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module == "object" && typeof require == "function";
+    var commonJSModule = typeof module !== 'undefined' && module.exports;
     var push = [].push;
 
     if (!sinon && commonJSModule) {

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -17,7 +17,7 @@
  */
 "use strict";
 
-if (typeof module == "object" && typeof require == "function") {
+if (typeof module !== 'undefined' && module.exports) {
     var sinon = require("../sinon");
     sinon.extend(sinon, require("./util/fake_timers"));
 }
@@ -119,7 +119,7 @@ if (typeof module == "object" && typeof require == "function") {
 
     sinon.sandbox.useFakeXMLHttpRequest = sinon.sandbox.useFakeServer;
 
-    if (typeof module == "object" && typeof require == "function") {
+    if (typeof module !== 'undefined' && module.exports) {
         module.exports = sinon.sandbox;
     }
 }());

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -15,7 +15,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module == "object" && typeof require == "function";
+    var commonJSModule = typeof module !== 'undefined' && module.exports;
     var push = Array.prototype.push;
     var slice = Array.prototype.slice;
     var callId = 0;

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -15,7 +15,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module == "object" && typeof require == "function";
+    var commonJSModule = typeof module !== 'undefined' && module.exports;
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");

--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -17,7 +17,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module == "object" && typeof require == "function";
+    var commonJSModule = typeof module !== 'undefined' && module.exports;
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");

--- a/lib/sinon/test_case.js
+++ b/lib/sinon/test_case.js
@@ -15,7 +15,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module == "object" && typeof require == "function";
+    var commonJSModule = typeof module !== 'undefined' && module.exports;
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -207,6 +207,6 @@ sinon.fakeServer = (function () {
     };
 }());
 
-if (typeof module == "object" && typeof require == "function") {
+if (typeof module !== 'undefined' && module.exports) {
     module.exports = sinon;
 }

--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -346,6 +346,6 @@ sinon.timers = {
     Date: Date
 };
 
-if (typeof module == "object" && typeof require == "function") {
+if (typeof module !== 'undefined' && module.exports) {
     module.exports = sinon;
 }

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -504,6 +504,6 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
     sinon.FakeXMLHttpRequest = FakeXMLHttpRequest;
 })(this);
 
-if (typeof module == "object" && typeof require == "function") {
+if (typeof module !== 'undefined' && module.exports) {
     module.exports = sinon;
 }


### PR DESCRIPTION
`typeof module == "object"` breaks inside [Component](https://github.com/component/component) (where it's a function). CommonJS spec is ambiguous on the issue (See #307). Using more common `typeof module !== "undefined" && module.exports`.
