### PR TITLE
Fix restoring globals on another frame fails on Firefox

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -87,8 +87,9 @@ var sinon = (function (buster) {
                 throw error;
             }
 
-            // IE 8 does not support hasOwnProperty on the window object.
-            var owned = hasOwn.call(object, property);
+            // IE 8 does not support hasOwnProperty on the window object and Firefox has a problem
+            // when using hasOwn.call on objects from other frames.
+            var owned = object.hasOwnProperty ? object.hasOwnProperty(property) : hasOwn.call(object, property);
             object[property] = method;
             method.displayName = property;
             // Set up a stack trace which can be used later to find what line of


### PR DESCRIPTION
We are using `sinon` across frames in the same domain and when we try to stub and restore globals on another frame, they become `undefined` since `hasOwnProperty` check fails and sinon deletes the global instead of restoring it.
