### PR TITLE
Added `spy.getCalls()` to allow iteration of invocations

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -179,6 +179,17 @@
                                     this.callIds[i]);
         },
 
+        getCalls: function () {
+            var calls = [];
+            var i;
+
+            for (i = 0; i < this.callCount; i++) {
+                calls.push(this.getCall(i));
+            }
+
+            return calls;
+        },
+
         calledBefore: function calledBefore(spyFn) {
             if (!this.called) {
                 return false;

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -1578,6 +1578,24 @@ if (typeof require === "function" && typeof module === "object") {
             }
         },
 
+        "getCalls": {
+            "returns an empty Array by default": function () {
+                var spy = sinon.spy();
+
+                assert.isArray(spy.getCalls());
+                assert.equals(spy.getCalls().length, 0);
+            },
+
+            "is analogous to using getCall(n)": function () {
+                var spy = sinon.spy();
+
+                spy();
+                spy();
+
+                assert.equals(spy.getCalls(), [ spy.getCall(0), spy.getCall(1) ]);
+            }
+        },
+
         "callArg": {
             "is function": function () {
                 var spy = sinon.spy();


### PR DESCRIPTION
I've come across a couple of situations where I want to use some of the Array iteration methods to filer which calls I want to interact with, for example:

``` js
// Yield all calls where the third argument was passed as `foo`.
spy.getCalls()
    .filter(function (call) {
        return call.args[2] === "foo";
    })
    .forEach(function (call) {
        call.yield();
    });
```
