### PR TITLE
Add AMD define if in an AMD environment

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -321,8 +321,13 @@ var sinon = (function (buster) {
     };
 
     var isNode = typeof module !== "undefined" && module.exports;
+    var isAMD = typeof define === 'function' && typeof define.amd === 'object' && define.amd;
 
-    if (isNode) {
+    if (isAMD) {
+        define(function(){
+            return sinon;
+        });
+    } else if (isNode) {
         try {
             buster = { format: require("buster-format") };
         } catch (e) {}


### PR DESCRIPTION
Adding the `define` allows AMD environments to know when Sinon is loaded.
