### PR TITLE
update 'returns numeric id' tests for setTimeout, setImmediate and setInterval

### DIFF
--- a/test/sinon/util/fake_timers_test.js
+++ b/test/sinon/util/fake_timers_test.js
@@ -37,10 +37,13 @@ buster.testCase("sinon.clock", {
             assert.exception(function () { clock.setTimeout(); });
         },
 
-        "returns numeric id": function () {
+        "returns numeric id or object with numeric id": function () {
             var result = this.clock.setTimeout("");
 
-            assert.isNumber(result);
+            if (typeof result === 'object')
+                assert.isNumber(result.id);
+            else
+                assert.isNumber(result);
         },
 
         "returns unique id": function () {
@@ -99,10 +102,13 @@ buster.testCase("sinon.clock", {
             this.clock = sinon.clock.create();
         },
 
-        "returns numeric id": function () {
+        "returns numeric id or object with numeric id": function () {
             var result = this.clock.setImmediate(function () { });
 
-            assert.isNumber(result);
+            if (typeof result === 'object')
+                assert.isNumber(result.id);
+            else
+                assert.isNumber(result);
         },
 
         "calls the given callback immediately": function () {
@@ -540,10 +546,13 @@ buster.testCase("sinon.clock", {
             });
         },
 
-        "returns numeric id": function () {
+        "returns numeric id or object with numeric id": function () {
             var result = this.clock.setInterval("");
 
-            assert.isNumber(result);
+            if (typeof result === 'object')
+                assert.isNumber(result.id);
+            else
+                assert.isNumber(result);
         },
 
         "returns unique id": function () {


### PR DESCRIPTION
@mantoni as promised, re #437.  pretty trivial.  I do see the flakiness that @cjohansen described, but at least the basic tests should work now.  (I did also test directly in my code w/ a sinon clearTimeout.)
