### PR TITLE
Remove extra `module.exports.assert`

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -353,7 +353,6 @@ var sinon = (function (formatio) {
         module.exports.sandbox = require("./sinon/sandbox");
         module.exports.test = require("./sinon/test");
         module.exports.testCase = require("./sinon/test_case");
-        module.exports.assert = require("./sinon/assert");
         module.exports.match = require("./sinon/match");
     }
 


### PR DESCRIPTION
`module.exports.assert` is already assigned at line 352. Remove the extra line of setting it again.
