### PR TITLE
Added withCredentials property to fake xhr

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -29,6 +29,7 @@
     xhr.supportsXHR = typeof xhr.GlobalXMLHttpRequest != "undefined";
     xhr.workingXHR = xhr.supportsXHR ? xhr.GlobalXMLHttpRequest : xhr.supportsActiveX
                                      ? function() { return new xhr.GlobalActiveXObject("MSXML2.XMLHTTP.3.0") } : false;
+    xhr.supportsCORS = 'withCredentials' in (new sinon.xhr.GlobalXMLHttpRequest());
 
     /*jsl:ignore*/
     var unsafeHeaders = {
@@ -60,7 +61,10 @@
         this.status = 0;
         this.statusText = "";
         this.upload = new UploadProgress();
-        this.withCredentials = false;
+        if (sinon.xhr.supportsCORS) {
+            this.withCredentials = false;
+        }
+
 
         var xhr = this;
         var events = ["loadstart", "load", "abort", "loadend"];

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -67,6 +67,17 @@
             assert.same(onCreate.getCall(0).args[0], xhr);
         },
 
+        "withCredentials": {
+            setUp: function () {
+                this.xhr = new sinon.FakeXMLHttpRequest();
+            },
+
+            "property is set if we support standards CORS": function () {
+                assert.equals(sinon.xhr.supportsCORS, "withCredentials" in this.xhr);
+            }
+
+        },
+
         "open": {
             setUp: function () {
                 this.xhr = new sinon.FakeXMLHttpRequest();
@@ -84,7 +95,7 @@
                 assert.isTrue(this.xhr.async);
                 assert.equals(this.xhr.username, "cjno");
                 assert.equals(this.xhr.password, "pass");
-                assert.equals(this.xhr.withCredentials, false);
+
             },
 
             "is async by default": function () {


### PR DESCRIPTION
Cross browser pattern to detect if CORS is supported is to create a XHR using XMLHTTPRequest2 and see if “withCredentials” property is present. Without this property, tests that use fake XHR will go through the code path assuming that CORS is not supported. For example, the code below will ways always return null since the fake xhr in sinon.js does not have withCredentials.

``` javascript
function createCORSRequest(method, url) {
  var xhr = new XMLHttpRequest();
  if ("withCredentials" in xhr) {
    //xhr2
    xhr.open(method, url, true);

  } else if (typeof XDomainRequest != "undefined") {
    //xDomain only exists in IE
    xhr = new XDomainRequest();
    xhr.open(method, url);

  } else {

    // CORS is not supported by the browser.
    xhr = null;

  }
  return xhr;
}

```
