### PR TITLE
Use SlimerJS for unit tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 coverage/
 pkg/
+scripts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
   - "0.12"
   - "4.2"
@@ -11,12 +10,13 @@ cache:
   directories:
   - node_modules
 
-before_install:
-  - npm config set strict-ssl false
-  # use a more modern npm than ships with 0.8
-  - 'if [ "x$TRAVIS_NODE_VERSION" = "x0.8" ]; then npm install -g npm@1.4; fi'
+env:
+  - SLIMERJSLAUNCHER=$(which firefox) DISPLAY=:99.0 PATH=$TRAVIS_BUILD_DIR/slimerjs:$PATH
+addons:
+  firefox: "25.0"
 
 before_script:
+  - ./scripts/travis-install-slimerjs
   # we only need to run eslint once per build, so let's conserve a few resources
   - 'if [ "x$TRAVIS_NODE_VERSION" = "x0.12" ]; then $(npm bin)/eslint .; fi'
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "buster-istanbul": "0.1.13",
     "eslint": "^1.7.1",
     "eslint-config-defaults": "^2.1.0",
-    "pre-commit": "1.0.10"
+    "pre-commit": "1.0.10",
+    "slimerjs": "^0.9.6"
   },
   "files": [
     "lib",

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -5,11 +5,12 @@ function finish {
     if [ -n "${TRAVIS+1}" ]; then
       echo "TRAVIS detected, skip killing child processes"
     else
-      kill $(jobs -pr)
+      pkill -P 1 -u $(id -u) -n xulrunner # clean up any leftover xulrunner processes from slimerjs
     fi
 }
 
 trap finish SIGINT SIGTERM EXIT
+# trap "kill -- -$BASHPID" SIGINT SIGTERM EXIT
 
 echo
 echo starting buster-server
@@ -17,8 +18,8 @@ echo starting buster-server
 sleep 4 # takes a while for buster server to start
 
 echo
-echo starting phantomjs
-phantomjs ./node_modules/buster/script/phantom.js &
+echo starting slimerjs
+./node_modules/.bin/slimerjs --load-images=false ./node_modules/buster/script/phantom.js &
 sleep 1 # give phantomjs a second to warm up
 
 echo

--- a/scripts/travis-install-slimerjs
+++ b/scripts/travis-install-slimerjs
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu
+
+sh -e /etc/init.d/xvfb start
+echo 'Installing Slimer'
+wget http://download.slimerjs.org/v0.9/0.9.6/slimerjs-0.9.6.zip
+unzip slimerjs-0.9.6.zip
+mv slimerjs-0.9.6 ./slimerjs


### PR DESCRIPTION
**TL;DR**
This PR replaces the use of PhantomJS for SlimerJS, hoping for more stability and fewer false positives (PhantomJS is often the cause for failed builds on Travis CI)

* Install and start SlimerJS on Travis
* Kill any leftover xulrunner processes after tests are done, when we're not using Travis
* Stop running tests in node@0.8, SlimerJS dependency `ncp` uses `setImmediate`