### PR TITLE
Fix for: Losing stack trace on error #677

### DIFF
--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -55,7 +55,7 @@
                 if (!doneIsWrapped) {
                     if (typeof exception !== "undefined") {
                         sandbox.restore();
-                        throw exception;
+                        throw exception.stack;
                     } else {
                         sandbox.verifyAndRestore();
                     }


### PR DESCRIPTION
Rethrowing exception.stack instead of exception.
This fix allow to not loose exception stack in Developer tools.

Rethrow exception:
![](http://snag.gy/hP1bi.jpg)

Rethrow exception.stack:
![](http://snag.gy/0w0vX.jpg)