### PR TITLE
First effort towards moving to CommonJS

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -132,7 +132,7 @@
         "func-style": [0, "declaration"],
         "generator-star": 0,
         "generator-star-spacing": 0,
-        "global-strict": [2, "never"],
+        "global-strict": [2, "always"],
         "guard-for-in": 2,
         "handle-callback-err": 0,
         "indent": [2, 4, {"indentSwitchCase": true}],

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ before_install:
   - npm install buster@0.7.18
 
 before_script:
-  - rvm install 2.2.0
-  - rvm use 2.2.0 --default
-  - gem install juicer
   # we only need to run eslint once per build, so let's conserve a few resources
   - 'if [ "x$TRAVIS_NODE_VERSION" = "x0.12" ]; then $(npm bin)/eslint .; fi'
 

--- a/build
+++ b/build
@@ -1,14 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  require "juicer/merger/javascript_merger"
-rescue LoadError => err
-  puts "Install juicer ruby gem to build Sinon.JS. Try `gem install juicer`."
-  if !defined?(Gem)
-    puts "RubyGems is not loaded. Perhaps that is why juicer can not be found?"
-  end
-  exit
-end
-
 require "fileutils"
 require "pathname"
 
@@ -28,61 +18,27 @@ def add_license(file, version)
 
 PREAMBLE
 
-    contents = contents.gsub("\"use strict\";\n", "")
-    declaration = "var sinon = (function () {"
-    f.puts(contents.sub(declaration, "#{declaration}\n\"use strict\";\n"))
+    f.puts(contents)
   end
 end
 
-def add_deps(file)
-  if !File.exists?("./node_modules/formatio")
-    puts <<-MSG
-formatio not found, skipping. To build with formatio support:
-    npm install formatio
-    MSG
-    return file
-  end
+# This code is an awful hack that is done here only because
+# PhantomJS 1.x incorrectly handles "use strict" statement in
+# some cases leading to sinon spy executing in a non-strict
+# mode, even though it explicitly says otherwise. Since the
+# people still use PhantomJS 1.x, this has to remain here
+# to add another wrapper with another "use strict" on top
+# of UMD bundle packaged by browserify.
+def add_use_strict(file)
 
   contents = File.read(file)
 
   File.open(file, "w") do |f|
-    f.puts("(function (root, factory) {")
-    f.puts("  'use strict';");
-    f.puts("  if (typeof define === 'function' && define.amd) {")
-    f.puts("    define('sinon', [], function () {")
-    f.puts("      return (root.sinon = factory());")
-    f.puts("    });")
-    f.puts("  } else if (typeof exports === 'object') {")
-    f.puts("    module.exports = factory();")
-    f.puts("  } else {")
-    f.puts("    root.sinon = factory();")
-    f.puts("  }")
-    f.puts("}(this, function () {")
-    f.puts("  'use strict';");
-    f.puts("  var samsam, formatio, lolex;")
-    f.puts("  (function () {")
-    f.puts(<<EOF)
-                function define(mod, deps, fn) {
-                  if (mod == "samsam") {
-                    samsam = deps();
-                  } else if (typeof deps === "function" && mod.length === 0) {
-                    lolex = deps();
-                  } else if (typeof fn === "function") {
-                    formatio = fn(samsam);
-                  }
-                }
-EOF
-    f.puts("    define.amd = {};")
-    f.puts(File.read("./node_modules/samsam/lib/samsam.js"))
-    f.puts(File.read("./node_modules/formatio/lib/formatio.js"))
-    f.puts(File.read("./node_modules/lolex/lolex.js"))
-    f.puts("  })();")
-    # mask the real define from the code so that it doesn't use it internally
-    f.puts("  var define;")
+    f.puts("(function () {")
+    f.puts("  'use strict';")
     f.puts(contents)
-    f.puts("  return sinon;")
-    f.puts("}));")
-    end
+    f.puts("}());")
+  end
 
   file
 end
@@ -91,14 +47,11 @@ Dir.chdir(File.dirname(__FILE__)) do
   version = File.read("package.json").match(/"version":\s+"(.*)"/)[1]
   version_string = ARGV[0] == "plain" ? "" : "-#{version}"
   output = "pkg/sinon#{version_string}.js"
+  browserify = "./node_modules/.bin/browserify"
 
   FileUtils.mkdir("pkg") unless File.exists?("pkg")
-  merger = Juicer::Merger::JavaScriptMerger.new
-  merger << "lib/sinon/test_case.js"
-  merger << "lib/sinon/assert.js"
-  merger << "lib/sinon/util/fake_xdomain_request.js"
-  merger.save(output)
-  add_license(add_deps(output), version)
+  `#{browserify} -s sinon lib/sinon.js -o #{output}`
+  add_license(add_use_strict(output), version)
 
   File.open("pkg/sinon-ie#{version_string}.js", "w") do |f|
     f.puts(File.read("lib/sinon/util/timers_ie.js"))
@@ -109,9 +62,11 @@ Dir.chdir(File.dirname(__FILE__)) do
 
   add_license("pkg/sinon-ie#{version_string}.js", version)
 
-  merger = Juicer::Merger::JavaScriptMerger.new
-  merger << "lib/sinon/util/fake_server_with_clock.js"
-  merger.save("pkg/sinon-server#{version_string}.js")
+  output_server = "pkg/sinon-server#{version_string}.js"
+  server_entry_point = "lib/sinon/util/fake_server_with_clock.js"
+  simulate_empty_sinon_core = "-i './lib/sinon/util/core.js'"
+  `#{browserify} #{server_entry_point} #{simulate_empty_sinon_core} -s sinon -o #{output_server}`
+
   add_license("pkg/sinon-server#{version_string}.js", version)
   FileUtils.cp(output, 'pkg/sinon.js')
   FileUtils.cp("pkg/sinon-ie#{version_string}.js", 'pkg/sinon-ie.js')

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -6,42 +6,12 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-var sinon = (function () { // eslint-disable-line no-unused-vars
-    "use strict";
+"use strict";
+module.exports = require("./sinon/util/core");
 
-    var sinonModule;
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
-
-    function loadDependencies(require, exports, module) {
-        sinonModule = module.exports = require("./sinon/util/core");
-        require("./sinon/extend");
-        require("./sinon/walk");
-        require("./sinon/typeOf");
-        require("./sinon/times_in_words");
-        require("./sinon/spy");
-        require("./sinon/call");
-        require("./sinon/behavior");
-        require("./sinon/stub");
-        require("./sinon/mock");
-        require("./sinon/collection");
-        require("./sinon/assert");
-        require("./sinon/sandbox");
-        require("./sinon/test");
-        require("./sinon/test_case");
-        require("./sinon/match");
-        require("./sinon/format");
-        require("./sinon/log_error");
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-    } else if (isNode) {
-        loadDependencies(require, module.exports, module);
-        sinonModule = module.exports;
-    } else {
-        sinonModule = {};
-    }
-
-    return sinonModule;
-}());
+// Modifying exports of another modules is not the right
+// way to handle exports in CommonJS but this is a minimal
+// change to how sinon was built before.
+require("./sinon/test_case");
+require("./sinon/assert");
+require("./sinon/util/fake_xdomain_request");

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -1,10 +1,4 @@
 /**
- * @depend times_in_words.js
- * @depend util/core.js
- * @depend match.js
- * @depend format.js
- */
-/**
  * Assertions matching the test spy retrieval interface.
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -12,8 +6,12 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-(function (sinonGlobal, global) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./times_in_words");
+    require("./match");
+    require("./format");
 
     var slice = Array.prototype.slice;
 
@@ -197,30 +195,6 @@
         return assert;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        require("./match");
-        require("./format");
-        module.exports = makeApi(sinon);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon, // eslint-disable-line no-undef
-    typeof global !== "undefined" ? global : self
-));
+}());

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -1,8 +1,4 @@
 /**
- * @depend util/core.js
- * @depend extend.js
- */
-/**
  * Stub behavior
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -11,8 +7,10 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./extend");
 
     var slice = Array.prototype.slice;
     var join = Array.prototype.join;
@@ -344,28 +342,6 @@
         return proto;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        require("./extend");
-        module.exports = makeApi(sinon);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -1,9 +1,4 @@
 /**
-  * @depend util/core.js
-  * @depend match.js
-  * @depend format.js
-  */
-/**
   * Spy calls
   *
   * @author Christian Johansen (christian@cjohansen.no)
@@ -13,8 +8,11 @@
   * Copyright (c) 2010-2013 Christian Johansen
   * Copyright (c) 2013 Maximilian Antoni
   */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./match");
+    require("./format");
 
     var slice = Array.prototype.slice;
 
@@ -207,29 +205,6 @@
         return createSpyCall;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        require("./match");
-        require("./format");
-        module.exports = makeApi(sinon);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -1,10 +1,4 @@
 /**
- * @depend util/core.js
- * @depend spy.js
- * @depend stub.js
- * @depend mock.js
- */
-/**
  * Collections of stubs, spies and mocks.
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -12,8 +6,12 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./mock");
+    require("./spy");
+    require("./stub");
 
     var push = [].push;
     var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -144,30 +142,6 @@
         return collection;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        require("./mock");
-        require("./spy");
-        require("./stub");
-        module.exports = makeApi(sinon);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/extend.js
+++ b/lib/sinon/extend.js
@@ -1,8 +1,5 @@
-/**
- * @depend util/core.js
- */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
 
     function makeApi(sinon) {
 
@@ -85,27 +82,6 @@
         return sinon.extend;
     }
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        module.exports = makeApi(sinon);
-    }
+    makeApi(require("./util/core"));
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/format.js
+++ b/lib/sinon/format.js
@@ -1,7 +1,4 @@
 /**
- * @depend util/core.js
- */
-/**
  * Format functions
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -9,13 +6,12 @@
  *
  * Copyright (c) 2010-2014 Christian Johansen
  */
-(function (sinonGlobal, formatio) {
-    "use strict";
+"use strict";
+(function () {
+
+    var formatio = require("formatio");
 
     function makeApi(sinon) {
-        function valueFormatter(value) {
-            return "" + value;
-        }
 
         function getFormatioFormatter() {
             var formatter = formatio.configure({
@@ -30,65 +26,10 @@
             return format;
         }
 
-        function getNodeFormatter() {
-            try {
-                var util = require("util");
-            } catch (e) {
-                /* Node, but no util module - would be very old, but better safe than sorry */
-            }
-
-            function format(v) {
-                var isObjectWithNativeToString = typeof v === "object" && v.toString === Object.prototype.toString;
-                return isObjectWithNativeToString ? util.inspect(v) : v;
-            }
-
-            return util ? format : valueFormatter;
-        }
-
-        var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-        var formatter;
-
-        if (isNode) {
-            try {
-                formatio = require("formatio");
-            }
-            catch (e) {} // eslint-disable-line no-empty
-        }
-
-        if (formatio) {
-            formatter = getFormatioFormatter();
-        } else if (isNode) {
-            formatter = getNodeFormatter();
-        } else {
-            formatter = valueFormatter;
-        }
-
-        sinon.format = formatter;
+        sinon.format = getFormatioFormatter();
         return sinon.format;
     }
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        module.exports = makeApi(sinon);
-    }
+    makeApi(require("./util/core"));
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon, // eslint-disable-line no-undef
-    typeof formatio === "object" && formatio // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/log_error.js
+++ b/lib/sinon/log_error.js
@@ -1,7 +1,4 @@
 /**
- * @depend util/core.js
- */
-/**
  * Logs errors
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -9,8 +6,8 @@
  *
  * Copyright (c) 2010-2014 Christian Johansen
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
 
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
@@ -58,27 +55,6 @@
         return exports;
     }
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        module.exports = makeApi(sinon);
-    }
+    makeApi(require("./util/core"));
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -1,10 +1,4 @@
 /**
- * @depend util/core.js
- * @depend typeOf.js
- */
-/*jslint eqeqeq: false, onevar: false, plusplus: false*/
-/*global module, require, sinon*/
-/**
  * Match functions
  *
  * @author Maximilian Antoni (mail@maxantoni.de)
@@ -12,8 +6,10 @@
  *
  * Copyright (c) 2012 Maximilian Antoni
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./typeOf");
 
     function makeApi(sinon) {
         function assertType(value, type, name) {
@@ -234,28 +230,6 @@
         return match;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        require("./typeOf");
-        module.exports = makeApi(sinon);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -1,14 +1,4 @@
 /**
- * @depend times_in_words.js
- * @depend util/core.js
- * @depend call.js
- * @depend extend.js
- * @depend match.js
- * @depend spy.js
- * @depend stub.js
- * @depend format.js
- */
-/**
  * Mock functions.
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -16,8 +6,16 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./times_in_words");
+    require("./call");
+    require("./extend");
+    require("./match");
+    require("./spy");
+    require("./stub");
+    require("./format");
 
     function makeApi(sinon) {
         var push = [].push;
@@ -457,35 +455,8 @@
         return mock;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        require("./times_in_words");
-        require("./call");
-        require("./extend");
-        require("./match");
-        require("./spy");
-        require("./stub");
-        require("./format");
-
-        module.exports = makeApi(sinon);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
 }(
     typeof sinon === "object" && sinon // eslint-disable-line no-undef
 ));

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -1,11 +1,4 @@
 /**
- * @depend util/core.js
- * @depend extend.js
- * @depend collection.js
- * @depend util/fake_timers.js
- * @depend util/fake_server_with_clock.js
- */
-/**
  * Manages fake collections as well as fake utilities such as Sinon's
  * timers and fake XHR implementation in one convenient object.
  *
@@ -14,8 +7,13 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./extend");
+    require("./collection");
+    require("./util/fake_server_with_clock");
+    require("./util/fake_timers");
 
     function makeApi(sinon) {
         var push = [].push;
@@ -140,31 +138,6 @@
         return sinon.sandbox;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        require("./extend");
-        require("./util/fake_server_with_clock");
-        require("./util/fake_timers");
-        require("./collection");
-        module.exports = makeApi(sinon);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -1,11 +1,4 @@
 /**
-  * @depend times_in_words.js
-  * @depend util/core.js
-  * @depend extend.js
-  * @depend call.js
-  * @depend format.js
-  */
-/**
   * Spy functions
   *
   * @author Christian Johansen (christian@cjohansen.no)
@@ -13,8 +6,13 @@
   *
   * Copyright (c) 2010-2013 Christian Johansen
   */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./times_in_words");
+    require("./extend");
+    require("./call");
+    require("./format");
 
     function makeApi(sinon) {
         var push = Array.prototype.push;
@@ -433,31 +431,6 @@
         return spy;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var core = require("./util/core");
-        require("./call");
-        require("./extend");
-        require("./times_in_words");
-        require("./format");
-        module.exports = makeApi(core);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -1,11 +1,4 @@
 /**
- * @depend util/core.js
- * @depend extend.js
- * @depend spy.js
- * @depend behavior.js
- * @depend walk.js
- */
-/**
  * Stub functions
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -13,8 +6,13 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./behavior");
+    require("./spy");
+    require("./extend");
+    require("./walk");
 
     function makeApi(sinon) {
         function stub(object, property, func) {
@@ -175,30 +173,6 @@
         return stub;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var core = require("./util/core");
-        require("./behavior");
-        require("./spy");
-        require("./extend");
-        module.exports = makeApi(core);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -1,8 +1,4 @@
 /**
- * @depend util/core.js
- * @depend sandbox.js
- */
-/**
  * Test function, sandboxes fakes
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -10,8 +6,10 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./sandbox");
 
     function makeApi(sinon) {
         var slice = Array.prototype.slice;
@@ -81,20 +79,6 @@
         return test;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var core = require("./util/core");
-        require("./sandbox");
-        module.exports = makeApi(core);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-    } else if (isNode) {
-        loadDependencies(require, module.exports, module);
-    } else if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(typeof sinon === "object" && sinon || null)); // eslint-disable-line no-undef
+}());

--- a/lib/sinon/test_case.js
+++ b/lib/sinon/test_case.js
@@ -1,8 +1,4 @@
 /**
- * @depend util/core.js
- * @depend test.js
- */
-/**
  * Test case, sandboxes all test functions
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -10,8 +6,10 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
+
+    require("./test");
 
     function createTest(property, setUp, tearDown) {
         return function () {
@@ -79,28 +77,6 @@
         return testCase;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./util/core"));
 
-    function loadDependencies(require, exports, module) {
-        var core = require("./util/core");
-        require("./test");
-        module.exports = makeApi(core);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/times_in_words.js
+++ b/lib/sinon/times_in_words.js
@@ -1,8 +1,5 @@
-/**
- * @depend util/core.js
- */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
 
     function makeApi(sinon) {
 
@@ -23,27 +20,6 @@
         return sinon.timesInWords;
     }
 
-    function loadDependencies(require, exports, module) {
-        var core = require("./util/core");
-        module.exports = makeApi(core);
-    }
+    makeApi(require("./util/core"));
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/lib/sinon/typeOf.js
+++ b/lib/sinon/typeOf.js
@@ -1,7 +1,4 @@
 /**
- * @depend util/core.js
- */
-/**
  * Format functions
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -9,8 +6,8 @@
  *
  * Copyright (c) 2010-2014 Christian Johansen
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
 
     function makeApi(sinon) {
         function typeOf(value) {
@@ -27,27 +24,5 @@
         return sinon.typeOf;
     }
 
-    function loadDependencies(require, exports, module) {
-        var core = require("./util/core");
-        module.exports = makeApi(core);
-    }
-
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+    makeApi(require("./util/core"));
+}());

--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -1,7 +1,4 @@
 /**
- * @depend ../../sinon.js
- */
-/**
  * Sinon core utilities. For internal use only.
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -9,8 +6,8 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
 
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
@@ -376,26 +373,5 @@
         return sinon;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
-
-    function loadDependencies(require, exports) {
-        makeApi(exports);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+    makeApi(exports);
+}());

--- a/lib/sinon/util/event.js
+++ b/lib/sinon/util/event.js
@@ -10,12 +10,8 @@
  *
  * Copyright (c) 2011 Sven Fuchs, Christian Johansen
  */
-if (typeof sinon === "undefined") {
-    this.sinon = {};
-}
-
+"use strict";
 (function () {
-    "use strict";
 
     var push = [].push;
 
@@ -93,19 +89,6 @@ if (typeof sinon === "undefined") {
         };
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./core"));
 
-    function loadDependencies(require) {
-        var sinon = require("./core");
-        makeApi(sinon);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-    } else if (isNode) {
-        loadDependencies(require);
-    } else {
-        makeApi(sinon); // eslint-disable-line no-undef
-    }
 }());

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -1,10 +1,4 @@
 /**
- * @depend fake_xdomain_request.js
- * @depend fake_xml_http_request.js
- * @depend ../format.js
- * @depend ../log_error.js
- */
-/**
  * The Sinon "server" mimics a web server that receives requests from
  * sinon.FakeXMLHttpRequest and provides an API to respond to those requests,
  * both synchronously and asynchronously. To respond synchronuously, canned
@@ -15,8 +9,13 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
+"use strict";
 (function () {
-    "use strict";
+
+    require("./fake_xdomain_request");
+    require("./fake_xml_http_request");
+    require("../format");
+    require("../log_error");
 
     var push = [].push;
 
@@ -225,23 +224,6 @@
         };
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./core"));
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./core");
-        require("./fake_xdomain_request");
-        require("./fake_xml_http_request");
-        require("../format");
-        makeApi(sinon);
-        module.exports = sinon;
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-    } else if (isNode) {
-        loadDependencies(require, module.exports, module);
-    } else {
-        makeApi(sinon); // eslint-disable-line no-undef
-    }
 }());

--- a/lib/sinon/util/fake_server_with_clock.js
+++ b/lib/sinon/util/fake_server_with_clock.js
@@ -1,8 +1,4 @@
 /**
- * @depend fake_server.js
- * @depend fake_timers.js
- */
-/**
  * Add-on for sinon.fakeServer that automatically handles a fake timer along with
  * the FakeXMLHttpRequest. The direct inspiration for this add-on is jQuery
  * 1.3.x, which does not use xhr object's onreadystatehandler at all - instead,
@@ -16,8 +12,11 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
+"use strict";
 (function () {
-    "use strict";
+
+    require("./fake_server");
+    require("./fake_timers");
 
     function makeApi(sinon) {
         function Server() {}
@@ -81,21 +80,6 @@
         };
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./core"));
 
-    function loadDependencies(require) {
-        var sinon = require("./core");
-        require("./fake_server");
-        require("./fake_timers");
-        makeApi(sinon);
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-    } else if (isNode) {
-        loadDependencies(require);
-    } else {
-        makeApi(sinon); // eslint-disable-line no-undef
-    }
 }());

--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -15,12 +15,10 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
+"use strict";
 (function () {
-    "use strict";
 
-    function makeApi(s, lol) {
-        /*global lolex */
-        var llx = typeof lolex !== "undefined" ? lolex : lol;
+    function makeApi(s, llx) {
 
         s.useFakeTimers = function () {
             var now;
@@ -54,20 +52,6 @@
         };
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./core"), require("lolex"));
 
-    function loadDependencies(require, epxorts, module, lolex) {
-        var core = require("./core");
-        makeApi(core, lolex);
-        module.exports = core;
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-    } else if (isNode) {
-        loadDependencies(require, module.exports, module, require("lolex"));
-    } else {
-        makeApi(sinon); // eslint-disable-line no-undef
-    }
 }());

--- a/lib/sinon/util/fake_xdomain_request.js
+++ b/lib/sinon/util/fake_xdomain_request.js
@@ -1,19 +1,13 @@
 /**
- * @depend core.js
- * @depend ../extend.js
- * @depend event.js
- * @depend ../log_error.js
- */
-/**
  * Fake XDomainRequest object
  */
-if (typeof sinon === "undefined") {
-    this.sinon = {};
-}
 
-// wrapper for global
+"use strict";
 (function (global) {
-    "use strict";
+
+    require("../extend");
+    require("./event");
+    require("../log_error");
 
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
@@ -201,23 +195,6 @@ if (typeof sinon === "undefined") {
         sinon.FakeXDomainRequest = FakeXDomainRequest;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./core"));
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./core");
-        require("../extend");
-        require("./event");
-        require("../log_error");
-        makeApi(sinon);
-        module.exports = sinon;
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-    } else if (isNode) {
-        loadDependencies(require, module.exports, module);
-    } else {
-        makeApi(sinon); // eslint-disable-line no-undef
-    }
 })(typeof global !== "undefined" ? global : self);

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -1,10 +1,4 @@
 /**
- * @depend core.js
- * @depend ../extend.js
- * @depend event.js
- * @depend ../log_error.js
- */
-/**
  * Fake XMLHttpRequest object
  *
  * @author Christian Johansen (christian@cjohansen.no)
@@ -12,8 +6,12 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-(function (sinonGlobal, global) {
-    "use strict";
+"use strict";
+(function (global) {
+
+    require("../extend");
+    require("./event");
+    require("../log_error");
 
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
@@ -685,32 +683,6 @@
         sinon.FakeXMLHttpRequest = FakeXMLHttpRequest;
     }
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
+    makeApi(require("./core"));
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./core");
-        require("../extend");
-        require("./event");
-        require("../log_error");
-        makeApi(sinon);
-        module.exports = sinon;
-    }
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon, // eslint-disable-line no-undef
-    typeof global !== "undefined" ? global : self
-));
+}(typeof global !== "undefined" ? global : self));

--- a/lib/sinon/util/timers_ie.js
+++ b/lib/sinon/util/timers_ie.js
@@ -11,7 +11,7 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-/*eslint-disable strict, no-inner-declarations, no-unused-vars*/
+/*eslint-disable strict, no-inner-declarations, no-unused-vars, global-strict*/
 if (typeof window !== "undefined") {
     function setTimeout() {}
     function clearTimeout() {}

--- a/lib/sinon/util/xdr_ie.js
+++ b/lib/sinon/util/xdr_ie.js
@@ -6,7 +6,7 @@
  *
  * If you don't require fake XDR to work in IE, don't include this file.
  */
-/*eslint-disable strict*/
+/*eslint-disable strict, global-strict*/
 if (typeof window !== "undefined") {
     function XDomainRequest() {} // eslint-disable-line no-unused-vars, no-inner-declarations
 

--- a/lib/sinon/util/xhr_ie.js
+++ b/lib/sinon/util/xhr_ie.js
@@ -11,7 +11,7 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-/*eslint-disable strict*/
+/*eslint-disable strict, global-strict*/
 if (typeof window !== "undefined") {
     function XMLHttpRequest() {} // eslint-disable-line no-unused-vars, no-inner-declarations
 

--- a/lib/sinon/walk.js
+++ b/lib/sinon/walk.js
@@ -1,8 +1,5 @@
-/**
- * @depend util/core.js
- */
-(function (sinonGlobal) {
-    "use strict";
+"use strict";
+(function () {
 
     function makeApi(sinon) {
         /* Public: walks the prototype chain of an object and iterates over every own property
@@ -41,30 +38,8 @@
         }
 
         sinon.walk = walk;
-        return sinon.walk;
     }
 
-    function loadDependencies(require, exports, module) {
-        var sinon = require("./util/core");
-        module.exports = makeApi(sinon);
-    }
+    makeApi(require("./util/core"));
 
-    var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
-    var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
-
-    if (isAMD) {
-        define(loadDependencies);
-        return;
-    }
-
-    if (isNode) {
-        loadDependencies(require, module.exports, module);
-        return;
-    }
-
-    if (sinonGlobal) {
-        makeApi(sinonGlobal);
-    }
-}(
-    typeof sinon === "object" && sinon // eslint-disable-line no-undef
-));
+}());

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "samsam": "1.1.2"
   },
   "devDependencies": {
+    "browserify": "^11.1.0",
     "buster": "0.7.18",
     "buster-core": "^0.6.4",
     "buster-istanbul": "0.1.13",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "global-strict": [2, "never"]
+    }
+}

--- a/test/buster.js
+++ b/test/buster.js
@@ -1,39 +1,5 @@
 var config = module.exports;
 
-config.browser = {
-    environment: "browser",
-    rootPath: "../",
-    libs: [
-        "node_modules/lolex/lolex.js",
-        "node_modules/samsam/lib/samsam.js",
-        "node_modules/formatio/lib/formatio.js"
-    ],
-    sources: [
-        "lib/sinon.js",
-        "lib/sinon/util/core.js",
-        "lib/sinon/typeOf.js",
-        "lib/**/*.js"
-    ],
-    testHelpers: [
-        "test/test-helper.js"
-    ],
-    tests: [
-        "test/**/*-test.js"
-    ]
-};
-
-config.coverage = {
-    extends: "browser",
-    "buster-istanbul": {
-        outputDirectory: "coverage",
-        format: "lcov",
-        excludes: ["**/*.json"]
-    },
-    extensions: [
-        require("buster-istanbul")
-    ]
-};
-
 config.node = {
     environment: "node",
     rootPath: "../",
@@ -43,5 +9,17 @@ config.node = {
     ],
     tests: [
         "test/**/*.js"
+    ]
+};
+
+config.coverage = {
+    extends: "node",
+    "buster-istanbul": {
+        outputDirectory: "coverage",
+        format: "lcov",
+        excludes: ["**/*.json"]
+    },
+    extensions: [
+        require("buster-istanbul")
     ]
 };


### PR DESCRIPTION
This PR contains minimal set of changes required to proceed with issue #834. I'm not sure it should be merged straight away as there some things to discuss but should be a good start.

Since I tried to minimize code changes, this PR is using CommonJS quite pervertedly — a `core` module is used as a kind of global namespace instead of previous `sinon` global.

The packaging is done via browserify but that ruby build file is still there for now for orchestration and can be easily removed in a separate PR. Reformatting the code and getting rid of extra wrappers can also be done in a separate PR to keep things manageable. And final part is to actually export the correct things in each of the modules and assemble them.

The biggest problem with testing is that it looks like PhantomJS 1.X incorrectly handles `"use strict"` statements and somehow inherits "strictness" from the calling function. I found where I need to insert additional "use strict" in the code generated by browserify, but this would be really hacky and unnecessary according to the standard. Switch to PhantomJS 2.X solved the problem.

Additional problem / annoyance is that previously non-packages browser build was used for code coverage, but since it's no more, I had to switch to node one, which doesn't run all of the tests, so coverage dropped. Using package version with source maps also won't work because `lcov` reporter in instanbul doesn't support source maps. Not quite sure what to do here.

More stuff about testing:
* CI build is working after switch to PhantomJS 2: https://travis-ci.org/grassator/Sinon.JS
* :warning: There is no BusterJS setup for sinon-server and I have no idea how to test it.
* It might be a good idea to try to run packaged tests in different IE versions (how far back do we want to support?)

As a bonus this PR should fix issue with requiring sinon from Webpack, but needs to be confirmed.