### PR TITLE
Add bithound badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sinon.JS
 
-[![Build status](https://secure.travis-ci.org/sinonjs/sinon.svg?branch=master)](http://travis-ci.org/sinonjs/sinon)
+[![Build status](https://secure.travis-ci.org/sinonjs/sinon.svg?branch=master)](http://travis-ci.org/sinonjs/sinon) [![bitHound Score](https://www.bithound.io/github/sinonjs/sinon/badges/score.svg)](https://www.bithound.io/github/sinonjs/sinon)
 
 Standalone and test framework agnostic JavaScript test spies, stubs and mocks.
 


### PR DESCRIPTION
Add a bithound badge to the README.md

I think it has interesting analysis and think it can help contributors find low hanging fruit (like duplication and outdated dependencies) they can pick.

Fixes #900 