### PR TITLE
Prevent stubbed getter from being called during restore()

### DIFF
--- a/lib/sinon/util/core/wrap-method.js
+++ b/lib/sinon/util/core/wrap-method.js
@@ -112,10 +112,18 @@ module.exports = function wrapMethod(object, property, method) {
             Object.defineProperty(object, property, wrappedMethodDesc);
         }
 
+        if (hasES5Support) {
+            var descriptor = getPropertyDescriptor(object, property);
+            if (descriptor && descriptor.value === method) {
+                object[property] = wrappedMethod;
+            }
+        }
+        else {
         // Use strict equality comparison to check failures then force a reset
         // via direct assignment.
-        if (object[property] === method) {
-            object[property] = wrappedMethod;
+            if (object[property] === method) {
+                object[property] = wrappedMethod;
+            }
         }
     };
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -714,6 +714,21 @@
                 refute.exception(function () {
                     sinon.stub(child);
                 });
+            },
+
+            "does not call getter during restore": function () {
+                var obj = {
+                    get prop() {
+                        fail("should not call getter");
+                    }
+                };
+                var stub = sinon.stub(obj, "prop", {get: function () {
+                    return 43;
+                }});
+
+                assert.equals(obj.prop, 43);
+
+                stub.restore();
             }
         },
 


### PR DESCRIPTION
It does what it says on the tin. This fixes #897.

![deal-with-it-cat](https://cloud.githubusercontent.com/assets/23887/11007696/5568d326-8491-11e5-9017-2c1c7a3beb39.gif)