### PR TITLE
Fix missing module.exports from format.js

### DIFF
--- a/lib/sinon/format.js
+++ b/lib/sinon/format.js
@@ -62,6 +62,7 @@
         }
 
         sinon.format = formatter;
+        return sinon.format;
     }
 
     function loadDependencies(require, exports, module) {


### PR DESCRIPTION
For completeness, we should assign something to `modules.exports`, somehow I missed that in `format.js`. This PR should fix that.
