### PR TITLE
Since 'juicer' is a generic term, it might make sense to add 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Standalone and test framework agnostic JavaScript test spies, stubs and mocks.
 via [npm (node package manager)](http://github.com/isaacs/npm)
 
     $ npm install sinon
-    
+
 via [NuGet (package manager for Microsoft development platform)](https://www.nuget.org/packages/SinonJS)
 
     Install-Package SinonJS
@@ -54,9 +54,12 @@ Node installed, and install Sinon's dependencies:
 ### In the browser
 
 Open `test/sinon.html` in a browser. To test against a built distribution, first
-make sure you have a build (requires Ruby and Juicer):
+make sure you have a build (requires [Ruby][ruby] and [Juicer][juicer]):
 
     $ ./build
+
+[ruby]: https://www.ruby-lang.org/en/
+[juicer]: http://rubygems.org/gems/juicer
 
 Then open `test/sinon-dist.html` in a browser.
 

--- a/build
+++ b/build
@@ -2,7 +2,7 @@
 begin
   require "juicer/merger/javascript_merger"
 rescue LoadError => err
-  puts "Install juicer to build Sinon.JS"
+  puts "Install juicer ruby gem to build Sinon.JS. Try `gem install juicer`."
   if !defined?(Gem)
     puts "RubyGems is not loaded. Perhaps that is why juicer can not be found?"
   end


### PR DESCRIPTION
... specific info on how to install juicer in the error output too.

This took an hour of my time to find out (googling for "juicer" gave me all kinds of stuff including images of actual juicers and blenders :) )

I've also added links to ruby, and juicer in the README file.
