### PR TITLE
Remove the use of `sinon.format` from the codebase

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -10,11 +10,11 @@
   */
 "use strict";
 
-var sinon = require("./util/core");
 var sinonMatch = require("./match");
 var deepEqual = require("./util/core/deep-equal").use(sinonMatch);
 var functionName = require("./util/core/function-name");
 var createInstance = require("./util/core/create");
+var sinonFormat = require("./util/core/format");
 var slice = Array.prototype.slice;
 
 function throwYieldError(proxy, text, args) {
@@ -161,13 +161,13 @@ var callProto = {
         }
 
         for (var i = 0, l = this.args.length; i < l; ++i) {
-            args.push(sinon.format(this.args[i]));
+            args.push(sinonFormat(this.args[i]));
         }
 
         callStr = callStr + args.join(", ") + ")";
 
         if (typeof this.returnValue !== "undefined") {
-            callStr += " => " + sinon.format(this.returnValue);
+            callStr += " => " + sinonFormat(this.returnValue);
         }
 
         if (this.exception) {

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -12,12 +12,12 @@ var extend = require("./extend");
 var functionName = require("./util/core/function-name");
 var functionToString = require("./util/core/function-to-string");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
-var sinon = require("./util/core");
 var sinonMatch = require("./match");
 var deepEqual = require("./util/core/deep-equal").use(sinonMatch);
 var spyCall = require("./call");
 var timesInWords = require("./util/core/times-in-words");
 var wrapMethod = require("./util/core/wrap-method");
+var sinonFormat = require("./util/core/format");
 
 var push = Array.prototype.push;
 var slice = Array.prototype.slice;
@@ -322,7 +322,7 @@ var spyApi = {
             if (typeof formatter === "function") {
                 return formatter.call(null, spyInstance, args);
             } else if (!isNaN(parseInt(specifyer, 10))) {
-                return sinon.format(args[specifyer - 1]);
+                return sinonFormat(args[specifyer - 1]);
             }
 
             return "%" + specifyer;
@@ -430,7 +430,7 @@ spyApi.formatters = {
         var objects = [];
 
         for (var i = 0, l = spyInstance.callCount; i < l; ++i) {
-            push.call(objects, sinon.format(spyInstance.thisValues[i]));
+            push.call(objects, sinonFormat(spyInstance.thisValues[i]));
         }
 
         return objects.join(", ");
@@ -440,7 +440,7 @@ spyApi.formatters = {
         var formatted = [];
 
         for (var i = 0, l = args.length; i < l; ++i) {
-            push.call(formatted, sinon.format(args[i]));
+            push.call(formatted, sinonFormat(args[i]));
         }
 
         return formatted.join(", ");

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -805,25 +805,21 @@
                 assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt() !TypeError(Oh noes!)");
             },
 
-            // these tests are ensuring that call.toString is tightly coupled to sinon.format
-            "formats arguments with sinon.format": function () {
-                this.format = sinon.stub(sinon, "format").returns("Forty-two");
+            // these tests are ensuring that call.toString is handled by sinonFormat
+            "formats arguments with sinonFormat": function () {
                 var object = { doIt: sinon.spy() };
 
                 object.doIt(42);
 
-                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt(Forty-two)");
-                assert(sinon.format.calledWith(42));
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt(42)");
             },
 
-            "formats return value with sinon.format": function () {
-                this.format = sinon.stub(sinon, "format").returns("Forty-two");
+            "formats return value with sinonFormat": function () {
                 var object = { doIt: sinon.stub().returns(42) };
 
                 object.doIt();
 
-                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt() => Forty-two");
-                assert(sinon.format.calledWith(42));
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt() => 42");
             }
         },
 


### PR DESCRIPTION
The `test-call` suite now check that the `util/core/format` module was invoked by asserting against the returned string value; this allows us to import `util/core/format` inside both `spy.js` and `call.js` instead of using `sinon.format`