### PR TITLE
Fixes behavior of AMD dependencies.

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -338,26 +338,28 @@ var sinon = (function (formatio) {
     var isNode = typeof module !== "undefined" && module.exports;
     var isAMD = typeof define === 'function' && typeof define.amd === 'object' && define.amd;
 
+    function makePublicAPI(require, exports, module) {
+        module.exports = sinon;
+        sinon.spy = require("./sinon/spy");
+        sinon.spyCall = require("./sinon/call");
+        sinon.behavior = require("./sinon/behavior");
+        sinon.stub = require("./sinon/stub");
+        sinon.mock = require("./sinon/mock");
+        sinon.collection = require("./sinon/collection");
+        sinon.assert = require("./sinon/assert");
+        sinon.sandbox = require("./sinon/sandbox");
+        sinon.test = require("./sinon/test");
+        sinon.testCase = require("./sinon/test_case");
+        sinon.match = require("./sinon/match");
+    }
+
     if (isAMD) {
-        define(function(){
-            return sinon;
-        });
+        define(makePublicAPI);
     } else if (isNode) {
         try {
             formatio = require("formatio");
         } catch (e) {}
-        module.exports = sinon;
-        module.exports.spy = require("./sinon/spy");
-        module.exports.spyCall = require("./sinon/call");
-        module.exports.behavior = require("./sinon/behavior");
-        module.exports.stub = require("./sinon/stub");
-        module.exports.mock = require("./sinon/mock");
-        module.exports.collection = require("./sinon/collection");
-        module.exports.assert = require("./sinon/assert");
-        module.exports.sandbox = require("./sinon/sandbox");
-        module.exports.test = require("./sinon/test");
-        module.exports.testCase = require("./sinon/test_case");
-        module.exports.match = require("./sinon/match");
+        makePublicAPI(require, exports, module);
     }
 
     if (formatio) {

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -189,9 +189,11 @@
     mirrorPropAsAssertion("threw", "%n did not throw exception%C");
     mirrorPropAsAssertion("alwaysThrew", "%n did not always throw exception%C");
 
-    if (commonJSModule) {
+    sinon.assert = assert;
+
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = assert; });
+    } else if (commonJSModule) {
         module.exports = assert;
-    } else {
-        sinon.assert = assert;
     }
 }(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global));

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -324,9 +324,11 @@
         }
     }
 
-    if (commonJSModule) {
+    sinon.behavior = proto;
+
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = proto; });
+    } else if (commonJSModule) {
         module.exports = proto;
-    } else {
-        sinon.behavior = proto;
     }
 }(typeof sinon == "object" && sinon || null));

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -194,10 +194,12 @@
     }
     createSpyCall.toString = callProto.toString; // used by mocks
 
-    if (commonJSModule) {
+    sinon.spyCall = createSpyCall;
+
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = createSpyCall; });
+    } else if (commonJSModule) {
         module.exports = createSpyCall;
-    } else {
-        sinon.spyCall = createSpyCall;
     }
 }(typeof sinon == "object" && sinon || null));
 

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -145,9 +145,11 @@
         }
     };
 
-    if (commonJSModule) {
+    sinon.collection = collection;
+
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = collection; });
+    } else if (commonJSModule) {
         module.exports = collection;
-    } else {
-        sinon.collection = collection;
     }
 }(typeof sinon == "object" && sinon || null));

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -235,9 +235,11 @@
     match.regexp = match.typeOf("regexp");
     match.date = match.typeOf("date");
 
-    if (commonJSModule) {
+    sinon.match = match;
+
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = match; });
+    } else if (commonJSModule) {
         module.exports = match;
-    } else {
-        sinon.match = match;
     }
 }(typeof sinon == "object" && sinon || null));

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -441,9 +441,11 @@
         };
     }());
 
-    if (commonJSModule) {
+    sinon.mock = mock;
+
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = mock; });
+    } else if (commonJSModule) {
         module.exports = mock;
-    } else {
-        sinon.mock = mock;
     }
 }(typeof sinon == "object" && sinon || null));

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -136,7 +136,9 @@ if (typeof module !== 'undefined' && module.exports) {
 
     sinon.sandbox.useFakeXMLHttpRequest = sinon.sandbox.useFakeServer;
 
-    if (typeof module !== 'undefined' && module.exports) {
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = sinon.sandbox; });
+    } else if (typeof module !== 'undefined' && module.exports) {
         module.exports = sinon.sandbox;
     }
 }());

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -398,10 +398,11 @@
     sinon.extend(spy, spyApi);
 
     spy.spyCall = sinon.spyCall;
+    sinon.spy = spy;
 
-    if (commonJSModule) {
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = spy; });
+    } else if (commonJSModule) {
         module.exports = spy;
-    } else {
-        sinon.spy = spy;
     }
 }(typeof sinon == "object" && sinon || null));

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -151,9 +151,11 @@
         return proto;
     }()));
 
-    if (commonJSModule) {
+    sinon.stub = stub;
+
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = stub; });
+    } else if (commonJSModule) {
         module.exports = stub;
-    } else {
-        sinon.stub = stub;
     }
 }(typeof sinon == "object" && sinon || null));

--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -67,9 +67,11 @@
         useFakeServer: true
     };
 
-    if (commonJSModule) {
+    sinon.test = test;
+
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = test; });
+    } else if (commonJSModule) {
         module.exports = test;
-    } else {
-        sinon.test = test;
     }
 }(typeof sinon == "object" && sinon || null));

--- a/lib/sinon/test_case.js
+++ b/lib/sinon/test_case.js
@@ -89,9 +89,11 @@
         return methods;
     }
 
-    if (commonJSModule) {
+    sinon.testCase = testCase;
+
+    if (typeof define === "function" && define.amd) {
+        define(["module"], function(module) { module.exports = testCase; });
+    } else if (commonJSModule) {
         module.exports = testCase;
-    } else {
-        sinon.testCase = testCase;
     }
 }(typeof sinon == "object" && sinon || null));


### PR DESCRIPTION
I've installed Sinon via Bower, but I cannot include it into my project without properly exporting the sub modules and attaching the main entry point correctly.
- Switches to Simplified CommonJS AMD syntax which allows code reuse
  with Node.
- Adds define call to each module.

All tests pass.
