### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   ],
   "dependencies": {
     "formatio": "1.1.1",
-    "util": ">=0.10.3 <1",
-    "lolex": "1.3.2",
+    "lolex": "^1.4.0",
     "samsam": "1.1.2",
-    "text-encoding": "0.5.2"
+    "text-encoding": "0.5.2",
+    "util": ">=0.10.3 <1"
   },
   "devDependencies": {
     "browserify": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "buster-istanbul": "^0.1.15",
     "eslint": "^1.7.1",
     "eslint-config-defaults": "^2.1.0",
-    "pre-commit": "1.0.10"
+    "pre-commit": "^1.1.2"
   },
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "formatio": "1.1.1",
     "lolex": "^1.4.0",
     "samsam": "^1.1.3",
-    "text-encoding": "0.5.2",
-    "util": ">=0.10.3 <1"
+    "text-encoding": "0.5.2"
   },
   "devDependencies": {
     "browserify": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "browserify": "^11.1.0",
     "buster": "0.7.18",
     "buster-core": "^0.6.4",
-    "buster-istanbul": "0.1.13",
+    "buster-istanbul": "^0.1.15",
     "eslint": "^1.7.1",
     "eslint-config-defaults": "^2.1.0",
     "pre-commit": "1.0.10"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "formatio": "1.1.1",
     "lolex": "^1.4.0",
-    "samsam": "1.1.2",
+    "samsam": "^1.1.3",
     "text-encoding": "0.5.2",
     "util": ">=0.10.3 <1"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "text-encoding": "0.5.2"
   },
   "devDependencies": {
-    "browserify": "^11.1.0",
+    "browserify": "^12.0.1",
     "buster": "0.7.18",
     "buster-core": "^0.6.4",
     "buster-istanbul": "^0.1.15",


### PR DESCRIPTION
This PR updates all the dependencies that are trivial updates. I still haven't found the time to figure out why formatio 1.1.2+ makes the tests fail, so we're leaving that one out.

This is ready for review