### PR TITLE
Fix stub.withArgs unable to recognize sinon matchers

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -9,7 +9,6 @@
 "use strict";
 
 var extend = require("./extend");
-var deepEqual = require("./util/core/deep-equal");
 var functionName = require("./util/core/function-name");
 var functionToString = require("./util/core/function-to-string");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
@@ -305,7 +304,7 @@ var spyApi = {
         var margs = this.matchingAguments;
 
         if (margs.length <= args.length &&
-            deepEqual(margs, args.slice(0, margs.length))) {
+            sinon.deepEqual(margs, args.slice(0, margs.length))) {
             return !strict || margs.length === args.length;
         }
     },

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -13,6 +13,8 @@ var functionName = require("./util/core/function-name");
 var functionToString = require("./util/core/function-to-string");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var sinon = require("./util/core");
+var sinonMatch = require("./match");
+var deepEqual = require("./util/core/deep-equal").use(sinonMatch);
 var spyCall = require("./call");
 var timesInWords = require("./util/core/times-in-words");
 var wrapMethod = require("./util/core/wrap-method");
@@ -304,7 +306,7 @@ var spyApi = {
         var margs = this.matchingAguments;
 
         if (margs.length <= args.length &&
-            sinon.deepEqual(margs, args.slice(0, margs.length))) {
+            deepEqual(margs, args.slice(0, margs.length))) {
             return !strict || margs.length === args.length;
         }
     },

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1306,6 +1306,14 @@
                 assert.exception(function () {
                     stub(42);
                 });
+            },
+
+            "ensure stub recognizes sinon.match fuzzy arguments": function () {
+                var stub = sinon.stub().returns(23);
+                stub.withArgs(sinon.match({ foo: "bar" })).returns(99);
+
+                assert.equals(stub(), 23);
+                assert.equals(stub({ foo: "bar", bar: "foo" }), 99);
             }
         },
 


### PR DESCRIPTION
I've noticed when converting to commonJS, `sinon.deepEqual` was mistakenly changed to the `deepEqual` function from `util/core/deep-equal.js`. This caused the unit tests of our project failing after upgrading to `v2.0.0-pre`.

I also added a unit test to cover this bug.