### PR TITLE
Removed unneeded path resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "ci-test": "npm run lint && ./scripts/ci-test.sh",
     "test": "./scripts/ci-test.sh",
-    "lint": "$(npm bin)/eslint .",
+    "lint": "eslint .",
     "prepublish": "./build",
     "eslint-pre-commit": "./scripts/eslint-pre-commit"
   },


### PR DESCRIPTION
Every `package.json` script is run with `$(npm bin)` in the path. So we don't need to manually add it.