### PR TITLE
Use PhantomJS 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
   - "0.12"
-  - "4.2"
+  # LTS release per February 2016
+  - "4.3"
   - "5"
 
 sudo: false
@@ -14,8 +13,6 @@ cache:
 
 before_install:
   - npm config set strict-ssl false
-  # use a more modern npm than ships with 0.8
-  - 'if [ "x$TRAVIS_NODE_VERSION" = "x0.8" ]; then npm install -g npm@1.4; fi'
 
 before_script:
   # we only need to run eslint once per build, so let's conserve a few resources

--- a/build
+++ b/build
@@ -22,27 +22,6 @@ PREAMBLE
   end
 end
 
-# This code is an awful hack that is done here only because
-# PhantomJS 1.x incorrectly handles "use strict" statement in
-# some cases leading to sinon spy executing in a non-strict
-# mode, even though it explicitly says otherwise. Since the
-# people still use PhantomJS 1.x, this has to remain here
-# to add another wrapper with another "use strict" on top
-# of UMD bundle packaged by browserify.
-def add_use_strict(file)
-
-  contents = File.read(file)
-
-  File.open(file, "w") do |f|
-    f.puts("(function () {")
-    f.puts("  'use strict';")
-    f.puts(contents)
-    f.puts("}());")
-  end
-
-  file
-end
-
 Dir.chdir(File.dirname(__FILE__)) do
   version = File.read("package.json").match(/"version":\s+"(.*)"/)[1]
   version_string = ARGV[0] == "plain" ? "" : "-#{version}"
@@ -51,7 +30,7 @@ Dir.chdir(File.dirname(__FILE__)) do
 
   FileUtils.mkdir("pkg") unless File.exists?("pkg")
   `#{browserify} -s sinon lib/sinon.js -o #{output}`
-  add_license(add_use_strict(output), version)
+  add_license(output, version)
 
   File.open("pkg/sinon-ie#{version_string}.js", "w") do |f|
     f.puts(File.read("lib/sinon/util-ie/timers.js"))

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "buster-istanbul": "^0.1.15",
     "eslint": "^1.7.1",
     "eslint-config-defaults": "^2.1.0",
+    "phantomjs-prebuilt": "^2.1.4",
     "pre-commit": "^1.1.2"
   },
   "files": [

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eu
 
+# Add our various executables to the path
+PATH="$(npm bin):$PATH"
+
 function finish {
     if [ -n "${TRAVIS+1}" ]; then
       echo "TRAVIS detected, skip killing child processes"
@@ -13,7 +16,7 @@ trap finish SIGINT SIGTERM EXIT
 
 echo
 echo starting buster-server
-./node_modules/buster/bin/buster-server & # fork to a subshell
+buster-server & # fork to a subshell
 sleep 4 # takes a while for buster server to start
 
 echo
@@ -23,9 +26,9 @@ sleep 1 # give phantomjs a second to warm up
 
 echo
 echo "starting buster-test (source)"
-./node_modules/buster/bin/buster-test --config-group coverage
+buster-test --config-group coverage
 
 echo
 echo "starting buster-test (packaged)"
 ./build
-./node_modules/buster/bin/buster-test --config test/buster-packaged.js
+buster-test --config test/buster-packaged.js


### PR DESCRIPTION
PhantomJS was made available on NPM in January, and this makes some hacks in the build script superfluous. This commit removes the hack and adds an explicit dependency on the PhantomJS package that is used in the tests of the packaged browser build.

Also removing older Node versions from Travis.