### PR TITLE
Fix #485 by settings value of `returns` to undefined during reset

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -286,8 +286,12 @@
 
         returns: function returns(value) {
             this.returnValue = value;
-            this.returnValueDefined = true;
-
+            if (value === undefined){
+                delete this.returnValueDefined;
+            } else {
+                this.returnValueDefined = true;    
+            }
+                    
             return this;
         },
 

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -117,6 +117,10 @@
                     this.fakes[i].reset();
                 }
             }
+        
+            if (typeof this.returns === 'function'){
+                this.returns(undefined);
+            }
         },
 
         create: function create(func) {

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -1485,6 +1485,15 @@ buster.testCase("sinon.stub", {
         assert(spy.calledTwice);
     },
 
+    "reset must set 'returns' value to undefined" : function(){
+        var stub = sinon.stub();
+        stub.returns(123);
+        assert.equals(stub(), 123);
+
+        stub.reset();
+        refute.defined(stub());
+    },
+
     "resetBehavior": {
         "clears yields* and callsArg* sequence": function () {
             var stub = sinon.stub().yields(1);


### PR DESCRIPTION
This pull request ensures that `reset` will also set the return value from a stub back to `undefined` in line with the expectations expressed in #485

It's a bit of a cludge, as some of the api is a bit convoluted and state is spread out. Hopefully, future refactorings will tidy this up.
