### PR TITLE
Fix setInterval test name typo

### DIFF
--- a/test/sinon/util/fake_timers_test.js
+++ b/test/sinon/util/fake_timers_test.js
@@ -458,7 +458,7 @@ buster.testCase("sinon.clock", {
         }
     },
 
-    "terval": {
+    "setInterval": {
         setUp: function () {
             this.clock = sinon.clock.create();
         },


### PR DESCRIPTION
Very minor, but the test name for the setInterval tests is clearly wrong, so I've fixed it en route to some other unrelated stuff. This now lines up with the other tests in the file: setTimeout, clearTimeout, etc.
