### PR TITLE
Use async AMD methods

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -338,7 +338,49 @@ var sinon = (function (formatio) {
     var isNode = typeof module !== "undefined" && module.exports && typeof require == "function";
     var isAMD = typeof define === 'function' && typeof define.amd === 'object' && define.amd;
 
-    function makePublicAPI(require, module) {
+    function defineAPIAMD(){
+        define([
+            "./sinon/spy",
+            "./sinon/call",
+            "./sinon/behavior",
+            "./sinon/stub",
+            "./sinon/mock",
+            "./sinon/collection",
+            "./sinon/assert",
+            "./sinon/sandbox",
+            "./sinon/test",
+            "./sinon/test_case",
+            "./sinon/match"
+        ], function(
+            spy,
+            spyCall,
+            behavior,
+            stub,
+            mock,
+            collection,
+            assert,
+            sandbox,
+            test,
+            testCase,
+            match
+        ){
+            sinon.spy = spy;
+            sinon.spyCall = spyCall;
+            sinon.behavior = behavior;
+            sinon.stub = stub;
+            sinon.mock = mock;
+            sinon.collection = collection;
+            sinon.assert = assert;
+            sinon.sandbox = sandbox;
+            sinon.test = test;
+            sinon.testCase;
+            sinon.match;
+
+            return sinon;
+        });
+    }
+
+    function makeAPINode(require, module) {
         module.exports = sinon;
         sinon.spy = require("./sinon/spy");
         sinon.spyCall = require("./sinon/call");
@@ -353,13 +395,13 @@ var sinon = (function (formatio) {
         sinon.match = require("./sinon/match");
     }
 
-    if (isAMD) {
-        define(makePublicAPI);
+    if (isAMD){
+        defineAPIAMD();
     } else if (isNode) {
         try {
             formatio = require("formatio");
         } catch (e) {}
-        makePublicAPI(require, module);
+        makeAPINode(require, module);
     }
 
     if (formatio) {


### PR DESCRIPTION
This pull request is under :construction:, things are likely to be broken. I am opening it now, to get feedback and discussion on the implmentation.

---

As @neonstalwart  points out in #523, there's opportunities for the AMD loader to bite us, when loading dependencies asynchronously. This only happens when using a non-built version of Sinon, but I think it's worth fixing.

The [calls to synchronous require](https://github.com/cjohansen/Sinon.JS/blob/v1.10.3/lib/sinon.js#L341-L354) should fail in compliant implementations, [as described in the amdjs wiki](https://github.com/amdjs/amdjs-api/wiki/require#requirestring-), but clearly it doesn't in all implementations.

Anyway. The first commit for this pull request adds a method to define the api using AMD's `define`, and not attempt to use synchronous `require` (which is not guaranteed to work).

Thoughts? Shall I continue down this path, and make sure that all the dependency resolution is bulletproof?
