### PR TITLE
Remove linting errors in switch cases

### DIFF
--- a/lib/sinon/util/fake_xdomain_request.js
+++ b/lib/sinon/util/fake_xdomain_request.js
@@ -88,6 +88,8 @@ extend(FakeXDomainRequest.prototype, event.EventTarget, {
                     eventName = "onload";
                 }
                 break;
+            default:
+                throw new Error("Unhandled state");
         }
 
         // raising event (if defined)

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -190,6 +190,7 @@ var apply = function (obj, method, args) {
         case 3: return obj[method](args[0], args[1], args[2]);
         case 4: return obj[method](args[0], args[1], args[2], args[3]);
         case 5: return obj[method](args[0], args[1], args[2], args[3], args[4]);
+        default: throw new Error("Unhandled case");
     }
 };
 


### PR DESCRIPTION
This pull request removes some linting errors we get in
master when running `npm run lint`.

Refer to the discussion in #898 for background info.