### PR TITLE
Fix issue #586

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -157,14 +157,14 @@
                         returnValue = (this.func || func).apply(thisValue, args);
                     }
 
-                    delete this.invoking;
-
                     var thisCall = this.getCall(this.callCount - 1);
                     if (thisCall.calledWithNew() && typeof returnValue !== "object") {
                         returnValue = thisValue;
                     }
                 } catch (e) {
                     exception = e;
+                } finally {
+                    delete this.invoking;
                 }
 
                 push.call(this.exceptions, exception);

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -205,6 +205,17 @@ buster.testCase("sinon.stub", {
             assert.exception(function () {
                 stub();
             }, "Error");
+        },
+
+        "resets 'invoking' flag": function () {
+            var stub = sinon.stub.create();
+            stub.throws();
+
+            try {
+                stub();
+            } catch (e) {
+                refute.defined(stub.invoking);
+            }
         }
     },
 


### PR DESCRIPTION
If a stub throws an exception the `invoking` flag should be deleted, so the stub can be reset without throwing an error.
