### PR TITLE
Wraps async test in sinon sandbox

### DIFF
--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -60,11 +60,11 @@
 
         if (callback.length) {
             return function sinonAsyncSandboxedTest(callback) {
-                return sinonSandboxedTest.apply(this, arguments)
-            }
+                return sinonSandboxedTest.apply(this, arguments);
+            };
         }
 
-        return sinonSandboxedTest
+        return sinonSandboxedTest;
     }
 
     test.config = {

--- a/test/sinon/test_test.js
+++ b/test/sinon/test_test.js
@@ -128,10 +128,10 @@ buster.testCase("sinon.test", {
 
     "async test with sandbox": function(done) {
         sinon.test(function(callback) {
-            assert.same(callback, done)
+            assert.same(callback, done);
 
-            callback()
-        }).call({}, done)
+            callback();
+        }).call({}, done);
     },
 
     "verifies mocks": function () {


### PR DESCRIPTION
Mocha async test require the function signature to have length > 0.
This PR aims to resolve #469.
