### PR TITLE
Ensure support for running inside a WebWorker

### DIFF
--- a/test/buster-packaged.js
+++ b/test/buster-packaged.js
@@ -17,3 +17,18 @@ config.packaged = {
         "test/**/*-test.js"
     ]
 };
+
+// The sole purpose of this test setup is to
+// ensure that Sinon could be run inside of
+// a WebWorker
+config.webworkerSupport = {
+    environment: "browser",
+    rootPath: "../",
+    sources: [
+        "pkg/sinon.js",
+        "test/webworker-script.js"
+    ],
+    tests: [
+        "test/webworker-support-assessment.js"
+    ]
+};

--- a/test/webworker-script.js
+++ b/test/webworker-script.js
@@ -1,0 +1,17 @@
+/* eslint-env worker */
+/* global sinon */
+(function () {
+    "use strict";
+
+    // Abort if we are not running in a WebWorker
+    if ( typeof importScripts === "undefined" ) { return; }
+
+    importScripts("../pkg/sinon.js");
+
+    var stub = sinon.stub().returns("worker response");
+
+    onmessage = function () {
+        postMessage( stub() );
+    };
+
+})();

--- a/test/webworker-support-assessment.js
+++ b/test/webworker-support-assessment.js
@@ -1,0 +1,33 @@
+(function (root) {
+    "use strict";
+    var supportsWorkers = typeof root.Worker !== "undefined";
+    var buster = root.buster || require("buster");
+    var assert = buster.assert;
+
+    buster.testCase("WebWorker support", {
+
+        requiresSupportFor: {
+            WebWorker: supportsWorkers
+        },
+
+        "should not crash": function (done) {
+            var worker = new root.Worker("./test/webworker-script.js");
+
+            worker.onmessage = function (msg) {
+                try {
+                    assert.same(msg.data, "worker response");
+                    done();
+                }catch (err) { done(err); }
+            };
+
+            function onError(err) {
+                done(new Error(err.message));
+            }
+
+            worker.addEventListener("error", onError, false);
+
+            worker.postMessage("whatever");
+        }
+    });
+
+})(this);


### PR DESCRIPTION
Related to the changes in #908.

It turned out that although we support running Sinon inside a WebWorker, we do not actually test this in any of the tests. So although manual inspection from sharp eyes might reveal that some change breaks the support  (thanks @mroderick), some not-so-sharp eyes (me) might not.

This test ensures we check for this by making a WebWorker load the packaged build and exercise some of sinon's functions. The PR is for the master branch, but I also ensured it runs fine on the v1.17 branch as well (where it was needed).

Up for discussion
To avoid loading the test in the `source` config I had to avoid getting the test matched with the `test/*/**.js` pattern, so I named the test `webworker-support-assessment.js`, which is kind of an awkward name, but at least dealt with the problem in a way...