### PR TITLE
fix fakeServer.respond() in IE8 by properly allowing queue to be spliced

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -166,7 +166,7 @@ sinon.fakeServer = (function () {
         respond: function respond() {
             if (arguments.length > 0) this.respondWith.apply(this, arguments);
             var queue = this.queue || [];
-            var requests = queue.splice(0);
+            var requests = queue.splice(0, queue.length);
             var request;
 
             while(request = requests.shift()) {


### PR DESCRIPTION
The request `queue` was not being properly emptied in IE8 due to the ECMA3 required argument for `deleteCount` being omitted. See the [MSDN documentation](http://msdn.microsoft.com/en-us/library/wctc5k7s%28v=VS.85%29.aspx) for more details.
