### PR TITLE
Auto-respond to successive requests made with a single XHR object

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -105,16 +105,16 @@ sinon.fakeServer = (function () {
 
             xhrObj.onSend = function () {
                 server.handleRequest(this);
+
+                if (server.autoRespond && !server.responding) {
+                    setTimeout(function () {
+                        server.responding = false;
+                        server.respond();
+                    }, server.autoRespondAfter || 10);
+
+                    server.responding = true;
+                }
             };
-
-            if (this.autoRespond && !this.responding) {
-                setTimeout(function () {
-                    server.responding = false;
-                    server.respond();
-                }, this.autoRespondAfter || 10);
-
-                this.responding = true;
-            }
         },
 
         getHTTPMethod: function getHTTPMethod(request) {

--- a/test/sinon/util/fake_server_test.js
+++ b/test/sinon/util/fake_server_test.js
@@ -674,6 +674,39 @@ buster.testCase("sinon.fakeServer", {
 
             this.clock.tick(1);
             assert.isTrue(request.respond.calledOnce);
+        },
+
+        "auto-responds if two successive requests are made with a single XHR": function () {
+            this.server.autoRespond = true;
+
+            var request = this.get("/path");
+
+            this.clock.tick(10);
+
+            assert.isTrue(request.respond.calledOnce);
+
+            request.open("get", "/other", true);
+            request.send();
+
+            this.clock.tick(10);
+
+            assert.isTrue(request.respond.calledTwice);
+        },
+
+        "auto-responds if timeout elapses between creating a XHR object and sending a request with it": function () {
+            this.server.autoRespond = true;
+
+            var request = new sinon.FakeXMLHttpRequest();
+            sinon.spy(request, "respond");
+
+            this.clock.tick(100);
+
+            request.open("get", "/path", true);
+            request.send();
+
+            this.clock.tick(10);
+
+            assert.isTrue(request.respond.calledOnce);
         }
     }
 });


### PR DESCRIPTION
fakeServer's auto-respond feature does not work for code that caches a single XHR instance and does several requests with it. 

The problem is that the auto-respond timeout starts ticking right after the XHR object is created, not when the request is actually sent.

This simple patch fixes that. Tests included.
