### PR TITLE
Tests and fixes for Issue #887

### DIFF
--- a/lib/sinon/util/core/deep-equal.js
+++ b/lib/sinon/util/core/deep-equal.js
@@ -69,7 +69,7 @@ var deepEqual = module.exports = function deepEqual(a, b) {
     }
 
     for (prop in a) {
-        if (a.hasOwnProperty(prop)) {
+        if (Object.prototype.hasOwnProperty.call(a, prop)) {
             aLength += 1;
 
             if (!(prop in b)) {
@@ -84,7 +84,7 @@ var deepEqual = module.exports = function deepEqual(a, b) {
     }
 
     for (prop in b) {
-        if (b.hasOwnProperty(prop)) {
+        if (Object.prototype.hasOwnProperty.call(b, prop)) {
             bLength += 1;
         }
     }

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -504,6 +504,49 @@
                 };
 
                 assert(sinon.deepEqual(obj1, obj2));
+            },
+
+            "passes object without prototype compared to equal object with prototype": function () {
+                var obj1 = Object.create(null);
+                obj1.a = 1;
+                obj1.b = 2;
+                obj1.c = "hey";
+
+                var obj2 = { a: 1, b: 2, c: "hey" };
+
+                assert(sinon.deepEqual(obj1, obj2));
+            },
+
+            "passes object with prototype compared to equal object without prototype": function () {
+                var obj1 = { a: 1, b: 2, c: "hey" };
+
+                var obj2 = Object.create(null);
+                obj2.a = 1;
+                obj2.b = 2;
+                obj2.c = "hey";
+
+                assert(sinon.deepEqual(obj1, obj2));
+            },
+
+            "passes equal objects without prototypes": function () {
+                var obj1 = Object.create(null);
+                obj1.a = 1;
+                obj1.b = 2;
+                obj1.c = "hey";
+
+                var obj2 = Object.create(null);
+                obj2.a = 1;
+                obj2.b = 2;
+                obj2.c = "hey";
+
+                assert(sinon.deepEqual(obj1, obj2));
+            },
+
+            "passes equal objects that override hasOwnProperty": function () {
+                var obj1 = { a: 1, b: 2, c: "hey", hasOwnProperty: "silly" };
+                var obj2 = { a: 1, b: 2, c: "hey", hasOwnProperty: "silly" };
+
+                assert(sinon.deepEqual(obj1, obj2));
             }
         },
 


### PR DESCRIPTION
Here are the tests and a fix the issue #887: deepEqual fails on objects without a prototype or that override hasOwnProperty