### PR TITLE
Prevent setRequestHeaders from being called twice (like setRequestBody)

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -214,6 +214,12 @@
     };
     FakeXMLHttpRequest.useFilters = false;
 
+    function verifyRequestOpened(xhr) {
+        if (xhr.readyState != FakeXMLHttpRequest.OPENED) {
+            throw new Error("INVALID_STATE_ERR - " + xhr.readyState);
+        }
+    }
+
     function verifyRequestSent(xhr) {
         if (xhr.readyState == FakeXMLHttpRequest.DONE) {
             throw new Error("Request done");
@@ -301,6 +307,7 @@
 
         // Helps testing
         setResponseHeaders: function setResponseHeaders(headers) {
+            verifyRequestOpened(this);
             this.responseHeaders = {};
 
             for (var header in headers) {

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -456,6 +456,18 @@
                 this.xhr.setResponseHeaders(object);
 
                 assert.equals(this.xhr.readyState, sinon.FakeXMLHttpRequest.HEADERS_RECEIVED);
+            },
+
+            "throws if headers were already set": function () {
+                var xhr = this.xhr;
+
+                xhr.open("GET", "/", false);
+                xhr.send();
+                xhr.setResponseHeaders({});
+
+                assert.exception(function () {
+                    xhr.setResponseHeaders({});
+                });
             }
         },
 


### PR DESCRIPTION
I added a missing verification to stop `setResponseHeaders` from setting the `readyState` from 3 and 4 to 2. This fixes #402.
