### PR TITLE
Declare log_error dependency.

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -1,6 +1,7 @@
 /**
  * @depend fake_xml_http_request.js
  * @depend ../format.js
+ * @depend ../log_error.js
  */
 /**
  * The Sinon "server" mimics a web server that receives requests from

--- a/lib/sinon/util/fake_xdomain_request.js
+++ b/lib/sinon/util/fake_xdomain_request.js
@@ -2,6 +2,7 @@
  * @depend core.js
  * @depend ../extend.js
  * @depend event.js
+ * @depend ../log_error.js
  */
 /**
  * Fake XDomainRequest object

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -2,6 +2,7 @@
  * @depend core.js
  * @depend ../extend.js
  * @depend event.js
+ * @depend ../log_error.js
  */
 /**
  * Fake XMLHttpRequest object


### PR DESCRIPTION
Related to #558 . With 6ca08380002d50e4c24d05dbef89c0933dc6ece4, it doesn't look like `sinon.log` and `sinon.logError` are being included in builds.
