### PR TITLE
fake timer creation returns an object having .ref() and .unref() calls, ...

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -23,14 +23,14 @@ if (typeof sinon == "undefined") {
     var sinon = {};
 }
 
-// node expects setTimeout/setInterval to return a fn object w/ .ref()/.unref()
-// browsers, a number.
-// see https://github.com/cjohansen/Sinon.JS/pull/436
-var timeoutResult = setTimeout(function() {}, 0);
-var addTimerReturnsObject = typeof timeoutResult === 'object';
-clearTimeout(timeoutResult);
-
 (function (global) {
+    // node expects setTimeout/setInterval to return a fn object w/ .ref()/.unref()
+    // browsers, a number.
+    // see https://github.com/cjohansen/Sinon.JS/pull/436
+    var timeoutResult = setTimeout(function() {}, 0);
+    var addTimerReturnsObject = typeof timeoutResult === 'object';
+    clearTimeout(timeoutResult);
+
     var id = 1;
 
     function addTimer(args, recurring) {

--- a/test/sinon/util/fake_timers_test.js
+++ b/test/sinon/util/fake_timers_test.js
@@ -857,9 +857,14 @@ buster.testCase("sinon.clock", {
 
             var to = setTimeout(stub, 1000);
 
-            assert.isNumber(to.id);
-            assert.isFunction(to.ref);
-            assert.isFunction(to.unref);
+            if (typeof (setTimeout(function() {}, 0)) === 'object') {
+                assert.isNumber(to.id);
+                assert.isFunction(to.ref);
+                assert.isFunction(to.unref);
+            }
+            else {
+                assert.isNumber(to);
+            }
         },
 
         "replaces global clearTimeout": function () {


### PR DESCRIPTION
...so that

nodejs timer functionality can be supported
