### PR TITLE
Improve Blob support detection logics

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -34,7 +34,13 @@ var supportsProgress = typeof ProgressEvent !== "undefined";
 var supportsCustomEvent = typeof CustomEvent !== "undefined";
 var supportsFormData = typeof FormData !== "undefined";
 var supportsArrayBuffer = typeof ArrayBuffer !== "undefined";
-var supportsBlob = typeof Blob === "function";
+var supportsBlob = (function () {
+    try {
+        return !!new Blob();
+    } catch (e) {
+        return false;
+    }
+})();
 var sinonXhr = { XMLHttpRequest: global.XMLHttpRequest };
 sinonXhr.GlobalXMLHttpRequest = global.XMLHttpRequest;
 sinonXhr.GlobalActiveXObject = global.ActiveXObject;

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -13,7 +13,13 @@
     var supportsProgressEvents = typeof ProgressEvent !== "undefined";
     var supportsFormData = typeof FormData !== "undefined";
     var supportsArrayBuffer = typeof ArrayBuffer !== "undefined";
-    var supportsBlob = typeof Blob === "function";
+    var supportsBlob = (function () {
+        try {
+            return !!new Blob();
+        } catch (e) {
+            return false;
+        }
+    })();
 
     var fakeXhrSetUp = function () {
         this.fakeXhr = sinon.useFakeXMLHttpRequest();


### PR DESCRIPTION
Current Blob support detection returns false in Safari 9 for example where `typeof Blob` is `object`.
This change is based on detection logics found in Modernizr.