### PR TITLE
stub.reset also resets behavior

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -125,6 +125,11 @@
                 }
             },
 
+            reset: function () {
+                sinon.spy.reset.call(this);
+                this.resetBehavior();
+            },
+
             onCall: function onCall(index) {
                 if (!this.behaviors[index]) {
                     this.behaviors[index] = sinon.behavior.create(this);

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1490,8 +1490,8 @@
 
                     stub.reset();
 
-                    assert.same(stub(5), 1);
-                    assert.same(stub(5), 2);
+                    assert.same(stub(5), undefined);
+                    assert.same(stub(5), undefined);
                     refute.defined(stub(5));
                 },
 
@@ -1641,16 +1641,29 @@
             }
         },
 
-        "reset only resets call history": function () {
-            var obj = { a: function () {} };
-            var spy = sinon.spy();
-            sinon.stub(obj, "a").callsArg(1);
+        ".reset": {
+            "resets behavior": function () {
+                var obj = { a: function () {} };
+                var spy = sinon.spy();
+                sinon.stub(obj, "a").callsArg(1);
 
-            obj.a(null, spy);
-            obj.a.reset();
-            obj.a(null, spy);
+                obj.a(null, spy);
+                obj.a.reset();
+                obj.a(null, spy);
 
-            assert(spy.calledTwice);
+                assert(spy.calledOnce);
+            },
+
+            "resets call history": function () {
+                var stub = sinon.stub();
+
+                stub(1);
+                stub.reset();
+                stub(2);
+
+                assert(stub.calledOnce);
+                assert.equals(stub.getCall(0).args[0], 2);
+            }
         },
 
         ".resetBehavior": {


### PR DESCRIPTION
Now reset() resets the complete stub - both call history and behavior.
This is incompatible but more consistent.

Fixes #806