### PR TITLE
Expose match on returned sandbox

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -87,6 +87,8 @@
                     obj.requests = this.server.requests;
                 }
 
+                obj.match = sinon.match;
+
                 return obj;
             },
 
@@ -126,7 +128,9 @@
                 }
 
                 return sandbox;
-            }
+            },
+
+            match: sinon.match
         });
 
         sinon.sandbox.useFakeXMLHttpRequest = sinon.sandbox.useFakeServer;

--- a/test/sinon/sandbox_test.js
+++ b/test/sinon/sandbox_test.js
@@ -36,6 +36,12 @@ if (typeof require == "function" && typeof module == "object") {
             assert(sinon.sandbox.isPrototypeOf(sandbox));
         },
 
+        "exposes match": function () {
+            var sandbox = sinon.sandbox.create();
+
+            assert.same(sandbox.match, sinon.match);
+        },
+
         ".useFakeTimers": {
             setUp: function () {
                 this.sandbox = sinon.create(sinon.sandbox);
@@ -404,6 +410,17 @@ if (typeof require == "function" && typeof module == "object") {
                 assert.equals(sandbox.args.length, 0);
                 assert.isFunction(object.spy);
                 assert.isObject(object.sandbox);
+            },
+
+            "injects match": function () {
+                var object = {};
+
+                var sandbox = sinon.sandbox.create(sinon.getConfig({
+                    properties: ["match"],
+                    injectInto: object
+                }));
+
+                assert.same(object.match, sinon.match);
             }
         }
     });


### PR DESCRIPTION
The sandbox has a reference to `sinon.match` allowing an instance to stand in for the full sinon library.
