### PR TITLE
Add missing @depend statements for build version

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -1,6 +1,7 @@
 /**
  * @depend util/core.js
  * @depend stub.js
+ * @depend format.js
  */
 /**
  * Assertions matching the test spy retrieval interface.

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -1,6 +1,7 @@
 /**
   * @depend util/core.js
   * @depend match.js
+  * @depend format.js
   */
 /**
   * Spy calls

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -1,6 +1,7 @@
 /**
  * @depend util/core.js
  * @depend stub.js
+ * @depend format.js
  */
 /**
  * Mock functions.

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -1,6 +1,7 @@
 /**
   * @depend util/core.js
   * @depend call.js
+  * @depend format.js
   */
 /**
   * Spy functions

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -1,5 +1,6 @@
 /**
  * @depend fake_xml_http_request.js
+ * @depend ../format.js
  */
 /**
  * The Sinon "server" mimics a web server that receives requests from


### PR DESCRIPTION
I've been trying to get the `sinon-dist.html` to work, so we can run the tests against the built version as well. 

This PR adds the missing `depend` statements, so the built version will create fewer errors. However, the tests still fail... but at least they fail in the same way as before we extracted `sinon.format` to a separate file :)
