### PR TITLE
Fix interaction with spy getters/setters - fixes #917

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -18,6 +18,8 @@ var slice = Array.prototype.slice;
 var callId = 0;
 
 function spy(object, property, types) {
+    var descriptor, i, methodDesc;
+
     if (!property && typeof object === "function") {
         return spy.create(object);
     }
@@ -27,11 +29,13 @@ function spy(object, property, types) {
     }
 
     if (types) {
-        var methodDesc = sinon.getPropertyDescriptor(object, property);
-        for (var i = 0; i < types.length; i++) {
-            methodDesc[types[i]] = spy.create(methodDesc[types[i]]);
+        descriptor = {};
+        methodDesc = sinon.getPropertyDescriptor(object, property);
+
+        for (i = 0; i < types.length; i++) {
+            descriptor[types[i]] = spy.create(methodDesc[types[i]]);
         }
-        return sinon.wrapMethod(object, property, methodDesc);
+        return sinon.wrapMethod(object, property, descriptor);
     }
 
     return sinon.wrapMethod(object, property, spy.create(object[property]));

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -1268,6 +1268,12 @@
                 spy.reset();
                 spy.call(true);
                 assert.equals(spy.printf("%t"), "true");
+            },
+
+            unmatched: function () {
+                var spy = sinon.spy();
+
+                assert.equals(spy.printf("%λ"), "%λ");
             }
         }
     });

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -258,7 +258,7 @@
             assert(spy.set.calledOnce);
             assert(spy.set.calledWith(42));
 
-            assert.equals(object.test, 42);
+            assert.equals(object.test, 84);
             assert.equals(object.property, 84);
         },
 
@@ -268,7 +268,7 @@
                     return this.property;
                 },
                 set test(value) {
-                    this.property = value;
+                    this.property = value * 2;
                 }
             };
             var spy = sinon.spy(object, "test", ["get", "set"]);
@@ -276,7 +276,7 @@
             object.test = 42;
             assert(spy.set.calledOnce);
 
-            assert.equals(object.test, 42);
+            assert.equals(object.test, 84);
             assert(spy.get.calledOnce);
         },
 

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -231,6 +231,55 @@
             assert.isArray(spy.exceptions);
         },
 
+        "works with getters": function () {
+            var object = {
+                get property() {
+                    return 42;
+                }
+            };
+            var spy = sinon.spy(object, "property", ["get"]);
+
+            assert.equals(object.property, 42);
+            assert(spy.get.calledOnce);
+        },
+
+        "works with setters": function () {
+            var object = {
+                get test() {
+                    return this.property;
+                },
+                set test(value) {
+                    this.property = value * 2;
+                }
+            };
+            var spy = sinon.spy(object, "test", ["set"]);
+
+            object.test = 42;
+            assert(spy.set.calledOnce);
+            assert(spy.set.calledWith(42));
+
+            assert.equals(object.test, 42);
+            assert.equals(object.property, 84);
+        },
+
+        "works with setters and getters combined": function () {
+            var object = {
+                get test() {
+                    return this.property;
+                },
+                set test(value) {
+                    this.property = value;
+                }
+            };
+            var spy = sinon.spy(object, "test", ["get", "set"]);
+
+            object.test = 42;
+            assert(spy.set.calledOnce);
+
+            assert.equals(object.test, 42);
+            assert(spy.get.calledOnce);
+        },
+
         ".named": {
             "sets displayName": function () {
                 var spy = sinon.spy();


### PR DESCRIPTION
Now passing a user -directed limited descriptor to `wrapMethod` so it doesn't blow up.

I also found a missing test (in `test/call-test.js` strangely) that pushes `lib/sinon/spy.js` coverage to 100%.  