### PR TITLE
Added response property for scoketio to work (Fixes #501)

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -168,7 +168,7 @@
     FakeXMLHttpRequest.defake = function(fakeXhr,xhrArgs) {
         var xhr = new sinon.xhr.workingXHR();
         each(["open","setRequestHeader","send","abort","getResponseHeader",
-              "getAllResponseHeaders","addEventListener","overrideMimeType","removeEventListener"],
+              "getAllResponseHeaders","addEventListener","overrideMimeType","removeEventListener", "response"],
              function(method) {
                  fakeXhr[method] = function() {
                    return apply(xhr,method,arguments);


### PR DESCRIPTION
Socketio client looks for `xhr.response` property which the fake xhr doesnt have on it.
