### PR TITLE
Add tests for #947

### DIFF
--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -125,6 +125,102 @@
                     sinon.createStubInstance(A);
                 });
             }
+        },
+
+        "#947 - sandbox.reset - prototype methods": {
+            "should reset callCount": function () {
+                function Car() {}
+
+                Car.prototype.honk = function () {
+                    return "honk honk";
+                };
+
+                var sandbox = sinon.sandbox.create();
+                var car1 = new Car();
+                var car2 = new Car();
+
+                var honkSpy = sandbox.spy(car1, "honk");
+                var honkStub = sandbox.stub(car2, "honk");
+
+                car1.honk();
+                car2.honk();
+
+                assert.equals(honkSpy.callCount, 1);
+                assert.equals(honkStub.callCount, 1);
+
+                sandbox.reset();
+
+                assert.equals(car1.honk.callCount, 0);
+                assert.equals(car2.honk.callCount, 0);
+
+                sandbox.restore();
+            }
+        },
+
+        "#947 - sandbox.reset - on instance methods": {
+            "should reset callCount": function () {
+                function Car() {
+                    this.honk = function () {
+                        return "honky honky";
+                    };
+                }
+
+                var sandbox = sinon.sandbox.create();
+                var car1 = new Car();
+                var car2 = new Car();
+
+                var honkSpy = sandbox.spy(car1, "honk");
+                var honkStub = sandbox.stub(car2, "honk");
+
+                honkStub.returns("forty two");
+
+                car1.honk();
+                car2.honk();
+
+                assert.equals(honkSpy.callCount, 1);
+                assert.equals(honkStub.callCount, 1);
+
+                sandbox.reset();
+
+                assert.equals(car1.honk.callCount, 0);
+                assert.equals(car2.honk.callCount, 0);
+
+                sandbox.restore();
+            }
+        },
+
+        "#947 - sandbox.reset - on literal object members": {
+            "should reset callCount": function () {
+                var car = {
+                    honk: function () {
+                        return "honker";
+                    },
+
+                    honky: function () {
+                        return "honkity honk";
+                    }
+                };
+
+                var sandbox = sinon.sandbox.create();
+
+                var honkSpy = sandbox.spy(car, "honk");
+                var honkStub = sandbox.stub(car, "honky", function () {
+                    return 42;
+                });
+
+                car.honk();
+                car.honky();
+
+                assert.equals(honkSpy.callCount, 1);
+                assert.equals(honkStub.callCount, 1);
+
+                sandbox.reset();
+
+                assert.equals(car.honk.callCount, 0);
+                assert.equals(car.honky.callCount, 0);
+
+                sandbox.restore();
+            }
         }
     });
 }(this));


### PR DESCRIPTION
This is a PR for **v1.17** branch. Once merged, I'll cherry pick the changes into a PR for **master**.

Having had the same experience of having to manually reset stubs, I thought I could try to show the issue with some tests. However, to the best of my understanding these tests show that the issue reported as #947 is resolved.

If someone can contribute tests that shows that `sandbox.reset()` **doesn't** reset the `callCount`, that would be great. Until that time, I think we can consider #947 fixed.