### PR TITLE
Fixes a Firefox test failure

### DIFF
--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -89,7 +89,11 @@ buster.testCase("sinon", {
 
         "originating stack traces": {
             requiresSupportFor: {
-                "stack traces": !!(new Error("").stack)
+                "stack traces": !!(new Error("").stack),
+                "error message in stack traces": function() {
+                    var error = new Error("foo");
+                    return error.stack && error.stack.match(/foo/);
+                }
             },
 
             "throws with stack trace showing original wrapMethod call": function () {


### PR DESCRIPTION
This fixes the test failure described at #342. I'm not sure this is the way to go but feature detection seemed like a good idea.

![tests-pass](https://f.cloud.github.com/assets/208469/1502233/bd44dac2-4897-11e3-9bca-2131e3f85482.png)

Cheers,
Arnaud.
