### PR TITLE
Make FakeXMLHttpRequest work under nodejs

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -14,13 +14,14 @@
  */
 "use strict";
 
-if (typeof sinon == "undefined") {
-    this.sinon = {};
-}
-sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
-
 // wrapper for global
 (function(global) {
+    
+    if (typeof sinon === "undefined") {
+        global.sinon = {};
+    }
+    sinon.xhr = { XMLHttpRequest: global.XMLHttpRequest };
+
     var xhr = sinon.xhr;
     xhr.GlobalXMLHttpRequest = global.XMLHttpRequest;
     xhr.GlobalActiveXObject = global.ActiveXObject;
@@ -502,7 +503,8 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
     };
 
     sinon.FakeXMLHttpRequest = FakeXMLHttpRequest;
-})(this);
+
+})(typeof global === "object" ? global : this);
 
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = sinon;


### PR DESCRIPTION
Moved the self-invoking wrapper in util/fake_xml_http_request.js to make FakeXMLHttpRequest work under nodejs
