### PR TITLE
Fix an issue passing NaN to spy#calledWith (Issue #441)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Ben Hockey, neonstalwart@gmail.com
 Benjamin Coe, ben@yesware.com
 Blaine Bublitz, blaine@iceddev.com
 Blake Embrey, hello@blakeembrey.com
+Blake Israel, blake@blakeisrael.com
 Brandon Heyer, brandonheyer@gmail.com
 Burak Yiğit Kaya, ben@byk.im
 Christian Johansen, christian@cjohansen.no

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,7 @@
+== 1.9.1 / 2014-??-??
+
+* Fix an issue passing `NaN` to `calledWith`
+
 == 1.9.0 / 2014-03-05
 
 * Add sinon.assert.match (Robin Pedersen)

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -41,6 +41,10 @@ var sinon = (function (formatio) {
         return typeof obj === "function" || !!(obj && obj.constructor && obj.call && obj.apply);
     }
 
+    function isReallyNaN(val) {
+        return typeof val === 'number' && isNaN(val);
+    }
+
     function mirrorProperties(target, source) {
         for (var prop in source) {
             if (!hasOwn.call(target, prop)) {
@@ -142,8 +146,13 @@ var sinon = (function (formatio) {
             if (sinon.match && sinon.match.isMatcher(a)) {
                 return a.test(b);
             }
-            if (typeof a != "object" || typeof b != "object") {
-                return a === b;
+
+            if (typeof a != 'object' || typeof b != 'object') {
+                if (isReallyNaN(a) && isReallyNaN(b)) {
+                    return true;
+                } else {
+                    return a === b;
+                }
             }
 
             if (isElement(a) || isElement(b)) {
@@ -159,7 +168,7 @@ var sinon = (function (formatio) {
             }
 
             if (a instanceof RegExp && b instanceof RegExp) {
-              return (a.source === b.source) && (a.global === b.global) && 
+              return (a.source === b.source) && (a.global === b.global) &&
                 (a.ignoreCase === b.ignoreCase) && (a.multiline === b.multiline);
             }
 

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -363,6 +363,10 @@ buster.testCase("sinon", {
 
         },
 
+        "passes NaN and NaN": function () {
+            assert(sinon.deepEqual(NaN, NaN));
+        },
+
         "passes equal objects": function () {
             var obj1 = { a: 1, b: 2, c: 3, d: "hey", e: "there" };
             var obj2 = { b: 2, c: 3, a: 1, d: "hey", e: "there" };


### PR DESCRIPTION
Fixes issue in linked Issue #441

isReallyNaN function is needed because `undefined` also appears as `NaN` to `isNaN`.

Includes test case addition, changelog addition and authors addition (of myself).

Builds and tests (but there are 2 tests failing from master that are there before this change)
