### PR TITLE
CommonJSify `sinon.mock`

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -12,6 +12,7 @@ var match = require("./sinon/match");
 
 module.exports = exports = require("./sinon/util/core");
 
+exports.assert = require("./sinon/assert");
 exports.extend = require("./sinon/extend");
 exports.match = match;
 exports.spy = require("./sinon/spy");
@@ -31,5 +32,4 @@ exports.deepEqual = exports.deepEqual.use(match);
 // way to handle exports in CommonJS but this is a minimal
 // change to how sinon was built before.
 require("./sinon/test_case");
-require("./sinon/assert");
 require("./sinon/util/fake_xdomain_request");

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -18,6 +18,8 @@ exports.match = match;
 exports.spy = require("./sinon/spy");
 exports.spyCall = require("./sinon/call");
 exports.stub = require("./sinon/stub");
+exports.mock = require("./sinon/mock");
+exports.expectation = require("./sinon/mock-expectation");
 exports.createStubInstance = require("./sinon/stub").createStubInstance;
 exports.typeOf = require("./sinon/typeOf");
 

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -8,8 +8,11 @@
  */
 "use strict";
 
-require("./match");
-var sinon = require("./util/core");
+var calledInOrder = require("./util/core/called-in-order");
+var orderByFirstCall = require("./util/core/order-by-first-call");
+var timesInWords = require("./util/core/times-in-words");
+var format = require("./util/core/format");
+var sinonMatch = require("./match");
 
 var slice = Array.prototype.slice;
 
@@ -95,7 +98,7 @@ assert = {
         var expected = "";
         var actual = "";
 
-        if (!sinon.calledInOrder(arguments)) {
+        if (!calledInOrder(arguments)) {
             try {
                 expected = [].join.call(arguments, ", ");
                 var calls = slice.call(arguments);
@@ -105,7 +108,7 @@ assert = {
                         calls.splice(i, 1);
                     }
                 }
-                actual = sinon.orderByFirstCall(calls).join(", ");
+                actual = orderByFirstCall(calls).join(", ");
             } catch (e) {
                 // If this fails, we'll just fall back to the blank string
             }
@@ -121,7 +124,7 @@ assert = {
         verifyIsStub(method);
 
         if (method.callCount !== count) {
-            var msg = "expected %n to be called " + sinon.timesInWords(count) +
+            var msg = "expected %n to be called " + timesInWords(count) +
                 " but was called %c%C";
             failAssertion(this, method.printf(msg));
         } else {
@@ -148,14 +151,14 @@ assert = {
     },
 
     match: function match(actual, expectation) {
-        var matcher = sinon.match(expectation);
+        var matcher = sinonMatch(expectation);
         if (matcher.test(actual)) {
             assert.pass("match");
         } else {
             var formatted = [
                 "expected value to match",
-                "    expected = " + sinon.format(expectation),
-                "    actual = " + sinon.format(actual)
+                "    expected = " + format(expectation),
+                "    actual = " + format(actual)
             ];
 
             failAssertion(this, formatted.join("\n"));
@@ -188,4 +191,4 @@ mirrorPropAsAssertion("neverCalledWithMatch", "expected %n to never be called wi
 mirrorPropAsAssertion("threw", "%n did not throw exception%C");
 mirrorPropAsAssertion("alwaysThrew", "%n did not always throw exception%C");
 
-sinon.assert = assert;
+module.exports = assert;

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -10,12 +10,15 @@
   */
 "use strict";
 
-require("./match");
 var sinon = require("./util/core");
+var sinonMatch = require("./match");
+var deepEqual = require("./util/core/deep-equal").use(sinonMatch);
+var functionName = require("./util/core/function-name");
+var createInstance = require("./util/core/create");
 var slice = Array.prototype.slice;
 
 function throwYieldError(proxy, text, args) {
-    var msg = sinon.functionName(proxy) + text;
+    var msg = functionName(proxy) + text;
     if (args.length) {
         msg += " Received [" + slice.call(args).join(", ") + "]";
     }
@@ -24,7 +27,7 @@ function throwYieldError(proxy, text, args) {
 
 var callProto = {
     calledOn: function calledOn(thisValue) {
-        if (sinon.match && sinon.match.isMatcher(thisValue)) {
+        if (sinonMatch && sinonMatch.isMatcher(thisValue)) {
             return thisValue.test(this.thisValue);
         }
         return this.thisValue === thisValue;
@@ -36,7 +39,7 @@ var callProto = {
             return false;
         }
         for (var i = 0; i < l; i += 1) {
-            if (!sinon.deepEqual(arguments[i], this.args[i])) {
+            if (!deepEqual(arguments[i], this.args[i])) {
                 return false;
             }
         }
@@ -52,7 +55,7 @@ var callProto = {
         for (var i = 0; i < l; i += 1) {
             var actual = this.args[i];
             var expectation = arguments[i];
-            if (!sinon.match || !sinon.match(expectation).test(actual)) {
+            if (!sinonMatch || !sinonMatch(expectation).test(actual)) {
                 return false;
             }
         }
@@ -73,7 +76,7 @@ var callProto = {
     },
 
     returned: function returned(value) {
-        return sinon.deepEqual(value, this.returnValue);
+        return deepEqual(value, this.returnValue);
     },
 
     threw: function threw(error) {
@@ -185,7 +188,7 @@ function createSpyCall(spy, thisValue, args, returnValue, exception, id, stack) 
     if (typeof id !== "number") {
         throw new TypeError("Call id is not a number");
     }
-    var proxyCall = sinon.create(callProto);
+    var proxyCall = createInstance(callProto);
     proxyCall.proxy = spy;
     proxyCall.thisValue = thisValue;
     proxyCall.args = args;

--- a/lib/sinon/mock-expectation.js
+++ b/lib/sinon/mock-expectation.js
@@ -1,0 +1,292 @@
+/**
+ * Mock expecations
+ *
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @license BSD
+ *
+ * Copyright (c) 2010-2013 Christian Johansen
+ */
+"use strict";
+
+var spyInvoke = require("./spy").invoke;
+var spyCallToString = require("./call").toString;
+var timesInWords = require("./util/core/times-in-words");
+var extend = require("./extend");
+var match = require("./match");
+var stub = require("./stub");
+var assert = require("./assert");
+var deepEqual = require("./util/core/deep-equal").use(match);
+var format = require("./util/core/format");
+
+var slice = Array.prototype.slice;
+var push = Array.prototype.push;
+
+function callCountInWords(callCount) {
+    if (callCount === 0) {
+        return "never called";
+    }
+
+    return "called " + timesInWords(callCount);
+}
+
+function expectedCallCountInWords(expectation) {
+    var min = expectation.minCalls;
+    var max = expectation.maxCalls;
+
+    if (typeof min === "number" && typeof max === "number") {
+        var str = timesInWords(min);
+
+        if (min !== max) {
+            str = "at least " + str + " and at most " + timesInWords(max);
+        }
+
+        return str;
+    }
+
+    if (typeof min === "number") {
+        return "at least " + timesInWords(min);
+    }
+
+    return "at most " + timesInWords(max);
+}
+
+function receivedMinCalls(expectation) {
+    var hasMinLimit = typeof expectation.minCalls === "number";
+    return !hasMinLimit || expectation.callCount >= expectation.minCalls;
+}
+
+function receivedMaxCalls(expectation) {
+    if (typeof expectation.maxCalls !== "number") {
+        return false;
+    }
+
+    return expectation.callCount === expectation.maxCalls;
+}
+
+function verifyMatcher(possibleMatcher, arg) {
+    var isMatcher = match && match.isMatcher(possibleMatcher);
+
+    return isMatcher && possibleMatcher.test(arg) || true;
+}
+
+var mockExpectation = {
+    minCalls: 1,
+    maxCalls: 1,
+
+    create: function create(methodName) {
+        var expectation = extend(stub.create(), mockExpectation);
+        delete expectation.create;
+        expectation.method = methodName;
+
+        return expectation;
+    },
+
+    invoke: function invoke(func, thisValue, args) {
+        this.verifyCallAllowed(thisValue, args);
+
+        return spyInvoke.apply(this, arguments);
+    },
+
+    atLeast: function atLeast(num) {
+        if (typeof num !== "number") {
+            throw new TypeError("'" + num + "' is not number");
+        }
+
+        if (!this.limitsSet) {
+            this.maxCalls = null;
+            this.limitsSet = true;
+        }
+
+        this.minCalls = num;
+
+        return this;
+    },
+
+    atMost: function atMost(num) {
+        if (typeof num !== "number") {
+            throw new TypeError("'" + num + "' is not number");
+        }
+
+        if (!this.limitsSet) {
+            this.minCalls = null;
+            this.limitsSet = true;
+        }
+
+        this.maxCalls = num;
+
+        return this;
+    },
+
+    never: function never() {
+        return this.exactly(0);
+    },
+
+    once: function once() {
+        return this.exactly(1);
+    },
+
+    twice: function twice() {
+        return this.exactly(2);
+    },
+
+    thrice: function thrice() {
+        return this.exactly(3);
+    },
+
+    exactly: function exactly(num) {
+        if (typeof num !== "number") {
+            throw new TypeError("'" + num + "' is not a number");
+        }
+
+        this.atLeast(num);
+        return this.atMost(num);
+    },
+
+    met: function met() {
+        return !this.failed && receivedMinCalls(this);
+    },
+
+    verifyCallAllowed: function verifyCallAllowed(thisValue, args) {
+        if (receivedMaxCalls(this)) {
+            this.failed = true;
+            mockExpectation.fail(this.method + " already called " + timesInWords(this.maxCalls));
+        }
+
+        if ("expectedThis" in this && this.expectedThis !== thisValue) {
+            mockExpectation.fail(this.method + " called with " + thisValue + " as thisValue, expected " +
+                this.expectedThis);
+        }
+
+        if (!("expectedArguments" in this)) {
+            return;
+        }
+
+        if (!args) {
+            mockExpectation.fail(this.method + " received no arguments, expected " +
+                format(this.expectedArguments));
+        }
+
+        if (args.length < this.expectedArguments.length) {
+            mockExpectation.fail(this.method + " received too few arguments (" + format(args) +
+                "), expected " + format(this.expectedArguments));
+        }
+
+        if (this.expectsExactArgCount &&
+            args.length !== this.expectedArguments.length) {
+            mockExpectation.fail(this.method + " received too many arguments (" + format(args) +
+                "), expected " + format(this.expectedArguments));
+        }
+
+        for (var i = 0, l = this.expectedArguments.length; i < l; i += 1) {
+
+            if (!verifyMatcher(this.expectedArguments[i], args[i])) {
+                mockExpectation.fail(this.method + " received wrong arguments " + format(args) +
+                    ", didn't match " + this.expectedArguments.toString());
+            }
+
+            if (!deepEqual(this.expectedArguments[i], args[i])) {
+                mockExpectation.fail(this.method + " received wrong arguments " + format(args) +
+                    ", expected " + format(this.expectedArguments));
+            }
+        }
+    },
+
+    allowsCall: function allowsCall(thisValue, args) {
+        if (this.met() && receivedMaxCalls(this)) {
+            return false;
+        }
+
+        if ("expectedThis" in this && this.expectedThis !== thisValue) {
+            return false;
+        }
+
+        if (!("expectedArguments" in this)) {
+            return true;
+        }
+
+        args = args || [];
+
+        if (args.length < this.expectedArguments.length) {
+            return false;
+        }
+
+        if (this.expectsExactArgCount &&
+            args.length !== this.expectedArguments.length) {
+            return false;
+        }
+
+        for (var i = 0, l = this.expectedArguments.length; i < l; i += 1) {
+            if (!verifyMatcher(this.expectedArguments[i], args[i])) {
+                return false;
+            }
+
+            if (!deepEqual(this.expectedArguments[i], args[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    },
+
+    withArgs: function withArgs() {
+        this.expectedArguments = slice.call(arguments);
+        return this;
+    },
+
+    withExactArgs: function withExactArgs() {
+        this.withArgs.apply(this, arguments);
+        this.expectsExactArgCount = true;
+        return this;
+    },
+
+    on: function on(thisValue) {
+        this.expectedThis = thisValue;
+        return this;
+    },
+
+    toString: function () {
+        var args = (this.expectedArguments || []).slice();
+
+        if (!this.expectsExactArgCount) {
+            push.call(args, "[...]");
+        }
+
+        var callStr = spyCallToString.call({
+            proxy: this.method || "anonymous mock expectation",
+            args: args
+        });
+
+        var message = callStr.replace(", [...", "[, ...") + " " +
+            expectedCallCountInWords(this);
+
+        if (this.met()) {
+            return "Expectation met: " + message;
+        }
+
+        return "Expected " + message + " (" +
+            callCountInWords(this.callCount) + ")";
+    },
+
+    verify: function verify() {
+        if (!this.met()) {
+            mockExpectation.fail(this.toString());
+        } else {
+            mockExpectation.pass(this.toString());
+        }
+
+        return true;
+    },
+
+    pass: function pass(message) {
+        assert.pass(message);
+    },
+
+    fail: function fail(message) {
+        var exception = new Error(message);
+        exception.name = "ExpectationError";
+
+        throw exception;
+    }
+};
+
+module.exports = mockExpectation;

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -8,18 +8,14 @@
  */
 "use strict";
 
-var sinon = require("./util/core");
+var mockExpectation = require("./mock-expectation");
 var spyCallToString = require("./call").toString;
-var spyInvoke = require("./spy").invoke;
 var extend = require("./extend");
-var assert = require("./assert");
-var stub = require("./stub");
 var match = require("./match");
 var deepEqual = require("./util/core/deep-equal").use(match);
-var timesInWords = require("./util/core/times-in-words");
 var wrapMethod = require("./util/core/wrap-method");
 
-var push = [].push;
+var push = Array.prototype.push;
 
 function mock(object) {
     // if (typeof console !== undefined && console.warn) {
@@ -27,7 +23,7 @@ function mock(object) {
     // }
 
     if (!object) {
-        return sinon.expectation.create("Anonymous mock");
+        return mockExpectation.create("Anonymous mock");
     }
 
     return mock.create(object);
@@ -90,7 +86,7 @@ extend(mock, {
             push.call(this.proxies, method);
         }
 
-        var expectation = sinon.expectation.create(method);
+        var expectation = mockExpectation.create(method);
         push.call(this.expectations[method], expectation);
 
         return expectation;
@@ -124,9 +120,9 @@ extend(mock, {
         this.restore();
 
         if (messages.length > 0) {
-            sinon.expectation.fail(messages.concat(met).join("\n"));
+            mockExpectation.fail(messages.concat(met).join("\n"));
         } else if (met.length > 0) {
-            sinon.expectation.pass(messages.concat(met).join("\n"));
+            mockExpectation.pass(messages.concat(met).join("\n"));
         }
 
         return true;
@@ -176,278 +172,8 @@ extend(mock, {
             args: args
         }));
 
-        sinon.expectation.fail(messages.join("\n"));
+        mockExpectation.fail(messages.join("\n"));
     }
 });
 
-var slice = Array.prototype.slice;
-
-function callCountInWords(callCount) {
-    if (callCount === 0) {
-        return "never called";
-    }
-
-    return "called " + timesInWords(callCount);
-}
-
-function expectedCallCountInWords(expectation) {
-    var min = expectation.minCalls;
-    var max = expectation.maxCalls;
-
-    if (typeof min === "number" && typeof max === "number") {
-        var str = timesInWords(min);
-
-        if (min !== max) {
-            str = "at least " + str + " and at most " + timesInWords(max);
-        }
-
-        return str;
-    }
-
-    if (typeof min === "number") {
-        return "at least " + timesInWords(min);
-    }
-
-    return "at most " + timesInWords(max);
-}
-
-function receivedMinCalls(expectation) {
-    var hasMinLimit = typeof expectation.minCalls === "number";
-    return !hasMinLimit || expectation.callCount >= expectation.minCalls;
-}
-
-function receivedMaxCalls(expectation) {
-    if (typeof expectation.maxCalls !== "number") {
-        return false;
-    }
-
-    return expectation.callCount === expectation.maxCalls;
-}
-
-function verifyMatcher(possibleMatcher, arg) {
-    var isMatcher = match && match.isMatcher(possibleMatcher);
-
-    return isMatcher && possibleMatcher.test(arg) || true;
-}
-
-sinon.expectation = {
-    minCalls: 1,
-    maxCalls: 1,
-
-    create: function create(methodName) {
-        var expectation = extend(stub.create(), sinon.expectation);
-        delete expectation.create;
-        expectation.method = methodName;
-
-        return expectation;
-    },
-
-    invoke: function invoke(func, thisValue, args) {
-        this.verifyCallAllowed(thisValue, args);
-
-        return spyInvoke.apply(this, arguments);
-    },
-
-    atLeast: function atLeast(num) {
-        if (typeof num !== "number") {
-            throw new TypeError("'" + num + "' is not number");
-        }
-
-        if (!this.limitsSet) {
-            this.maxCalls = null;
-            this.limitsSet = true;
-        }
-
-        this.minCalls = num;
-
-        return this;
-    },
-
-    atMost: function atMost(num) {
-        if (typeof num !== "number") {
-            throw new TypeError("'" + num + "' is not number");
-        }
-
-        if (!this.limitsSet) {
-            this.minCalls = null;
-            this.limitsSet = true;
-        }
-
-        this.maxCalls = num;
-
-        return this;
-    },
-
-    never: function never() {
-        return this.exactly(0);
-    },
-
-    once: function once() {
-        return this.exactly(1);
-    },
-
-    twice: function twice() {
-        return this.exactly(2);
-    },
-
-    thrice: function thrice() {
-        return this.exactly(3);
-    },
-
-    exactly: function exactly(num) {
-        if (typeof num !== "number") {
-            throw new TypeError("'" + num + "' is not a number");
-        }
-
-        this.atLeast(num);
-        return this.atMost(num);
-    },
-
-    met: function met() {
-        return !this.failed && receivedMinCalls(this);
-    },
-
-    verifyCallAllowed: function verifyCallAllowed(thisValue, args) {
-        if (receivedMaxCalls(this)) {
-            this.failed = true;
-            sinon.expectation.fail(this.method + " already called " + timesInWords(this.maxCalls));
-        }
-
-        if ("expectedThis" in this && this.expectedThis !== thisValue) {
-            sinon.expectation.fail(this.method + " called with " + thisValue + " as thisValue, expected " +
-                this.expectedThis);
-        }
-
-        if (!("expectedArguments" in this)) {
-            return;
-        }
-
-        if (!args) {
-            sinon.expectation.fail(this.method + " received no arguments, expected " +
-                sinon.format(this.expectedArguments));
-        }
-
-        if (args.length < this.expectedArguments.length) {
-            sinon.expectation.fail(this.method + " received too few arguments (" + sinon.format(args) +
-                "), expected " + sinon.format(this.expectedArguments));
-        }
-
-        if (this.expectsExactArgCount &&
-            args.length !== this.expectedArguments.length) {
-            sinon.expectation.fail(this.method + " received too many arguments (" + sinon.format(args) +
-                "), expected " + sinon.format(this.expectedArguments));
-        }
-
-        for (var i = 0, l = this.expectedArguments.length; i < l; i += 1) {
-
-            if (!verifyMatcher(this.expectedArguments[i], args[i])) {
-                sinon.expectation.fail(this.method + " received wrong arguments " + sinon.format(args) +
-                    ", didn't match " + this.expectedArguments.toString());
-            }
-
-            if (!deepEqual(this.expectedArguments[i], args[i])) {
-                sinon.expectation.fail(this.method + " received wrong arguments " + sinon.format(args) +
-                    ", expected " + sinon.format(this.expectedArguments));
-            }
-        }
-    },
-
-    allowsCall: function allowsCall(thisValue, args) {
-        if (this.met() && receivedMaxCalls(this)) {
-            return false;
-        }
-
-        if ("expectedThis" in this && this.expectedThis !== thisValue) {
-            return false;
-        }
-
-        if (!("expectedArguments" in this)) {
-            return true;
-        }
-
-        args = args || [];
-
-        if (args.length < this.expectedArguments.length) {
-            return false;
-        }
-
-        if (this.expectsExactArgCount &&
-            args.length !== this.expectedArguments.length) {
-            return false;
-        }
-
-        for (var i = 0, l = this.expectedArguments.length; i < l; i += 1) {
-            if (!verifyMatcher(this.expectedArguments[i], args[i])) {
-                return false;
-            }
-
-            if (!deepEqual(this.expectedArguments[i], args[i])) {
-                return false;
-            }
-        }
-
-        return true;
-    },
-
-    withArgs: function withArgs() {
-        this.expectedArguments = slice.call(arguments);
-        return this;
-    },
-
-    withExactArgs: function withExactArgs() {
-        this.withArgs.apply(this, arguments);
-        this.expectsExactArgCount = true;
-        return this;
-    },
-
-    on: function on(thisValue) {
-        this.expectedThis = thisValue;
-        return this;
-    },
-
-    toString: function () {
-        var args = (this.expectedArguments || []).slice();
-
-        if (!this.expectsExactArgCount) {
-            push.call(args, "[...]");
-        }
-
-        var callStr = spyCallToString.call({
-            proxy: this.method || "anonymous mock expectation",
-            args: args
-        });
-
-        var message = callStr.replace(", [...", "[, ...") + " " +
-            expectedCallCountInWords(this);
-
-        if (this.met()) {
-            return "Expectation met: " + message;
-        }
-
-        return "Expected " + message + " (" +
-            callCountInWords(this.callCount) + ")";
-    },
-
-    verify: function verify() {
-        if (!this.met()) {
-            sinon.expectation.fail(this.toString());
-        } else {
-            sinon.expectation.pass(this.toString());
-        }
-
-        return true;
-    },
-
-    pass: function pass(message) {
-        assert.pass(message);
-    },
-
-    fail: function fail(message) {
-        var exception = new Error(message);
-        exception.name = "ExpectationError";
-
-        throw exception;
-    }
-};
-
-sinon.mock = mock;
+module.exports = mock;

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -8,15 +8,18 @@
  */
 "use strict";
 
-require("./extend");
-require("./match");
-require("./stub");
 var sinon = require("./util/core");
 var spyCallToString = require("./call").toString;
 var spyInvoke = require("./spy").invoke;
+var extend = require("./extend");
+var assert = require("./assert");
+var stub = require("./stub");
+var match = require("./match");
+var deepEqual = require("./util/core/deep-equal").use(match);
+var timesInWords = require("./util/core/times-in-words");
+var wrapMethod = require("./util/core/wrap-method");
 
 var push = [].push;
-var match = sinon.match;
 
 function mock(object) {
     // if (typeof console !== undefined && console.warn) {
@@ -46,20 +49,20 @@ function arrayEquals(arr1, arr2, compareLength) {
     }
 
     for (var i = 0, l = arr1.length; i < l; i++) {
-        if (!sinon.deepEqual(arr1[i], arr2[i])) {
+        if (!deepEqual(arr1[i], arr2[i])) {
             return false;
         }
     }
     return true;
 }
 
-sinon.extend(mock, {
+extend(mock, {
     create: function create(object) {
         if (!object) {
             throw new TypeError("object is null");
         }
 
-        var mockObject = sinon.extend({}, mock);
+        var mockObject = extend({}, mock);
         mockObject.object = object;
         delete mockObject.create;
 
@@ -80,7 +83,7 @@ sinon.extend(mock, {
             this.expectations[method] = [];
             var mockObject = this;
 
-            sinon.wrapMethod(this.object, method, function () {
+            wrapMethod(this.object, method, function () {
                 return mockObject.invokeMethod(method, this, arguments);
             });
 
@@ -177,7 +180,6 @@ sinon.extend(mock, {
     }
 });
 
-var times = sinon.timesInWords;
 var slice = Array.prototype.slice;
 
 function callCountInWords(callCount) {
@@ -185,7 +187,7 @@ function callCountInWords(callCount) {
         return "never called";
     }
 
-    return "called " + times(callCount);
+    return "called " + timesInWords(callCount);
 }
 
 function expectedCallCountInWords(expectation) {
@@ -193,20 +195,20 @@ function expectedCallCountInWords(expectation) {
     var max = expectation.maxCalls;
 
     if (typeof min === "number" && typeof max === "number") {
-        var str = times(min);
+        var str = timesInWords(min);
 
         if (min !== max) {
-            str = "at least " + str + " and at most " + times(max);
+            str = "at least " + str + " and at most " + timesInWords(max);
         }
 
         return str;
     }
 
     if (typeof min === "number") {
-        return "at least " + times(min);
+        return "at least " + timesInWords(min);
     }
 
-    return "at most " + times(max);
+    return "at most " + timesInWords(max);
 }
 
 function receivedMinCalls(expectation) {
@@ -233,7 +235,7 @@ sinon.expectation = {
     maxCalls: 1,
 
     create: function create(methodName) {
-        var expectation = sinon.extend(sinon.stub.create(), sinon.expectation);
+        var expectation = extend(stub.create(), sinon.expectation);
         delete expectation.create;
         expectation.method = methodName;
 
@@ -308,7 +310,7 @@ sinon.expectation = {
     verifyCallAllowed: function verifyCallAllowed(thisValue, args) {
         if (receivedMaxCalls(this)) {
             this.failed = true;
-            sinon.expectation.fail(this.method + " already called " + times(this.maxCalls));
+            sinon.expectation.fail(this.method + " already called " + timesInWords(this.maxCalls));
         }
 
         if ("expectedThis" in this && this.expectedThis !== thisValue) {
@@ -343,7 +345,7 @@ sinon.expectation = {
                     ", didn't match " + this.expectedArguments.toString());
             }
 
-            if (!sinon.deepEqual(this.expectedArguments[i], args[i])) {
+            if (!deepEqual(this.expectedArguments[i], args[i])) {
                 sinon.expectation.fail(this.method + " received wrong arguments " + sinon.format(args) +
                     ", expected " + sinon.format(this.expectedArguments));
             }
@@ -379,7 +381,7 @@ sinon.expectation = {
                 return false;
             }
 
-            if (!sinon.deepEqual(this.expectedArguments[i], args[i])) {
+            if (!deepEqual(this.expectedArguments[i], args[i])) {
                 return false;
             }
         }
@@ -437,7 +439,7 @@ sinon.expectation = {
     },
 
     pass: function pass(message) {
-        sinon.assert.pass(message);
+        assert.pass(message);
     },
 
     fail: function fail(message) {


### PR DESCRIPTION
Following on from #920 and #932, I've extracted `sinon.mock`; and just for fun, `sinon.assert` and `createSpyCall` into standalone CommonJS modules! :rocket: 

## Notable Changes
* Extracted `sinon.expectation` into it's own module, `mock-expectation` to satisfy the tests and keep the `mock` module clean.  Once the tests are migrated to CommonJS we can remove this from the public API.

