### PR TITLE
Extract `sandbox` into a CommonJS module.

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -20,6 +20,7 @@ exports.spy = require("./sinon/spy");
 exports.spyCall = require("./sinon/call");
 exports.stub = require("./sinon/stub");
 exports.mock = require("./sinon/mock");
+exports.sandbox = require("./sinon/sandbox");
 exports.expectation = require("./sinon/mock-expectation");
 exports.createStubInstance = require("./sinon/stub").createStubInstance;
 exports.typeOf = require("./sinon/typeOf");

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -9,13 +9,16 @@
  */
 "use strict";
 
-require("./extend");
-require("./collection");
-require("./util/fake_server_with_clock");
-require("./util/fake_timers");
 var sinon = require("./util/core");
 
+var extend = require("./extend");
+var createInstance = require("./util/core/create");
+var sinonCollection = require("./collection");
+var sinonMatch = require("./match");
+
 var push = [].push;
+
+var sinonSandbox = createInstance(sinonCollection);
 
 function exposeValue(sandbox, config, key, value) {
     if (!value) {
@@ -31,7 +34,7 @@ function exposeValue(sandbox, config, key, value) {
 }
 
 function prepareSandboxFromConfig(config) {
-    var sandbox = sinon.create(sinon.sandbox);
+    var sandbox = createInstance(sinonSandbox);
 
     if (config.useFakeServer) {
         if (typeof config.useFakeServer === "object") {
@@ -52,14 +55,14 @@ function prepareSandboxFromConfig(config) {
     return sandbox;
 }
 
-sinon.sandbox = sinon.extend(sinon.create(sinon.collection), {
+extend(sinonSandbox, {
     useFakeTimers: function useFakeTimers() {
         this.clock = sinon.useFakeTimers.apply(sinon, arguments);
 
         return this.add(this.clock);
     },
 
-    serverPrototype: sinon.fakeServer,
+    serverPrototype: sinon.fakeServerWithClock,
 
     useFakeServer: function useFakeServer() {
         var proto = this.serverPrototype || sinon.fakeServer;
@@ -73,7 +76,7 @@ sinon.sandbox = sinon.extend(sinon.create(sinon.collection), {
     },
 
     inject: function (obj) {
-        sinon.collection.inject.call(this, obj);
+        sinonCollection.inject.call(this, obj);
 
         if (this.clock) {
             obj.clock = this.clock;
@@ -84,13 +87,13 @@ sinon.sandbox = sinon.extend(sinon.create(sinon.collection), {
             obj.requests = this.server.requests;
         }
 
-        obj.match = sinon.match;
+        obj.match = sinonMatch;
 
         return obj;
     },
 
     restore: function () {
-        sinon.collection.restore.apply(this, arguments);
+        sinonCollection.restore.apply(this, arguments);
         this.restoreContext();
     },
 
@@ -105,7 +108,7 @@ sinon.sandbox = sinon.extend(sinon.create(sinon.collection), {
 
     create: function (config) {
         if (!config) {
-            return sinon.create(sinon.sandbox);
+            return createInstance(sinonSandbox);
         }
 
         var sandbox = prepareSandboxFromConfig(config);
@@ -129,7 +132,9 @@ sinon.sandbox = sinon.extend(sinon.create(sinon.collection), {
         return sandbox;
     },
 
-    match: sinon.match
+    match: sinonMatch
 });
 
-sinon.sandbox.useFakeXMLHttpRequest = sinon.sandbox.useFakeServer;
+sinonSandbox.useFakeXMLHttpRequest = sinonSandbox.useFakeServer;
+
+module.exports = sinonSandbox;


### PR DESCRIPTION
Tests are tightly coupled to `sinon.useFakeTimers` and `sinon.fakeServer`; however we should be able to resolve this once we CJSify the tests. :rocket: 