### PR TITLE
Add support for function binding

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -75,13 +75,16 @@
     function createProxy(func) {
         // Retain the function length:
         var p;
+        function getTarget(self) {
+          return p.bound ? p.bound : self;
+        }
         if (func.length) {
             eval("p = (function proxy(" + vars.substring(0, func.length * 2 - 1) +
-                ") { return p.invoke(func, this, slice.call(arguments)); });");
+                ") { return p.invoke(func, getTarget(this), slice.call(arguments)); });");
         }
         else {
             p = function proxy() {
-                return p.invoke(func, this, slice.call(arguments));
+                return p.invoke(func, getTarget(this), slice.call(arguments));
             };
         }
         return p;
@@ -135,6 +138,12 @@
             proxy.toString = sinon.functionToString;
             proxy._create = sinon.spy.create;
             proxy.id = "spy#" + uuid++;
+
+            var _bind = proxy.bind;
+            proxy.bind = function (target) {
+              proxy.bound = target;
+              _bind.apply(proxy, arguments);
+            };
 
             return proxy;
         },

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -535,6 +535,14 @@ if (typeof require === "function" && typeof module === "object") {
                 assert.isFalse(this.spy.calledOn({}));
             },
 
+            "is true if called on a bound target": function () {
+                var target = {};
+                this.spy.bind(target);
+                this.spy();
+
+                assert(this.spy.calledOn(target));
+            },
+
             "is true if called with matcher that returns true": function () {
                 var matcher = sinon.match(function () { return true; });
                 this.spy();
@@ -559,7 +567,8 @@ if (typeof require === "function" && typeof module === "object") {
                 }));
 
                 assert.same(actual, expected);
-            }
+            },
+
         },
 
         "alwaysCalledOn": {
@@ -976,7 +985,7 @@ if (typeof require === "function" && typeof module === "object") {
                 this.spyWithTypeError = sinon.spy.create(function () {
                     throw new TypeError();
                 });
-                
+
                 this.spyWithStringError = sinon.spy.create(function() {
                 	throw "error";
                 });
@@ -1031,20 +1040,20 @@ if (typeof require === "function" && typeof module === "object") {
 
                 assert.isFalse(this.spy.threw("Error"));
             },
-            
+
             "returns true if string matches": function () {
             	try {
             		this.spyWithStringError();
             	} catch (e) {}
-            	
+
             	assert(this.spyWithStringError.threw("error"));
             },
-            
+
             "returns false if strings do not match": function() {
             	try {
             		this.spyWithStringError();
             	} catch (e) {}
-            	
+
             	assert.isFalse(this.spyWithStringError.threw("not the error"));
             }
         },


### PR DESCRIPTION
In the existing implementation, functions that are bound with
`fn.bind(target)` do not properly report `true` when called with
`fn.calledOn(target)`. This patch adds special bind logic to the spy
proxy to keep track of the bound target.
