### PR TITLE
Fix onload call, 'this' should be equal to XHR object

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -75,7 +75,7 @@
                 var listener = xhr["on" + eventName];
 
                 if (listener && typeof listener == "function") {
-                    listener(event);
+                    listener.call(this, event);
                 }
             });
         }

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -643,6 +643,20 @@
                 assert.equals(this.spy.callCount, 1);
             },
 
+            "fire onload event with this set to the XHR object": function (done) {
+                var xhr = new sinon.FakeXMLHttpRequest();
+                xhr.open("GET", "/");
+
+                xhr.onload = function() {
+                    assert.same(this, xhr);
+
+                    done();
+                };
+
+                xhr.send();
+                xhr.respond(200, {}, "");
+            },
+
             "calls readystate handler with readyState DONE once": function () {
                 this.xhr.respond(200, {}, "");
 


### PR DESCRIPTION
With `"use strict"` the `this` object will be undefined when onload is called. This PR takes care of that issue.
