### PR TITLE
Fix fake xhr events

### DIFF
--- a/lib/sinon/util/event.js
+++ b/lib/sinon/util/event.js
@@ -36,8 +36,8 @@ sinon.Event.prototype = {
 
 sinon.ProgressEvent = function ProgressEvent(type, progressEventRaw, target) {
     this.initEvent(type, false, false, target);
-    this.loaded = progressEventRaw.loaded || null;
-    this.total = progressEventRaw.total || null;
+    this.loaded = typeof progressEventRaw.loaded === "number" ? progressEventRaw.loaded : null;
+    this.total = typeof progressEventRaw.total === "number" ? progressEventRaw.total : null;
     this.lengthComputable = !!progressEventRaw.total;
 };
 

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -70,10 +70,11 @@ var unsafeHeaders = {
 // and uploadError.
 function UploadProgress() {
     this.eventListeners = {
-        progress: [],
-        load: [],
         abort: [],
-        error: []
+        error: [],
+        load: [],
+        loadend: [],
+        progress: []
     };
 }
 
@@ -439,6 +440,7 @@ sinon.extend(FakeXMLHttpRequest.prototype, sinon.EventTarget, {
         this.readyState = state;
 
         var readyStateChangeEvent = new sinon.Event("readystatechange", false, false, this);
+        var event, progress;
 
         if (typeof this.onreadystatechange === "function") {
             try {
@@ -448,16 +450,25 @@ sinon.extend(FakeXMLHttpRequest.prototype, sinon.EventTarget, {
             }
         }
 
-        switch (this.readyState) {
-            case FakeXMLHttpRequest.DONE:
-                if (supportsProgress) {
-                    this.upload.dispatchEvent(new sinon.ProgressEvent("progress", {loaded: 100, total: 100}));
-                    this.dispatchEvent(new sinon.ProgressEvent("progress", {loaded: 100, total: 100}));
-                }
-                this.upload.dispatchEvent(new sinon.Event("load", false, false, this));
-                this.dispatchEvent(new sinon.Event("load", false, false, this));
-                this.dispatchEvent(new sinon.Event("loadend", false, false, this));
-                break;
+        if (this.readyState === FakeXMLHttpRequest.DONE) {
+            if (this.status < 200 || this.status > 299) {
+                progress = {loaded: 0, total: 0};
+                event = this.aborted ? "abort" : "error";
+            }
+            else {
+                progress = {loaded: 100, total: 100};
+                event = "load";
+            }
+
+            if (supportsProgress) {
+                this.upload.dispatchEvent(new sinon.ProgressEvent("progress", progress, this));
+                this.upload.dispatchEvent(new sinon.ProgressEvent(event, progress, this));
+                this.upload.dispatchEvent(new sinon.ProgressEvent("loadend", progress, this));
+            }
+
+            this.dispatchEvent(new sinon.ProgressEvent("progress", progress, this));
+            this.dispatchEvent(new sinon.ProgressEvent(event, progress, this));
+            this.dispatchEvent(new sinon.ProgressEvent("loadend", progress, this));
         }
 
         this.dispatchEvent(readyStateChangeEvent);
@@ -536,14 +547,6 @@ sinon.extend(FakeXMLHttpRequest.prototype, sinon.EventTarget, {
         }
 
         this.readyState = FakeXMLHttpRequest.UNSENT;
-
-        this.dispatchEvent(new sinon.Event("abort", false, false, this));
-
-        this.upload.dispatchEvent(new sinon.Event("abort", false, false, this));
-
-        if (typeof this.onerror === "function") {
-            this.onerror();
-        }
     },
 
     getResponseHeader: function getResponseHeader(header) {

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1751,10 +1751,13 @@
                 var xhr = this.xhr;
 
                 this.xhr.addEventListener("abort", function () {
-                    assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.UNSENT);
+                    assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.DONE);
                     assert.equals(xhr.status, 0);
 
-                    done();
+                    setTimeout(function () {
+                        assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.UNSENT);
+                        done();
+                    }, 0);
                 });
 
                 this.xhr.send();
@@ -1778,10 +1781,13 @@
                 var xhr = this.xhr;
 
                 this.xhr.onabort = function () {
-                    assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.UNSENT);
+                    assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.DONE);
                     assert.equals(xhr.status, 0);
 
-                    done();
+                    setTimeout(function () {
+                        assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.UNSENT);
+                        done();
+                    }, 0);
                 };
 
                 this.xhr.send();
@@ -1929,10 +1935,13 @@
                 var xhr = this.xhr;
 
                 this.xhr.upload.addEventListener("abort", function () {
-                    assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.UNSENT);
+                    assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.DONE);
                     assert.equals(xhr.status, 0);
 
-                    done();
+                    setTimeout(function () {
+                        assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.UNSENT);
+                        done();
+                    }, 0);
                 });
 
                 this.xhr.send();

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -959,15 +959,13 @@
             },
 
             "sets aborted flag to true": function () {
-                this.xhr.aborted = true;
-
                 this.xhr.abort();
 
                 assert.isTrue(this.xhr.aborted);
             },
 
             "sets response to empty string": function () {
-                this.xhr.responseText = "Partial data";
+                this.xhr.response = "Partial data";
 
                 this.xhr.abort();
 
@@ -983,8 +981,6 @@
             },
 
             "sets errorFlag to true": function () {
-                this.xhr.errorFlag = true;
-
                 this.xhr.abort();
 
                 assert.isTrue(this.xhr.errorFlag);

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1731,6 +1731,22 @@
                 this.xhr.respond(200, {}, "");
             },
 
+            "does not trigger 'load' event on abort": function (done) {
+                this.xhr.addEventListener("load", function () {
+                    assert(false);
+                });
+
+                this.xhr.addEventListener("abort", function () {
+                    assert(true);
+
+                    // finish on next tick
+                    setTimeout(done, 0);
+                });
+
+                this.xhr.send();
+                this.xhr.abort();
+            },
+
             "triggers 'abort' event on cancel": function (done) {
                 var xhr = this.xhr;
 

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1789,7 +1789,8 @@
             },
 
             "triggers 'loadend' event at the end": function (done) {
-                this.xhr.addEventListener("loadend", function () {
+                this.xhr.addEventListener("loadend", function (e) {
+                    assertProgressEvent(e, 0);
                     assert(true);
 
                     done();
@@ -1803,6 +1804,7 @@
                 var xhr = this.xhr;
 
                 this.xhr.addEventListener("loadend", function (event) {
+                    assertProgressEvent(event, 100);
                     assert.same(xhr, event.target);
 
                     done();
@@ -1813,7 +1815,8 @@
             },
 
             "calls #onloadend at the end": function (done) {
-                this.xhr.onloadend = function () {
+                this.xhr.onloadend = function (e) {
+                    assertProgressEvent(e, 0);
                     assert(true);
 
                     done();


### PR DESCRIPTION
From [v1.12.2 to v1.13](https://github.com/sinonjs/sinon/compare/v1.12.2...v1.13.0) a bug was introduced. On errors and aborted calls, a `progress` event started being fired with `e.lengthComputable` set to true (This was the thing that broke my tests). The `progress` event was erraneously being fired with `{loaded: 100, total: 100}` also. In tracking down this issue, I ended up fixing a few other things along the way. I had to look at the XHR spec to get an idea of what was to be expected. So I updated `readyStateChange` to align more closesly to the [w3c spec](https://xhr.spec.whatwg.org/#request-error-steps). 

Here are the changes I've made based on the spec:
    
* aligned order of events (xhr && xhr.upload)
* added 'loadend' event to xhr.upload
* all `done` events are now progress events (`e.loaded`, `e.total`, `e.lengthComputable`)
* *bug fix*: 'load' was fired before 'abort'
* *bug fix*: progress events were showing complete (100 of 100) on error/abort (instead of 0 of 0)
* *bug fix*: `e.lengthComputable` was true in error/abort events
* *bug fix*: `xhr.onerror` was being called for aborted requests
