### PR TITLE
Add sinon.assert.match

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -159,9 +159,9 @@
                 assert.pass("match");
             } else {
                 var formatted = [
-                    "expected value to match:",
-                    "expected = " + sinon.format(expectation),
-                    "actual = " + sinon.format(actual)
+                    "expected value to match",
+                    "    expected = " + sinon.format(expectation),
+                    "    actual = " + sinon.format(actual)
                 ]
                 failAssertion(this, formatted.join("\n"));
             }

--- a/test/sinon/assert_test.js
+++ b/test/sinon/assert_test.js
@@ -1368,6 +1368,13 @@ buster.testCase("sinon.assert", {
             assert.equals(this.message("alwaysThrew", this.obj.doSomething),
                           "doSomething did not always throw exception\n" +
                           "    doSomething(1, 3, hey)\n    doSomething(1, 3)");
+        },
+
+        "assert.match exception message": function () {
+            assert.equals(this.message("match", { foo: 1 }, [1, 3]),
+                          "expected value to match\n" +
+                          "    expected = [1, 3]\n" +
+                          "    actual = { foo: 1 }");
         }
     }
 });


### PR DESCRIPTION
Makes it possible to use the Sinon matcher API on arbitrary data,
without a spy having been called.
