### PR TITLE
New documentation site!

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Docs
+
+This folder structure contains the markdown files that become the Sinon.JS documentation site available at http://sinonjs.org.
+
+
+## Source files
+
+There are two folder structures
+
+<dl>
+    <dt><code>current</code></dt>
+    <dd>documentation for <code>master</code> branch</dd>
+
+    <dt><code>releases</code></dt>
+    <dd>each new release will have it's own folder</dd>
+</dl>
+
+## Release process
+
+Whenever a new release is created, the tree from `current` (or an existing release) is copied into it's own folder with an appropriate name under the `releases` folder.
+
+### Example - new release from `master`
+
+Let's say that we're making a new `v2.0.3` release from `master`.
+
+We copy `docs/current/` into a new folder `docs/releases/v2.0.3`.
+
+The release is packaged, tagged and pushed to GitHub. The documentation build process will be notified and will compile a new version of the website and deploy it.
+
+FIXME: We still need to build all this automation.
+
+
+## Contribruting documentation
+
+If you're contributing changes to the `master` branch, then documentation in `current` should be updated.
+
+If you're contributing documentation to existing releases, then your documentation changes should go into the documentation for that release, and probably many of the following releases.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,3 +5,4 @@
 * Build documentation for 1.17.x
 * Build changelong for each release
 * Updating CONTRIBUTING.md
+* Use consistent quoting in examples

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,7 @@
+# TODO for new documentation site
+
+* Build new site using `metalsmith`
+* Verify that there are anchors for everything
+* Build documentation for 1.17.x
+* Build changelong for each release
+* Updating CONTRIBUTING.md

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,6 @@
 # TODO for new documentation site
 
+* TOC in each file
 * Build new site using `metalsmith`
 * Verify that there are anchors for everything
 * Build documentation for 1.17.x
@@ -8,3 +9,4 @@
 * Use consistent quoting in examples
 * Specify which versions of IE are supported, and where you need to load `sinon-ie.js`
 * Register a twitter account for sinonjs and automatically tweet when a new release is deployed
+* Add link verification

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,3 +6,5 @@
 * Build changelong for each release
 * Updating CONTRIBUTING.md
 * Use consistent quoting in examples
+* Specify which versions of IE are supported, and where you need to load `sinon-ie.js`
+* Register a twitter account for sinonjs and automatically tweet when a new release is deployed

--- a/docs/current/assertions.md
+++ b/docs/current/assertions.md
@@ -1,0 +1,165 @@
+# Assertions
+
+Sinon.JS ships with a set of assertions that mirror most behavior verification methods and properties on spies and stubs. The advantage of using the assertions is that failed expectations on stubs and spies can be expressed directly as assertion failures with detailed and helpful error messages.
+
+To make sure assertions integrate nicely with your test framework, you should customize either `sinon.assert.fail` or `sinon.assert.failException` and look into `sinon.assert.expose` and `sinon.assert.pass`.
+
+The assertions can be used with either spies or stubs.
+
+```javascript
+"test should call subscribers with message as first argument" : function () {
+    var message = "an example message";
+    var spy = sinon.spy();
+
+    PubSub.subscribe(message, spy);
+    PubSub.publishSync(message, "some payload");
+
+    sinon.assert.calledOnce(spy);
+    sinon.assert.calledWith(spy, message);
+}
+```
+
+## Assertions API
+
+#### `sinon.assert.fail(message)`
+
+Every assertion fails by calling this method.
+
+By default it throws an error of type `sinon.assert.failException`.
+
+If the test framework looks for assertion errors by checking for a specific exception, you can simply override the kind of exception thrown. If that does not fit with your testing framework of choice, override the `fail` method to do the right thing.
+
+
+#### `sinon.assert.failException;`
+
+Defaults to `AssertError`.
+
+
+#### `sinon.assert.pass(assertion);`
+
+Called every time `assertion` passes.
+
+Default implementation does nothing.
+
+
+#### `sinon.assert.notCalled(spy);`
+
+Passes if `spy` was never called
+
+#### `sinon.assert.called(spy);`
+
+Passes if `spy` was called at least once.
+
+
+#### `sinon.assert.calledOnce(spy);`
+
+Passes if `spy` was called once and only once.
+
+
+#### `sinon.assert.calledTwice(spy);`
+
+Passes if `spy` was called exactly twice.
+
+
+#### `sinon.assert.calledThrice(spy)`
+
+Passes if `spy` was called exactly three times.
+
+
+#### `sinon.assert.callCount(spy, num)`
+Passes if `spy` was called exactly `num` times.
+
+
+#### `sinon.assert.callOrder(spy1, spy2, ...)`
+Passes if provided spies where called in the specified order.
+
+
+#### `sinon.assert.calledOn(spy, obj)`
+
+Passes if `spy` was ever called with `obj` as its `this` value.
+
+
+#### `sinon.assert.alwaysCalledOn(spy, obj)`
+
+Passes if `spy` was always called with `obj` as its `this` value.
+
+
+#### `sinon.assert.calledWith(spy, arg1, arg2, ...);`
+
+Passes if `spy` was called with the provided arguments.
+
+
+#### `sinon.assert.alwaysCalledWith(spy, arg1, arg2, ...);`
+
+Passes if `spy` was always called with the provided arguments.
+
+
+#### `sinon.assert.neverCalledWith(spy, arg1, arg2, ...);`
+
+Passes if `spy` was never called with the provided arguments.
+
+
+#### `sinon.assert.calledWithExactly(spy, arg1, arg2, ...);`
+
+Passes if `spy` was called with the provided arguments and no others.
+
+
+#### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
+
+Passes if `spy` was always called with the provided arguments and no others.
+
+
+#### `sinon.assert.calledWithMatch(spy, arg1, arg2, ...)`
+
+Passes if `spy` was called with matching arguments.
+
+This behaves the same way as `sinon.assert.calledWith(spy, sinon.match(arg1), sinon.match(arg2), ...)`.
+
+
+#### `sinon.assert.alwaysCalledWithMatch(spy, arg1, arg2, ...)`
+
+Passes if `spy` was always called with matching arguments.
+
+This behaves the same way as `sinon.assert.alwaysCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...)`.
+
+
+#### `sinon.assert.neverCalledWithMatch(spy, arg1, arg2, ...)`
+
+Passes if `spy` was never called with matching arguments.
+
+This behaves the same way as `sinon.assert.neverCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...)`.
+
+
+#### `sinon.assert.threw(spy, exception);`
+
+Passes if `spy` threw the given exception.
+
+The exception can be a `String` denoting its type, or an actual object.
+
+If only one argument is provided, the assertion passes if `spy` ever threw any exception.
+
+
+#### `sinon.assert.alwaysThrew(spy, exception);`
+
+Like above, only required for all calls to the spy.
+
+
+#### `sinon.assert.expose(object, options);`
+
+Exposes assertions into another object, to better integrate with the test framework. For instance, JsTestDriver uses global assertions, and to make Sinon.JS assertions appear alongside them, you can do.
+
+```javascript
+sinon.assert.expose(this);
+```
+
+This will give you `assertCalled(spy)`,`assertCallOrder(spy1, spy2, ...)` and so on.
+
+The method accepts an optional options object with two options.
+
+<dl>
+    <dt>prefix</dt>
+    <dd>is a prefix to give assertions. By default it is "assert", so <code>sinon.assert.called</code> becomes <code>target.assertCalled</code>. By passing a blank string, the exposed method will be <code>target.called</code>.</dd>
+
+    <dt>includeFail</dt>
+    <dd><code>true</code> by default, copies over the <code>fail</code> and <code>failException</code> properties</dd>
+</dl>

--- a/docs/current/fake-timers.md
+++ b/docs/current/fake-timers.md
@@ -1,0 +1,73 @@
+# Fake timers
+
+Fake timers are synchronous implementations of `setTimeout` and friends that
+Sinon.JS can overwrite the global functions with to allow you to more easily
+test code using them.
+
+Fake timers provide a `clock` object to pass time, which can also be used to control `Date` objects created through either `new Date();`
+or `Date.now();` (if supported by the browser).
+
+When faking timers with IE you also need `sinon-ie.js`, which
+should be loaded after `sinon.js`.
+
+For standalone usage of fake timers it is recommended to use [lolex](https://github.com/sinonjs/lolex) package instead. It provides the same
+set of features and was previously extracted from Sinon.JS.
+
+```javascript
+{
+    setUp: function () {
+        this.clock = sinon.useFakeTimers();
+    },
+
+    tearDown: function () {
+        this.clock.restore();
+    },
+
+    "test should animate element over 500ms" : function(){
+        var el = jQuery("<div></div>");
+        el.appendTo(document.body);
+
+        el.animate({ height: "200px", width: "200px" });
+        this.clock.tick(510);
+
+        assertEquals("200px", el.css("height"));
+        assertEquals("200px", el.css("width"));
+    }
+}
+```
+
+
+## Fake timers API
+
+
+#### `var clock = sinon.useFakeTimers();`
+
+Causes Sinon to replace the global `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval` and `Date` with a custom implementation which is bound to the returned `clock` object.
+
+Starts the clock at the UNIX epoch (timestamp of 0).
+
+
+#### `var clock = sinon.useFakeTimers(now);`
+
+As above, but rather than starting the clock with a timestamp of 0, start at the provided timestamp.
+
+
+#### `var clock = sinon.useFakeTimers([now, ]prop1, prop2, ...);`
+
+Sets the clock start timestamp and names functions to fake.
+
+Possible functions are setTimeout, clearTimeout, setInterval, clearInterval, and Date. Can also be called without the timestamp.
+
+
+#### `clock.tick(ms);`
+
+Tick the clock ahead `ms` milliseconds.
+
+Causes all timers scheduled within the affected time range to be called.
+
+
+#### `clock.restore();"
+
+Restore the faked methods.
+
+Call in e.g. `tearDown`.

--- a/docs/current/fake-xhr-and-server.md
+++ b/docs/current/fake-xhr-and-server.md
@@ -1,0 +1,384 @@
+# Fake `XHR` and server
+
+## Fake `XMLHttpRequest`
+
+Provides a fake implementation of `XMLHttpRequest` and provides
+several interfaces for manipulating objects created by it.
+
+Also fakes native `XMLHttpRequest` and `ActiveXObject` (when available, and only for `XMLHTTP` progids). Helps with testing requests made with `XHR`.
+
+When faking `XHR` with IE you also need `sinon-ie.js`, which
+should be loaded after `sinon.js`.
+
+The fake server and XHR can be used completely stand-alone by downloading `sinon-server.js`.
+
+When using the fake server in IE you also need `sinon-ie.js`. Load it
+after the first file.
+
+```javascript
+{
+    setUp: function () {
+        this.xhr = sinon.useFakeXMLHttpRequest();
+        var requests = this.requests = [];
+
+        this.xhr.onCreate = function (xhr) {
+            requests.push(xhr);
+        };
+    },
+
+    tearDown: function () {
+        this.xhr.restore();
+    },
+
+    "test should fetch comments from server" : function () {
+        var callback = sinon.spy();
+        myLib.getCommentsFor("/some/article", callback);
+        assertEquals(1, this.requests.length);
+
+        this.requests[0].respond(200, { "Content-Type": "application/json" },
+                                 '[{ "id": 12, "comment": "Hey there" }]');
+        assert(callback.calledWith([{ id: 12, comment: "Hey there" }]));
+    }
+}
+```
+
+
+### `sinon.useFakeXMLHttpRequest`
+
+#### var xhr = sinon.useFakeXMLHttpRequest();"
+
+Causes Sinon to replace the native `XMLHttpRequest` object in browsers that support it with a custom implementation which does not send actual requests.
+
+In browsers that support `ActiveXObject`, this constructor is replaced, and fake objects are returned for `XMLHTTP` progIds. Other progIds, such as `XMLDOM` are left untouched.
+
+The native `XMLHttpRequest` object will be available at `sinon.xhr.XMLHttpRequest`
+
+
+#### `xhr.onCreate = function (xhr) {};`
+
+By assigning a function to the `onCreate` property of the returned object from `useFakeXMLHttpRequest()` you can subscribe to newly created `FakeXMLHttpRequest` objects. See below for the fake xhr object API.
+
+Using this observer means you can still reach objects created by e.g. `jQuery.ajax` (or other abstractions/frameworks).
+
+#### `xhr.restore();`
+
+Restore original function(s).
+
+
+### `FakeXMLHttpRequest`
+
+#### `String request.url`
+
+The URL set on the request object.
+
+
+#### `String request.method`
+
+The request method as a string.
+
+
+#### `Object request.requestHeaders`
+
+An object of all request headers, i.e.:
+
+```javascript
+{
+    "Accept": "text/html, */*",
+    "Connection": "keep-alive"
+}
+```
+
+
+#### `String request.requestBody`
+
+The request body
+
+#### `int request.status`
+
+The request's status code.
+
+`undefined` if the request has not been handled (see [`respond`](#respond) below)
+
+
+#### `String request.statusText`
+
+Only populated if the [`respond`](#respond) method is called (see below).
+
+
+#### `boolean request.async`
+
+Whether or not the request is asynchronous.
+
+
+#### `String request.username`
+
+Username, if any.
+
+
+#### `String request.password`
+
+Password, if any.
+
+
+#### `Document request.responseXML`
+
+When using [`respond`](#respond), this property is populated with a parsed document if response headers indicate as much (see [the spec](http://www.w3.org/TR/XMLHttpRequest/))
+
+
+#### `String request.getResponseHeader(header);`
+
+The value of the given response header, if the request has been responded to (see [`respond`](#respond)).
+
+
+#### `Object request.getAllResponseHeaders();`
+
+All response headers as an object.
+
+
+### Filtered requests
+
+When using Sinon.JS for mockups or partial integration/functional testing, you might want to fake some requests, while allowing others to go throught to the backend server. With filtered `FakeXMLHttpRequest`s (new in v1.3.0), you can.
+
+
+#### `FakeXMLHttpRequest.useFilters`
+
+Default `false`.
+
+When set to `true`, Sinon will check added filters if certain requests should be "unfaked"
+
+
+#### `FakeXMLHttpRequest.addFilter(fn)`
+
+Add a filter that will decide whether or not to fake a request.
+
+The filter will be called when `xhr.open` is called, with the exact same arguments (`method`, `url`, `async`, `username`, `password`). If the filter returns `true`, the request will not be faked.
+
+
+### Simulating server responses
+
+#### `request.setResponseHeaders(object);``
+
+Sets response headers (e.g. `{ "Content-Type": "text/html", /* ... */ }`, updates the `readyState` property and fires `onreadystatechange`.
+
+
+#### `request.setResponseBody(body);`
+
+Sets the respond body, updates the `readyState` property and fires `onreadystatechange`.
+
+Additionally, populates `responseXML` with a parsed document if [response headers indicate as much](http://www.w3.org/TR/XMLHttpRequest/).
+
+
+#### `request.respond(status, headers, body);``
+
+Calls the above two methods and sets the `status` and `statusText` properties.
+
+Status should be a number, the status text is looked up from `sinon.FakeXMLHttpRequest.statusCodes`.
+
+
+#### `Boolean request.autoRespond`
+
+When set to `true`, causes the server to automatically respond to incoming requests after a timeout.
+
+The default timeout is 10ms but you can control it through the `autoRespondAfter` property.
+
+Note that this feature is intended to help during mockup development, and is not suitable for use in tests.
+
+#### `Number request.autoRespondAfter`
+
+When `autoRespond` is `true`, respond to requests after this number of milliseconds. Default is 10.
+
+
+## Fake server
+High-level API to manipulate `FakeXMLHttpRequest` instances.
+
+<small>For help with handling JSON-P please refer to our [notes below](#json-p)</small>
+
+```javascript
+{
+    setUp: function () {
+        this.server = sinon.fakeServer.create();
+    },
+
+    tearDown: function () {
+        this.server.restore();
+    },
+
+    "test should fetch comments from server" : function () {
+        this.server.respondWith("GET", "/some/article/comments.json",
+            [200, { "Content-Type": "application/json" },
+             '[{ "id": 12, "comment": "Hey there" }]']);
+
+        var callback = sinon.spy();
+        myLib.getCommentsFor("/some/article", callback);
+        this.server.respond();
+
+        sinon.assert.calledWith(callback, [{ id: 12, comment: "Hey there" }]);
+    }
+}
+```
+
+
+#### `var server = sinon.fakeServer.create([config]);``
+
+Creates a new server.
+
+This function also calls `sinon.useFakeXMLHttpRequest()`.
+
+`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+
+
+#### `var server = sinon.fakeServerWithClock.create();`
+
+Creates a server that also manages fake timers.
+
+This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which uses a timer to poll the object for completion, rather than the usual `onreadystatechange`.
+
+
+#### `server.configure(config);`
+
+Configures the fake server.
+
+See [options](#options) below for configuration parameters.
+
+#### `server.respondWith(response);`
+
+Causes the server to respond to any request not matched by another response with the provided data. The default catch-all response is `[404, {}, ""]`.
+
+`response` can be on of three things:
+
+1. A `String` representing the response body
+2. An `Array` with status, headers and response body, e.g. `[200, { "Content-Type": "text/html", "Content-Length": 2 }, "OK"]`
+3. A `Function`.
+
+Default status is 200 and default headers are none.
+
+When the response is a `Function`, it will be passed the request object. You
+must manually call [respond](#respond) on it to complete the
+request.
+
+
+#### `server.respondWith(url, response);`
+
+Responds to all requests to given URL, e.g. `/posts/1`.
+
+
+#### `server.respondWith(method, url, response);`
+
+Responds to all `method` requests to the given URL with the given response.
+
+`method` is an HTTP verb.
+
+
+#### `server.respondWith(urlRegExp, response);`
+
+URL may be a regular expression, e.g. `/\\/post\\//\\d+`
+
+If the response is a `Function`, it will be passed any capture groups from the regular expression along with the XMLHttpRequest object:
+
+```javascript
+server.respondWith(/\/todo-items\/(\d+)/, function (xhr, id) {
+    xhr.respond(200, { "Content-Type": "application/json" }, '[{ "id": ' + id + " }]");
+});
+```
+
+
+#### `server.respondWith(method, urlRegExp, response);`
+
+Responds to all `method` requests to URLs matching the regular expression.
+
+#### `server.respond();`
+
+Causes all queued asynchronous requests to receive a response.
+
+If none of the responses added through `respondWith` match, the default response is `[404, {}, ""]`.
+
+Synchronous requests are responded to immediately, so make sure to call `respondWith` upfront.
+
+If called with arguments, `respondWith` will be called with those arguments before responding to requests.
+
+
+#### `server.autoRespond = true;`
+`
+If set, will automatically respond to every request after a timeout.
+
+The default timeout is 10ms but you can control it through the `autoRespondAfter` property.
+
+Note that this feature is intended to help during mockup development, and is not suitable for use in tests. For synchronous immediate responses, use `respondImmediately` instead.
+
+
+#### `server.autoRespondAfter = ms;`
+
+Causes the server to automatically respond to incoming requests after a timeout.
+
+#### `server.respondImmediately = true;`
+
+If set, the server will respond to every request immediately and synchronously.
+
+This is ideal for faking the server from within a test without having to call `server.respond()` after each request made in that test.
+
+As this is synchronous and immediate, this is not suitable for simulating actual network latency in tests or mockups. To simulate network latency with automatic responses, see `server.autoRespond` and `server.autoRespondAfter`.
+
+#### `Boolean server.fakeHTTPMethods`
+
+If set to `true`, server will find `_method` parameter in POST body and recognize that as the actual method.
+
+Supports a pattern common to Ruby on Rails applications (FIXME: which pattern? Links?). For custom HTTP method faking, override `server.getHTTPMethod(request)`.
+
+
+#### `server.getHTTPMethod(request)`
+
+Used internally to determine the HTTP method used with the provided request.
+
+By default this method simply returns `request.method`. When `server.fakeHTTPMethods` is true, the method will return the value of the `_method` parameter if the method is "POST".
+
+This method can be overridden to provide custom behavior.
+
+
+#### `server.restore();`
+
+Restores the native XHR constructor.
+
+
+### Fake server options
+
+These options are properties on the server object and can be set directly
+
+
+```javascript
+server.autoRespond = true
+```
+
+You can also pass options with an object literal to `fakeServer.create` and `.configure`.
+
+#### `Boolean autoRespond`
+
+If set, will automatically respond to every request after a timeout.
+
+The default timeout is 10ms but you can control it through the `autoRespondAfter` property.
+
+Note that this feature is intended to help during mockup development, and is not suitable for use in tests.
+
+For synchronous immediate responses, use `respondImmediately` instead.
+
+
+#### `Number autoRespondAfter (ms)`
+
+Causes the server to automatically respond to incoming requests after a timeout.
+
+#### `Boolean respondImmediately`
+
+If set, the server will respond to every request immediately and synchronously.
+
+This is ideal for faking the server from within a test without having to call `server.respond()` after each request made in that test.
+
+As this is synchronous and immediate, this is not suitable for simulating actual network latency in tests or mockups. To simulate network latency with automatic responses, see `server.autoRespond` and `server.autoRespondAfter`.
+
+
+#### `boolean fakeHTTPMethods`
+
+If set to `true`, server will find `_method` parameter in `POST` body and recognize that as the actual method.
+
+Supports a pattern common to Ruby on Rails applications (FIXME: which pattern? Links?).
+
+For custom HTTP method faking, override `server.getHTTPMethod(request)`
+

--- a/docs/current/index.md
+++ b/docs/current/index.md
@@ -10,7 +10,8 @@ This page contains the entire Sinon.JS API documentation along with brief    int
 * [JSON-P](./json-p.md)
 * [Assertions](./assertions.md)
 * [Matchers](./matchers.md)
-
+* [Sandboxes](./sandbox.md)
+* [Utils](./utils.md)
 
 ## Stuck?
 

--- a/docs/current/index.md
+++ b/docs/current/index.md
@@ -3,4 +3,4 @@
 This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements. Please ask questions on <a href=\"http://groups.google.com/group/sinonjs\">the mailing list</a> if you're stuck. We also really appreciate suggestions to improve the documentation so Sinon.JS is easier to work with. Get in touch!
 
 * [Spies](./spies.md)
-*
+* [Stubs](./stubs.md)

--- a/docs/current/index.md
+++ b/docs/current/index.md
@@ -1,6 +1,16 @@
 # Sinon.JS
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements. Please ask questions on <a href=\"http://groups.google.com/group/sinonjs\">the mailing list</a> if you're stuck. We also really appreciate suggestions to improve the documentation so Sinon.JS is easier to work with. Get in touch!
+This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
 
 * [Spies](./spies.md)
 * [Stubs](./stubs.md)
+* [Mocks](./mocks.md)
+
+## Stuck?
+
+Please ask questions on <a href=\"http://groups.google.com/group/sinonjs\">the mailing list</a> if you're stuck.
+
+## Contribute
+
+We really appreciate suggestions to improve the documentation so Sinon.JS can be easy to work with. Get in touch!
+

--- a/docs/current/index.md
+++ b/docs/current/index.md
@@ -9,6 +9,7 @@ This page contains the entire Sinon.JS API documentation along with brief    int
 * [Fake <code>XHR</code> and server](./fake-xhr-and-server.md)
 * [JSON-P](./json-p.md)
 * [Assertions](./assertions.md)
+* [Matchers](./matchers.md)
 
 
 ## Stuck?

--- a/docs/current/index.md
+++ b/docs/current/index.md
@@ -8,6 +8,7 @@ This page contains the entire Sinon.JS API documentation along with brief    int
 * [Fake timers](./fake-timers.md)
 * [Fake <code>XHR</code> and server](./fake-xhr-and-server.md)
 * [JSON-P](./json-p.md)
+* [Assertions](./assertions.md)
 
 
 ## Stuck?

--- a/docs/current/index.md
+++ b/docs/current/index.md
@@ -1,0 +1,6 @@
+# Sinon.JS
+
+This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements. Please ask questions on <a href=\"http://groups.google.com/group/sinonjs\">the mailing list</a> if you're stuck. We also really appreciate suggestions to improve the documentation so Sinon.JS is easier to work with. Get in touch!
+
+* [Spies](./spies.md)
+*

--- a/docs/current/index.md
+++ b/docs/current/index.md
@@ -7,6 +7,7 @@ This page contains the entire Sinon.JS API documentation along with brief    int
 * [Mocks](./mocks.md)
 * [Fake timers](./fake-timers.md)
 * [Fake <code>XHR</code> and server](./fake-xhr-and-server.md)
+* [JSON-P](./json-p.md)
 
 
 ## Stuck?

--- a/docs/current/index.md
+++ b/docs/current/index.md
@@ -5,6 +5,7 @@ This page contains the entire Sinon.JS API documentation along with brief    int
 * [Spies](./spies.md)
 * [Stubs](./stubs.md)
 * [Mocks](./mocks.md)
+* [Fake timers](./fake-timers.md)
 
 ## Stuck?
 

--- a/docs/current/index.md
+++ b/docs/current/index.md
@@ -6,6 +6,8 @@ This page contains the entire Sinon.JS API documentation along with brief    int
 * [Stubs](./stubs.md)
 * [Mocks](./mocks.md)
 * [Fake timers](./fake-timers.md)
+* [Fake <code>XHR</code> and server](./fake-xhr-and-server.md)
+
 
 ## Stuck?
 

--- a/docs/current/json-p.md
+++ b/docs/current/json-p.md
@@ -1,0 +1,12 @@
+# JSON-P
+
+JSON-P doesn't use `XHR requests, which is what the fake server is concerned with. A JSON-P request creates a script element and inserts it into the document.
+
+There is no sufficiently unobtrusive way to fake this automatically. The best option is to simply stub jQuery in this case:
+
+```javascript
+sinon.stub(jQuery, "ajax");
+sinon.assert.calledOnce(jQuery.ajax);
+```
+
+We could potentially have had the fake server detect `jQuery` and fake any calls to `jQuery.ajax when JSON-P is used, but that felt like a compromise in the focus of the Sinon project compared to simply documenting the above practice.

--- a/docs/current/matchers.md
+++ b/docs/current/matchers.md
@@ -1,0 +1,177 @@
+# Matchers
+
+Matchers can be passed as arguments to `spy.calledWith`, `spy.returned` and the
+corresponding `sinon.assert` functions as well as `spy.withArgs`. Matchers allow to be either more fuzzy or more specific about the expected value.
+
+```javascript
+"test should assert fuzzy": function () {
+    var book = {
+        pages: 42,
+        author: "cjno"
+    };
+    var spy = sinon.spy();
+
+    spy(book);
+
+    sinon.assert.calledWith(spy, sinon.match({ author: "cjno" }));
+    sinon.assert.calledWith(spy, sinon.match.has("pages", 42));
+}
+```
+
+```javascript
+"test should stub method differently based on argument types": function () {
+    var callback = sinon.stub();
+    callback.withArgs(sinon.match.string).returns(true);
+    callback.withArgs(sinon.match.number).throws("TypeError");
+
+    callback("abc"); // Returns true
+    callback(123); // Throws TypeError
+}
+```
+
+## Matchers API
+
+#### `sinon.match(number);`
+
+Requires the value to be == to the given number.
+
+
+#### `sinon.match(string);`
+
+Requires the value to be a string and have the expectation as a substring.
+
+
+#### `sinon.match(regexp);`
+
+Requires the value to be a string and match the given regular expression.
+
+
+#### `sinon.match(object);`
+
+Requires the value to be not `null` or `undefined` and have at least the same properties as `expectation`.
+
+This supports nested matchers.
+
+
+#### `sinon.match(function)`
+
+See `custom matchers`.
+
+
+#### `sinon.match.any`
+
+Matches anything.
+
+
+#### `sinon.match.defined`
+
+Requires the value to be defined.
+
+
+#### `sinon.match.truthy`
+
+Requires the value to be truthy.
+
+
+#### `sinon.match.falsy`
+
+Requires the value to be falsy.
+
+
+#### `sinon.match.bool`
+
+Requires the value to be a `Boolean`
+
+
+#### `sinon.match.number`
+
+Requires the value to be a `Number`.
+
+
+#### `sinon.match.string`
+
+Requires the value to be a `String`.
+
+
+#### `sinon.match.object"
+
+Requires the value to be an `Object`.
+
+
+#### `sinon.match.func"
+
+Requires the value to be a `Function`.
+
+
+#### `sinon.match.array"
+
+Requires the value to be an `Array`.
+
+
+#### `sinon.match.regexp"
+
+Requires the value to be a regular expression.
+
+
+#### `sinon.match.date"
+
+Requires the value to be a `Date object.
+
+
+#### `sinon.match.same(ref)"
+
+Requires the value to strictly equal `ref`.
+
+
+#### `sinon.match.typeOf(type)"
+
+Requires the value to be of the given type, where `type` can be one of
+    `"undefined"`,
+    `"null"`,
+    `"boolean"`,
+    `"number"`,
+    `"string"`,
+    `"object"`,
+    `"function"`,
+    `"array"`,
+    `"regexp"` or
+    `"date"`.
+
+
+#### `sinon.match.instanceOf(type)"
+
+Requires the value to be an instance of the given `type`.
+
+
+#### `sinon.match.has(property[, expectation])"
+
+Requires the value to define the given `property`.
+
+The property might be inherited via the prototype chain. If the optional expectation is given, the value of the property is deeply compared with the expectation. The expectation can be another matcher.
+
+#### `sinon.match.hasOwn(property[, expectation])"
+
+Same as `sinon.match.has` but the property must be defined by the value itself. Inherited properties are ignored.
+
+
+## Combining matchers
+
+All matchers implement `and` and `or`. This allows to logically combine mutliple matchers. The result is a new matchers that requires both (and) or one of the matchers (or) to return `true`.
+
+```javascript
+var stringOrNumber = sinon.match.string.or(sinon.match.number);
+var bookWithPages = sinon.match.instanceOf(Book).and(sinon.match.has("pages"));
+```
+
+
+## Custom matchers
+
+Custom matchers are created with the `sinon.match` factory which takes a test function and an optional message.
+
+The test function takes a value as the only argument, returns `true` if the value matches the expectation and `false` otherwise. The message string is used to generate the error message in case the value does not match the expectation.
+
+```javascript
+var trueIsh = sinon.match(function (value) {
+    return !!value;
+}, "trueIsh");
+```

--- a/docs/current/mocks.md
+++ b/docs/current/mocks.md
@@ -1,0 +1,46 @@
+# Mocks
+
+## What are mocks?
+
+Mocks (and mock expectations) are fake methods (like spies) with pre-programmed behavior (like stubs) as well as **pre-programmed expectations**.
+
+A mock will fail your test if it is not used as expected.
+
+
+## When to use mocks?
+
+Mocks should only be used for the *method under test*. In every unit test, there should be one unit under test.
+
+If you want to control how your unit is being used and like stating expectations upfront (as opposed to asserting after the fact), use a mock.
+
+
+## When to **not** use mocks?
+
+Mocks come with built-in expectations that may fail your test.
+
+Thus, they enforce implementation details. The rule of thumb is: if you wouldn't add an assertion for some specific call, don't mock it. Use a stub instead.
+
+In general you should never have more than **one** mock (possibly with several expectations) in a single test.
+
+[Expectations](#expectations) implement both the [spies](#spies) and [stubs](#stubs) APIs.
+
+To see what mocks look like in Sinon.JS, here is one of the [PubSubJS][pubsubjs] tests again, this time using a method as callback and using mocks to verify its behavior
+
+```javascript
+"test should call all subscribers when exceptions": function () {
+    var myAPI = { method: function () {} };
+
+    var spy = sinon.spy();
+    var mock = sinon.mock(myAPI);
+    mock.expects("method").once().throws();
+
+    PubSub.subscribe("message", myAPI.method);
+    PubSub.subscribe("message", spy);
+    PubSub.publishSync("message", undefined);
+
+    mock.verify();
+    assert(spy.calledOnce);
+}
+```
+
+[pubsubjs]: https://github.com/mroderick/pubsubjs

--- a/docs/current/mocks.md
+++ b/docs/current/mocks.md
@@ -1,26 +1,28 @@
 # Mocks
 
-## What are mocks?
+## Introduction
+
+### What are mocks?
 
 Mocks (and mock expectations) are fake methods (like spies) with pre-programmed behavior (like stubs) as well as **pre-programmed expectations**.
 
 A mock will fail your test if it is not used as expected.
 
 
-## When to use mocks?
+### When to use mocks?
 
 Mocks should only be used for the *method under test*. In every unit test, there should be one unit under test.
 
 If you want to control how your unit is being used and like stating expectations upfront (as opposed to asserting after the fact), use a mock.
 
 
-## When to **not** use mocks?
+### When to **not** use mocks?
 
 Mocks come with built-in expectations that may fail your test.
 
 Thus, they enforce implementation details. The rule of thumb is: if you wouldn't add an assertion for some specific call, don't mock it. Use a stub instead.
 
-In general you should never have more than **one** mock (possibly with several expectations) in a single test.
+In general you should have **no more than one** mock (possibly with several expectations) in a single test.
 
 [Expectations](#expectations) implement both the [spies](#spies) and [stubs](#stubs) APIs.
 
@@ -44,3 +46,113 @@ To see what mocks look like in Sinon.JS, here is one of the [PubSubJS][pubsubjs]
 ```
 
 [pubsubjs]: https://github.com/mroderick/pubsubjs
+
+
+## Mocks API
+
+### Properties
+
+#### `var mock = sinon.mock(obj);`
+
+Creates a mock for the provided object.
+
+Does not change the object, but returns a mock object to set expectations on the object's methods.
+
+
+#### `var expectation = mock.expects(\"method\");`
+
+Overrides `obj.method` with a mock function and returns it.
+
+See [expectations](#expectations-api) below.
+
+
+#### `mock.restore();`
+
+Restores all mocked methods.
+
+
+#### `mock.verify();`
+
+Verifies all expectations on the mock.
+
+If any expectation is not satisfied, an exception is thrown.
+
+Also restores the mocked methods.
+
+
+### Expectations
+
+All the expectation methods return the expectation, meaning you can chain them.
+
+Typical usage:
+
+```javascript
+sinon.mock(jQuery).expects("ajax").atLeast(2).atMost(5);
+jQuery.ajax.verify();
+```
+
+
+#### `var expectation = sinon.expectation.create([methodName]);`
+
+Creates an expectation without a mock object, basically an anonymous mock function.
+
+Method name is optional and is used in exception messages to make them more readable.
+
+
+#### `var expectation = sinon.mock();`
+
+The same as the above.
+
+
+#### `expectation.atLeast(number);`
+
+Specify the minimum amount of calls expected.
+
+
+#### `expectation.atMost(number);`
+
+Specify the maximum amount of calls expected.
+
+
+#### `expectation.never();`
+Expect the method to never be called.
+
+
+#### `expectation.once();`
+
+Expect the method to be called exactly once.
+
+
+#### `expectation.twice();`
+
+Expect the method to be called exactly twice.
+
+
+#### `expectation.thrice();`
+
+Expect the method to be called exactly thrice.
+
+
+#### `expectation.exactly(number);`
+
+Expect the method to be called exactly `number` times.
+
+
+#### `expectation.withArgs(arg1, arg2, ...);`
+
+Expect the method to be called with the provided arguments and possibly others.
+
+
+#### `expectation.withExactArgs(arg1, arg2, ...);`
+
+Expect the method to be called with the provided arguments and no others.
+
+
+#### `expectation.on(obj);`
+
+Expect the method to be called with `obj` as `this`."}
+
+
+#### `expectation.verify();`
+
+Verifies the expectation and throws an exception if it's not met.

--- a/docs/current/sandbox.md
+++ b/docs/current/sandbox.md
@@ -1,0 +1,176 @@
+# Sandboxes
+
+Sandboxes simplify working with fakes that need to be restored and/or verified.
+
+If you're using fake timers, fake XHR, or you are stubbing/spying on globally
+accessible properties you should use a sandbox to ease cleanup. By default the
+spy, stub and mock properties of the sandbox is bound to whatever object the
+function is run on, so if you don't want to manually `restore()`, you have to
+use `this.spy()` instead of `sinon.spy()` (and stub, mock).
+
+```javascript
+"test using sinon.test sandbox": sinon.test(function () {
+    var myAPI = { method: function () {} };
+    this.mock(myAPI).expects("method").once();
+
+    PubSub.subscribe("message", myAPI.method);
+    PubSub.publishSync("message", undefined);
+})
+```
+
+## Sandbox API
+
+#### `var sandbox = sinon.sandbox.create();`
+
+Creates a sandbox object
+
+
+#### `var sandbox = sinon.sandbox.create(config);`
+
+The `sinon.sandbox.create(config)` method is mostly an integration feature, and as an end-user of Sinon.JS you will probably not need it.
+
+Creates a pre-configured sandbox object. The configuration can instruct the sandbox to include fake timers, fake server, and how to interact with these.
+
+The default configuration looks like:
+
+```javascript
+sinon.defaultConfig = {
+    // ...
+    injectInto: null,
+    properties: ["spy", "stub", "mock", "clock", "server", "requests"],
+    useFakeTimers: true,
+    useFakeServer: true
+}
+```
+
+<dl>
+  <dt>injectInto</dt>
+  <dd>The sandbox's methods can be injected into another object for convenience. The <code>injectInto</code> configuration option can name an object to add properties to. Usually, this is set by <code>sinon.test</code> such that it is the <code>this</code> value in a given test function.</dd>
+
+  <dt>properties</dt>
+  <dd>What properties to inject. Note that simply naming "server" here is not sufficient to have a <code>server</code> property show up in the target object, you also have to set <code>useFakeServer</code> to <code>true</code>.
+  </dd>
+
+  <dt>useFakeTimers</dt>
+  <dd>If <code>true</code>, the sandbox will have a <code>clock</code> property. Can also be an <code>Array</code> of timer properties to fake.</dd>
+
+  <dt>useFakeServer</dt>
+  <dd>If <code>true</code>, <code>server</code> and <code>requests</code> properties are added to the sandbox. Can also be an object to use for fake server. The default one is <code>sinon.fakeServer</code>, but if you're using jQuery 1.3.x or some other library that does not set the XHR's <code>onreadystatechange</code> handler, you might want to do:
+
+<pre class=\"code-snippet\" data-lang=\"javascript\"><code>sinon.config = {
+    useFakeServer: sinon.fakeServerWithClock
+};</code></pre></dd>
+</dl>
+
+
+#### `sandbox.spy();`
+
+Works exactly like `sinon.spy`, only also adds the returned spy to the internal collection of fakes for easy restoring through `sandbox.restore()`
+
+
+#### `sandbox.stub();`
+
+Works almost exactly like `sinon.stub`, only also adds the returned stub to the internal collection of fakes for easy restoring through `sandbox.restore()`.
+
+The sandbox `stub` method can also be used to stub any kind of property. This is useful if you need to override an object's property for the duration of a test, and have it restored when the test completes
+
+#### `sandbox.mock();`
+
+Works exactly like `sinon.mock`, only also adds the returned mock to the internal collection of fakes for easy restoring through `sandbox.restore()`
+
+
+#### `sandbox.useFakeTimers();`
+
+Fakes timers and binds the `clock` object to the sandbox such that it too is restored when calling `sandbox.restore()`.
+
+Access through `sandbox.clock`.
+
+
+#### `sandbox.useFakeXMLHttpRequest();`
+
+Fakes XHR and binds the resulting object to the sandbox such that it too is restored when calling `sandbox.restore()`.
+
+Access requests through `sandbox.requests`.
+
+
+#### `sandbox.useFakeServer();`
+
+Fakes XHR and binds a server object to the sandbox such that it too is restored when calling `sandbox.restore()`.
+
+Access requests through `sandbox.requests` and server through `sandbox.server`
+
+
+#### `sandbox.restore();`
+
+Restores all fakes created through sandbox.
+
+
+## Test methods
+
+Wrapping test methods in `sinon.test` allows Sinon.JS to automatically create
+and manage sandboxes for you. The function's behavior can be configured through
+`sinon.config`.
+
+
+#### `var wrappedFn = sinon.test(fn);``
+
+The `wrappedFn` function works exactly like the original one in all respects - in addition a sandbox object is created and automatically restored when the function finishes a call.
+
+By default the spy, stub and mock properties of the sandbox is bound to whatever object the function is run on, so you can do `this.spy()` (and stub, mock) and it works exactly like `sandbox.spy()` (and stub, mock), except you don't need to manually `restore()`.
+
+
+```javascript
+{
+    injectIntoThis: true,
+    injectInto: null,
+    properties: ["spy", "stub", "mock", "clock", "server", "requests"],
+    useFakeTimers: true,
+    useFakeServer: true
+}
+```
+
+Simply set `sinon.config` to override any or all of these, e.g.:
+
+```javavscript
+sinon.config = {
+    useFakeTimers: false,
+    useFakeServer: false
+}
+```
+
+In this case, defaults are used for the non-existent properties. Additionally,
+sandboxes and tests will not have automatic access to the fake timers and fake
+server when using this configuration.
+
+## sinon.config
+
+The configuration controls how Sinon binds properties when using `sinon.test`.
+
+The default configuration looks like:
+
+<dl>
+    <dt><code>Boolean injectIntoThis</code></dt>
+    <dd>Causes properties to be injected into the `this` object of the test
+    function. Default <code>true</code>.</dd>
+
+    <dt><code>Object injectInto</code></dt>
+    <dd>Object to bind properties to. If this is <code>null</code> (default) and <code>injectIntoThis</code> is <code>false</code> (not default), the properties are passed as arguments to the test function instead.</dd>
+
+    <dt><code>Array properties</code></dt>
+    <dd>Properties to expose. Default is all: <code>["spy", "stub", "mock", "clock", "server", "requests"]</code>. However, the last three properties are only bound if the following two configuration options are <code>true</code> (which is the default).</dd>
+
+    <dt><code>Boolean useFakeTimers</code></dt>
+    <dd>Causes timers to be faked and allows <code>clock</code> property to be exposed. Default is <code>true</code>.</dd>
+
+    <dt><code>Boolean useFakeServer</code></dt>
+    <dd>Causes fake XHR and server to be created and allows <code>server</code> and <code>requests</code> properties to be exposed. Default is <code>true</code>.</dd>
+</dl>
+
+## Test cases
+
+If you need the behavior of `sinon.test` for more than one test method in a test case, you can use `sinon.testCase`, which behaves exactly like wrapping each test in `sinon.test` with one exception: `setUp` and
+`tearDown` can share fakes.
+
+#### `var obj = sinon.testCase({});
+
+

--- a/docs/current/spies.md
+++ b/docs/current/spies.md
@@ -1,0 +1,478 @@
+# Spies
+
+
+## Introduction
+
+
+### What is a test spy?
+
+A test spy is a function that records arguments, return value, the value of
+`this` and exception thrown (if any) for all its calls. A test spy can be an
+anonymous function or it can wrap an existing function.
+
+
+### When to use spies?
+
+Test spies are useful to test both callbacks and how certain functions/methods
+are used throughout the system under test. The following simplified example
+shows how to use spies to test how a function handles a callback:
+
+```javascript
+"test should call subscribers on publish": function () {
+    var callback = sinon.spy();
+    PubSub.subscribe("message", callback);
+
+    PubSub.publishSync("message");
+
+    assertTrue(callback.called);
+}
+```
+
+
+### Spying on existing methods
+
+`sinon.spy` can also spy on existing functions. When doing so, the original
+function will behave just as normal (including when used as a constructor) but
+you will have access to data about all calls. The following is a slightly
+contrived example:
+
+```javascript
+{
+    setUp: function () {
+        sinon.spy(jQuery, "ajax");
+    },
+
+    tearDown: function () {
+        jQuery.ajax.restore(); // Unwraps the spy
+    },
+
+    "test should inspect jQuery.getJSON's usage of jQuery.ajax": function () {
+        jQuery.getJSON("/some/resource");
+
+        assert(jQuery.ajax.calledOnce);
+        assertEquals("/some/resource", jQuery.ajax.getCall(0).args[0].url);
+        assertEquals("json", jQuery.ajax.getCall(0).args[0].dataType);
+    }
+}
+```
+
+
+### Creating spies: `sinon.spy()`
+
+<dl>
+  <dt><code>var spy = sinon.spy();</code></dt>
+  <dd>
+    Creates an anonymous function that records arguments, <code>this</code> value,
+    exceptions and return values for all calls.
+  </dd>
+  <dt><code>var spy = sinon.spy(myFunc);</code></dt>
+  <dd>Spies on the provided function</dd>
+  <dt><code>var spy = sinon.spy(object, "method");</code></dt>
+  <dd>
+    Creates a <a href="#spyprops">spy</a> for <code>object.method</code> and
+    replaces the original method with the spy. The spy acts exactly like the
+    original method in all cases. The original method can be restored by calling
+    <code>object.method.restore()</code>. The returned spy is the function
+    object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+</dl>
+
+
+### Spy API
+
+Spies provide a rich interface to inspect their usage. The above examples showed
+the `calledOnce` boolean property as well as the `getCall` method and the
+returned object's `args` property. There are three ways of inspecting call data.
+
+The preferred approach is to use the spy's `calledWith` method (and friends)
+because it keeps your test from being too specific about which call did what and
+so on. It will return `true` if the spy was ever called with the provided
+arguments.
+
+```javascript
+"test should call subscribers with message as first argument" : function () {
+    var message = 'an example message';
+    var spy = sinon.spy();
+
+    PubSub.subscribe(message, spy);
+    PubSub.publishSync(message, "some payload");
+
+    assert(spy.calledWith(message));
+}
+```
+
+If you want to be specific, you can directly check the first argument of the
+first call. There are two ways of achieving this:
+
+```javascript
+"test should call subscribers with message as first argument" : function () {
+    var message = 'an example message';
+    var spy = sinon.spy();
+
+    PubSub.subscribe(message, spy);
+    PubSub.publishSync(message, "some payload");
+
+    assertEquals(message, spy.args[0][0]);
+}
+```
+
+```javascript
+"test should call subscribers with message as first argument" : function () {
+    var message = 'an example message';
+    var spy = sinon.spy();
+
+    PubSub.subscribe(message, spy);
+    PubSub.publishSync(message, "some payload");
+
+    assertEquals(message, spy.getCall(0).args[0]);
+}
+```
+
+The first example uses the two-dimensional `args` array directly on the spy,
+while the second example fetches the first call object and then accesses it's
+`args` array. Which one to use is a matter of preference, but the recommended
+approach is going with `spy.calledWith(arg1, arg2, ...)` unless there's a need
+to make the tests highly specific.
+
+
+## API
+
+Spy objects are objects returned from `sinon.spy()`. When spying on existing
+methods with `sinon.spy(object, method)`, the following properties and methods
+are also available on `object.method`.
+
+### Properties
+
+
+#### `spy.withArgs(arg1[, arg2, ...]);`
+
+Creates a spy that only records calls when the received arguments match those passed to `withArgs`. This is useful to be more expressive in your assertions, where you can access the spy with the same call.
+
+```javascript
+"should call method once with each argument": function () {
+    var object = { method: function () {} };
+    var spy = sinon.spy(object, "method");
+    spy.withArgs(42);
+    spy.withArgs(1);
+
+    object.method(42);
+    object.method(1);
+
+    assert(spy.withArgs(42).calledOnce);
+    assert(spy.withArgs(1).calledOnce);
+}
+```
+
+
+#### `spy.callCount`
+
+The number of recorded calls.
+
+
+#### `spy.called`
+
+`true` if the spy was called at least once
+
+
+#### `spy.calledOnce`
+
+`true` if spy was called exactly once
+
+
+#### `spy.calledTwice`
+
+`true` if the spy was called exactly twice
+
+
+#### `spy.calledThrice`
+
+`true` if the spy was called exactly thrice
+
+
+#### `spy.firstCall`
+
+The first call
+
+
+#### `spy.secondCall`
+
+The second call
+
+
+#### `spy.thirdCall`
+
+The third call
+
+
+#### `spy.lastCall`
+
+The last call
+
+
+#### `spy.calledBefore(anotherSpy);`
+
+Returns `true` if the spy was called before `anotherSpy`
+
+
+#### `spy.calledAfter(anotherSpy);`
+
+Returns `true` if the spy was called after `anotherSpy`
+
+
+#### `spy.calledOn(obj);`
+
+Returns `true` if the spy was called at least once with `obj` as `this`.
+
+
+#### `spy.alwaysCalledOn(obj);`
+
+Returns `true` if the spy was always called with `obj` as `this`.
+
+
+#### `spy.calledWith(arg1, arg2, ...);`
+
+Returns `true` if spy was called at least once with the provided arguments.
+
+Can be used for partial matching, Sinon only checks the provided arguments against actual arguments, so a call that received the provided arguments (in the same spots) and possibly others as well will return `true`.
+
+
+#### `spy.alwaysCalledWith(arg1, arg2, ...);`
+
+Returns `true` if spy was always called with the provided arguments (and possibly others).
+
+
+#### `spy.calledWithExactly(arg1, arg2, ...);`
+
+Returns `true` if spy was called at least once with the provided arguments and no others.
+
+
+#### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`
+
+Returns `true` if spy was always called with the exact provided arguments.
+
+
+#### `spy.calledWithMatch(arg1, arg2, ...);`
+
+Returns `true` if spy was called with matching arguments (and possibly others).
+
+This behaves the same as `spy.calledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
+
+
+#### `spy.alwaysCalledWithMatch(arg1, arg2, ...);`
+
+Returns `true` if spy was always called with matching arguments (and possibly others).
+
+This behaves the same as `spy.alwaysCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
+
+
+#### `spy.calledWithNew();`
+
+Returns `true` if spy/stub was called the `new` operator.
+
+Beware that this is inferred based on the value of the `this` object and the spy function's `prototype`, so it may give false positives if you actively return the right kind of object.
+
+
+#### `spy.neverCalledWith(arg1, arg2, ...);`
+
+Returns `true` if the spy/stub was never called with the provided arguments.
+
+
+#### `spy.neverCalledWithMatch(arg1, arg2, ...);`
+
+Returns `true` if the spy/stub was never called with matching arguments.
+
+This behaves the same as `spy.neverCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
+
+
+#### `spy.threw();`
+
+Returns `true` if spy threw an exception at least once.
+
+
+#### `spy.threw(\"TypeError\");`
+
+Returns `true` if spy threw an exception of the provided type at least once.
+
+
+#### `spy.threw(obj);`
+
+Returns `true` if spy threw the provided exception object at least once.
+
+
+#### `spy.alwaysThrew();`
+
+Returns `true` if spy always threw an exception.
+
+
+#### `spy.alwaysThrew(\"TypeError\");`
+
+Returns `true` if spy always threw an exception of the provided type.
+
+
+#### `spy.alwaysThrew(obj);`
+
+Returns `true` if spy always threw the provided exception object.
+
+
+#### `spy.returned(obj);`
+
+Returns `true` if spy returned the provided value at least once.
+
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+
+
+#### `spy.alwaysReturned(obj);`
+
+Returns `true` if spy always returned the provided value.
+
+
+#### `var spyCall = spy.getCall(n);`
+
+Returns the *nth* [call](#spycall).
+
+Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+
+```javascript
+sinon.spy(jQuery, "ajax");
+jQuery.ajax("/stuffs");
+var spyCall = jQuery.ajax.getCall(0);
+
+assertEquals("/stuffs", spyCall.args[0]);
+```
+
+
+#### `spy.thisValues`
+
+Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.
+
+
+#### `spy.args`
+
+Array of arguments received, `spy.args[0]` is an array of arguments received in the first call.
+
+
+#### `spy.exceptions`
+
+Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
+
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+
+
+#### `spy.returnValues`
+
+Array of return values, `spy.returnValues[0]` is the return value of the first call.
+
+If the call did not explicitly return a value, the value at the call's location in `.returnValues` will be `undefined`.
+
+
+#### `spy.reset()`
+
+Resets the state of a spy.
+
+
+#### `spy.printf(format string\", [arg1, arg2, ...])`
+
+Returns the passed format string with the following replacements performed:
+
+<dl>
+    <dt><code>%n</code></dt>
+    <dd>the name of the spy "spy" by default)</dd>
+
+    <dt><code>%c</code></dt>
+    <dd>the number of times the spy was called, in words ("once", "twice", etc.)</dd>
+    <dt><code>%C</code></dt>
+    <dd>a list of string representations of the calls to the spy, with each call prefixed by a newline and four spaces</dd>
+
+    <dt><code>%t</code></dt>
+    <dd>a comma-delimited list of <code>this</code> values the spy was called on</dd>
+
+    <dt><code>%<var>n</var></code></dt>
+    <dd>the formatted value of the <var>n</var>th argument passed to <code>printf</code> <br/>FIXME: needs example</dd>
+
+    <dt><code>%*</code></dt>
+    <dd>a comma-delimited list of the (non-format string) arguments passed to <code>printf</code></dd>
+</dl>
+
+
+### Individual spy calls"
+
+
+##### `var spyCall = spy.getCall(n)`
+
+Returns the *nth* [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+
+```javascript
+sinon.spy(jQuery, "ajax");
+jQuery.ajax("/stuffs");
+var spyCall = jQuery.ajax.getCall(0);
+
+assertEquals("/stuffs", spyCall.args[0]);
+```
+
+
+#### `spyCall.calledOn(obj);`
+
+Returns `true` if `obj` was `this` for this call.
+
+
+#### `spyCall.calledWith(arg1, arg2, ...);`
+
+Returns `true` if call received provided arguments (and possibly others).
+
+
+#### `spyCall.calledWithExactly(arg1, arg2, ...);`
+
+Returns `true` if call received provided arguments and no others.
+
+
+#### `spyCall.calledWithMatch(arg1, arg2, ...);`
+
+Returns `true` if call received matching arguments (and possibly others).
+This behaves the same as `spyCall.calledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
+
+
+#### `spyCall.notCalledWith(arg1, arg2, ...);`
+
+Returns `true` if call did not receive provided arguments.
+
+
+#### `spyCall.notCalledWithMatch(arg1, arg2, ...);`
+
+Returns `true` if call did not receive matching arguments.
+This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
+
+
+#### `spyCall.threw();`
+
+Returns `true` if call threw an exception.
+
+
+#### `spyCall.threw(TypeError\");`
+
+Returns `true` if call threw exception of provided type.
+
+
+#### `spyCall.threw(obj);`
+
+Returns `true` if call threw provided exception object.
+
+
+#### `spyCall.thisValue`
+
+The call's `this` value.
+
+
+#### `spyCall.args`
+
+Array of received arguments.
+
+
+#### `spyCall.exception`
+
+Exception thrown, if any.
+
+
+#### `spyCall.returnValue`
+
+Return value.]}]}
+

--- a/docs/current/stubs.md
+++ b/docs/current/stubs.md
@@ -58,3 +58,279 @@ calls. As of 1.8, this functionality has been removed in favor of the <a
 href="#stub-onCall"><code>onCall</code></a> API.
 
 [pubsubjs]: https://github.com/mroderick/pubsubjs
+
+## Stub API
+
+### Properties
+
+#### `var stub = sinon.stub();`
+
+Creates an anonymous stub function
+
+
+#### `var stub = sinon.stub(object, \"method\");`
+
+Replaces `object.method` with a stub function.
+
+The original function can be restored by calling `object.method.restore();` (or `stub.restore();`).
+
+An exception is thrown if the property is not already a function, to help avoid typos when stubbing methods.
+
+
+#### `var stub = sinon.stub(object, \"method\", func);`
+
+Replaces `object.method` with a `func`, wrapped in a `spy`.
+
+As usual, `object.method.restore();` can be used to restore the original method.
+
+#### `name "var stub = sinon.stub(obj);`
+
+Stubs all the object's methods.
+
+Note that it's usually better practice to stub individual methods, particularly on objects that you don't understand or control all the methods for (e.g. library dependencies).
+
+Stubbing individual methods tests intent more precisely and is less susceptible to unexpected behavior as the object's code evolves.
+
+If you want to create a stub object of `MyConstructor`, but don't want the constructor to be invoked, use this utility function.
+
+```javascript
+var stub = sinon.createStubInstance(MyConstructor)
+```
+
+#### `name "stub.withArgs(arg1[, arg2, ...]);`
+
+Stubs the method only for the provided arguments.
+
+This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
+
+```javascript
+"test should stub method differently based on arguments\": function () {
+    var callback = sinon.stub();
+    callback.withArgs(42).returns(1);
+    callback.withArgs(1).throws("TypeError");
+
+    callback(); // No return value, no exception
+    callback(42); // Returns 1
+    callback(1); // Throws TypeError
+}
+```
+
+#### `name "stub.onCall(n);` *Added in v1.8*
+
+Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
+
+```javascript
+"test should stub method differently on consecutive calls\": function () {
+    var callback = sinon.stub();
+    callback.onCall(0).returns(1);
+    callback.onCall(1).returns(2);
+    callback.returns(3);
+
+    callback(); // Returns 1
+    callback(); // Returns 2
+    callback(); // All following calls return 3
+}
+```
+
+There are methods `onFirstCall`, `onSecondCall`,`onThirdCall` to make stub definitions read more naturally.
+
+`onCall` can be combined with all of the behavior defining methods in this section.  In particular, it can be used together with `withArgs`.
+
+```javascript
+"test should stub method differently on consecutive calls with certain argument\": function () {
+    var callback = sinon.stub();
+    callback.withArgs(42)
+        .onFirstCall().returns(1)
+        .onSecondCall().returns(2);
+    callback.returns(0);
+
+    callback(1); // Returns 0
+    callback(42); // Returns 1
+    callback(1); // Returns 0
+    callback(42); // Returns 2
+    callback(1); // Returns 0
+    callback(42); // Returns 0
+}
+```
+
+Note how the behavior of the stub for argument `42` falls back to the default behavior once no more calls have been defined.
+
+#### `stub.onFirstCall();`
+
+Alias for `stub.onCall(0);`
+
+#### `stub.onSecondCall();`
+
+Alias for `stub.onCall(1);`
+
+#### `stub.onThirdCall();`
+Alias for `stub.onCall(2);`
+
+#### `stub.returns(obj);`
+Makes the stub return the provided value.
+
+
+#### `stub.returnsArg(index);`
+
+Causes the stub to return the argument at the provided index.
+
+`stub.returnsArg(0);` causes the stub to return the first argument.
+
+
+#### `stub.returnsThis();`
+Causes the stub to return its <code>this</code> value.
+
+Useful for stubbing jQuery-style fluent APIs.
+
+
+#### `stub.throws();`
+
+Causes the stub to throw an exception (`Error`).
+
+
+#### `stub.throws("TypeError");`
+
+Causes the stub to throw an exception of the provided type.
+
+
+#### `stub.throws(obj);`
+
+Causes the stub to throw the provided exception object.
+
+
+#### `stub.callsArg(index);`
+
+Causes the stub to call the argument at the provided index as a callback function. `stub.callsArg(0);` causes the stub to call the first argument as a callback.
+
+
+#### `stub.callsArgOn(index, context);`
+
+Like `stub.callsArg(index);` but with an additional parameter to pass the `this` context.
+
+
+#### `stub.callsArgWith(index, arg1, arg2, ...);`
+
+Like `callsArg`, but with arguments to pass to the callback.
+
+
+#### `stub.callsArgOnWith(index, context, arg1, arg2, ...);`
+Like above but with an additional parameter to pass the `this` context.
+
+#### `stub.yields([arg1, arg2, ...])`
+
+Similar to `callsArg`.
+
+Causes the stub to call the first callback it receives with the provided arguments (if any).
+
+If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+
+
+#### `stub.yieldsOn(context, [arg1, arg2, ...])`
+
+Like above but with an additional parameter to pass the `this` context.
+
+
+#### `stub.yieldsTo(property, [arg1, arg2, ...])`
+
+Causes the spy to invoke a callback passed as a property of an object to the spy.
+
+Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback and calls it with the (optional) arguments.
+
+
+#### `stub.yieldsToOn(property, context, [arg1, arg2, ...])`
+
+Like above but with an additional parameter to pass the `this` context."
+
+```javascript
+"test should fake successful ajax request\": function () {
+    sinon.stub(jQuery, "ajax").yieldsTo("success", [1, 2, 3]);
+
+    jQuery.ajax({
+        success: function (data) {
+            assertEquals([1, 2, 3], data);
+        }
+    });
+}
+```
+
+
+#### `stub.yield([arg1, arg2, ...])`
+
+Invoke callbacks passed to the `stub` with the given arguments.
+
+If the stub was never called with a function argument, `yield` throws an error.
+
+Also aliased as `invokeCallback`.
+
+
+#### `stub.yieldTo(callback, [arg1, arg2, ...])``
+
+Invokes callbacks passed as a property of an object to the stub.
+
+Like `yield`, `yieldTo` grabs the first matching argument, finds the callback and calls it with the (optional) arguments.
+
+```javascript
+"calling callbacks": function () {
+    var callback = sinon.stub();
+    callback({
+        "success": function () {
+            console.log("Success!");
+        },
+        "failure": function () {
+            console.log("Oh noes!");
+        }
+    });
+
+    callback.yieldTo("failure"); // Logs "Oh noes!"
+}
+```
+
+
+#### `stub.callArg(argNum)`
+
+Like `yield`, but with an explicit argument number specifying which callback to call.
+
+Useful if a function is called with more than one callback, and simply calling the first callback is not desired.
+
+```javascript
+"calling the last callback": function () {
+    var callback = sinon.stub();
+    callback(function () {
+        console.log("Success!");
+    }, function () {
+        console.log("Oh noes!");
+    });
+
+    callback.callArg(1); // Logs "Oh noes!"
+}
+```
+
+#### `stub.callArgWith(argNum, [arg1, arg2, ...])`
+
+Like `callArg`, but with arguments.
+
+
+#### `stub.callsArgAsync(index);`
+
+Same as their corresponding non-Async counterparts, but with callback being deferred (executed not immediately but after short timeout and in another "thread")
+
+FIXME: call stack?
+FIXME: link to some article explaining asynchronous JavaScript
+
+#### `stub.callsArgAsync(index);`
+
+#### `stub.callsArgOnAsync(index, context);`
+
+#### `stub.callsArgWithAsync(index, arg1, arg2, ...);`
+
+#### `stub.callsArgOnWithAsync(index, context, arg1, arg2, ...);`
+
+#### `stub.yieldsAsync([arg1, arg2, ...]);`
+
+#### `stub.yieldsOnAsync(context, [arg1, arg2, ...]);`
+
+#### `stub.yieldsToAsync(property, [arg1, arg2, ...]);`
+
+#### `stub.yieldsToOnAsync(property, context, [arg1, arg2, ...])`
+
+Same as their corresponding non-Async counterparts, but with callback being deferred (executed not immediately but after short timeout and in another "thread")

--- a/docs/current/stubs.md
+++ b/docs/current/stubs.md
@@ -1,0 +1,60 @@
+# Stubs
+
+
+## What are stubs?
+
+Test stubs are functions (spies) with pre-programmed behavior.
+
+They support the full <a href="#spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
+
+As spies, stubs can be either anonymous, or wrap existing functions. When
+wrapping an existing function with a stub, the original function is not called.
+
+
+## When to use stubs?
+
+Use a stub when you want to:
+
+1. Control a method's behavior from a test to force the code down a specific path. Examples include forcing a method to throw an error in order to test error handling.
+
+2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest or similar).
+
+The following example is yet another test from [PubSubJS][pubsubjs] which shows how to create an anonymous stub that throws an exception when called.
+
+```javascript
+"test should call all subscribers, even if there are exceptions" : function(){
+    var message = 'an example message';
+    var error = 'an example error message';
+    var stub = sinon.stub().throws();
+    var spy1 = sinon.spy();
+    var spy2 = sinon.spy();
+
+    PubSub.subscribe(message, stub);
+    PubSub.subscribe(message, spy1);
+    PubSub.subscribe(message, spy2);
+
+    PubSub.publishSync(message, undefined);
+
+    assert(spy1.called);
+    assert(spy2.called);
+    assert(stub.calledBefore(spy1));
+}
+```
+
+Note how the stub also implements the spy interface. The test verifies that all
+callbacks were called, and also that the exception throwing stub was called
+before one of the other callbacks.
+
+### Defining stub behavior on consecutive calls
+
+Calling behavior defining methods like `returns` or `throws` multiple times
+overrides the behavior of the stub. As of Sinon version 1.8, you can use the
+[`onCall`]("#stub-onCall) method to make a stub respond differently on
+consecutive calls.
+
+Note that in Sinon version 1.5 to version 1.7, multiple calls to the `yields*`
+and `callsArg*` family of methods define a sequence of behaviors for consecutive
+calls. As of 1.8, this functionality has been removed in favor of the <a
+href="#stub-onCall"><code>onCall</code></a> API.
+
+[pubsubjs]: https://github.com/mroderick/pubsubjs

--- a/docs/current/utils.md
+++ b/docs/current/utils.md
@@ -1,0 +1,30 @@
+# Sinon.JS utilities
+
+Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the method in question is documented here, it should not be considered part of the public API, and thus is subject to change.
+
+## Utils API
+
+#### `sinon.createStubInstance(constructor);``
+
+Creates a new object with the given function as the protoype and stubs all implemented functions.
+
+The given constructor function is not invoked. See also the [stub API](#stubs).
+
+#### `sinon.format(object);`
+
+Formats an object for pretty printing in error messages. Sinon < 1.3.0
+defaulted to coercing objects to strings. As of 1.3.0, Sinon uses [buster-format](https://busterjs.org/docs/buster-format/) by default, or Node's
+[util](http://nodejs.org/docs/v0.6.6/api/util.html) module. Feel free to
+override this method with your own implementation if you prefer different
+visualization of e.g. objects. The method should return a string.
+
+#### `sinon.log(string);`
+
+Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
+environment for more help, e.g. (if you are using JsTestDriver):
+
+```javascript
+sinon.log = function (message) {
+    jstestdriver.console.log(message);
+};
+```


### PR DESCRIPTION
#### TL;DR
I would like to create a new documentation site for Sinon.JS. I was hoping we could have this done for 2.0, but then someone merged backwards incompatible changes into `master` ;-)

This PR is the first step towards a new site, importing and tidying up the existing `sinonjs/sinon-docs` as Markdown files. We don't have to merge it in it's current state, but it would be easier to recruit contributors to the effort, if it's in the `master` branch.

#### Thoughts

##### High barrier to entry

Current docs are difficult for casual contributors to contribute to.

Solution: use GitHub Flavoured Markdown, or something very close to it

##### Source changes without documentation updates

Contributors (repository owners included) often neglect updating the documentation when source changes.

Solution: keep documentation sources in the same repository as source code, so contributors can update them in same PR as source code changes.

##### Human interaction required for documentation site updates

Currently, only @cjohansen can deploy a new version of the documentation site.

Solution: fully automate build and deployment of documentation site using [metalsmith.io]( http://www.metalsmith.io) or [jekyll](http://jekyllrb.com) via heroku (or similar). Every new tag in the git repository should trigger rebuild and deploy of the site without any reliance on humans.

##### Documentation only covers current version

We should provide documentation for each tagged version (going forwards), it isn't that difficult, and makes it a lot easier for users to quickly find correct information. I've outlined the process in `docs/README.md`.

##### Misc.

* Embed the changelog to make it easier to follow changes
* Build some twitter automation to announce new versions
* Provide more examples of how to use Sinon.JS
* Provide a links page with links to related resources
