### PR TITLE
Removed unit test for GET body being null

### DIFF
--- a/test/util/fake-xdomain-request-test.js
+++ b/test/util/fake-xdomain-request-test.js
@@ -106,12 +106,6 @@
                     xdr.send();
                 });
             },
-            "sets GET body to null": function () {
-                this.xdr.open("GET", "/");
-                this.xdr.send("Data");
-
-                assert.isNull(this.xdr.requestBody);
-            },
 
             "sets HEAD body to null": function () {
                 this.xdr.open("HEAD", "/");


### PR DESCRIPTION
Now that GET bodies are allowed (as per the spec), this is no longer
true.