### PR TITLE
Fix to allow fakeserver response body to be function

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -187,7 +187,7 @@ sinon.fakeServer = (function () {
                         if (match.call(this, this.responses[i], request)) {
                             if (typeof this.responses[i].response == "function") {
                                 var ru = this.responses[i].url;
-                                var args = [request].concat(ru && typeof ru.exec == "function" ? ru.exec(requestUrl).slice(1) : []);
+                                var args = [request].concat(ru && typeof ru.exec == "function" ? ru.exec(request.url).slice(1) : []);
                                 response = this.responses[i].response.apply(this.responses[i], args);
                             }
                             else

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -185,7 +185,16 @@ sinon.fakeServer = (function () {
                 if (this.responses) {
                     for (var l = this.responses.length, i = l - 1; i >= 0; i--) {
                         if (match.call(this, this.responses[i], request)) {
-                            response = this.responses[i].response;
+                            if (typeof this.responses[i].response == "function") {
+                                var ru = this.responses[i].url;
+                                var args = [request].concat(ru && typeof ru.exec == "function" ? ru.exec(requestUrl).slice(1) : []);
+                                response = this.responses[i].response.apply(this.responses[i], args);
+                            }
+                            else
+                            {
+                                response = this.responses[i].response;    
+                            }
+
                             break;
                         }
                     }


### PR DESCRIPTION
Something like this was supposed to be possible (pardon the coffeescript) using fakeserver.  The function was being used to perform the match, but not to generate the response.

```
server.respondWith("POST","/api/users",
  ()->
    params = JSON.parse(arguments[0].requestBody)
    return [200, {"Content-Type":"application/json"},JSON.stringify(params)]
)
```
