### PR TITLE
Fixed problem with chained timers with delay=0

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -162,7 +162,7 @@ if (typeof sinon == "undefined") {
         },
 
         firstTimerInRange: function (from, to) {
-            var timer, smallest, originalTimer;
+            var timer, smallest = null, originalTimer;
 
             for (var id in this.timeouts) {
                 if (this.timeouts.hasOwnProperty(id)) {
@@ -170,7 +170,7 @@ if (typeof sinon == "undefined") {
                         continue;
                     }
 
-                    if (!smallest || this.timeouts[id].callAt < smallest) {
+                    if (smallest === null || this.timeouts[id].callAt < smallest) {
                         originalTimer = this.timeouts[id];
                         smallest = this.timeouts[id].callAt;
 

--- a/test/sinon/util/fake_timers_test.js
+++ b/test/sinon/util/fake_timers_test.js
@@ -152,6 +152,27 @@ buster.testCase("sinon.clock", {
             assert(spies[3].called);
         },
 
+        "triggers multiple simultaneous timers with zero callAt": function () {
+            var test = this;
+            var spies = [
+                sinon.spy(function() {
+                    test.clock.setTimeout(spies[1], 0)
+                }),
+                sinon.spy(),
+                sinon.spy()
+            ];
+
+            // First spy calls another setTimeout with delay=0
+            this.clock.setTimeout(spies[0], 0);
+            this.clock.setTimeout(spies[2], 10);
+
+            this.clock.tick(10);
+
+            assert(spies[0].called);
+            assert(spies[1].called);
+            assert(spies[2].called);
+        },
+
         "waits after setTimeout was called": function () {
             this.clock.tick(100);
             var stub = sinon.stub.create();


### PR DESCRIPTION
There was an issue with the firstTimerInRange() method where timers that did not have the smallest delay (callAt) were returned when some timeouts had a delay of zero. Specifically, if the "smallest" variable was zero, then the next callback was processed regardless of whether that timeout's callAt was less than zero or not. This caused some timeouts to be skipped entirely when the tick() method was called.
