### PR TITLE
Extract extend method to it's own file

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -15,6 +15,7 @@ var sinon = (function () {
 
     function loadDependencies(require, exports, module) {
         sinon = module.exports = require("./sinon/util/core");
+        require("./sinon/extend");
         require("./sinon/times_in_words");
         require("./sinon/spy");
         require("./sinon/call");

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -1,5 +1,6 @@
 /**
  * @depend util/core.js
+ * @depend extend.js
  */
 /**
  * Stub behavior

--- a/lib/sinon/extend.js
+++ b/lib/sinon/extend.js
@@ -1,0 +1,103 @@
+/**
+ * @depend ../sinon.js
+ */
+"use strict";
+
+(function (sinon) {
+    function makeApi(sinon) {
+
+        // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
+        var hasDontEnumBug = (function () {
+            var obj = {
+                constructor: function () {
+                    return "0";
+                },
+                toString: function () {
+                    return "1";
+                },
+                valueOf: function () {
+                    return "2";
+                },
+                toLocaleString: function () {
+                    return "3";
+                },
+                prototype: function () {
+                    return "4";
+                },
+                isPrototypeOf: function () {
+                    return "5";
+                },
+                propertyIsEnumerable: function () {
+                    return "6";
+                },
+                hasOwnProperty: function () {
+                    return "7";
+                },
+                length: function () {
+                    return "8";
+                },
+                unique: function () {
+                    return "9"
+                }
+            };
+
+            var result = [];
+            for (var prop in obj) {
+                result.push(obj[prop]());
+            }
+            return result.join("") !== "0123456789";
+        })();
+
+        /* Public: Extend target in place with all (own) properties from sources in-order. Thus, last source will
+         *         override properties in previous sources.
+         *
+         * target - The Object to extend
+         * sources - Objects to copy properties from.
+         *
+         * Returns the extended target
+         */
+        function extend(target /*, sources */) {
+            var sources = Array.prototype.slice.call(arguments, 1),
+                source, i, prop;
+
+            for (i = 0; i < sources.length; i++) {
+                source = sources[i];
+
+                for (prop in source) {
+                    if (source.hasOwnProperty(prop)) {
+                        target[prop] = source[prop];
+                    }
+                }
+
+                // Make sure we copy (own) toString method even when in JScript with DontEnum bug
+                // See https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
+                if (hasDontEnumBug && source.hasOwnProperty("toString") && source.toString !== target.toString) {
+                    target.toString = source.toString;
+                }
+            }
+
+            return target;
+        };
+
+        sinon.extend = extend;
+        return sinon.extend;
+    }
+
+    function loadDependencies(require, exports, module) {
+        var sinon = require("./util/core");
+        module.exports = makeApi(sinon);
+    }
+
+    var isNode = typeof module !== "undefined" && module.exports && typeof require == "function";
+    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+
+    if (isAMD) {
+        define(loadDependencies);
+    } else if (isNode) {
+        loadDependencies(require, module.exports, module);
+    } else if (!sinon) {
+        return;
+    } else {
+        makeApi(sinon);
+    }
+}(typeof sinon == "object" && sinon || null));

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -1,6 +1,7 @@
 /**
  * @depend times_in_words.js
  * @depend util/core.js
+ * @depend extend.js
  * @depend stub.js
  * @depend format.js
  */

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -1,5 +1,6 @@
 /**
  * @depend util/core.js
+ * @depend extend.js
  * @depend collection.js
  * @depend util/fake_timers.js
  * @depend util/fake_server_with_clock.js

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -1,6 +1,7 @@
 /**
   * @depend times_in_words.js
   * @depend util/core.js
+  * @depend extend.js
   * @depend call.js
   * @depend format.js
   */

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -1,5 +1,6 @@
 /**
  * @depend util/core.js
+ * @depend extend.js
  * @depend spy.js
  * @depend behavior.js
  */

--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -115,24 +115,6 @@
             return method;
         };
 
-        sinon.extend = function extend(target) {
-            for (var i = 1, l = arguments.length; i < l; i += 1) {
-                for (var prop in arguments[i]) {
-                    if (arguments[i].hasOwnProperty(prop)) {
-                        target[prop] = arguments[i][prop];
-                    }
-
-                    // DONT ENUM bug, only care about toString
-                    if (arguments[i].hasOwnProperty("toString") &&
-                        arguments[i].toString != target.toString) {
-                        target.toString = arguments[i].toString;
-                    }
-                }
-            }
-
-            return target;
-        };
-
         sinon.create = function create(proto) {
             var F = function () {};
             F.prototype = proto;

--- a/lib/sinon/util/fake_xdomain_request.js
+++ b/lib/sinon/util/fake_xdomain_request.js
@@ -1,5 +1,6 @@
 /**
  * @depend core.js
+ * @depend ../extend.js
  * @depend event.js
  */
 /**

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -1,5 +1,6 @@
 /**
  * @depend core.js
+ * @depend ../extend.js
  * @depend event.js
  */
 /**

--- a/test/node/run.js
+++ b/test/node/run.js
@@ -1,4 +1,5 @@
 require("../sinon_test.js");
+require("../sinon/extend_test.js");
 require("../sinon/spy_test.js");
 require("../sinon/call_test.js");
 require("../sinon/stub_test.js");

--- a/test/rhino/run.js
+++ b/test/rhino/run.js
@@ -5,6 +5,7 @@ load("test/Asserts.js");
 load("test/test_case_shim.js");
 
 load("lib/sinon.js");
+load("lib/sinon/extend.js");
 load("lib/sinon/assert.js");
 load("lib/sinon/collection.js");
 load("lib/sinon/mock.js");
@@ -30,6 +31,7 @@ load("test/sinon/stub_test.js");
 load("test/sinon/test_case_test.js");
 load("test/sinon/test_test.js");
 load("test/sinon/match_test.js");
+load("test/sinon/extend_test.js");
 load("test/sinon/format_test.js");
 load("test/sinon/times_in_words_test.js");
 load("test/sinon/util/fake_server_test.js");

--- a/test/sinon.html
+++ b/test/sinon.html
@@ -33,6 +33,7 @@
     <!-- Sources -->
     <script src="../lib/sinon.js"></script>
     <script src="../lib/sinon/util/core.js"></script>
+    <script src="../lib/sinon/extend.js"></script>
     <script src="../lib/sinon/times_in_words.js"></script>
     <script src="../lib/sinon/match.js"></script>
     <script src="../lib/sinon/spy.js"></script>
@@ -58,6 +59,7 @@
     <script src="../lib/sinon/test_case.js"></script>
     <!-- Tests -->
     <script src="sinon_test.js"></script>
+    <script src="sinon/extend_test.js"></script>
     <script src="sinon/times_in_words_test.js"></script>
     <script src="sinon/spy_test.js"></script>
     <script src="sinon/call_test.js"></script>

--- a/test/sinon/extend_test.js
+++ b/test/sinon/extend_test.js
@@ -1,0 +1,49 @@
+"use strict";
+
+if (typeof require === "function" && typeof module === "object") {
+    var buster = require("../runner");
+    var sinon = require("../../lib/sinon");
+}
+
+buster.testCase("sinon.extend", {
+    "should return unaltered target when only one argument": function () {
+        var target = { hello: "world" };
+
+        sinon.extend(target);
+
+        assert.equals(target, { hello: "world" });
+    },
+
+    "should copy all (own) properties into first argument, from all subsequent arguments": function () {
+        var target = { hello: "world" };
+
+        sinon.extend(target, { a: "a" }, { b: "b" });
+
+        assert.equals(target.hello, "world");
+        assert.equals(target.a, "a");
+        assert.equals(target.b, "b");
+    },
+
+    "should copy toString method into target": function () {
+        var target = { hello: "world", toString: function () { return "hello world"; }},
+            source = { toString: function () { return "hello source"; }};
+
+        sinon.extend(target, source);
+
+        assert.same(target.toString, source.toString);
+    },
+
+    "must copy the last occuring property into the target": function () {
+        var target =  { a: 0, b: 0, c: 0, d: 0 },
+            source1 = { a: 1, b: 1, c: 1 },
+            source2 = { a: 2, b: 2 },
+            soruce3 = { a: 3 };
+
+        sinon.extend(target, source1, source2, soruce3);
+
+        assert.equals(target.a, 3);
+        assert.equals(target.b, 2);
+        assert.equals(target.c, 1);
+        assert.equals(target.d, 0);
+    }
+});


### PR DESCRIPTION
- Extract extend method to it's own file
- Add unit tests
- Add test to see if we're in an environment with the JScript DontEnum bug before copying (own) toString method
- Refactor extend internals for better readability by using more variables
- Add [tomdoc](http://tomdoc.org) style documentation for extend method (experiment, I find them much easier to write and read)
