### PR TITLE
be able to use only sinon.js file

### DIFF
--- a/build
+++ b/build
@@ -45,14 +45,16 @@ formatio not found, skipping. To build with formatio support:
   contents = File.read(file)
 
   File.open(file, "w") do |f|
-    f.puts("(function () {")
+    f.puts("(function (define) {")
     f.puts("var samsam, formatio;")
-    f.puts("function define(mod, deps, fn) { if (mod == \"samsam\") { samsam = deps(); } else { formatio = fn(samsam); } }")
+    f.puts("var defineOld = define;")
+    f.puts("define = function(mod, deps, fn) { if (mod == \"samsam\") { samsam = deps(); } else { formatio = fn(samsam); } }")
     f.puts("define.amd = {};")
     f.puts(File.read("./node_modules/formatio/node_modules/samsam/lib/samsam.js"))
     f.puts(File.read("./node_modules/formatio/lib/formatio.js"))
+    f.puts("define = defineOld;")
     f.puts(contents)
-    f.puts("return sinon;}.call(typeof window != 'undefined' && window || {}));")
+    f.puts("return sinon;}.call(typeof window != 'undefined' && window || {}, typeof define !== 'undefined' && define || {}));")
   end
 
   file

--- a/build
+++ b/build
@@ -45,7 +45,7 @@ formatio not found, skipping. To build with formatio support:
   contents = File.read(file)
 
   File.open(file, "w") do |f|
-    f.puts("this.sinon = (function () {")
+    f.puts("(function () {")
     f.puts("var samsam, formatio;")
     f.puts("function define(mod, deps, fn) { if (mod == \"samsam\") { samsam = deps(); } else { formatio = fn(samsam); } }")
     f.puts("define.amd = {};")

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -339,22 +339,24 @@ var sinon = (function (formatio) {
             return sinon;
         });
     } else if (isNode) {
-        try {
-            formatio = require("formatio");
-        } catch (e) {}
         module.exports = sinon;
-        module.exports.spy = require("./sinon/spy");
-        module.exports.spyCall = require("./sinon/call");
-        module.exports.behavior = require("./sinon/behavior");
-        module.exports.stub = require("./sinon/stub");
-        module.exports.mock = require("./sinon/mock");
-        module.exports.collection = require("./sinon/collection");
-        module.exports.assert = require("./sinon/assert");
-        module.exports.sandbox = require("./sinon/sandbox");
-        module.exports.test = require("./sinon/test");
-        module.exports.testCase = require("./sinon/test_case");
-        module.exports.assert = require("./sinon/assert");
-        module.exports.match = require("./sinon/match");
+        if (!formatio) {
+            try {
+                formatio = require("formatio");
+            } catch (e) {}
+            module.exports.spy = require("./sinon/spy");
+            module.exports.spyCall = require("./sinon/call");
+            module.exports.behavior = require("./sinon/behavior");
+            module.exports.stub = require("./sinon/stub");
+            module.exports.mock = require("./sinon/mock");
+            module.exports.collection = require("./sinon/collection");
+            module.exports.assert = require("./sinon/assert");
+            module.exports.sandbox = require("./sinon/sandbox");
+            module.exports.test = require("./sinon/test");
+            module.exports.testCase = require("./sinon/test_case");
+            module.exports.assert = require("./sinon/assert");
+            module.exports.match = require("./sinon/match");
+        }
     }
 
     if (formatio) {

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -15,6 +15,7 @@
 "use strict";
 
 (function (sinon, global) {
+    var sinonIsNull = (sinon == null);
     var commonJSModule = typeof module !== "undefined" && module.exports;
     var slice = Array.prototype.slice;
     var assert;
@@ -189,7 +190,7 @@
     mirrorPropAsAssertion("threw", "%n did not throw exception%C");
     mirrorPropAsAssertion("alwaysThrew", "%n did not always throw exception%C");
 
-    if (commonJSModule) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = assert;
     } else {
         sinon.assert = assert;

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -15,6 +15,7 @@
 "use strict";
 
 (function (sinon) {
+    var sinonIsNull = (sinon == null);
     var commonJSModule = typeof module !== 'undefined' && module.exports;
 
     if (!sinon && commonJSModule) {
@@ -324,7 +325,7 @@
         }
     }
 
-    if (commonJSModule) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = proto;
     } else {
         sinon.behavior = proto;

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -17,6 +17,7 @@
 "use strict";
 
 (function (sinon) {
+    var sinonIsNull = (sinon == null);
     var commonJSModule = typeof module !== 'undefined' && module.exports;
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");
@@ -194,7 +195,7 @@
     }
     createSpyCall.toString = callProto.toString; // used by mocks
 
-    if (commonJSModule) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = createSpyCall;
     } else {
         sinon.spyCall = createSpyCall;

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -16,6 +16,7 @@
 "use strict";
 
 (function (sinon) {
+    var sinonIsNull = (sinon == null);
     var commonJSModule = typeof module !== 'undefined' && module.exports;
     var push = [].push;
     var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -145,7 +146,7 @@
         }
     };
 
-    if (commonJSModule) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = collection;
     } else {
         sinon.collection = collection;

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -12,6 +12,7 @@
 "use strict";
 
 (function (sinon) {
+    var sinonIsNull = (sinon == null);
     var commonJSModule = typeof module !== 'undefined' && module.exports;
 
     if (!sinon && commonJSModule) {
@@ -235,7 +236,7 @@
     match.regexp = match.typeOf("regexp");
     match.date = match.typeOf("date");
 
-    if (commonJSModule) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = match;
     } else {
         sinon.match = match;

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -15,6 +15,7 @@
 "use strict";
 
 (function (sinon) {
+    var sinonIsNull = (sinon == null);
     var commonJSModule = typeof module !== 'undefined' && module.exports;
     var push = [].push;
     var match;
@@ -441,7 +442,7 @@
         };
     }());
 
-    if (commonJSModule) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = mock;
     } else {
         sinon.mock = mock;

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -17,12 +17,15 @@
  */
 "use strict";
 
-if (typeof module !== 'undefined' && module.exports) {
-    var sinon = require("../sinon");
-    sinon.extend(sinon, require("./util/fake_timers"));
-}
+(function(sinon) {
+    var sinonIsNull = (sinon == null);
+    var commonJSModule = typeof module !== 'undefined' && module.exports;
 
-(function () {
+    if (!sinon && commonJSModule) {
+        sinon = require("../sinon");
+        sinon.extend(sinon, require("./util/fake_timers"));
+    }
+
     var push = [].push;
 
     function exposeValue(sandbox, config, key, value) {
@@ -136,7 +139,8 @@ if (typeof module !== 'undefined' && module.exports) {
 
     sinon.sandbox.useFakeXMLHttpRequest = sinon.sandbox.useFakeServer;
 
-    if (typeof module !== 'undefined' && module.exports) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = sinon.sandbox;
     }
-}());
+
+}(typeof sinon == "object" && sinon || null));

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -15,6 +15,7 @@
 "use strict";
 
 (function (sinon) {
+    var sinonIsNull = (sinon == null);
     var commonJSModule = typeof module !== 'undefined' && module.exports;
     var push = Array.prototype.push;
     var slice = Array.prototype.slice;
@@ -399,7 +400,7 @@
 
     spy.spyCall = sinon.spyCall;
 
-    if (commonJSModule) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = spy;
     } else {
         sinon.spy = spy;

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -16,6 +16,7 @@
 "use strict";
 
 (function (sinon) {
+    var sinonIsNull = (sinon == null);
     var commonJSModule = typeof module !== 'undefined' && module.exports;
 
     if (!sinon && commonJSModule) {
@@ -151,7 +152,7 @@
         return proto;
     }()));
 
-    if (commonJSModule) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = stub;
     } else {
         sinon.stub = stub;

--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -17,6 +17,7 @@
 "use strict";
 
 (function (sinon) {
+    var sinonIsNull = (sinon == null);
     var commonJSModule = typeof module !== 'undefined' && module.exports;
 
     if (!sinon && commonJSModule) {
@@ -67,7 +68,7 @@
         useFakeServer: true
     };
 
-    if (commonJSModule) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = test;
     } else {
         sinon.test = test;

--- a/lib/sinon/test_case.js
+++ b/lib/sinon/test_case.js
@@ -15,6 +15,7 @@
 "use strict";
 
 (function (sinon) {
+    var sinonIsNull = (sinon == null);
     var commonJSModule = typeof module !== 'undefined' && module.exports;
 
     if (!sinon && commonJSModule) {
@@ -89,7 +90,7 @@
         return methods;
     }
 
-    if (commonJSModule) {
+    if (sinonIsNull && commonJSModule) {
         module.exports = testCase;
     } else {
         sinon.testCase = testCase;

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -30,7 +30,7 @@
     xhr.supportsXHR = typeof xhr.GlobalXMLHttpRequest != "undefined";
     xhr.workingXHR = xhr.supportsXHR ? xhr.GlobalXMLHttpRequest : xhr.supportsActiveX
                                      ? function() { return new xhr.GlobalActiveXObject("MSXML2.XMLHTTP.3.0") } : false;
-    xhr.supportsCORS = 'withCredentials' in (new sinon.xhr.GlobalXMLHttpRequest());
+    xhr.supportsCORS = xhr.supportsActiveX && 'withCredentials' in (new sinon.xhr.GlobalXMLHttpRequest());
 
     /*jsl:ignore*/
     var unsafeHeaders = {

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -30,7 +30,7 @@
     xhr.supportsXHR = typeof xhr.GlobalXMLHttpRequest != "undefined";
     xhr.workingXHR = xhr.supportsXHR ? xhr.GlobalXMLHttpRequest : xhr.supportsActiveX
                                      ? function() { return new xhr.GlobalActiveXObject("MSXML2.XMLHTTP.3.0") } : false;
-    xhr.supportsCORS = xhr.supportsActiveX && 'withCredentials' in (new sinon.xhr.GlobalXMLHttpRequest());
+    xhr.supportsCORS = xhr.supportsXHR && 'withCredentials' in (new sinon.xhr.GlobalXMLHttpRequest());
 
     /*jsl:ignore*/
     var unsafeHeaders = {


### PR DESCRIPTION
I could not use only the sinon.js in Titanium environment, so I made some modifications.
As @omorandi said in https://github.com/cjohansen/Sinon.JS/issues/135#issuecomment-6047799, that is Titanium's problem which cannot handle relative paths correctly.