### PR TITLE
Added response property for scoketio to work (Fixes #501)

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -191,7 +191,7 @@
                 copyAttrs(["status","statusText"]);
             }
             if(xhr.readyState >= FakeXMLHttpRequest.LOADING) {
-                copyAttrs(["responseText"]);
+                copyAttrs(["responseText", "response"]);
             }
             if(xhr.readyState === FakeXMLHttpRequest.DONE) {
                 copyAttrs(["responseXML"]);

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -1191,6 +1191,7 @@
                 req.onreadystatechange = function () {
                     if (this.readyState == 4) {
                         assert.match(this.responseText, /loaded successfully/);
+                        assert.match(this.response, /loaded successfully/);
                         done();
                     }
                 };
@@ -1205,6 +1206,7 @@
                 req.send();
 
                 assert.match(req.responseText, /loaded successfully/);
+                assert.match(req.response, /loaded successfully/);
             }
         },
 


### PR DESCRIPTION
Socketio client looks for xhr.response property which the fake xhr doesnt have on it.

Quick catch here is: when ever you do a initiate a socketio server on client side always set the `forceBase64` to `true`.

Example:
`var socket = io("http://localhost:3000", {
        "forceBase64" : true
    });`
