### PR TITLE
Fix issue #570

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -223,7 +223,7 @@ if (typeof sinon == "undefined") {
     if (isAMD) {
         define(loadDependencies);
     } else if (isNode) {
-        loadDependencies(require, module.export, module);
+        loadDependencies(require, module.exports, module);
     } else {
         makeApi(sinon);
     }


### PR DESCRIPTION
IE<9 complains about the use of `module.export` as `export` is a
reserved word.

Solution is to use `module.exports`
