### PR TITLE
Implemented stub#resetHistory method - fixes #863

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -126,8 +126,10 @@
                 }
             },
 
+            resetHistory: sinon.spy.reset,
+
             reset: function () {
-                sinon.spy.reset.call(this);
+                this.resetHistory();
                 this.resetBehavior();
             },
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1666,6 +1666,19 @@
             }
         },
 
+        ".resetHistory": {
+            "resets history": function () {
+                var stub = sinon.stub();
+
+                stub(1);
+                stub.reset();
+                stub(2);
+
+                assert(stub.calledOnce);
+                assert.equals(stub.getCall(0).args[0], 2);
+            }
+        },
+
         ".resetBehavior": {
             "clears yields* and callsArg* sequence": function () {
                 var stub = sinon.stub().yields(1);


### PR DESCRIPTION
I refactored `stub#reset` to call `.resetHistory()` and `.resetBehvaior()`.