### PR TITLE
Return a proper stub for custom subbed methods with callsFake

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -141,7 +141,9 @@
             invoke: function invoke(context, args) {
                 callCallback(this, args);
 
-                if (this.exception) {
+                if (this.fakeFn) {
+                    return this.fakeFn.apply(context, args);
+                } else if (this.exception) {
                     throw this.exception;
                 } else if (typeof this.returnArgAt === "number") {
                     return args[this.returnArgAt];
@@ -174,6 +176,11 @@
                     "is not supported. Use \"stub.withArgs(...).onCall(...)\" " +
                     "to define sequential behavior for calls with certain arguments."
                 );
+            },
+
+            callsFake: function callsFake(fn) {
+                this.fakeFn = fn;
+                return this;
             },
 
             callsArg: function callsArg(pos) {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -26,7 +26,7 @@
 
             if (func) {
                 if (typeof func === "function") {
-                    wrapper = sinon.spy && sinon.spy.create ? sinon.spy.create(func) : func;
+                    wrapper = sinon.stub && sinon.stub.create ? sinon.stub.create().callsFake(func) : func;
                 } else {
                     wrapper = func;
                     if (sinon.spy && sinon.spy.create) {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -226,6 +226,19 @@
             }
         },
 
+        ".callsFake": {
+           setUp: function () {
+               this.stub = sinon.stub.create();
+           },
+
+           "calls fake function": function () {
+               var fake = sinon.stub.create();
+               this.stub.callsFake(fake);
+               this.stub(1, 2);
+               assert(fake.calledWith(1, 2));
+           }
+       },
+
         ".callsArg": {
             setUp: function () {
                 this.stub = sinon.stub.create();
@@ -541,11 +554,11 @@
                 assert.isFunction(stub.throws);
             },
 
-            "custom stubbed method should not be proper stub": function () {
+            "custom stubbed method should be proper stub": function () {
                 var stub = sinon.stub(this.object, "method", function () {});
 
-                refute.defined(stub.returns);
-                refute.defined(stub.throws);
+                assert.isFunction(stub.onCall);
+                assert.isFunction(stub.resetBehavior);
             },
 
             "stub should be spy": function () {


### PR DESCRIPTION
Here's the problem I was having:

``` js
// In the preamble of a suite, fail if an error is logged, even in a try ... catch
sinon.stub(logger, 'error', function() {
  setImmediate(function() {
    throw new Error("Error logged in test")
  });
})

// later, testing a path that should error
logger.error.resetBehavior() // <- logger.error has no reset behavior!
expect(logger.error).to.have.been.called
```

The quickest path to implement was to pull in the proposed `callsFake` from #768.  I understand `callsFake` style behavior has also been discussed in #278.  I hope this PR strikes the right balance of expanding the API a little bit to make the library more productive.  

Benefits:
- Custom stubs are now composable. Ex: `sinon.stub(beep, 'boop').onSecondCall().callsFake(x => {value: x})` 
- It's easier to switch from `sinon.stub(beep, 'boop').returns(x)` to `sinon.stub(beep, 'boop').callsFake(x => {value: x})` as I'm thinking through my test.  Less syntax thrashing.
- Sinon is more consistent with Jasmine, making it easier for new developers and reducing context switching.
- The api is more internally consistent and predictable: `sinon.stub()` now always returns a stub

Drawbacks:
- There are 2 ways to define custom stub behavior.  `callsFake` could be the only syntax after a major version bump.
