### PR TITLE
Adding functionality to test against sparse arrays

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -186,6 +186,10 @@ var sinon = (function (formatio) {
                 }
             }
 
+            if (aString == "[object Array]") {
+                return true;
+            }
+
             for (prop in b) {
                 bLength += 1;
             }

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -265,6 +265,13 @@ buster.testCase("sinon", {
             assert(sinon.deepEqual(arr1, arr2));
         },
 
+        "passes when comparing lengths of sparse array": function () {
+            var arr1 = new [].constructor(2);
+            var arr2 = [undefined, undefined];
+
+            assert(sinon.deepEqual(arr1, arr2));
+        },
+
         "passes equal arrays with custom properties": function () {
             var arr1 = [1, 2, 3, "hey", "there"];
             var arr2 = [1, 2, 3, "hey", "there"];


### PR DESCRIPTION
I ran into an issue with the following:

`spy.calledWith([2,undefined])`

which failed because I was creating the array using the following in the code being tested:

```
var array  = new [].constructor(1);
array.splice(0,0,2);
spy(array);
```

This was because it won't loop over the sparse elements using a for in loop.

The issue can also be resolved by creating the array in a similar fashion in calledWith argument, however it seemed to be a comparison issue as the lengths are actually equal.
