### PR TITLE
Update README.md with AMD specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Don't forget to include the parts of Sinon.JS that you want to use as well
 
 See the [sinon project homepage](http://sinonjs.org/)
 
+### Important: AMD needs pre-built version
+
+Sinon.JS *as source* **doesn't work with AMD loaders** (when they're asynchrnous, like loading via script tags in the browser). For that you will have to use a pre-built version. You can either [build it yourself](CONTRIBUTING.md#testing-a-built-version) or get a numbered version from (http://sinonjs.org)[http://sinonjs.org].
+
+This might or might not change in future versions, depending of outcome of investigations. Please don't report this as a bug, just use pre-built versions.
+
 ## Goals
 
 * No global pollution


### PR DESCRIPTION
Adding details about Sinon.JS not working when loaded asynchronously by AMD loaders. Hopefully this will cut down on the amount of issues created by people trying to use it that way ... or at least provide a linkable explanation that is easy to paste when closing these issues.
