### PR TITLE
Use immediate exceptions

### DIFF
--- a/lib/sinon/log_error.js
+++ b/lib/sinon/log_error.js
@@ -40,7 +40,7 @@ function logError(label, err) {
 
 // When set to true, any errors logged will be thrown immediately;
 // If set to false, the errors will be thrown in separate execution frame.
-logError.useImmediateExceptions = false;
+logError.useImmediateExceptions = true;
 
 // wrap realSetTimeout with something we can stub in tests
 logError.setTimeout = function (func, timeout) {

--- a/test/log-error-test.js
+++ b/test/log-error-test.js
@@ -14,6 +14,7 @@
 
     buster.testCase("sinon.logError", {
         setUp: function () {
+            sinon.logError.useImmediateExceptions = false;
             this.sandbox = sinon.sandbox.create();
             this.timeOutStub = this.sandbox.stub(sinon.logError, "setTimeout");
         },


### PR DESCRIPTION
Since we're getting ready to do a new major release, I think now is a good time to change the default to use immediate exceptions instead of throwing Error in a new call stack.

People are still getting confused, see #172 