### PR TITLE
Set returnValues correctly when the spied function is called as a constructor

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -154,6 +154,11 @@
                 } else {
                     returnValue = (this.func || func).apply(thisValue, args);
                 }
+
+                var thisCall = this.getCall(this.callCount - 1);
+                if (thisCall.calledWithNew() && typeof returnValue !== 'object') {
+                    returnValue = thisValue;
+                }
             } catch (e) {
                 push.call(this.returnValues, undefined);
                 exception = e;

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -1324,6 +1324,36 @@ if (typeof require === "function" && typeof module === "object") {
                 refute.defined(spy.returnValues[0]);
             },
 
+            "contains the created object for spied constructors": function () {
+                var spy = sinon.spy.create(function() { });
+
+                var result = new spy();
+
+                assert.equals(spy.returnValues[0], result);
+            },
+
+            "contains the return value for spied constructors that explicitly return objects": function () {
+                var spy = sinon.spy.create(function() {
+                    return { isExplicitlyCreatedValue: true };
+                });
+
+                var result = new spy();
+
+                assert.isTrue(result.isExplicitlyCreatedValue);
+                assert.equals(spy.returnValues[0], result);
+            },
+
+            "contains the created object for spied constructors that explicitly return primitive values": function () {
+                var spy = sinon.spy.create(function() {
+                    return 10;
+                });
+
+                var result = new spy();
+
+                refute.equals(result, 10);
+                assert.equals(spy.returnValues[0], result);
+            },
+
             "stacks up return values": function () {
                 var calls = 0;
 


### PR DESCRIPTION
This patch changes Sinon to fix #351. Now, when working out the return value of a spied method, we check whether it's being called with new, and whether the method didn't explicitly return an object value, and if so we update the return value to be the constructed object instead.

I'm happy personally that all of this works and with the tests themselves, but I feel like the `thisCall = ...` bit is slightly messy. I've not played with Sinon's internals before now, and I can't find a nicer way to do this, but if you do have any suggestions I'd be very happy to hear them!
