### PR TITLE
Explicate dependency on util package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "prepublish": "./build"
     },
     "dependencies": {
-        "formatio": "~1.0"
+        "formatio": "~1.0",
+        "util": "^0.10.3"
     },
     "devDependencies": {
         "buster-core": ">=0.6.4",


### PR DESCRIPTION
[Mr](https://github.com/montagejs/mr) and [Mop](https://github.com/montagejs/mop) serve a similar function to [Browserify](https://github.com/substack/node-browserify) but
supports refresh-to-reload during development using Mr and whole package
application transformation with Mop. Thus a build step is not necessary
during development, and transforming packages for use in production does
not require any configuration changes in source. These loaders support
Node.js modules and packages with very high fidelity, inferring where
npm installed packages, but with one major caveat, unlike Browserify, Mr
does not assume that the running environment has Node.js global modules.
This is easily rectified by explicating the dependency on the
corresponding package from npm.
