### PR TITLE
Freeze formatio dependency to 1.1.1 to allow tests to continue working

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepublish": "./build"
   },
   "dependencies": {
-    "formatio": "~1.1.1",
+    "formatio": "1.1.1",
     "util": ">=0.10.3 <1",
     "lolex": "1.1.0"
   },


### PR DESCRIPTION
formatio 1.1.2 introduces "(empty string)" as special formatting of
empty strings, which is a breaking change and should really be 1.2.0

However, right now we just need to have the tests passing so people
can keep working on **this** codebase.

@mantoni @cjno this one is important, as it's preventing people from working
