### PR TITLE
Adding support for XMLHttpRequest.upload to FakeXMLHttpRequest

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -431,7 +431,7 @@
         },
 
         uploadError: function uploadError(error) {
-            this.upload.dispatchEvent(new ErrorEvent("error", error));
+            this.upload.dispatchEvent(new CustomEvent("error", {"detail": error}));
         }
     });
 

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -1414,7 +1414,6 @@
                 this.xhr.upload.addEventListener("progress", function(e) {
                     assert.equals(e.total, 100);
                     assert.equals(e.loaded, 20);
-                    assert.equals(e.constructor.name, "ProgressEvent");
                     done();
                 });
                 this.xhr.uploadProgress({
@@ -1440,7 +1439,6 @@
                 this.xhr.upload.addEventListener("progress", function(e) {
                     assert.equals(e.total, 100);
                     assert.equals(e.loaded, 100);
-                    assert.equals(e.constructor.name, "ProgressEvent");
                     done();
                 });
 
@@ -1464,8 +1462,7 @@
 
             "error event is triggered with xhr.uploadError(new Error('foobar'))": function(done) {
                 this.xhr.upload.addEventListener("error", function(e) {
-                    assert.equals(e.message, "foobar");
-                    assert.equals(e.constructor.name, "ErrorEvent");
+                    assert.equals(e.detail.message, "foobar");
 
                     done();
                 });


### PR DESCRIPTION
I've added support for HTML 5 upload events to the FakeXMLHttpRequest. Here's an issue requesting/discussing functionality:

https://github.com/cjohansen/Sinon.JS/issues/185

Please let me know if there are any changes I can make, to get you pumped about pulling this in :thumbsup: 

**Reading**
- MDN article discussing upload functionality: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Monitoring_progress
- RFC outlining progress events: http://www.w3.org/TR/progress-events/#progresseventinit
