### PR TITLE
Fix non enumerable methods stub restore

### DIFF
--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -10,6 +10,8 @@
 
 var sinon = require("./util/core");
 var sinonSpy = require("./spy");
+var walk = require("./util/core/walk");
+var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 
 var push = [].push;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -103,13 +105,16 @@ var collection = {
             }
         }
         if (!property && !!object && typeof object === "object") {
+            var col = this;
             var stubbedObj = sinon.stub.apply(sinon, arguments);
 
-            for (var prop in stubbedObj) {
-                if (typeof stubbedObj[prop] === "function") {
-                    this.add(stubbedObj[prop]);
+            walk(stubbedObj, function (val, prop, propOwner) {
+                if (
+                    typeof getPropertyDescriptor(propOwner, prop).value === "function"
+                ) {
+                    col.add(stubbedObj[prop]);
                 }
-            }
+            });
 
             return stubbedObj;
         }

--- a/lib/sinon/util/core/restore.js
+++ b/lib/sinon/util/core/restore.js
@@ -1,16 +1,18 @@
 "use strict";
 
+var walk = require("./walk");
+
 function isRestorable(obj) {
     return typeof obj === "function" && typeof obj.restore === "function" && obj.restore.sinon;
 }
 
 module.exports = function restore(object) {
     if (object !== null && typeof object === "object") {
-        for (var prop in object) {
+        walk(object, function (value, prop) {
             if (isRestorable(object[prop])) {
                 object[prop].restore();
             }
-        }
+        });
     } else if (isRestorable(object)) {
         object.restore();
     }

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -80,8 +80,13 @@
             "adds all object methods to fake array": function () {
                 var object = {
                     method: function () {},
-                    method2: function () {}
+                    method2: function () {},
+                    method3: function () {}
                 };
+
+                Object.defineProperty(object, "method3", {
+                    enumerable: false
+                });
 
                 sinon.stub = function () {
                     return object;
@@ -89,8 +94,8 @@
 
                 this.collection.stub(object);
 
-                assert.equals(this.collection.fakes, [object.method, object.method2]);
-                assert.equals(this.collection.fakes.length, 2);
+                assert.equals(this.collection.fakes, [object.method, object.method2, object.method3]);
+                assert.equals(this.collection.fakes.length, 3);
             },
 
             "returns a stubbed object": function () {

--- a/test/util/core/restore-test.js
+++ b/test/util/core/restore-test.js
@@ -9,13 +9,19 @@
         "restores all methods of supplied object": function () {
             var methodA = function () {};
             var methodB = function () {};
-            var obj = { methodA: methodA, methodB: methodB };
+            var nonEnumerableMethod = function () {};
+            var obj = { methodA: methodA, methodB: methodB, nonEnumerableMethod: nonEnumerableMethod };
+
+            Object.defineProperty(obj, "nonEnumerableMethod", {
+                enumerable: false
+            });
 
             sinon.stub(obj);
             sinon.restore(obj);
 
             assert.same(obj.methodA, methodA);
             assert.same(obj.methodB, methodB);
+            assert.same(obj.nonEnumerableMethod, nonEnumerableMethod);
         },
 
         "only restores restorable methods": function () {


### PR DESCRIPTION
hello,

I had a case where I've stubbed an object with non enumerable methods. It works fine, however, those methods are **not** restored because a simple for-in loop is used in the restore process (ignoring non enumerable methods...) but sinon.walk method is used to actually stub all the methods, including non enumerable ones....

I fixed that and added tests.