### PR TITLE
Added onLastCall function

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -166,6 +166,10 @@
                 return this.stub.onThirdCall();
             },
 
+            onLastCall: function onLastCall() {
+                return this.stub.onLastCall();
+            },
+
             withArgs: function withArgs(/* arguments */) {
                 throw new Error("Defining a stub by invoking \"stub.onCall(...).withArgs(...)\" is not supported. " +
                                 "Use \"stub.withArgs(...).onCall(...)\" to define sequential behavior for calls with certain arguments.");

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -166,10 +166,6 @@
                 return this.stub.onThirdCall();
             },
 
-            onLastCall: function onLastCall() {
-                return this.stub.onLastCall();
-            },
-
             withArgs: function withArgs(/* arguments */) {
                 throw new Error("Defining a stub by invoking \"stub.onCall(...).withArgs(...)\" is not supported. " +
                                 "Use \"stub.withArgs(...).onCall(...)\" to define sequential behavior for calls with certain arguments.");

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -133,7 +133,7 @@
             onThirdCall: function onThirdCall() {
                 return this.onCall(2);
             },
-            
+
             onLastCall: function onLastCall() {
                 return this.onCall(this.behaviors.length);
             }

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -115,7 +115,9 @@
             },
 
             onCall: function onCall(index) {
-                if (!this.behaviors[index]) {
+                if (typeof index === "undefined") {
+                    return this.onCall(this.behaviors.length);
+                } else if (!this.behaviors[index]) {
                     this.behaviors[index] = sinon.behavior.create(this);
                 }
 
@@ -132,10 +134,6 @@
 
             onThirdCall: function onThirdCall() {
                 return this.onCall(2);
-            },
-
-            onLastCall: function onLastCall() {
-                return this.onCall(this.behaviors.length);
             }
         };
 

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -132,6 +132,10 @@
 
             onThirdCall: function onThirdCall() {
                 return this.onCall(2);
+            },
+            
+            onLastCall: function onLastCall() {
+                return this.onCall(this.behaviors.length);
             }
         };
 

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -1339,7 +1339,7 @@ buster.testCase("sinon.stub", {
             var stub = sinon.stub().returns(3);
             stub.onFirstCall().returns(1)
                 .onCall(2).returns(2)
-                .onLastCall().returns(4);
+                .onCall().returns(4);
 
             assert.same(stub(), 1);
             assert.same(stub(), 3);

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -1338,11 +1338,13 @@ buster.testCase("sinon.stub", {
         "can be used with returns to produce sequence": function () {
             var stub = sinon.stub().returns(3);
             stub.onFirstCall().returns(1)
-                .onCall(2).returns(2);
+                .onCall(2).returns(2)
+                .onLastCall().returns(4);
 
             assert.same(stub(), 1);
             assert.same(stub(), 3);
             assert.same(stub(), 2);
+            assert.same(stub(), 4);
             assert.same(stub(), 3);
         },
 


### PR DESCRIPTION
When tests change the behavior of a stub, they have to mention the index of the call to the stub.

Most of the time a test is only concerned with the latest behavior, which is onCall(this.behaviors.length)

I have added this convenience function along with the existing onFirstCall, onSecondCall, onThirdCall functions.