### PR TITLE
Adding `stub.safe()` functionality

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -91,6 +91,7 @@ var sinon = (function (buster) {
             var owned = hasOwn.call(object, property);
             object[property] = method;
             method.displayName = property;
+            method.arity = wrappedMethod.length;
             // Set up a stack trace which can be used later to find what line of
             // code the original method was created on.
             method._stack = (new Error('Stack Trace for original')).stack;

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -77,6 +77,10 @@
         proto = {
             create: function create() {
                 var functionStub = function () {
+                    var behavior = getCurrentBehavior(functionStub);
+                    if (functionStub._safe && functionStub.arity < arguments.length) {
+                      throw new ArityError("Attempted to call function of arity " + functionStub.arity +  " with " + arguments.length + " arguments.");
+                    }
                     return getCurrentBehavior(functionStub).invoke(this, arguments);
                 };
 
@@ -111,6 +115,11 @@
                         this.fakes[i].resetBehavior();
                     }
                 }
+            },
+
+            safe: function () {
+              this._safe = true;
+              return this;
             },
 
             onCall: function(index) {
@@ -152,6 +161,13 @@
 
         return proto;
     }()));
+
+    function ArityError(message) {
+      this.name = "ArityError";
+      this.message = message || "Function called with too many arguments.";
+    }
+    ArityError.prototype = new Error();
+    ArityError.prototype.constructor = ArityError;
 
     if (commonJSModule) {
         module.exports = stub;

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -1499,6 +1499,23 @@ buster.testCase("sinon.stub", {
         assert(spy.calledTwice);
     },
 
+    "safe": {
+        "protects against calls with unsafe arity": function () {
+            var stubObj = { stubFn: function (one) {} };
+            var stub = sinon.stub(stubObj, 'stubFn').safe();
+            assert.exception(function () {
+              stub(1, 2);
+            }, "ArityError");
+        },
+
+        "allows calls with correct arity": function () {
+            var stubObj = { stubFn: function (one) {} };
+            var stub = sinon.stub(stubObj, 'stubFn').safe();
+            stub(1);
+            assert(stub.calledOnce);
+        }
+    },
+
     "resetBehavior": {
         "clears yields* and callsArg* sequence": function () {
             var stub = sinon.stub().yields(1);


### PR DESCRIPTION
Sinon's stubs already protect against API drift by checking an object
for the existance of a property name before stubbing the property. (If a
target object no longer implements a property, existing tests which
stub that property will fail). But there's currently no protection
against an API decreasing its number of accepted arguments. For example,
image a stub that expects an interface will be called with `foo, bar`;
if the target interface's signature changes from accepting `foo, bar` to
accepting an options hash, the test will continue being green.

Because it's sometimes desirable in JavaScript to allow more arguments
than a function signature expects, there can't be a universal check of
target function arity. Instead, this PR adds a new `safe` method to
stubs, which turns an arity check on. If a target function's signature
changes to accept less arguments than a test with `safe` supplies, the
test will turn red, further protecting against API drift.
