### PR TITLE
Fix loading in Web Workers.

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -30,7 +30,7 @@
     xhr.supportsXHR = typeof xhr.GlobalXMLHttpRequest != "undefined";
     xhr.workingXHR = xhr.supportsXHR ? xhr.GlobalXMLHttpRequest : xhr.supportsActiveX
                                      ? function() { return new xhr.GlobalActiveXObject("MSXML2.XMLHTTP.3.0") } : false;
-    xhr.supportsCORS = 'withCredentials' in (new sinon.xhr.GlobalXMLHttpRequest());
+    xhr.supportsCORS = xhr.supportsXHR && 'withCredentials' in (new sinon.xhr.GlobalXMLHttpRequest());
 
     /*jsl:ignore*/
     var unsafeHeaders = {
@@ -568,7 +568,7 @@
 
     sinon.FakeXMLHttpRequest = FakeXMLHttpRequest;
 
-})(typeof global === "object" ? global : this);
+})((function(){ return typeof global === "object" ? global : this; })());
 
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = sinon;


### PR DESCRIPTION
When sinon.js is loaded via an importScript in a Web Worker, "this" is
not set to the global object. This caused an exception in
fake_xml_http_request.js, which calls  XMLHttpRequest.

The change fixes the global parameter passed to the
fake_xml_http_request module and adds a missing check before the
XMLHttpRequest constructor is called.
