### PR TITLE
Fix isssues #508 #511

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -568,7 +568,7 @@
 
     sinon.FakeXMLHttpRequest = FakeXMLHttpRequest;
 
-})((function(){ return typeof global === "object" ? global : this; })());
+})(typeof self !== "undefined" ? self : this);
 
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = sinon;


### PR DESCRIPTION
By using `self` (and detecting the presence of it for NodeJS's benefit), the problem of detecting the global scope in Web Workers and in regular browser environments go away.

See
- https://developer.mozilla.org/en-US/docs/Web/API/Window.self
- http://www.w3.org/TR/workers/#the-global-scope

This fixes #508 and #511
