### PR TITLE
Fix wrapMethod error handling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ Maximilian Antoni, mail@maxantoni.de
 Michael Heim, heim@zeilenwechsel.de
 Michael Jackson, mjijackson@gmail.com
 Márton Salomváry, salomvary@gmail.com
+Nikita Litvin, deltaidea@derpy.ru
 Niklas Andreasson, eaglus_@hotmail.com
 Olmo Maldonado, olmo.maldonado@gmail.com
 Phred, fearphage@gmail.com

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -73,19 +73,15 @@ var sinon = (function (formatio) {
             if (!isFunction(wrappedMethod)) {
                 error = new TypeError("Attempted to wrap " + (typeof wrappedMethod) + " property " +
                                     property + " as function");
-            }
-
-            if (wrappedMethod.restore && wrappedMethod.restore.sinon) {
+            } else if (wrappedMethod.restore && wrappedMethod.restore.sinon) {
                 error = new TypeError("Attempted to wrap " + property + " which is already wrapped");
-            }
-
-            if (wrappedMethod.calledBefore) {
+            } else if (wrappedMethod.calledBefore) {
                 var verb = !!wrappedMethod.returns ? "stubbed" : "spied on";
                 error = new TypeError("Attempted to wrap " + property + " which is already " + verb);
             }
 
             if (error) {
-                if (wrappedMethod._stack) {
+                if (wrappedMethod && wrappedMethod._stack) {
                     error.stack += '\n--------------\n' + wrappedMethod._stack;
                 }
                 throw error;

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -45,6 +45,14 @@ buster.testCase("sinon", {
             assert.exception(function () {
                 sinon.wrapMethod(object, "prop", function () {});
             });
+
+            try {
+                sinon.wrapMethod(object, "prop", function () {});
+                throw new Error("Didn't throw");
+            } catch (e) {
+                assert.match(e.message,
+                    /Attempted to wrap .* property .* as function/);
+            }
         },
 
         "throws if third argument is missing": function () {


### PR DESCRIPTION
`sinon.wrapMethod` was actually failing with this error when the property wasn't defined:
`"Cannot read property 'restore' of undefined"`

It tried to access `wrappedMethod.restore` despite results of previous check if the `wrappedMethod` is a function.

This commit fixes this issue and the corresponding test.
