### PR TITLE
Avoid useless formatting before logging

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -275,6 +275,12 @@ var sinon = (function (buster) {
             });
         },
 
+        log: function () {
+		        var log = function() {};
+				log.noop = true;
+				return log;
+		    }(),
+		
         logError: function (label, err) {
             var msg = label + " threw exception: "
             if (sinon.log) {

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -78,7 +78,7 @@ sinon.fakeServer = (function () {
     }
 
     function log(response, request) {
-        if (sinon.log) {
+        if (!sinon.log.noop) {
             var str;
 
             str =  "Request:\n"  + sinon.format(request)  + "\n\n";

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -443,6 +443,14 @@ buster.testCase("sinon", {
         }
     },
 
+    "log": {
+        "does nothing gracefully": function () {
+            refute.exception(function () {
+                sinon.log("Oh, hiya");
+            });
+        }
+    },
+
     "format": {
         "formats with buster by default": function () {
             assert.equals(sinon.format({ id: 42 }), "{ id: 42 }");


### PR DESCRIPTION
I have a use-case where sinon.format was taking an extended amount of time. In IE7, when loading a big (30000 characters) file, the format was performed unnecessarily. As sinon.log was undocumented, I removed it and protected the code that was calling it. 
