### PR TITLE
Fix #867: Walk properties only once

### DIFF
--- a/lib/sinon/walk.js
+++ b/lib/sinon/walk.js
@@ -2,7 +2,7 @@
 
 var sinon = require("./util/core");
 
-function walkInternal(obj, iterator, context, originalObj) {
+function walkInternal(obj, iterator, context, originalObj, seen) {
     var proto, prop;
 
     if (typeof Object.getOwnPropertyNames !== "function") {
@@ -18,14 +18,17 @@ function walkInternal(obj, iterator, context, originalObj) {
     }
 
     Object.getOwnPropertyNames(obj).forEach(function (k) {
-        var target = typeof Object.getOwnPropertyDescriptor(obj, k).get === "function" ?
-            originalObj : obj;
-        iterator.call(context, target[k], k, target);
+        if (!seen[k]) {
+            seen[k] = true;
+            var target = typeof Object.getOwnPropertyDescriptor(obj, k).get === "function" ?
+                originalObj : obj;
+            iterator.call(context, target[k], k, target);
+        }
     });
 
     proto = Object.getPrototypeOf(obj);
     if (proto) {
-        walkInternal(proto, iterator, context, originalObj);
+        walkInternal(proto, iterator, context, originalObj, seen);
     }
 }
 
@@ -40,7 +43,7 @@ function walkInternal(obj, iterator, context, originalObj) {
  * context - (Optional) When given, the iterator will be called with this object as the receiver.
  */
 function walk(obj, iterator, context) {
-    return walkInternal(obj, iterator, context, obj);
+    return walkInternal(obj, iterator, context, obj, {});
 }
 
 sinon.walk = walk;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -702,6 +702,18 @@
                 refute.isFunction(obj.toString.restore);
                 refute.isFunction(obj.toLocaleString.restore);
                 refute.isFunction(obj.propertyIsEnumerable.restore);
+            },
+
+            "does not fail on overrides": function () {
+                var parent = {
+                    func: function () {}
+                };
+                var child = sinon.create(parent);
+                child.func = function () {};
+
+                refute.exception(function () {
+                    sinon.stub(child);
+                });
             }
         },
 

--- a/test/walk-test.js
+++ b/test/walk-test.js
@@ -139,6 +139,19 @@
             }
 
             assert.isNull(err, "sinon.walk tests failed with message '" + (err && err.message) + "'");
+        },
+
+        "does not walk the same property twice": function () {
+            var parent = {
+                func: function () {}
+            };
+            var child = sinon.create(parent);
+            child.func = function () {};
+            var iterator = sinon.spy();
+
+            sinon.walk(child, iterator);
+
+            assert.equals(iterator.callCount, 1);
         }
     });
 }(this));


### PR DESCRIPTION
This fixes `createStubInstance` for prototype chains with overrides as reported in #867. One could argue that the fix belongs into the iterator function in `sinon.stub`. I tried adding a check for whether a property is already stubbed and that also does the trick, but it seemed a bit messy.

Thoughts?