### PR TITLE
Move format into separate module

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -29,6 +29,7 @@ var sinon = (function () {
         require("./sinon/test");
         require("./sinon/test_case");
         require("./sinon/match");
+        require("./sinon/format");
     }
 
     if (isAMD) {

--- a/lib/sinon/format.js
+++ b/lib/sinon/format.js
@@ -1,0 +1,89 @@
+/**
+ * @depend ../sinon.js
+ */
+/*jslint eqeqeq: false, onevar: false*/
+/*global module, require, sinon*/
+/**
+ * Format functions
+ *
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @license BSD
+ *
+ * Copyright (c) 2010-2014 Christian Johansen
+ */
+"use strict";
+
+(function (sinon, formatio) {
+    function makeApi(sinon){
+        function valueFormatter(value) {
+            return "" + value;
+        }
+
+        function getFormatioFormatter(){
+            var formatter = formatio.configure({
+                    quoteStrings: false,
+                    limitChildrenCount: 250
+                });
+
+            function format(){
+                return formatter.ascii.apply(formatter, arguments);
+            };
+
+            return format;
+        }
+
+        function getNodeFormatter(value){
+            function format(value) {
+                return typeof value == "object" && value.toString === Object.prototype.toString ? util.inspect(value) : value;
+            };
+
+            try {
+                var util = require("util");
+            } catch (e) {
+                /* Node, but no util module - would be very old, but better safe than sorry */
+            }
+
+            return util ? format : valueFormatter;
+        }
+
+        var isNode = typeof module !== "undefined" && module.exports && typeof require == "function",
+            formatter;
+
+        if (isNode){
+            try {
+                formatio = require("formatio");
+            } catch (e) {}
+        }
+
+        if (formatio){
+            formatter = getFormatioFormatter()
+        } else if (isNode){
+            formatter = getNodeFormatter();
+        } else {
+            formatter = valueFormatter;
+        }
+
+        sinon.format = formatter;
+    }
+
+    function loadDependencies(require, exports, module) {
+        var sinon = require('./util/core');
+        module.exports = makeApi(sinon);
+    }
+
+    var isNode = typeof module !== "undefined" && module.exports && typeof require == "function";
+    var isAMD = typeof define === 'function' && typeof define.amd === 'object' && define.amd;
+
+    if (isAMD) {
+        define(loadDependencies);
+    } else if (isNode) {
+        loadDependencies(require, module.exports, module);
+    } else if (!sinon) {
+        return;
+    } else {
+        makeApi(sinon);
+    }
+}(
+    (typeof sinon == "object" && sinon || null),
+    (typeof formatio == "object" && formatio)
+));

--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -13,7 +13,7 @@
  */
 "use strict";
 
-(function (sinon, formatio) {
+(function (sinon) {
     var div = typeof document != "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -253,10 +253,6 @@
             return config;
         };
 
-        sinon.format = function (val) {
-            return "" + val;
-        };
-
         sinon.defaultConfig = {
             injectIntoThis: true,
             injectInto: null,
@@ -338,26 +334,6 @@
             }
         };
 
-        if (formatio) {
-            var formatter = formatio.configure({
-                quoteStrings: false,
-                limitChildrenCount: 250
-            });
-            sinon.format = function () {
-                return formatter.ascii.apply(formatter, arguments);
-            };
-        } else if (isNode) {
-            try {
-                var util = require("util");
-                sinon.format = function (value) {
-                    return typeof value == "object" && value.toString === Object.prototype.toString ? util.inspect(value) : value;
-                };
-            } catch (e) {
-                /* Node, but no util module - would be very old, but better safe than
-                sorry */
-            }
-        }
-
         return sinon;
     }
 
@@ -371,13 +347,10 @@
     if (isAMD) {
         define(loadDependencies);
     } else if (isNode) {
-        try {
-            formatio = require("formatio");
-        } catch (e) {}
         loadDependencies(require, module.exports);
     } else if (!sinon) {
         return;
     } else {
          makeApi(sinon);
     }
-}(typeof sinon == "object" && sinon || null, typeof formatio == "object" && formatio));
+}(typeof sinon == "object" && sinon || null));

--- a/test/node/run.js
+++ b/test/node/run.js
@@ -9,6 +9,7 @@ require("../sinon/assert_test.js");
 require("../sinon/test_test.js");
 require("../sinon/test_case_test.js");
 require("../sinon/match_test.js");
+require("../sinon/format_test.js");
 require("../sinon/issues/issues.js");
 
 var buster = require("../runner");

--- a/test/rhino/run.js
+++ b/test/rhino/run.js
@@ -30,6 +30,7 @@ load("test/sinon/stub_test.js");
 load("test/sinon/test_case_test.js");
 load("test/sinon/test_test.js");
 load("test/sinon/match_test.js");
+load("test/sinon/format_test.js");
 load("test/sinon/util/fake_server_test.js");
 load("test/sinon/util/fake_server_with_clock_test.js");
 load("test/sinon/util/fake_timers_test.js");

--- a/test/sinon.html
+++ b/test/sinon.html
@@ -40,6 +40,7 @@
     <script src="../lib/sinon/stub.js"></script>
     <script src="../lib/sinon/mock.js"></script>
     <script src="../lib/sinon/assert.js"></script>
+    <script src="../lib/sinon/format.js"></script>
     <script src="../lib/sinon/util/event.js"></script>
     <script src="../lib/sinon/util/fake_xml_http_request.js"></script>
     <script src="../lib/sinon/util/fake_timers.js"></script>
@@ -64,6 +65,7 @@
     <script src="sinon/collection_test.js"></script>
     <script src="sinon/test_test.js"></script>
     <script src="sinon/test_case_test.js"></script>
+    <script src="sinon/format_test.js"></script>
     <script src="sinon/util/event_test.js"></script>
     <script src="sinon/util/fake_xdomain_request_test.js"></script>
     <script src="sinon/util/fake_xml_http_request_test.js"></script>

--- a/test/sinon/format_test.js
+++ b/test/sinon/format_test.js
@@ -1,0 +1,31 @@
+/*jslint onevar: false*/
+/*globals sinon buster require assert*/
+/**
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @license BSD
+ *
+ * Copyright (c) 2010-2014 Christian Johansen
+ */
+"use strict";
+
+if (typeof require === "function" && typeof module === "object") {
+    var buster = require("../runner");
+    var sinon = require("../../lib/sinon");
+}
+
+buster.testCase("sinon.format", {
+    "formats with formatio by default": function () {
+        assert.equals(sinon.format({ id: 42 }), "{ id: 42 }");
+    },
+
+    "// should configure formatio to use maximum 250 entries" : function(){
+        // not sure how we can verify this integration with the current setup
+        // where sinon.js calls formatio as part of it's loading
+        // extracting sinon.format into a separate module would make this a lot
+        // easier
+    },
+
+    "formats strings without quotes": function () {
+        assert.equals(sinon.format("Hey"), "Hey");
+    }
+});

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -563,23 +563,6 @@ buster.testCase("sinon", {
         }
     },
 
-    "format": {
-        "formats with formatio by default": function () {
-            assert.equals(sinon.format({ id: 42 }), "{ id: 42 }");
-        },
-
-        "// should configure formatio to use maximum 250 entries" : function(){
-            // not sure how we can verify this integration with the current setup
-            // where sinon.js calls formatio as part of it's loading
-            // extracting sinon.format into a separate module would make this a lot
-            // easier
-        },
-
-        "formats strings without quotes": function () {
-            assert.equals(sinon.format("Hey"), "Hey");
-        }
-    },
-
     "typeOf": {
         "returns boolean": function () {
             assert.equals(sinon.typeOf(false), "boolean");


### PR DESCRIPTION
This PR extracts `sinon.format` into a separate module.

Testing the integration with `formatio` is still difficult with the way that sinon uses `require`. Once we get things ported to Browserify, this should be a lot easier.
