### PR TITLE
Add clearImmediate mocking support to the timers API

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -142,6 +142,10 @@ if (typeof sinon == "undefined") {
             return addTimer.call(this, [callback, 0].concat(passThruArgs), false);
         },
 
+        clearImmediate: function clearImmediate(timerId) {
+            this.clearTimeout(timerId);
+        },
+
         tick: function tick(ms) {
             ms = typeof ms == "number" ? ms : parseTime(ms);
             var tickFrom = this.now, tickTo = this.now + ms, previous = this.now;
@@ -303,6 +307,10 @@ if (typeof sinon == "undefined") {
         methods.push("setImmediate");
     }
 
+    if (typeof global.clearImmediate !== "undefined") {
+        methods.push("clearImmediate");
+    }
+
     function restore() {
         var method;
 
@@ -366,6 +374,7 @@ sinon.timers = {
     setTimeout: setTimeout,
     clearTimeout: clearTimeout,
     setImmediate: (typeof setImmediate !== "undefined" ? setImmediate : undefined),
+    clearImmediate: (typeof clearImmediate !== "undefined" ? clearImmediate: undefined),
     setInterval: setInterval,
     clearInterval: clearInterval,
     Date: Date

--- a/lib/sinon/util/timers_ie.js
+++ b/lib/sinon/util/timers_ie.js
@@ -15,6 +15,7 @@
 function setTimeout() {}
 function clearTimeout() {}
 function setImmediate() {}
+function clearImmediate() {}
 function setInterval() {}
 function clearInterval() {}
 function Date() {}
@@ -24,6 +25,7 @@ function Date() {}
 setTimeout = sinon.timers.setTimeout;
 clearTimeout = sinon.timers.clearTimeout;
 setImmediate = sinon.timers.setImmediate;
+clearImmediate = sinon.timers.clearImmediate;
 setInterval = sinon.timers.setInterval;
 clearInterval = sinon.timers.clearInterval;
 Date = sinon.timers.Date;

--- a/test/sinon/test_test.js
+++ b/test/sinon/test_test.js
@@ -392,8 +392,9 @@ buster.testCase("sinon.test", {
                     Date: Date,
                     setTimeout: setTimeout,
                     clearTimeout: clearTimeout,
-                    // setImmediate is not yet available in all environments
+                    // clear & setImmediate are not yet available in all environments
                     setImmediate: (typeof setImmediate !== "undefined" ? setImmediate : undefined),
+                    clearImmediate: (typeof clearImmediate !== "undefined" ? clearImmediate : undefined),
                     setInterval: setInterval,
                     clearInterval: clearInterval
                 };
@@ -403,6 +404,7 @@ buster.testCase("sinon.test", {
             refute.same(props.setTimeout, sinon.timers.setTimeout);
             assert.same(props.clearTimeout, sinon.timers.clearTimeout);
             assert.same(props.setImmediate, sinon.timers.setImmediate);
+            assert.same(props.clearImmediate, sinon.timers.clearImmediate);
             assert.same(props.setInterval, sinon.timers.setInterval);
             assert.same(props.clearInterval, sinon.timers.clearInterval);
         },

--- a/test/sinon/util/fake_timers_test.js
+++ b/test/sinon/util/fake_timers_test.js
@@ -145,6 +145,22 @@ buster.testCase("sinon.clock", {
         }
     },
 
+    "clearImmediate": {
+        setUp: function () {
+            this.clock = sinon.clock.create();
+        },
+
+        "removes immediate callbacks": function () {
+            var callback = sinon.stub.create();
+
+            var id = this.clock.setImmediate(callback);
+            this.clock.clearImmediate(id);
+            this.clock.tick(1);
+
+            assert.isFalse(callback.called);
+        }
+    },
+
     "tick": {
         setUp: function () {
             this.clock = sinon.useFakeTimers(0);


### PR DESCRIPTION
This is the other half of #372, and extends the timers the same way to add clearImmediate in too.
