### PR TITLE
Remove JSCS from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "buster-istanbul": "0.1.13",
     "eslint": "^1.7.1",
     "eslint-config-defaults": "^2.1.0",
-    "jscs": "1.13.1",
     "pre-commit": "1.0.10"
   },
   "files": [


### PR DESCRIPTION
We haven't used it for awhile, let's stop installing it