### PR TITLE
Fake server instance log

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -196,7 +196,7 @@ if (typeof sinon == "undefined") {
                     }
 
                     if (request.readyState != 4) {
-                        sinon.fakeServer.log(response, request);
+                        this.log(response, request);
 
                         request.respond(response[0], response[1], response[2]);
                     }

--- a/test/sinon/util/fake_server_test.js
+++ b/test/sinon/util/fake_server_test.js
@@ -756,14 +756,25 @@ buster.testCase("sinon.fakeServer", {
         },
 
         "logs response and request": function () {
-            sinon.spy(sinon.fakeServer, "log");
+            sinon.spy(this.server, "log");
             var xhr = new sinon.FakeXMLHttpRequest();
             xhr.open("GET", "/hello");
             xhr.send();
             var response = [200, {}, "Hello!"];
             this.server.respond("GET", /.*/, response);
-            assert(sinon.fakeServer.log.calledOnce);
-            assert(sinon.fakeServer.log.calledWithExactly(response, xhr));
+            assert(this.server.log.calledOnce);
+            assert(this.server.log.calledWithExactly(response, xhr));
+        },
+
+        "can be overridden": function () {
+            this.server.log = sinon.spy();
+            var xhr = new sinon.FakeXMLHttpRequest();
+            xhr.open("GET", "/hello");
+            xhr.send();
+            var response = [200, {}, "Hello!"];
+            this.server.respond("GET", /.*/, response);
+            assert(this.server.log.calledOnce);
+            assert(this.server.log.calledWithExactly(response, xhr));
         }
     }
 });


### PR DESCRIPTION
Allow overriding log implementation on fake server instance.

``` javascript
var server = sinon.fakeServer.create();
server.log = function (response, request) {
  console.log('response: %o request: %o', response, request);
};
```
