### PR TITLE
Fixed #758 by checking the global variables are set

### DIFF
--- a/lib/sinon/util/fake_xdomain_request.js
+++ b/lib/sinon/util/fake_xdomain_request.js
@@ -15,14 +15,16 @@
  */
 function getGlobal() {
     "use strict";
-    if (typeof window !== "undefined") {
-        return window;
-    }
-    return typeof global !== "undefined" ? global : this;
+
+    return typeof window !== "undefined" ? window : global;
 }
 
 if (typeof sinon === "undefined") {
-    getGlobal().sinon = {};
+    if (typeof this === "undefined") {
+        getGlobal().sinon = {};
+    } else {
+        this.sinon = {};
+    }
 }
 
 // wrapper for global
@@ -234,4 +236,4 @@ if (typeof sinon === "undefined") {
     } else {
         makeApi(sinon); // eslint-disable-line no-undef
     }
-})(getGlobal());
+})(typeof global !== "undefined" ? global : self);

--- a/lib/sinon/util/fake_xdomain_request.js
+++ b/lib/sinon/util/fake_xdomain_request.js
@@ -7,8 +7,22 @@
 /**
  * Fake XDomainRequest object
  */
+
+/**
+ * Returns the global to prevent assigning values to 'this' when this is undefined.
+ * This can occur when files are interpreted by node in strict mode.
+ * @private
+ */
+function getGlobal() {
+    "use strict";
+    if (typeof window !== "undefined") {
+        return window;
+    }
+    return typeof global !== "undefined" ? global : this;
+}
+
 if (typeof sinon === "undefined") {
-    this.sinon = {};
+    getGlobal().sinon = {};
 }
 
 // wrapper for global
@@ -220,4 +234,4 @@ if (typeof sinon === "undefined") {
     } else {
         makeApi(sinon); // eslint-disable-line no-undef
     }
-})(typeof global !== "undefined" ? global : self);
+})(getGlobal());


### PR DESCRIPTION
By adding a function that checks if the 'window' or 'global' is set, it then picks corresponding one. This makes it work in a browser and Node.js (strict and non-strict). The strict mode caused the this pointer in the module to become undefined.