### PR TITLE
Add PhantomJS runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ node_js:
   - "0.10"
 before_install:
   - "npm config set strict-ssl false"
+script:
+  - "./test/ci-test.sh"

--- a/README.md
+++ b/README.md
@@ -78,3 +78,11 @@ in a browser.
 
 The Rhino tests are currently out of commission (pending update after switch to
 Buster.JS for tests).
+
+### In PhantomJS
+
+If you have [PhantomJS](http://phantomjs.org) installed as a global, you can run the test suite in PhantomJS
+
+```
+$ test/phantom/run.sh
+```

--- a/test/ci-test.sh
+++ b/test/ci-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eu
+
+npm test
+test/phantom/run.sh

--- a/test/phantom/run-tests-in-phantom.js
+++ b/test/phantom/run-tests-in-phantom.js
@@ -1,0 +1,100 @@
+var system = require('system');
+
+/**
+ * Wait until the test condition is true or a timeout occurs. Useful for waiting
+ * on a server response or for a ui change (fadeIn, etc.) to occur.
+ *
+ * @param testFx javascript condition that evaluates to a boolean,
+ * it can be passed in as a string (e.g.: "1 == 1" or "$('#bar').is(':visible')" or
+ * as a callback function.
+ * @param onReady what to do when testFx condition is fulfilled,
+ * it can be passed in as a string (e.g.: "1 == 1" or "$('#bar').is(':visible')" or
+ * as a callback function.
+ * @param timeOutMillis the max amount of time to wait. If not specified, 3 sec is used.
+ */
+function waitFor(testFx, onReady, timeOutMillis) {
+    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 10001, //< Default Max Timeout is 10s
+        start = new Date().getTime(),
+        condition = false,
+        interval = setInterval(function(){
+            if ((new Date().getTime() - start < maxtimeOutMillis) && !condition) {
+                // If not time-out yet and condition not yet fulfilled
+                condition = (typeof(testFx) === "string" ? eval(testFx) : testFx()); //< defensive code
+            } else {
+                if (!condition) {
+                    // If condition still not fulfilled (timeout but condition is 'false')
+                    console.log("'waitFor()' timeout");
+                    phantom.exit(1);
+                } else {
+                    // Condition fulfilled (timeout and/or condition is 'true')
+                    console.log("'waitFor()' finished in " + (new Date().getTime() - start) + "ms." );
+                    console.log('');
+                    typeof(onReady) === "string" ? eval(onReady) : onReady(); //< Do what it's supposed to do once the condition is fulfilled
+                    clearInterval(interval); //< Stop this interval
+                }
+            }
+        }, 100); //< repeat check every 100ms
+}
+
+
+if (system.args.length !== 2) {
+    console.log('Usage: run.js URL');
+    phantom.exit(1);
+}
+
+var page = require('webpage').create();
+
+// Route "console.log()" calls from within the Page context to the main Phantom context (i.e. current "this")
+page.onConsoleMessage = function(msg) {
+    console.log(msg);
+};
+
+function testForResults(){
+    return page.evaluate(function(){
+        return document.body.querySelector('.stats') !== null;
+    });
+}
+
+page.open(system.args[1], function(status) {
+    if (status !== "success") {
+        console.log("Unable to access network");
+        phantom.exit();
+    } else {
+
+        waitFor(
+            testForResults,
+            function(){
+
+
+                var exitCode = page.evaluate(function(){
+                    function formatResultsSummary(ul){
+                        return Array.prototype.slice.call(ul.querySelectorAll('li')).reduce(function(memo, current){
+                            return memo + current.innerText + '\n';
+                        }, '');                        
+                    }                
+                    console.log(formatResultsSummary(document.body.querySelector('.stats')));
+
+                    var list = document.body.querySelectorAll('.test-results li.failure, .test-results li.timeout');
+                    if (list && list.length > 0) {
+                        console.log('');
+                        console.log(list.length + ' test(s) FAILED:');
+                        for (i = 0; i < list.length; ++i) {
+                            var el = list[i],
+                                desc = el.querySelector('h3'),
+                                msg = el.querySelector('p.error-message');
+
+                            console.log('');
+                            console.log('description: ', desc.innerText);
+                            console.log('message: ', msg.innerText);
+                        }
+                        return 1;
+                    } else {
+                        console.log(document.body.querySelector('div.stats.success h2').innerText);
+                        return 0;
+                    }
+                });
+                phantom.exit(exitCode);
+            }
+        );
+    }
+});

--- a/test/phantom/run.sh
+++ b/test/phantom/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eu
+
+function finish {
+	if [ -n "${TRAVIS+1}" ]; then
+	  echo "TRAVIS detected, skip killing child processes"
+	else
+	  kill $(jobs -pr)
+	fi
+}
+
+trap finish SIGINT SIGTERM EXIT
+
+echo 'Starting webserver on port 8666'
+python -m SimpleHTTPServer 8666 &
+
+echo 'Running unit tests in PhantomJS'
+phantomjs test/phantom/run-tests-in-phantom.js http://localhost:8666/test/sinon.html

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -1524,13 +1524,19 @@
                 this.xhr.abort();
             },
 
-            "error event is triggered with xhr.uploadError(new Error('foobar'))": function(done) {
-                this.xhr.upload.addEventListener("error", function(e) {
-                    assert.equals(e.detail.message, "foobar");
+            "error event": {
+                requiresSupportFor: {
+                    "CustomEvent" : typeof CustomEvent !== "undefined"
+                },
 
-                    done();
-                });
-                this.xhr.uploadError(new Error("foobar"));
+                "is triggered with xhr.uploadError(new Error('foobar'))": function(done) {
+                    this.xhr.upload.addEventListener("error", function(e) {
+                        assert.equals(e.detail.message, "foobar");
+
+                        done();
+                    });
+                    this.xhr.uploadError(new Error("foobar"));
+                }
             },
 
             "event listeners can be removed": function() {

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -96,6 +96,11 @@ buster.testCase("sinon", {
         },
 
         "originating stack traces": {
+            requiresSupportFor: {
+                "overriding Error and TypeError": (function(){                
+                    return !(typeof navigator === "object" && /PhantomJS/.test(navigator.userAgent));
+                }())
+            },            
 
             setUp: function () {
                 this.oldError = Error;


### PR DESCRIPTION
This pull request adds a very basic runner for getting the unit tests to run in PhantomJS. The idea is that we can run this in Travis along with the node tests, and feel safer that the tests will stay green in browser environments also.

You can run it with

```
$ test/phantom/run.sh
```

One further improvement would be to silence the output of the python SimpleHTTPServer (or use another webserver to serve the files to PhantomJS). For now it works
##### TODO
- [x] Stop leaking a python process after each run
- [x] Fix failing tests
- [x] Update README.md with details on how to run tests in PhantomJS
