### PR TITLE
Fix duplicate onload function calls

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -16,7 +16,7 @@
 
 // wrapper for global
 (function(global) {
-    
+
     if (typeof sinon === "undefined") {
         global.sinon = {};
     }
@@ -393,10 +393,6 @@
             this.status = typeof status == "number" ? status : 200;
             this.statusText = FakeXMLHttpRequest.statusCodes[this.status];
             this.setResponseBody(body || "");
-            if (typeof this.onload === "function"){
-                this.onload();
-            }
-
         }
     });
 

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -626,12 +626,9 @@
             },
 
             "fire onload event": function () {
-                var fireOnLoad = false;
-                this.onload = function(){
-                    fireOnLoad = true;
-                }
+                this.onload = this.spy;
                 this.xhr.respond(200, {}, "");
-                assert.isTrue(fireOnLoad);
+                assert.equals(this.spy.callCount, 1);
             },
 
             "calls readystate handler with readyState DONE once": function () {
@@ -815,13 +812,10 @@
             },
 
             "fire onerror event": function () {
-                var testFlag = false,
-                    this.onerror = function(){
-                        testFlag = true;
-                    };
-                this.xhr.aborted = true;
+                var spy = sinon.spy();
+                this.xhr.onerror = spy;
                 this.xhr.abort();
-                assert.isTrue(testFlag);
+                assert.equals(spy.callCount, 1);
             },
 
             "nulls request headers": function () {


### PR DESCRIPTION
Sinon was previously calling the `onload` callback twice which resulted in some issues running tests in my own test suite. This PR removes the additional `onload` function call and adds a more comprehensive coverage (by checking how many times it was actually called). In development of the solution, I had to also fix another failing test case for the `onerror` callback.
