### PR TITLE
Fixed defake responseType and attribute updates.

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -213,12 +213,42 @@ FakeXMLHttpRequest.defake = function defake(fakeXhr, xhrArgs) {
         "removeEventListener"
     ], function (method) {
         fakeXhr[method] = function () {
+
+            // responseType can be configures any time
+            // prior to send. This ensure we capture it
+            // at the last possible moment.
+            if (method === "send") {
+                xhr.responseType = fakeXhr.responseType;
+            }
+
             return apply(xhr, method, arguments);
         };
     });
 
-    var copyAttrs = function (args) {
-        each(args, function (attr) {
+    // Map attributes from the workingXHR back to our fakeXhr
+    //
+    // available response attributes depend on the the responseType.
+    // https://www.w3.org/TR/XMLHttpRequest/#the-responsetext-attribute
+    // https://www.w3.org/TR/XMLHttpRequest/#the-responsexml-attribute
+    var stateChange = function stateChange() {
+
+        var attributes = ["readyState", "response", "status", "statusText"];
+        switch (xhr.responseType) {
+            case "":
+                attributes.push("responseText");
+                attributes.push("responseXML");
+                break;
+            case "document":
+                attributes.push("responseXML");
+                break;
+            case "text":
+                attributes.push("responseText");
+                break;
+            default:
+                // noop
+        }
+
+        each(attributes, function (attr) {
             try {
                 fakeXhr[attr] = xhr[attr];
             } catch (e) {
@@ -227,22 +257,11 @@ FakeXMLHttpRequest.defake = function defake(fakeXhr, xhrArgs) {
                 }
             }
         });
-    };
 
-    var stateChange = function stateChange() {
-        fakeXhr.readyState = xhr.readyState;
-        if (xhr.readyState >= FakeXMLHttpRequest.HEADERS_RECEIVED) {
-            copyAttrs(["status", "statusText"]);
-        }
-        if (xhr.readyState >= FakeXMLHttpRequest.LOADING) {
-            copyAttrs(["responseText", "response"]);
-        }
-        if (xhr.readyState === FakeXMLHttpRequest.DONE) {
-            copyAttrs(["responseXML"]);
-        }
         if (fakeXhr.onreadystatechange) {
             fakeXhr.onreadystatechange.call(fakeXhr, { target: fakeXhr });
         }
+
     };
 
     if (xhr.addEventListener) {

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1467,6 +1467,118 @@
                 });
             },
 
+            "updates response, responseText and responseXML if responseType is an empty string": function () {
+                var workingXHRInstance,
+                    readyStateCb;
+                var workingXHROverride = function () {
+                    workingXHRInstance = this;
+                    this.addEventListener = function (str, fn) {
+                        readyStateCb = fn;
+                    };
+                    this.open = function () {};
+                    this.send = function () {
+                        readyStateCb();
+                    };
+                };
+                var fakeXhr = this.fakeXhr;
+
+                runWithWorkingXHROveride(workingXHROverride, function () {
+                    sinon.FakeXMLHttpRequest.defake(fakeXhr, []);
+                    fakeXhr.responseType = "";
+                    workingXHRInstance.response = "This is the response of the real XHR";
+                    workingXHRInstance.responseText = "This is the responseText of the real XHR";
+                    workingXHRInstance.responseXML = "This is the responseXML of the real XHR";
+                    fakeXhr.send();
+                    assert.equals(fakeXhr.response, "This is the response of the real XHR");
+                    assert.equals(fakeXhr.responseText, "This is the responseText of the real XHR");
+                    assert.equals(fakeXhr.responseXML, "This is the responseXML of the real XHR");
+                });
+            },
+
+            "updates only response and responseXML if the responseType is document": function () {
+                var workingXHRInstance,
+                    readyStateCb;
+                var workingXHROverride = function () {
+                    workingXHRInstance = this;
+                    this.addEventListener = function (str, fn) {
+                        readyStateCb = fn;
+                    };
+                    this.open = function () {};
+                    this.send = function () {
+                        readyStateCb();
+                    };
+                };
+                var fakeXhr = this.fakeXhr;
+
+                runWithWorkingXHROveride(workingXHROverride, function () {
+                    sinon.FakeXMLHttpRequest.defake(fakeXhr, []);
+                    fakeXhr.responseType = "document";
+                    workingXHRInstance.response = "This is the response of the real XHR";
+                    workingXHRInstance.responseText = "This is the responseText of the real XHR";
+                    workingXHRInstance.responseXML = "This is the responseXML of the real XHR";
+                    fakeXhr.send();
+                    assert.equals(fakeXhr.responseText, undefined);
+                    assert.equals(fakeXhr.response, "This is the response of the real XHR");
+                    assert.equals(fakeXhr.responseXML, "This is the responseXML of the real XHR");
+                });
+            },
+
+            "updates only response and responseText if the responseType is 'text'": function () {
+                var workingXHRInstance,
+                    readyStateCb;
+                var workingXHROverride = function () {
+                    workingXHRInstance = this;
+                    this.addEventListener = function (str, fn) {
+                        readyStateCb = fn;
+                    };
+                    this.open = function () {};
+                    this.send = function () {
+                        readyStateCb();
+                    };
+                };
+                var fakeXhr = this.fakeXhr;
+
+                runWithWorkingXHROveride(workingXHROverride, function () {
+                    sinon.FakeXMLHttpRequest.defake(fakeXhr, []);
+                    fakeXhr.responseType = "text";
+                    workingXHRInstance.response = "This is the response of the real XHR";
+                    workingXHRInstance.responseText = "This is the responseText of the real XHR";
+                    workingXHRInstance.responseXML = "This is the responseXML of the real XHR";
+                    fakeXhr.send();
+                    assert.equals(fakeXhr.response, "This is the response of the real XHR");
+                    assert.equals(fakeXhr.responseText, "This is the responseText of the real XHR");
+                    assert.equals(fakeXhr.responseXML, undefined);
+                });
+            },
+
+            "updates only response if the responseType is not not '', document or text": function () {
+                var workingXHRInstance,
+                    readyStateCb;
+                var workingXHROverride = function () {
+                    workingXHRInstance = this;
+                    this.addEventListener = function (str, fn) {
+                        readyStateCb = fn;
+                    };
+                    this.open = function () {};
+                    this.send = function () {
+                        readyStateCb();
+                    };
+                };
+                var fakeXhr = this.fakeXhr;
+
+                runWithWorkingXHROveride(workingXHROverride, function () {
+                    sinon.FakeXMLHttpRequest.defake(fakeXhr, []);
+                    fakeXhr.responseType = "arraybuffer";
+                    workingXHRInstance.response = "This is the response of the real XHR";
+                    workingXHRInstance.responseText = "This is the responseText of the real XHR";
+                    workingXHRInstance.responseXML = "This is the responseXML of the real XHR";
+                    fakeXhr.send();
+                    assert.equals(fakeXhr.response, "This is the response of the real XHR");
+                    assert.equals(fakeXhr.responseText, undefined);
+                    assert.equals(fakeXhr.responseXML, undefined);
+                });
+            },
+
             "passes on methods to working XHR object": function () {
                 var workingXHRInstance,
                     spy;
@@ -1503,6 +1615,24 @@
                     // Fix to make weinre work
                     assert.isObject(spy.args[0][0]);
                     assert.equals(spy.args[0][0].target, fakeXhr);
+                });
+            },
+
+            "configures responseType on send": function () {
+                var workingXHRInstance;
+                var workingXHROverride = function () {
+                    workingXHRInstance = this;
+                    this.addEventListener = function () {};
+                    this.send = function () {};
+                    this.open = function () {};
+                };
+                var fakeXhr = this.fakeXhr;
+
+                runWithWorkingXHROveride(workingXHROverride, function () {
+                    sinon.FakeXMLHttpRequest.defake(fakeXhr, []);
+                    fakeXhr.responseType = "arraybuffer";
+                    fakeXhr.send();
+                    assert.equals(workingXHRInstance.responseType, "arraybuffer");
                 });
             },
 


### PR DESCRIPTION
https://github.com/sinonjs/sinon/issues/976

When using sinon.useFakeXMLHttpRequests, it is possible to specify
filters to allow specific requests to pass through to a working XHR.

Unfortunately, the implementation did not apply the responseType
configured on the fakeXhr. Thus any filtered request for an
arraybufffer, blobs or json responseType returns the wrong data type.

In addition to applying the responseType from the fakeXhr to the working
XHR, the mapping of attribute updates from the working XHR to the
fakeXhr on state change needed to be brought inline with the
specification.

Implementation details:

1. responseType is applied to the working XHR object when the fakeXhr
recieves 'send'.

This allows consumers to specify responseType any time prior to sending
the request.

Concretely - both of these work for unfaked requests:

var xhr = new XMLHttpRequest();
xhr.open('GET', url, true);
xhr.responseType = 'arraybuffer';

var xhr = new XMLHttpRequest();
xhr.responseType = 'arraybuffer';
xhr.open('GET', url, true);

2. All valid attributes are mapped from the working XHR to the fakeXhr.

Depending on the responseType specified, requesting responseText or
responseXML can result in an InvalidState error.

Concretely:

- responseText throws an InvalidState error if the responseType is not and
empty string or "text"
- responseXML throws an InvalidState error if the responseType is not an
  empty string or "document"

https://www.w3.org/TR/XMLHttpRequest/#the-responsetext-attribute
https://www.w3.org/TR/XMLHttpRequest/#the-responsexml-attribute

Instead of querying readyState and making partial, potentially fatal
updates, I've opted to ensure that all valid attributes of the working
XHR are applied to the fakeXhr on all state changes.