### PR TITLE
Remove unused "exports" variable for makePublicAPI

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -338,7 +338,7 @@ var sinon = (function (formatio) {
     var isNode = typeof module !== "undefined" && module.exports && typeof require == "function";
     var isAMD = typeof define === 'function' && typeof define.amd === 'object' && define.amd;
 
-    function makePublicAPI(require, exports, module) {
+    function makePublicAPI(require, module) {
         module.exports = sinon;
         sinon.spy = require("./sinon/spy");
         sinon.spyCall = require("./sinon/call");
@@ -359,7 +359,7 @@ var sinon = (function (formatio) {
         try {
             formatio = require("formatio");
         } catch (e) {}
-        makePublicAPI(require, exports, module);
+        makePublicAPI(require, module);
     }
 
     if (formatio) {


### PR DESCRIPTION
Alternatively, if the # of parameters really matters for define() and/or backwards compatibility, just pass in undefined as the second parameter on line 362.  Either way works, but having it as-is actually throws an error due to exports being an implicit variable
