### PR TITLE
Use SVG badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sinon.JS
 
-[![Build status](https://secure.travis-ci.org/cjohansen/Sinon.JS.png?branch=master)](http://travis-ci.org/cjohansen/Sinon.JS)
+[![Build status](https://secure.travis-ci.org/cjohansen/Sinon.JS.svg?branch=master)](http://travis-ci.org/cjohansen/Sinon.JS)
 
 Standalone and test framework agnostic JavaScript test spies, stubs and mocks.
 


### PR DESCRIPTION
I changed the image format of the build status badge from [PNG](https://api.travis-ci.org/cjohansen/Sinon.JS.png?branch=master) to [SVG](https://api.travis-ci.org/cjohansen/Sinon.JS.svg?branch=master). SVG badges look beautiful on retina displays.
