### PR TITLE
Allow requestBody in FakeXDomainRequest, FakeXMLHttpRequest for GET requests

### DIFF
--- a/lib/sinon/util/fake_xdomain_request.js
+++ b/lib/sinon/util/fake_xdomain_request.js
@@ -107,7 +107,7 @@ sinon.extend(FakeXDomainRequest.prototype, sinon.EventTarget, {
     send: function send(data) {
         verifyState(this);
 
-        if (!/^(get|head)$/i.test(this.method)) {
+        if (!/^(head)$/i.test(this.method)) {
             this.requestBody = data;
         }
         this.requestHeaders["Content-Type"] = "text/plain;charset=utf-8";

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -501,7 +501,7 @@ sinon.extend(FakeXMLHttpRequest.prototype, sinon.EventTarget, {
     send: function send(data) {
         verifyState(this);
 
-        if (!/^(get|head)$/i.test(this.method)) {
+        if (!/^(head)$/i.test(this.method)) {
             var contentType = getHeader(this.requestHeaders, "Content-Type");
             if (this.requestHeaders[contentType]) {
                 var value = this.requestHeaders[contentType].split(";");

--- a/test/util/fake-xdomain-request-test.js
+++ b/test/util/fake-xdomain-request-test.js
@@ -106,12 +106,6 @@
                     xdr.send();
                 });
             },
-            "sets GET body to null": function () {
-                this.xdr.open("GET", "/");
-                this.xdr.send("Data");
-
-                assert.isNull(this.xdr.requestBody);
-            },
 
             "sets HEAD body to null": function () {
                 this.xdr.open("HEAD", "/");
@@ -128,7 +122,13 @@
                     assert.equals(this.xdr.requestHeaders["Content-Type"], "text/plain;charset=utf-8");
                 }
             },
-            "sets request body to string data": function () {
+            "sets request body to string data for GET": function () {
+                this.xdr.open("GET", "/");
+                this.xdr.send("Data");
+
+                assert.equals(this.xdr.requestBody, "Data");
+            },
+            "sets request body to string data for POST": function () {
                 this.xdr.open("POST", "/");
                 this.xdr.send("Data");
 

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -342,13 +342,6 @@
                 });
             },
 
-            "sets GET body to null": function () {
-                this.xhr.open("GET", "/");
-                this.xhr.send("Data");
-
-                assert.isNull(this.xhr.requestBody);
-            },
-
             "sets HEAD body to null": function () {
                 this.xhr.open("HEAD", "/");
                 this.xhr.send("Data");
@@ -401,7 +394,14 @@
                 }
             },
 
-            "sets request body to string data": function () {
+            "sets request body to string data for GET": function () {
+                this.xhr.open("GET", "/");
+                this.xhr.send("Data");
+
+                assert.equals(this.xhr.requestBody, "Data");
+            },
+
+            "sets request body to string data for POST": function () {
                 this.xhr.open("POST", "/");
                 this.xhr.send("Data");
 


### PR DESCRIPTION
It looks like you're explicitly stopping both GET and HEAD requests from allowing the request body to have a body. 

Why not GET? It's in the spec that GETs should be allowed a body, which makes sense for APIs that take in large amounts of data for GET requests.

Reference quoted from http://bugs.jquery.com/ticket/8961:

> This is all explained in the  HTTP 1.1 Spec, RFC 2616...
> 
> Essentially it breaks down to the fact that the message body should be allowed unless specified otherwise in the request type specifications, as in HEAD. The GET request does not mention the message body at all, so by default **should be able to use a message body**. This is useful if you want to query the server with structured (e.g. JSON) data.