### PR TITLE
Reinstate check for typeof `require` == "function"

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -335,7 +335,7 @@ var sinon = (function (formatio) {
         }
     };
 
-    var isNode = typeof module !== "undefined" && module.exports;
+    var isNode = typeof module !== "undefined" && module.exports && typeof require == "function";
     var isAMD = typeof define === 'function' && typeof define.amd === 'object' && define.amd;
 
     function makePublicAPI(require, exports, module) {

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -15,7 +15,7 @@
 "use strict";
 
 (function (sinon, global) {
-    var commonJSModule = typeof module !== "undefined" && module.exports;
+    var commonJSModule = typeof module !== "undefined" && module.exports && typeof require == "function";
     var slice = Array.prototype.slice;
     var assert;
 

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -15,7 +15,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module !== 'undefined' && module.exports;
+    var commonJSModule = typeof module !== "undefined" && module.exports && typeof require == "function";
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -17,7 +17,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module !== 'undefined' && module.exports;
+    var commonJSModule = typeof module !== "undefined" && module.exports && typeof require == "function";
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");
     }

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -16,7 +16,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module !== 'undefined' && module.exports;
+    var commonJSModule = typeof module !== "undefined" && module.exports && typeof require == "function";
     var push = [].push;
     var hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -12,7 +12,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module !== 'undefined' && module.exports;
+    var commonJSModule = typeof module !== "undefined" && module.exports && typeof require == "function";
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -15,7 +15,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module !== 'undefined' && module.exports;
+    var commonJSModule = typeof module !== "undefined" && module.exports && typeof require == "function";
     var push = [].push;
     var match;
 

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -17,7 +17,7 @@
  */
 "use strict";
 
-if (typeof module !== 'undefined' && module.exports) {
+if (typeof module !== "undefined" && module.exports && typeof require == "function") {
     var sinon = require("../sinon");
     sinon.extend(sinon, require("./util/fake_timers"));
 }

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -15,7 +15,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module !== 'undefined' && module.exports;
+    var commonJSModule = typeof module !== "undefined" && module.exports && typeof require == "function";
     var push = Array.prototype.push;
     var slice = Array.prototype.slice;
     var callId = 0;

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -16,7 +16,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module !== 'undefined' && module.exports;
+    var commonJSModule = typeof module !== "undefined" && module.exports && typeof require == "function";
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");

--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -17,7 +17,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module !== 'undefined' && module.exports;
+    var commonJSModule = typeof module !== "undefined" && module.exports && typeof require == "function";
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");

--- a/lib/sinon/test_case.js
+++ b/lib/sinon/test_case.js
@@ -15,7 +15,7 @@
 "use strict";
 
 (function (sinon) {
-    var commonJSModule = typeof module !== 'undefined' && module.exports;
+    var commonJSModule = typeof module !== "undefined" && module.exports && typeof require == "function";
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");


### PR DESCRIPTION
This is still an imperfect test for the presence of CommonJS, but
at least it will not attempt to call `require` if it doesn't exist.
