### PR TITLE
Actually use useFakeXMLHTTPRequest for sandbox

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -75,6 +75,11 @@ extend(sinonSandbox, {
         return this.add(this.server);
     },
 
+    useFakeXMLHttpRequest: function useFakeXMLHttpRequest() {
+        var xhr = sinon.useFakeXMLHttpRequest();
+        return this.add(xhr);
+    },
+
     inject: function (obj) {
         sinonCollection.inject.call(this, obj);
 
@@ -134,7 +139,5 @@ extend(sinonSandbox, {
 
     match: sinonMatch
 });
-
-sinonSandbox.useFakeXMLHttpRequest = sinonSandbox.useFakeServer;
 
 module.exports = sinonSandbox;

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -113,6 +113,13 @@ describe("sinon.sandbox", function () {
                     assert(sinon.useFakeXMLHttpRequest.called);
                 });
 
+                it("doesn't secretly use useFakeServer", function () {
+                    this.sandbox.stub(sinon.fakeServer, "create").returns({ restore: function () {} });
+                    this.sandbox.useFakeXMLHttpRequest();
+
+                    assert(sinon.fakeServer.create.notCalled);
+                });
+
                 it("adds fake xhr to fake collection", function () {
                     this.sandbox.useFakeXMLHttpRequest();
                     this.sandbox.restore();


### PR DESCRIPTION
useFakeServer returns something very different from useFakeXMLHttpRequest so we can't use sandbox as a drop-in replacement for useFakeXMLHttpRequest right now.

This just uses sinon.useFakeXMLHttpRequest and adds it to the sandbox
