### PR TITLE
Fix #867: Walk properties only once

### DIFF
--- a/lib/sinon/walk.js
+++ b/lib/sinon/walk.js
@@ -5,7 +5,7 @@
     "use strict";
 
     function makeApi(sinon) {
-        function walkInternal(obj, iterator, context, originalObj) {
+        function walkInternal(obj, iterator, context, originalObj, seen) {
             var proto, prop;
 
             if (typeof Object.getOwnPropertyNames !== "function") {
@@ -21,14 +21,17 @@
             }
 
             Object.getOwnPropertyNames(obj).forEach(function (k) {
-                var target = typeof Object.getOwnPropertyDescriptor(obj, k).get === "function" ?
-                    originalObj : obj;
-                iterator.call(context, target[k], k, target);
+                if (!seen[k]) {
+                    seen[k] = true;
+                    var target = typeof Object.getOwnPropertyDescriptor(obj, k).get === "function" ?
+                        originalObj : obj;
+                    iterator.call(context, target[k], k, target);
+                }
             });
 
             proto = Object.getPrototypeOf(obj);
             if (proto) {
-                walkInternal(proto, iterator, context, originalObj);
+                walkInternal(proto, iterator, context, originalObj, seen);
             }
         }
 
@@ -43,7 +46,7 @@
          * context - (Optional) When given, the iterator will be called with this object as the receiver.
          */
         function walk(obj, iterator, context) {
-            return walkInternal(obj, iterator, context, obj);
+            return walkInternal(obj, iterator, context, obj, {});
         }
 
         sinon.walk = walk;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -690,6 +690,18 @@
                 refute.isFunction(obj.toString.restore);
                 refute.isFunction(obj.toLocaleString.restore);
                 refute.isFunction(obj.propertyIsEnumerable.restore);
+            },
+
+            "does not fail on overrides": function () {
+                var parent = {
+                    func: function () {}
+                };
+                var child = sinon.create(parent);
+                child.func = function () {};
+
+                refute.exception(function () {
+                    sinon.stub(child);
+                });
             }
         },
 

--- a/test/walk-test.js
+++ b/test/walk-test.js
@@ -139,6 +139,19 @@
             }
 
             assert.isNull(err, "sinon.walk tests failed with message '" + (err && err.message) + "'");
+        },
+
+        "does not walk the same property twice": function () {
+            var parent = {
+                func: function () {}
+            };
+            var child = sinon.create(parent);
+            child.func = function () {};
+            var iterator = sinon.spy();
+
+            sinon.walk(child, iterator);
+
+            assert.equals(iterator.callCount, 1);
         }
     });
 }(this));


### PR DESCRIPTION
Backport #868 for `1.17`.