### PR TITLE
Fix #835: avoid uncaught TypeError in log_error

### DIFF
--- a/lib/sinon/util/core/log_error.js
+++ b/lib/sinon/util/core/log_error.js
@@ -29,8 +29,9 @@ function configure(config) {
         config.setTimeout = realSetTimeout;
     }
 
-    return function logError(label, err) {
+    return function logError(label, e) {
         var msg = label + " threw exception: ";
+        var err = { name: e.name || label, message: e.message || e.toString(), stack: e.stack };
 
         function throwLoggedError() {
             err.message = msg + err.message;

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -5,6 +5,7 @@
     var sinon = root.sinon || require("../../lib/sinon");
     var assert = buster.assert;
     var refute = buster.refute;
+    var configureLogError = sinon.configureLogError || require("../../lib/sinon/util/core/log_error.js");
 
     buster.testCase("issues", {
         setUp: function () {
@@ -124,6 +125,27 @@
                     sinon.createStubInstance(A);
                     sinon.createStubInstance(A);
                 });
+            }
+        },
+
+        "#835": {
+            "logError() throws an exception if the passed err is read-only": function () {
+                var logError = configureLogError({useImmediateExceptions: true});
+
+                // passes
+                var err = { name: "TestError", message: "this is a proper exception" };
+                try {
+                    logError("#835 test", err);
+                } catch (ex) {
+                    assert.equals(ex.name, err.name);
+                }
+
+                // fails until this issue is fixed
+                try {
+                    logError("#835 test", "this literal string is not a proper exception");
+                } catch (ex) {
+                    assert.equals(ex.name, "#835 test");
+                }
             }
         }
     });


### PR DESCRIPTION
This is a repack of #844 as the author failed to update his PR.

It fixes #835 by creating a new, conforming error object that we can play with.