### PR TITLE
Fixes typo error in docs

### DIFF
--- a/docs/current/assertions.md
+++ b/docs/current/assertions.md
@@ -71,7 +71,7 @@ Passes if `spy` was called exactly `num` times.
 
 
 #### `sinon.assert.callOrder(spy1, spy2, ...)`
-Passes if provided spies where called in the specified order.
+Passes if provided spies were called in the specified order.
 
 
 #### `sinon.assert.calledOn(spy, obj)`

--- a/docs/current/fake-xhr-and-server.md
+++ b/docs/current/fake-xhr-and-server.md
@@ -137,7 +137,7 @@ All response headers as an object.
 
 ### Filtered requests
 
-When using Sinon.JS for mockups or partial integration/functional testing, you might want to fake some requests, while allowing others to go throught to the backend server. With filtered `FakeXMLHttpRequest`s (new in v1.3.0), you can.
+When using Sinon.JS for mockups or partial integration/functional testing, you might want to fake some requests, while allowing others to go through to the backend server. With filtered `FakeXMLHttpRequest`s (new in v1.3.0), you can.
 
 
 #### `FakeXMLHttpRequest.useFilters`


### PR DESCRIPTION
Changes "provided spies where called" to "provided spies were called" line 74.