### PR TITLE
When creating a sandbox, do not overwrite existing properties when injecting properties into an object

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -30,7 +30,7 @@ if (typeof module !== 'undefined' && module.exports) {
             return;
         }
 
-        if (config.injectInto) {
+        if (config.injectInto && !(key in config.injectInto) ) {
             config.injectInto[key] = value;
         } else {
             push.call(sandbox.args, value);

--- a/test/sinon/sandbox_test.js
+++ b/test/sinon/sandbox_test.js
@@ -297,6 +297,22 @@ if (typeof require == "function" && typeof module == "object") {
                 assert.mock(sandbox.args[1]({}));
             },
 
+            "does not inject properties if they are already present": function() {
+                var server = function(){},
+                    clock = {},
+                    spy = false,
+                    object = { server: server, clock: clock, spy: spy};
+
+                sinon.sandbox.create(sinon.getConfig({
+                    properties: ["server", "clock", "spy"],
+                    injectInto: object
+                }));
+
+                assert.same(object.server, server);
+                assert.same(object.clock, clock);
+                assert.same(object.spy, spy);
+            },
+
             "ajax options": {
                 requiresSupportFor: { "ajax/browser": supportsAjax },
 


### PR DESCRIPTION
The problem:
Currently, we have thousands of QUnit + Sinon tests. Some of them are using sandboxes, created in the setup and saved into "this.sandbox". We would like to use sinon-qunit, but it breaks those tests that are using sandboxes ("this.sandbox" is overwritten therefore we cannot restore the stubs created in the setup using the original sandbox)

The fix:
When injecting properties into 'this', only inject the property if it is not already there. In our case, tests that were previously using "this.sandbox" can still use that object to create/restore stubs.
