### PR TITLE
Fake XHR: set status before readyState HEADERS_RECEIVED

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -435,9 +435,9 @@
         },
 
         respond: function respond(status, headers, body) {
-            this.setResponseHeaders(headers || {});
             this.status = typeof status == "number" ? status : 200;
             this.statusText = FakeXMLHttpRequest.statusCodes[this.status];
+            this.setResponseHeaders(headers || {});
             this.setResponseBody(body || "");
         },
 

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -688,6 +688,20 @@
                 this.xhr.respond(200, {}, "'tis some body text");
 
                 assert.equals(this.xhr.onreadystatechange.callCount, 4);
+            },
+
+            "sets status before transitioning to readyState HEADERS_RECEIVED": function () {
+                var status, statusText;
+                this.xhr.onreadystatechange = function () {
+                    if (this.readyState == 2) {
+                        status = this.status;
+                        statusText = this.statusText;
+                    }
+                };
+                this.xhr.respond(204);
+
+                assert.equals(status, 204);
+                assert.equals(statusText, "No Content");
             }
         },
 


### PR DESCRIPTION
Just a small fix for Sinon's fake XHR. This PR ensures that both status and headers are available when transitioning `readyState` to `HEADERS_RECEIVED` as described in the [W3C working draft of XHR](http://www.w3.org/TR/XMLHttpRequest/#response) and in the [XHR reference on MDN](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#Properties).
