### PR TITLE
Drop unnecessary extra getHTTPMethod call

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -57,7 +57,6 @@ sinon.fakeServer = (function () {
     }
 
     function match(response, request) {
-        var requestMethod = this.getHTTPMethod(request);
         var requestUrl = request.url;
 
         if (!/^https?:\/\//.test(requestUrl) || rCurrLoc.test(requestUrl)) {


### PR DESCRIPTION
Minor, but there's one last extra line I missed in my previous tidy up (#367), sorry. Currently this tests the request method and parses the body twice for each request, but never looks at the first result; this drops that entirely.
