### PR TITLE
Fix #342 Originating stack traces are properly set

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -91,6 +91,8 @@ var sinon = (function (buster) {
             var owned = hasOwn.call(object, property);
             object[property] = method;
             method.displayName = property;
+            // Set up a stack trace which can be used later to find what line of
+            // code the original method was created on.
             method._stack = (new Error('Stack Trace for original')).stack;
 
             method.restore = function () {

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -88,8 +88,19 @@ buster.testCase("sinon", {
         },
 
         "originating stack traces": {
-            requiresSupportFor: {
-                "stack traces": !!(new Error("").stack)
+
+            setUp: function () {
+                this.oldError = Error;
+                this.oldTypeError = TypeError;
+                var i = 0;
+                Error = TypeError = function () {
+                    this.stack = ':STACK' + ++i + ':';
+                }
+            },
+
+            tearDown: function () {
+                Error = this.oldError;
+                TypeError = this.oldTypeError;
             },
 
             "throws with stack trace showing original wrapMethod call": function () {
@@ -99,7 +110,7 @@ buster.testCase("sinon", {
                 try {
                     sinon.wrapMethod(object, "method", function () {});
                 } catch(e) {
-                    assert.match(e.stack, /Stack Trace for original/);
+                    assert.equals(e.stack, ':STACK2:\n--------------\n:STACK1:');
                 }
             }
         },


### PR DESCRIPTION
I rewrote the test because simply adding the try-catch was still making it fail. I think the new test and the new code does clear up a lot of the confusion now though.

Fixes #342
