### PR TITLE
Introduced type-checking on setTimeout() timeout argument.

### DIFF
--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -45,6 +45,10 @@ if (typeof sinon == "undefined") {
         var toId = id++;
         var delay = args[1] || 0;
 
+		if (typeof delay !== "number" || isNaN(delay)) {
+            throw new Error("Timer call with non-number");
+		}
+
         if (!this.timeouts) {
             this.timeouts = {};
         }


### PR DESCRIPTION
I accidentally used a setTimeout() call with a wrong argument: setTimeout(callback, object). 
In SinonJS, this is allowed, and execution continues.  But after a while, the Date() constructor starts outputting invalid dates with NaN values. I introduced some error checking in addTimer() to prevent this.
