### PR TITLE
Allow explicit naming of spies and stubs

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -173,6 +173,11 @@
             return returnValue;
         },
 
+        named: function named(name) {
+            this.displayName = name;
+            return this;
+        },
+
         getCall: function getCall(i) {
             if (i < 0 || i >= this.callCount) {
                 return null;

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -233,6 +233,15 @@ if (typeof require === "function" && typeof module === "object") {
             assert.isArray(spy.exceptions);
         },
 
+        "named": {
+            "sets displayName": function() {
+                var spy = sinon.spy();
+                var retval = spy.named("beep");
+                assert.equals(spy.displayName, "beep");
+                assert.same(spy, retval);
+            }
+        },
+
         "call": {
             "calls underlying function": function () {
                 var called = false;

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -22,6 +22,15 @@ buster.testCase("sinon.stub", {
         assert.isFunction(stub.calledOn);
     },
 
+    "named": {
+        "sets displayName": function() {
+            var spy = sinon.spy();
+            var retval = spy.named("beep");
+            assert.equals(spy.displayName, "beep");
+            assert.same(spy, retval);
+        }
+    },
+
     "should contain asynchronous versions of callsArg*, and yields* methods": function() {
         var stub = sinon.stub.create();
 


### PR DESCRIPTION
Here's the implementation for #418 - a bit later than intended!

Took me a while to decide where to put the tests, but functionToString explicitly mentions displayName, so I figure it's reasonable to assert on it as part of the external interface of spy/stub.
