### PR TITLE
Use ESLint --cache for CI speedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pkg
 node_modules
 coverage/
+.eslintcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ sudo: false
 
 cache:
   directories:
+  - .eslintcache
   - node_modules
 
 before_install:
@@ -18,7 +19,7 @@ before_install:
 
 before_script:
   # we only need to run eslint once per build, so let's conserve a few resources
-  - 'if [ "x$TRAVIS_NODE_VERSION" = "x0.12" ]; then $(npm bin)/eslint .; fi'
+  - 'if [ "x$TRAVIS_NODE_VERSION" = "x0.12" ]; then ./scripts/ci-eslint; fi'
 
 script:
   - ./scripts/ci-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ sudo: false
 
 cache:
   directories:
-  - .eslintcache
   - node_modules
 
 before_install:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,4351 @@
+{
+  "name": "sinon",
+  "version": "1.17.0",
+  "npm-shrinkwrap-version": "5.4.0",
+  "node-version": "v0.10.40",
+  "dependencies": {
+    "browserify": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-11.2.0.tgz",
+      "dependencies": {
+        "JSONStream": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.6.tgz",
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+            },
+            "through": {
+              "version": "2.3.8",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
+        "assert": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+        },
+        "browser-pack": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+          "dependencies": {
+            "combine-source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+              "dependencies": {
+                "convert-source-map": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+                },
+                "inline-source-map": {
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                },
+                "lodash.memoize": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "umd": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
+            }
+          }
+        },
+        "browser-resolve": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.10.1.tgz"
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "dependencies": {
+            "pako": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+            }
+          }
+        },
+        "buffer": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.1.tgz",
+          "dependencies": {
+            "base64-js": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+            },
+            "ieee754": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+            },
+            "is-array": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+            }
+          }
+        },
+        "builtins": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+        },
+        "commondir": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
+        },
+        "concat-stream": {
+          "version": "1.4.10",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                }
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "constants-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+        },
+        "crypto-browserify": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.10.0.tgz",
+          "dependencies": {
+            "browserify-cipher": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+              "dependencies": {
+                "browserify-aes": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz",
+                  "dependencies": {
+                    "buffer-xor": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                    },
+                    "cipher-base": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                    }
+                  }
+                },
+                "browserify-des": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+                  "dependencies": {
+                    "cipher-base": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                    },
+                    "des.js": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "evp_bytestokey": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                }
+              }
+            },
+            "browserify-sign": {
+              "version": "3.0.8",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.8.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                },
+                "browserify-rsa": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
+                },
+                "elliptic": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                    },
+                    "hash.js": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "parse-asn1": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.2.tgz",
+                  "dependencies": {
+                    "asn1.js": {
+                      "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "browserify-aes": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz",
+                      "dependencies": {
+                        "buffer-xor": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                        },
+                        "cipher-base": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "evp_bytestokey": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "create-ecdh": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.2.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                },
+                "elliptic": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                    },
+                    "hash.js": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "create-hash": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+              "dependencies": {
+                "cipher-base": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                },
+                "ripemd160": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+                },
+                "sha.js": {
+                  "version": "2.4.4",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+                }
+              }
+            },
+            "create-hmac": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+            },
+            "diffie-hellman": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                },
+                "miller-rabin": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "pbkdf2": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
+            },
+            "public-encrypt": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                },
+                "browserify-rsa": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
+                },
+                "parse-asn1": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.2.tgz",
+                  "dependencies": {
+                    "asn1.js": {
+                      "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "browserify-aes": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz",
+                      "dependencies": {
+                        "buffer-xor": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                        },
+                        "cipher-base": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "evp_bytestokey": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "randombytes": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
+            }
+          }
+        },
+        "defined": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+        },
+        "deps-sort": {
+          "version": "1.3.9",
+          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz"
+        },
+        "domain-browser": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+        },
+        "duplexer2": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "events": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+        },
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.1",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "has": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+          "dependencies": {
+            "function-bind": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.0.2.tgz"
+            }
+          }
+        },
+        "htmlescape": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.0.tgz"
+        },
+        "https-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "insert-module-globals": {
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+          "dependencies": {
+            "combine-source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+              "dependencies": {
+                "convert-source-map": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+                },
+                "inline-source-map": {
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                },
+                "lodash.memoize": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "is-buffer": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+            },
+            "lexical-scope": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+              "dependencies": {
+                "astw": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
+                  "dependencies": {
+                    "acorn": {
+                      "version": "1.2.2",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "labeled-stream-splicer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+          "dependencies": {
+            "stream-splicer": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+              "dependencies": {
+                "indexof": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                },
+                "readable-wrap": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "module-deps": {
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+          "dependencies": {
+            "detective": {
+              "version": "4.3.1",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                }
+              }
+            },
+            "stream-combiner2": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "dependencies": {
+                "through2": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+        },
+        "parents": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+          "dependencies": {
+            "path-platform": {
+              "version": "0.11.15",
+              "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
+            }
+          }
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+        },
+        "process": {
+          "version": "0.11.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+        },
+        "read-only-stream": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                }
+              }
+            },
+            "readable-wrap": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            },
+            "process-nextick-args": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+        },
+        "shasum": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+          "dependencies": {
+            "json-stable-stringify": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                }
+              }
+            },
+            "sha.js": {
+              "version": "2.4.4",
+              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+            }
+          }
+        },
+        "shell-quote": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
+        },
+        "stream-browserify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz"
+        },
+        "stream-http": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-1.7.1.tgz",
+          "dependencies": {
+            "builtin-status-codes": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-1.0.0.tgz"
+            },
+            "foreach": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+            },
+            "indexof": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+            },
+            "object-keys": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "subarg": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            }
+          }
+        },
+        "syntax-error": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "timers-browserify": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz"
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "dependencies": {
+            "querystring": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+            }
+          }
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "dependencies": {
+            "indexof": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+            }
+          }
+        },
+        "xtend": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+        }
+      }
+    },
+    "buster": {
+      "version": "0.7.18",
+      "resolved": "https://registry.npmjs.org/buster/-/buster-0.7.18.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "bane": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/bane/-/bane-1.0.0.tgz"
+        },
+        "buster-autotest": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/buster-autotest/-/buster-autotest-0.5.0.tgz",
+          "dependencies": {
+            "chokidar": {
+              "version": "0.10.9",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.10.9.tgz",
+              "dependencies": {
+                "async-each": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                },
+                "fsevents": {
+                  "version": "0.3.8",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+                    }
+                  }
+                },
+                "readdirp": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.1.0.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.7.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "multi-glob": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/multi-glob/-/multi-glob-0.4.0.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.1",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "buster-ci": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/buster-ci/-/buster-ci-0.2.3.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "buster-ci-agent": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/buster-ci-agent/-/buster-ci-agent-0.1.6.tgz",
+              "dependencies": {
+                "ffi": {
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/ffi/-/ffi-1.3.2.tgz",
+                  "dependencies": {
+                    "bindings": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "nan": {
+                      "version": "1.9.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
+                    },
+                    "ref-struct": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/ref-struct/-/ref-struct-1.0.2.tgz"
+                    }
+                  }
+                },
+                "ref": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/ref/-/ref-1.0.2.tgz",
+                  "dependencies": {
+                    "bindings": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "nan": {
+                      "version": "1.8.4",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "faye": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/faye/-/faye-1.0.3.tgz",
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.5.1",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    }
+                  }
+                },
+                "cookiejar": {
+                  "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.4.tgz",
+                  "dependencies": {
+                    "jshint": {
+                      "version": "2.8.0",
+                      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
+                      "dependencies": {
+                        "cli": {
+                          "version": "0.6.6",
+                          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "3.2.11",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                              "dependencies": {
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "0.3.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "2.7.0",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                                    },
+                                    "sigmund": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "console-browserify": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                          "dependencies": {
+                            "date-now": {
+                              "version": "0.1.4",
+                              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                            }
+                          }
+                        },
+                        "exit": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                        },
+                        "htmlparser2": {
+                          "version": "3.8.3",
+                          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+                          "dependencies": {
+                            "domelementtype": {
+                              "version": "1.3.0",
+                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                            },
+                            "domhandler": {
+                              "version": "2.3.0",
+                              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                            },
+                            "domutils": {
+                              "version": "1.5.1",
+                              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                              "dependencies": {
+                                "dom-serializer": {
+                                  "version": "0.1.0",
+                                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                                  "dependencies": {
+                                    "domelementtype": {
+                                      "version": "1.1.3",
+                                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                                    },
+                                    "entities": {
+                                      "version": "1.1.1",
+                                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "entities": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                            },
+                            "readable-stream": {
+                              "version": "1.1.13",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash": {
+                          "version": "3.7.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
+                        },
+                        "minimatch": {
+                          "version": "2.0.10",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.1",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.1",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "shelljs": {
+                          "version": "0.3.0",
+                          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+                        },
+                        "strip-json-comments": {
+                          "version": "1.0.4",
+                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "csprng": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/csprng/-/csprng-0.1.1.tgz",
+                  "dependencies": {
+                    "sequin": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/sequin/-/sequin-0.1.0.tgz"
+                    }
+                  }
+                },
+                "faye-websocket": {
+                  "version": "0.10.0",
+                  "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+                  "dependencies": {
+                    "websocket-driver": {
+                      "version": "0.6.2",
+                      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.2.tgz",
+                      "dependencies": {
+                        "websocket-extensions": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "formatio": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.2.tgz"
+            },
+            "stream-logger": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/stream-logger/-/stream-logger-1.0.0.tgz"
+            },
+            "when": {
+              "version": "3.5.2",
+              "resolved": "https://registry.npmjs.org/when/-/when-3.5.2.tgz"
+            }
+          }
+        },
+        "buster-server-cli": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/buster-server-cli/-/buster-server-cli-0.3.4.tgz",
+          "dependencies": {
+            "buster-cli": {
+              "version": "0.6.3",
+              "resolved": "https://registry.npmjs.org/buster-cli/-/buster-cli-0.6.3.tgz",
+              "dependencies": {
+                "ansi-colorizer": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-colorizer/-/ansi-colorizer-1.0.0.tgz"
+                },
+                "buster-configuration": {
+                  "version": "0.7.6",
+                  "resolved": "https://registry.npmjs.org/buster-configuration/-/buster-configuration-0.7.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.1.22",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+                    },
+                    "glob": {
+                      "version": "3.1.21",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                        },
+                        "inherits": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "when": {
+                      "version": "1.3.0",
+                      "from": "when@https://github.com/cujojs/when/tarball/1.3.0",
+                      "resolved": "https://github.com/cujojs/when/tarball/1.3.0"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "posix-argv-parser": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/posix-argv-parser/-/posix-argv-parser-1.0.2.tgz"
+                },
+                "rimraf": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-1.0.9.tgz"
+                },
+                "stream-logger": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-logger/-/stream-logger-1.0.0.tgz"
+                }
+              }
+            },
+            "ejs": {
+              "version": "0.4.3",
+              "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.4.3.tgz"
+            },
+            "paperboy": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/paperboy/-/paperboy-0.0.5.tgz"
+            },
+            "phantom-proxy": {
+              "version": "0.1.792",
+              "resolved": "https://registry.npmjs.org/phantom-proxy/-/phantom-proxy-0.1.792.tgz",
+              "dependencies": {
+                "colors": {
+                  "version": "0.6.2",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+                },
+                "event-stream": {
+                  "version": "3.0.20",
+                  "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
+                  "dependencies": {
+                    "duplexer": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                    },
+                    "from": {
+                      "version": "0.1.3",
+                      "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+                    },
+                    "map-stream": {
+                      "version": "0.0.6",
+                      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.6.tgz"
+                    },
+                    "pause-stream": {
+                      "version": "0.0.11",
+                      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+                    },
+                    "split": {
+                      "version": "0.2.10",
+                      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
+                    },
+                    "stream-combiner": {
+                      "version": "0.0.4",
+                      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "express": {
+                  "version": "3.0.6",
+                  "resolved": "https://registry.npmjs.org/express/-/express-3.0.6.tgz",
+                  "dependencies": {
+                    "buffer-crc32": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.1.1.tgz"
+                    },
+                    "commander": {
+                      "version": "0.6.1",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                    },
+                    "connect": {
+                      "version": "2.7.2",
+                      "resolved": "https://registry.npmjs.org/connect/-/connect-2.7.2.tgz",
+                      "dependencies": {
+                        "bytes": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.1.0.tgz"
+                        },
+                        "formidable": {
+                          "version": "1.0.11",
+                          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.11.tgz"
+                        },
+                        "pause": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+                        },
+                        "qs": {
+                          "version": "0.5.1",
+                          "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.1.tgz"
+                        }
+                      }
+                    },
+                    "cookie": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.0.5.tgz"
+                    },
+                    "cookie-signature": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-0.0.1.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "fresh": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz"
+                    },
+                    "methods": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.3.3",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz"
+                    },
+                    "range-parser": {
+                      "version": "0.0.4",
+                      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz"
+                    },
+                    "send": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/send/-/send-0.1.0.tgz",
+                      "dependencies": {
+                        "mime": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.6.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "form-data": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "q": {
+                  "version": "0.8.12",
+                  "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz"
+                },
+                "socket.io": {
+                  "version": "0.9.17",
+                  "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
+                  "dependencies": {
+                    "base64id": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+                    },
+                    "policyfile": {
+                      "version": "0.0.4",
+                      "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
+                    },
+                    "redis": {
+                      "version": "0.7.3",
+                      "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
+                    },
+                    "socket.io-client": {
+                      "version": "0.9.16",
+                      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+                      "dependencies": {
+                        "active-x-obfuscator": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                          "dependencies": {
+                            "zeparser": {
+                              "version": "0.0.5",
+                              "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "uglify-js": {
+                          "version": "1.2.5",
+                          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
+                        },
+                        "ws": {
+                          "version": "0.4.32",
+                          "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+                          "dependencies": {
+                            "commander": {
+                              "version": "2.1.0",
+                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+                            },
+                            "nan": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
+                            },
+                            "options": {
+                              "version": "0.0.6",
+                              "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                            },
+                            "tinycolor": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                            }
+                          }
+                        },
+                        "xmlhttprequest": {
+                          "version": "1.4.2",
+                          "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "underscore": {
+                  "version": "1.4.4",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                }
+              }
+            },
+            "ramp": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/ramp/-/ramp-1.0.6.tgz",
+              "dependencies": {
+                "ejs": {
+                  "version": "0.8.8",
+                  "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.8.8.tgz"
+                },
+                "faye": {
+                  "version": "0.8.11",
+                  "resolved": "https://registry.npmjs.org/faye/-/faye-0.8.11.tgz",
+                  "dependencies": {
+                    "cookiejar": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.4.tgz",
+                      "dependencies": {
+                        "jshint": {
+                          "version": "2.8.0",
+                          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
+                          "dependencies": {
+                            "cli": {
+                              "version": "0.6.6",
+                              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+                              "dependencies": {
+                                "glob": {
+                                  "version": "3.2.11",
+                                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                                  "dependencies": {
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "minimatch": {
+                                      "version": "0.3.0",
+                                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                                      "dependencies": {
+                                        "lru-cache": {
+                                          "version": "2.7.0",
+                                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                                        },
+                                        "sigmund": {
+                                          "version": "1.0.1",
+                                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "console-browserify": {
+                              "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                              "dependencies": {
+                                "date-now": {
+                                  "version": "0.1.4",
+                                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "exit": {
+                              "version": "0.1.2",
+                              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                            },
+                            "htmlparser2": {
+                              "version": "3.8.3",
+                              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+                              "dependencies": {
+                                "domelementtype": {
+                                  "version": "1.3.0",
+                                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                                },
+                                "domhandler": {
+                                  "version": "2.3.0",
+                                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                                },
+                                "domutils": {
+                                  "version": "1.5.1",
+                                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                                  "dependencies": {
+                                    "dom-serializer": {
+                                      "version": "0.1.0",
+                                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                                      "dependencies": {
+                                        "domelementtype": {
+                                          "version": "1.1.3",
+                                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                                        },
+                                        "entities": {
+                                          "version": "1.1.1",
+                                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "entities": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                                },
+                                "readable-stream": {
+                                  "version": "1.1.13",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash": {
+                              "version": "3.7.0",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
+                            },
+                            "minimatch": {
+                              "version": "2.0.10",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.1",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.1",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "shelljs": {
+                              "version": "0.3.0",
+                              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "faye-websocket": {
+                      "version": "0.10.0",
+                      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+                      "dependencies": {
+                        "websocket-driver": {
+                          "version": "0.6.2",
+                          "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.2.tgz",
+                          "dependencies": {
+                            "websocket-extensions": {
+                              "version": "0.1.1",
+                              "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "mori": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/mori/-/mori-0.2.1.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "when": {
+                  "version": "2.2.1",
+                  "resolved": "https://registry.npmjs.org/when/-/when-2.2.1.tgz"
+                }
+              }
+            },
+            "ramp-resources": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/ramp-resources/-/ramp-resources-1.0.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.7.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "0.5.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.5.2.tgz"
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                },
+                "minimatch": {
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.1.5.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "1.0.6",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.0.6.tgz"
+                    }
+                  }
+                },
+                "when": {
+                  "version": "1.3.0",
+                  "from": "when@https://github.com/cujojs/when/tarball/1.3.0",
+                  "resolved": "https://github.com/cujojs/when/tarball/1.3.0"
+                }
+              }
+            }
+          }
+        },
+        "buster-sinon": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/buster-sinon/-/buster-sinon-0.7.1.tgz"
+        },
+        "buster-static": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/buster-static/-/buster-static-0.6.5.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.8.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz"
+            },
+            "buster-cli": {
+              "version": "0.6.3",
+              "resolved": "https://registry.npmjs.org/buster-cli/-/buster-cli-0.6.3.tgz",
+              "dependencies": {
+                "ansi-colorizer": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-colorizer/-/ansi-colorizer-1.0.0.tgz"
+                },
+                "buster-configuration": {
+                  "version": "0.7.6",
+                  "resolved": "https://registry.npmjs.org/buster-configuration/-/buster-configuration-0.7.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.1.22",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+                    },
+                    "glob": {
+                      "version": "3.1.21",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                        },
+                        "inherits": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "when": {
+                      "version": "1.3.0",
+                      "from": "when@https://github.com/cujojs/when/tarball/1.3.0",
+                      "resolved": "https://github.com/cujojs/when/tarball/1.3.0"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "posix-argv-parser": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/posix-argv-parser/-/posix-argv-parser-1.0.2.tgz"
+                },
+                "rimraf": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-1.0.9.tgz"
+                },
+                "stream-logger": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-logger/-/stream-logger-1.0.0.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "ramp-resources": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/ramp-resources/-/ramp-resources-1.0.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.7.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "0.5.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.5.2.tgz"
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                },
+                "minimatch": {
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.1.5.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "1.0.6",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.0.6.tgz"
+                    }
+                  }
+                },
+                "when": {
+                  "version": "1.3.0",
+                  "from": "when@https://github.com/cujojs/when/tarball/1.3.0",
+                  "resolved": "https://github.com/cujojs/when/tarball/1.3.0"
+                }
+              }
+            }
+          }
+        },
+        "buster-syntax": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/buster-syntax/-/buster-syntax-0.4.3.tgz",
+          "dependencies": {
+            "jsdom": {
+              "version": "0.10.6",
+              "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-0.10.6.tgz",
+              "dependencies": {
+                "contextify": {
+                  "version": "0.1.14",
+                  "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.14.tgz",
+                  "dependencies": {
+                    "bindings": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                    },
+                    "nan": {
+                      "version": "1.8.4",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                    }
+                  }
+                },
+                "cssom": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
+                },
+                "cssstyle": {
+                  "version": "0.2.30",
+                  "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.30.tgz"
+                },
+                "htmlparser2": {
+                  "version": "3.8.3",
+                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    },
+                    "domhandler": {
+                      "version": "2.3.0",
+                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                    },
+                    "domutils": {
+                      "version": "1.5.1",
+                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                      "dependencies": {
+                        "dom-serializer": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                          "dependencies": {
+                            "domelementtype": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                            },
+                            "entities": {
+                              "version": "1.1.1",
+                              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "entities": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "nwmatcher": {
+                  "version": "1.3.6",
+                  "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.6.tgz"
+                },
+                "request": {
+                  "version": "2.65.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
+                  "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "bl": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "2.0.4",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "1.5.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+                        }
+                      }
+                    },
+                    "har-validator": {
+                      "version": "2.0.2",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "commander": {
+                          "version": "2.9.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "is-my-json-valid": {
+                          "version": "2.12.2",
+                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                          "dependencies": {
+                            "generate-function": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                            },
+                            "generate-object-property": {
+                              "version": "1.2.0",
+                              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                              "dependencies": {
+                                "is-property": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "jsonpointer": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                            },
+                            "xtend": {
+                              "version": "4.0.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        },
+                        "pinkie-promise": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                      "dependencies": {
+                        "boom": {
+                          "version": "2.10.1",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                        },
+                        "hoek": {
+                          "version": "2.16.3",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                        },
+                        "sntp": {
+                          "version": "1.0.9",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.11.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        }
+                      }
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.7",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.19.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                        }
+                      }
+                    },
+                    "node-uuid": {
+                      "version": "1.4.3",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
+                    "qs": {
+                      "version": "5.2.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.1",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                    }
+                  }
+                },
+                "xmlhttprequest": {
+                  "version": "1.8.0",
+                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "1.2.6",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz"
+            }
+          }
+        },
+        "buster-test": {
+          "version": "0.7.13",
+          "resolved": "https://registry.npmjs.org/buster-test/-/buster-test-0.7.13.tgz",
+          "dependencies": {
+            "ansi-colorizer": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-colorizer/-/ansi-colorizer-1.0.0.tgz"
+            },
+            "async": {
+              "version": "0.1.22",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+            },
+            "jsdom": {
+              "version": "0.10.6",
+              "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-0.10.6.tgz",
+              "dependencies": {
+                "contextify": {
+                  "version": "0.1.14",
+                  "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.14.tgz",
+                  "dependencies": {
+                    "bindings": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                    },
+                    "nan": {
+                      "version": "1.8.4",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                    }
+                  }
+                },
+                "cssom": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
+                },
+                "cssstyle": {
+                  "version": "0.2.30",
+                  "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.30.tgz"
+                },
+                "htmlparser2": {
+                  "version": "3.8.3",
+                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    },
+                    "domhandler": {
+                      "version": "2.3.0",
+                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                    },
+                    "domutils": {
+                      "version": "1.5.1",
+                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                      "dependencies": {
+                        "dom-serializer": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                          "dependencies": {
+                            "domelementtype": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                            },
+                            "entities": {
+                              "version": "1.1.1",
+                              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "entities": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "nwmatcher": {
+                  "version": "1.3.6",
+                  "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.6.tgz"
+                },
+                "request": {
+                  "version": "2.65.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
+                  "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "bl": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "2.0.4",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "1.5.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+                        }
+                      }
+                    },
+                    "har-validator": {
+                      "version": "2.0.2",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "commander": {
+                          "version": "2.9.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "is-my-json-valid": {
+                          "version": "2.12.2",
+                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                          "dependencies": {
+                            "generate-function": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                            },
+                            "generate-object-property": {
+                              "version": "1.2.0",
+                              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                              "dependencies": {
+                                "is-property": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "jsonpointer": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                            },
+                            "xtend": {
+                              "version": "4.0.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        },
+                        "pinkie-promise": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                      "dependencies": {
+                        "boom": {
+                          "version": "2.10.1",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                        },
+                        "hoek": {
+                          "version": "2.16.3",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                        },
+                        "sntp": {
+                          "version": "1.0.9",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.11.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        }
+                      }
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.7",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.19.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                        }
+                      }
+                    },
+                    "node-uuid": {
+                      "version": "1.4.3",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
+                    "qs": {
+                      "version": "5.2.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.1",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                    }
+                  }
+                },
+                "xmlhttprequest": {
+                  "version": "1.8.0",
+                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "buster-test-cli": {
+          "version": "0.8.8",
+          "resolved": "https://registry.npmjs.org/buster-test-cli/-/buster-test-cli-0.8.8.tgz",
+          "dependencies": {
+            "ansi-colorizer": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-colorizer/-/ansi-colorizer-1.0.0.tgz"
+            },
+            "ansi-grid": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/ansi-grid/-/ansi-grid-0.5.0.tgz"
+            },
+            "buster-analyzer": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/buster-analyzer/-/buster-analyzer-0.5.0.tgz"
+            },
+            "buster-cli": {
+              "version": "0.6.3",
+              "resolved": "https://registry.npmjs.org/buster-cli/-/buster-cli-0.6.3.tgz",
+              "dependencies": {
+                "buster-configuration": {
+                  "version": "0.7.6",
+                  "resolved": "https://registry.npmjs.org/buster-configuration/-/buster-configuration-0.7.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.1.22",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+                    },
+                    "glob": {
+                      "version": "3.1.21",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                        },
+                        "inherits": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ramp-resources": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/ramp-resources/-/ramp-resources-1.0.5.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "3.2.11",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "0.3.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                              "dependencies": {
+                                "lru-cache": {
+                                  "version": "2.7.0",
+                                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                                },
+                                "sigmund": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash": {
+                          "version": "0.5.2",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.5.2.tgz"
+                        },
+                        "mime": {
+                          "version": "1.3.4",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.1.5.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "1.0.6",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.0.6.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "when": {
+                      "version": "1.3.0",
+                      "from": "when@https://github.com/cujojs/when/tarball/1.3.0",
+                      "resolved": "https://github.com/cujojs/when/tarball/1.3.0"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "posix-argv-parser": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/posix-argv-parser/-/posix-argv-parser-1.0.2.tgz"
+                },
+                "rimraf": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-1.0.9.tgz"
+                },
+                "stream-logger": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-logger/-/stream-logger-1.0.0.tgz"
+                }
+              }
+            },
+            "ejs": {
+              "version": "0.4.3",
+              "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.4.3.tgz"
+            },
+            "ramp": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/ramp/-/ramp-1.0.6.tgz",
+              "dependencies": {
+                "ejs": {
+                  "version": "0.8.8",
+                  "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.8.8.tgz"
+                },
+                "faye": {
+                  "version": "0.8.11",
+                  "resolved": "https://registry.npmjs.org/faye/-/faye-0.8.11.tgz",
+                  "dependencies": {
+                    "cookiejar": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.4.tgz",
+                      "dependencies": {
+                        "jshint": {
+                          "version": "2.8.0",
+                          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
+                          "dependencies": {
+                            "cli": {
+                              "version": "0.6.6",
+                              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+                              "dependencies": {
+                                "glob": {
+                                  "version": "3.2.11",
+                                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                                  "dependencies": {
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "minimatch": {
+                                      "version": "0.3.0",
+                                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                                      "dependencies": {
+                                        "lru-cache": {
+                                          "version": "2.7.0",
+                                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                                        },
+                                        "sigmund": {
+                                          "version": "1.0.1",
+                                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "console-browserify": {
+                              "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                              "dependencies": {
+                                "date-now": {
+                                  "version": "0.1.4",
+                                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "exit": {
+                              "version": "0.1.2",
+                              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                            },
+                            "htmlparser2": {
+                              "version": "3.8.3",
+                              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+                              "dependencies": {
+                                "domelementtype": {
+                                  "version": "1.3.0",
+                                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                                },
+                                "domhandler": {
+                                  "version": "2.3.0",
+                                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                                },
+                                "domutils": {
+                                  "version": "1.5.1",
+                                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                                  "dependencies": {
+                                    "dom-serializer": {
+                                      "version": "0.1.0",
+                                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                                      "dependencies": {
+                                        "domelementtype": {
+                                          "version": "1.1.3",
+                                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                                        },
+                                        "entities": {
+                                          "version": "1.1.1",
+                                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "entities": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                                },
+                                "readable-stream": {
+                                  "version": "1.1.13",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash": {
+                              "version": "3.7.0",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
+                            },
+                            "minimatch": {
+                              "version": "2.0.10",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.1",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.1",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "shelljs": {
+                              "version": "0.3.0",
+                              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "faye-websocket": {
+                      "version": "0.10.0",
+                      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+                      "dependencies": {
+                        "websocket-driver": {
+                          "version": "0.6.2",
+                          "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.2.tgz",
+                          "dependencies": {
+                            "websocket-extensions": {
+                              "version": "0.1.1",
+                              "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "mori": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/mori/-/mori-0.2.1.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "ramp-resources": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/ramp-resources/-/ramp-resources-1.0.5.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "3.2.11",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "0.5.2",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.5.2.tgz"
+                    },
+                    "mime": {
+                      "version": "1.3.4",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.1.5",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.1.5.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "1.0.6",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.0.6.tgz"
+                        }
+                      }
+                    },
+                    "when": {
+                      "version": "1.3.0",
+                      "from": "when@https://github.com/cujojs/when/tarball/1.3.0",
+                      "resolved": "https://github.com/cujojs/when/tarball/1.3.0"
+                    }
+                  }
+                },
+                "when": {
+                  "version": "2.2.1",
+                  "resolved": "https://registry.npmjs.org/when/-/when-2.2.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "evented-logger": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/evented-logger/-/evented-logger-1.0.0.tgz"
+        },
+        "formatio": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.0.2.tgz"
+        },
+        "lodash": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+        },
+        "platform": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/platform/-/platform-1.2.0.tgz"
+        },
+        "referee": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/referee/-/referee-1.1.1.tgz"
+        },
+        "referee-sinon": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/referee-sinon/-/referee-sinon-1.0.2.tgz"
+        },
+        "sinon": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.9.1.tgz"
+        },
+        "stack-filter": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/stack-filter/-/stack-filter-1.0.0.tgz"
+        },
+        "when": {
+          "version": "1.8.1",
+          "from": "when@https://github.com/cujojs/when/tarball/1.8.1",
+          "resolved": "https://github.com/cujojs/when/tarball/1.8.1"
+        }
+      }
+    },
+    "buster-core": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buster-core/-/buster-core-0.6.4.tgz"
+    },
+    "buster-istanbul": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/buster-istanbul/-/buster-istanbul-0.1.13.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "once": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            }
+          }
+        },
+        "istanbul": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.0.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            },
+            "async": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+            },
+            "escodegen": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.0.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.2.5",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                },
+                "estraverse": {
+                  "version": "1.9.3",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "optionator": {
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                  "dependencies": {
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.0.7",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                    },
+                    "levn": {
+                      "version": "0.2.5",
+                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                    },
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                    },
+                    "type-check": {
+                      "version": "0.3.1",
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz"
+            },
+            "fileset": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz"
+            },
+            "handlebars": {
+              "version": "4.0.4",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.4.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.4.24",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.34",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "uglify-to-browserify": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                    },
+                    "yargs": {
+                      "version": "3.5.4",
+                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                        },
+                        "decamelize": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                        },
+                        "window-size": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.4.3",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.10.1",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.7.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz"
+            },
+            "once": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+            },
+            "supports-color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+              "dependencies": {
+                "is-absolute": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                  "dependencies": {
+                    "is-relative": {
+                      "version": "0.1.3",
+                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "eslint": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.8.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "readable-stream": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "doctrine": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.0.tgz",
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+        },
+        "escope": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.2.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.8",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz"
+                },
+                "es6-iterator": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                },
+                "es6-set": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz"
+                },
+                "es6-symbol": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
+                },
+                "event-emitter": {
+                  "version": "0.3.4",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.8",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
+                    }
+                  }
+                },
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                },
+                "es6-symbol": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
+            },
+            "estraverse": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+            }
+          }
+        },
+        "espree": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+        },
+        "estraverse": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+        },
+        "estraverse-fb": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        },
+        "file-entry-cache": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
+          "dependencies": {
+            "flat-cache": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.9.tgz",
+              "dependencies": {
+                "del": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/del/-/del-2.0.2.tgz",
+                  "dependencies": {
+                    "globby": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
+                      "dependencies": {
+                        "array-union": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                          "dependencies": {
+                            "array-uniq": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "arrify": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "is-path-cwd": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+                    },
+                    "is-path-in-cwd": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                      "dependencies": {
+                        "is-path-inside": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0",
+                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.4.3",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.2",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                },
+                "read-json-sync": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "3.0.8",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                    }
+                  }
+                },
+                "write": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "once": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.11.0.tgz"
+        },
+        "handlebars": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.4.tgz",
+          "dependencies": {
+            "async": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.4.24",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "decamelize": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+            },
+            "cli-width": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
+            },
+            "figures": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "run-async": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "rx-lite": {
+              "version": "2.5.2",
+              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz"
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+            },
+            "through": {
+              "version": "2.3.8",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+          "dependencies": {
+            "generate-function": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "dependencies": {
+                "is-property": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                }
+              }
+            },
+            "jsonpointer": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+          "dependencies": {
+            "tryit": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz"
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            }
+          }
+        },
+        "lodash.clonedeep": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+          "dependencies": {
+            "lodash._baseclone": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                },
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+            }
+          }
+        },
+        "lodash.merge": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+          "dependencies": {
+            "lodash._arraycopy": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+            },
+            "lodash._arrayeach": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                }
+              }
+            },
+            "lodash._getnative": {
+              "version": "3.9.1",
+              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+            },
+            "lodash.isarguments": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+            },
+            "lodash.isarray": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+            },
+            "lodash.isplainobject": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                }
+              }
+            },
+            "lodash.istypedarray": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
+            },
+            "lodash.toplainobject": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash.omit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+          "dependencies": {
+            "lodash._arraymap": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
+            },
+            "lodash._basedifference": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+              "dependencies": {
+                "lodash._baseindexof": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
+                },
+                "lodash._cacheindexof": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
+                },
+                "lodash._createcache": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._baseflatten": {
+              "version": "3.1.4",
+              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+            },
+            "lodash._pickbyarray": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+            },
+            "lodash._pickbycallback": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                }
+              }
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
+        "optionator": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+          "dependencies": {
+            "deep-is": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+            },
+            "fast-levenshtein": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+            },
+            "levn": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+            },
+            "type-check": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+        },
+        "path-is-inside": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        },
+        "to-double-quotes": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+            }
+          }
+        },
+        "to-single-quotes": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+            }
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+        },
+        "xml-escape": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+        }
+      }
+    },
+    "eslint-config-defaults": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-defaults/-/eslint-config-defaults-2.1.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+        }
+      }
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
+    },
+    "pre-commit": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.0.10.tgz",
+      "dependencies": {
+        "shelljs": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
+        }
+      }
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
+    },
+    "text-encoding": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.5.2.tgz"
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   ],
   "dependencies": {
     "formatio": "1.1.1",
-    "util": ">=0.10.3 <1",
     "lolex": "1.3.2",
     "samsam": "1.1.2",
-    "text-encoding": "0.5.2"
+    "text-encoding": "0.5.2",
+    "util": ">=0.10.3 <1"
   },
   "devDependencies": {
     "browserify": "^11.1.0",

--- a/scripts/ci-eslint
+++ b/scripts/ci-eslint
@@ -3,5 +3,7 @@ set -eu
 
 # This script runs eslint on all files
 # It's configuration is specific to running on Travis CI and might not work locally
+# Travis build cache doens't support caching single files, so we'll store the
+# ESLint cache file in `node_modules`, which does get cached between builds.
 
-time $(npm bin)/eslint --cache .
+time $(npm bin)/eslint --cache --cache-file ./node_modules/.eslintcache .

--- a/scripts/ci-eslint
+++ b/scripts/ci-eslint
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+
+# This script runs eslint on all files
+# It's configuration is specific to running on Travis CI and might not work locally
+
+time $(npm bin)/eslint --cache .


### PR DESCRIPTION
With `eslint@1.4.0` came the new [`--cache` flag](http://eslint.org/blog/2015/09/eslint-v1.4.0-released/#cached-results).

#### Before

type | Local | Travis
--------|---------|-----
real | 0m3.444s | 0m4.984s
user | 0m3.323s | 0m5.428s
sys | 0m0.132s | 0m0.196s

#### After

type | Local | Travis
--------|---------|-----
real | 0m0.949s | 0m4.916s
user | 0m0.854s | 0m5.211s
sys | 0m0.095s | 0m0.136s

I've moved the `.eslintcache` file into `node_modules`, which gets cached in the Travis build cache. And yet, it's still just as slow on Travis, yet speed up locally.

Tips welcome!

cc: @mantoni @fatso83 @cjohansen @tenzer