### PR TITLE
Handle stubbing falsey properties

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -39,11 +39,11 @@
             wrapper = stub.create();
         }
 
-        if (!object && !property) {
+        if (!object && typeof property === "undefined") {
             return sinon.stub.create();
         }
 
-        if (!property && !!object && typeof object == "object") {
+        if (typeof property === "undefined" && typeof object == "object") {
             for (var prop in object) {
                 if (typeof object[prop] === "function") {
                     stub(object, prop);

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -576,6 +576,16 @@ buster.testCase("sinon.stub", {
             assert.equals(obj.someProp, 42);
         },
 
+        "successfully stubs falsey properties": function () {
+            var obj = { 0: function() { } };
+
+            sinon.stub(obj, 0, function () {
+                return "stubbed value";
+            });
+
+            assert.equals(obj[0](), "stubbed value");
+        },
+
         "does not stub function object": function () {
             assert.exception(function () {
                 sinon.stub(function () {});


### PR DESCRIPTION
This fixes #251, so you can stub x[0].
