### PR TITLE
Fix 648: test for this.proxy before trying toString on it

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -155,8 +155,12 @@
             },
 
             toString: function () {
-                var callStr = this.proxy.toString() + "(";
+                var callStr = this.proxy ? this.proxy.toString() + "(" : "";
                 var args = [];
+
+                if (!this.args) {
+                    return ":(";
+                }
 
                 for (var i = 0, l = this.args.length; i < l; ++i) {
                     args.push(sinon.format(this.args[i]));


### PR DESCRIPTION
Fixes #648

I am not sure how we can test this, as it's not an error that shows up in our test suite.

The PR merely implements the hotfix that people have discovered and reported in #648 
