### PR TITLE
Matching multiple arguments at once

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -45,9 +45,13 @@
         },
 
         calledWith: function calledWith() {
-            for (var i = 0, l = arguments.length; i < l; i += 1) {
-                if (!sinon.deepEqual(arguments[i], this.args[i])) {
-                    return false;
+            if (1 == arguments.length && sinon.match && sinon.match.isMatcher(arguments[0])) {
+                return arguments[0].test.apply(sinon, this.args);
+            } else {
+                for (var i = 0, l = arguments.length; i < l; i += 1) {
+                    if (!sinon.deepEqual(arguments[i], this.args[i])) {
+                        return false;
+                    }
                 }
             }
 

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -196,6 +196,13 @@
         }, "instanceOf(" + sinon.functionName(type) + ")");
     };
 
+    match.all = function (expectation, message) {
+        message = message || 'custom matcher (sinon.match.all)';
+        var m = match(expectation, message);
+        m.name = 'sinon.match.all';
+        return m;
+    };
+
     function createPropertyMatcher(propertyTest, messagePrefix) {
         return function (property, value) {
             assertType(property, "string", "property");

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -221,6 +221,10 @@
             }
         }
 
+        function matchAllArgs(args) {
+            return (1 == args.length && match && match.isMatcher(args[0]) && 'sinon.match.all' == args[0].name);
+        }
+
         return {
             minCalls: 1,
             maxCalls: 1,
@@ -329,16 +333,23 @@
                         "), expected " + sinon.format(this.expectedArguments));
                 }
 
-                for (var i = 0, l = this.expectedArguments.length; i < l; i += 1) {
-
-                    if (!verifyMatcher(this.expectedArguments[i],args[i])) {
+                if (matchAllArgs(this.expectedArguments)) {
+                    if (!this.expectedArguments[0].test.apply(sinon, args)) {
                         sinon.expectation.fail(this.method + " received wrong arguments " + sinon.format(args) +
                             ", didn't match " + this.expectedArguments.toString());
                     }
+                } else {
+                    for (var i = 0, l = this.expectedArguments.length; i < l; i += 1) {
 
-                    if (!sinon.deepEqual(this.expectedArguments[i], args[i])) {
-                        sinon.expectation.fail(this.method + " received wrong arguments " + sinon.format(args) +
-                            ", expected " + sinon.format(this.expectedArguments));
+                        if (!verifyMatcher(this.expectedArguments[i],args[i])) {
+                            sinon.expectation.fail(this.method + " received wrong arguments " + sinon.format(args) +
+                                ", didn't match " + this.expectedArguments.toString());
+                        }
+
+                        if (!sinon.deepEqual(this.expectedArguments[i], args[i])) {
+                            sinon.expectation.fail(this.method + " received wrong arguments " + sinon.format(args) +
+                                ", expected " + sinon.format(this.expectedArguments));
+                        }
                     }
                 }
             },
@@ -367,13 +378,17 @@
                     return false;
                 }
 
-                for (var i = 0, l = this.expectedArguments.length; i < l; i += 1) {
-                    if (!verifyMatcher(this.expectedArguments[i],args[i])) {
-                        return false;
-                    }
+                if (matchAllArgs(this.expectedArguments)) {
+                    return true;
+                } else {
+                    for (var i = 0, l = this.expectedArguments.length; i < l; i += 1) {
+                        if (!verifyMatcher(this.expectedArguments[i],args[i])) {
+                            return false;
+                        }
 
-                    if (!sinon.deepEqual(this.expectedArguments[i], args[i])) {
-                        return false;
+                        if (!sinon.deepEqual(this.expectedArguments[i], args[i])) {
+                            return false;
+                        }
                     }
                 }
 


### PR DESCRIPTION
These two commits makes it possible to match multiple arguments with a single matcher.

The first commit makes the following scenario work:

``` javascript
var obj = { foo: function() { }};
var ex = sinon.mock(obj).expects('foo');

obj.foo('bar', 'abc', 123);

sinon.assert.calledWith(ex, sinon.match(function(arg1, arg2, arg3) {
    return 'bar' == arg1
            && 'abc' == arg2
            && 123 == arg3;
}));
```

The second commit makes this, slighly less verbose, example work:

``` javascript
var obj = { foo: function() { }};
var mock = sinon.mock(obj);

mock.expects('foo').once()
    .withArgs(sinon.match.all(function(arg1, arg2, arg3) {
            return 'bar' == arg1 && 'abc' == arg2 && 123 == arg3;
    }));

obj.foo('bar', 'abc', 123);
```
