### PR TITLE
Close #458 by proving that there is no failure

### DIFF
--- a/test/node/run.js
+++ b/test/node/run.js
@@ -9,8 +9,9 @@ require("../sinon/assert_test.js");
 require("../sinon/test_test.js");
 require("../sinon/test_case_test.js");
 require("../sinon/match_test.js");
-var buster = require("../runner");
+require("../sinon/issues/issues.js");
 
+var buster = require("../runner");
 var args = process.argv.slice(2);
 
 while (args.length) {

--- a/test/sinon/issues/issues.js
+++ b/test/sinon/issues/issues.js
@@ -1,0 +1,40 @@
+/*jslint onevar: false, eqeqeq: false*/
+/*globals sinon buster*/
+/**
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @license BSD
+ *
+ * Copyright (c) 2010-2014 Christian Johansen
+ */
+"use strict";
+
+if (typeof require == "function" && typeof module == "object") {
+    var buster = require("../../runner");
+    var sinon = require("../../../lib/sinon");
+}
+
+buster.testCase("issues", {
+    setUp : function(){
+        this.sandbox = sinon.sandbox.create();
+    },
+
+    tearDown : function(){
+        this.sandbox.restore();
+    },
+
+    "458": {
+        "on node": {
+            requiresSupportFor: { "process": typeof process !== "undefined" },
+
+            "stub out fs.readFileSync": function () {
+                var testCase = this,
+                    fs = require('fs'),
+                    stub;
+                
+                refute.exception(function(){
+                    testCase.sandbox.stub(fs, "readFileSync");
+                });
+            }
+        }
+    }
+});


### PR DESCRIPTION
This pull request closes issue #458 by implementing a test that shows that it is possible to stub fs.readFileSync. 

I've run the tests on node 0.10.25 and 0.10.29 and cannot reproduce the bug.
