### PR TITLE
Allow yieldsOn, callsArgOn to use any defined context (not just an object)

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -191,9 +191,6 @@ var proto = {
         if (typeof pos !== "number") {
             throw new TypeError("argument index is not number");
         }
-        if (typeof context !== "object") {
-            throw new TypeError("argument context is not an object");
-        }
 
         this.callArgAt = pos;
         this.callbackArguments = [];
@@ -221,9 +218,6 @@ var proto = {
     callsArgOnWith: function callsArgWith(pos, context) {
         if (typeof pos !== "number") {
             throw new TypeError("argument index is not number");
-        }
-        if (typeof context !== "object") {
-            throw new TypeError("argument context is not an object");
         }
 
         this.callArgAt = pos;
@@ -256,10 +250,6 @@ var proto = {
     },
 
     yieldsOn: function (context) {
-        if (typeof context !== "object") {
-            throw new TypeError("argument context is not an object");
-        }
-
         this.callArgAt = useLeftMostCallback;
         this.callbackArguments = slice.call(arguments, 1);
         this.callbackContext = context;
@@ -280,10 +270,6 @@ var proto = {
     },
 
     yieldsToOn: function (prop, context) {
-        if (typeof context !== "object") {
-            throw new TypeError("argument context is not an object");
-        }
-
         this.callArgAt = useLeftMostCallback;
         this.callbackArguments = slice.call(arguments, 2);
         this.callbackContext = context;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -111,14 +111,6 @@
                 assert.exception(function () {
                     stub.returnsArg();
                 }, "TypeError");
-            },
-
-            "throws if index is not number": function () {
-                var stub = sinon.stub.create();
-
-                assert.exception(function () {
-                    stub.returnsArg({});
-                }, "TypeError");
             }
         },
 
@@ -357,6 +349,26 @@
                 assert(callback.calledOn(this.fakeContext));
             },
 
+            "calls argument at specified index with undefined context": function () {
+                this.stub.callsArgOn(2, undefined);
+                var callback = sinon.stub.create();
+
+                this.stub(1, 2, callback);
+
+                assert(callback.called);
+                assert(callback.calledOn(undefined));
+            },
+
+            "calls argument at specified index with number context": function () {
+                this.stub.callsArgOn(2, 5);
+                var callback = sinon.stub.create();
+
+                this.stub(1, 2, callback);
+
+                assert(callback.called);
+                assert(callback.calledOn(5));
+            },
+
             "returns stub": function () {
                 var stub = this.stub.callsArgOn(2, this.fakeContext);
 
@@ -379,27 +391,11 @@
                 }, "TypeError");
             },
 
-            "throws if no context is specified": function () {
-                var stub = this.stub;
-
-                assert.exception(function () {
-                    stub.callsArgOn(3);
-                }, "TypeError");
-            },
-
             "throws if index is not number": function () {
                 var stub = this.stub;
 
                 assert.exception(function () {
                     stub.callsArgOn(this.fakeContext, 2);
-                }, "TypeError");
-            },
-
-            "throws if context is not an object": function () {
-                var stub = this.stub;
-
-                assert.exception(function () {
-                    stub.callsArgOn(2, 2);
                 }, "TypeError");
             }
         },
@@ -419,6 +415,50 @@
 
                 assert(callback.calledWith(object));
                 assert(callback.calledOn(this.fakeContext));
+            },
+
+            "calls argument at specified index with provided args and undefined context": function () {
+                var object = {};
+                this.stub.callsArgOnWith(1, undefined, object);
+                var callback = sinon.stub.create();
+
+                this.stub(1, callback);
+
+                assert(callback.calledWith(object));
+                assert(callback.calledOn(undefined));
+            },
+
+            "calls argument at specified index with provided args and number context": function () {
+                var object = {};
+                this.stub.callsArgOnWith(1, 5, object);
+                var callback = sinon.stub.create();
+
+                this.stub(1, callback);
+
+                assert(callback.calledWith(object));
+                assert(callback.calledOn(5));
+            },
+
+            "calls argument at specified index with provided args with undefined context": function () {
+                var object = {};
+                this.stub.callsArgOnWith(1, undefined, object);
+                var callback = sinon.stub.create();
+
+                this.stub(1, callback);
+
+                assert(callback.calledWith(object));
+                assert(callback.calledOn(undefined));
+            },
+
+            "calls argument at specified index with provided args with number context": function () {
+                var object = {};
+                this.stub.callsArgOnWith(1, 5, object);
+                var callback = sinon.stub.create();
+
+                this.stub(1, callback);
+
+                assert(callback.calledWith(object));
+                assert(callback.calledOn(5));
             },
 
             "returns function": function () {
@@ -457,27 +497,11 @@
                 }, "TypeError");
             },
 
-            "throws if no context is specified": function () {
-                var stub = this.stub;
-
-                assert.exception(function () {
-                    stub.callsArgOnWith(3);
-                }, "TypeError");
-            },
-
             "throws if index is not number": function () {
                 var stub = this.stub;
 
                 assert.exception(function () {
                     stub.callsArgOnWith({});
-                }, "TypeError");
-            },
-
-            "throws if context is not an object": function () {
-                var stub = this.stub;
-
-                assert.exception(function () {
-                    stub.callsArgOnWith(2, 2);
                 }, "TypeError");
             }
         },
@@ -1146,10 +1170,26 @@
                 assert.equals(callback.args[0].length, 0);
             },
 
-            "throws if no context is specified": function () {
-                assert.exception(function () {
-                    this.stub.yieldsToOn("success");
-                }, "TypeError");
+            "yields to property of object argument with undefined context": function () {
+                this.stub.yieldsToOn("success", undefined);
+                var callback = sinon.spy();
+
+                this.stub({ success: callback });
+
+                assert(callback.calledOnce);
+                assert(callback.calledOn(undefined));
+                assert.equals(callback.args[0].length, 0);
+            },
+
+            "yields to property of object argument with number context": function () {
+                this.stub.yieldsToOn("success", 5);
+                var callback = sinon.spy();
+
+                this.stub({ success: callback });
+
+                assert(callback.calledOnce);
+                assert(callback.calledOn(5));
+                assert.equals(callback.args[0].length, 0);
             },
 
             "throws understandable error if no object with callback is passed": function () {


### PR DESCRIPTION
Currently, sinon throws an error if a stub is told to call an argument with a context that is not of type object, "TypeError: argument context is not an object", via the yieldsOn, callsArgOn, etc methods.

In certain rare circumstances, this is not desirable. For example, https://github.com/substack/node-seq calls its chained functions with a `this` context of its async callback. While this is a very strange and generally non-standard behavior, it is permitted by JS, so sinon should permit it.

This PR updates the error check to verify that `undefined` isn't being passed as the context, otherwise permits all JS types as contexts. I could update the PR to permit only functions or objects, but feel this is the better approach as `(function() {}).call(5)` seems to be valid.