### PR TITLE
Fixes #852: Do not attempt to re-stub constructors

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -54,6 +54,7 @@
                     // is not Object.prototype
                     if (
                         propOwner !== Object.prototype &&
+                        prop !== "constructor" &&
                         typeof sinon.getPropertyDescriptor(propOwner, prop).value === "function"
                     ) {
                         stub(object, prop);

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -101,6 +101,30 @@
                 clock = sinon.useFakeTimers(new Date("2015-1-5").getTime());
                 assert.equals(clock.now, Date.now());
             }
+        },
+
+        "#852 - createStubInstance on intherited constructors": {
+            "must not throw error": function () {
+                var A = function () {};
+                var B = function () {};
+
+                B.prototype = Object.create(A.prototype);
+                B.prototype.constructor = A;
+
+                refute.exception(function () {
+                    sinon.createStubInstance(B);
+                });
+            }
+        },
+
+        "#852(2) - createStubInstance should on same constructor": {
+            "must be idempotent": function () {
+                var A = function () {};
+                refute.exception(function () {
+                    sinon.createStubInstance(A);
+                    sinon.createStubInstance(A);
+                });
+            }
         }
     });
 }(this));


### PR DESCRIPTION
Prevents walk was iterating over `constructor` which would essentially attempt to re-stub if `createStubInstance` was already called on the constructor or an instance of it.