### PR TITLE
Fix clearTimeout() for Node.js mode

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -138,7 +138,11 @@ if (typeof sinon == "undefined") {
             if (!this.timeouts) {
                 this.timeouts = [];
             }
-
+            // in Node, timerId is an object with .ref()/.unref(), and
+            // its .id field is the actual timer id.
+            if (typeof timerId === 'object') {
+              timerId = timerId.id
+            }
             if (timerId in this.timeouts) {
                 delete this.timeouts[timerId];
             }


### PR DESCRIPTION
In Node, `timerId` returned by `setTimeout()` is an object with `.ref()`/`.unref()`, and its `.id` field is the actual timer id. `clearTimeout()` needs to use the actual timer id to remove a timeout.
