### PR TITLE
Feature/es6 symbols support

### DIFF
--- a/docs/current/matchers.md
+++ b/docs/current/matchers.md
@@ -118,6 +118,11 @@ Requires the value to be a regular expression.
 Requires the value to be a `Date object.
 
 
+#### `sinon.match.symbol"
+
+Requires the value to be a `Symbol.
+
+
 #### `sinon.match.same(ref)"
 
 Requires the value to strictly equal `ref`.
@@ -134,8 +139,9 @@ Requires the value to be of the given type, where `type` can be one of
     `"object"`,
     `"function"`,
     `"array"`,
-    `"regexp"` or
-    `"date"`.
+    `"regexp"`,
+    `"date"` or
+    `"symbol"`.
 
 
 #### `sinon.match.instanceOf(type)"

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -83,7 +83,7 @@ function getCallbackError(behavior, func, args) {
 
         if (behavior.callArgProp) {
             msg = functionName(behavior.stub) +
-                " expected to yield to '" + behavior.callArgProp +
+                " expected to yield to '" + String(behavior.callArgProp) +
                 "', but no object with such a property was passed.";
         } else {
             msg = functionName(behavior.stub) +

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -11,6 +11,7 @@
 
 var extend = require("./extend");
 var functionName = require("./util/core/function-name");
+var valueToString = require("./util/core/value-to-string");
 
 var slice = Array.prototype.slice;
 var join = Array.prototype.join;
@@ -83,7 +84,7 @@ function getCallbackError(behavior, func, args) {
 
         if (behavior.callArgProp) {
             msg = functionName(behavior.stub) +
-                " expected to yield to '" + String(behavior.callArgProp) +
+                " expected to yield to '" + valueToString(behavior.callArgProp) +
                 "', but no object with such a property was passed.";
         } else {
             msg = functionName(behavior.stub) +

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -15,6 +15,7 @@ var deepEqual = require("./util/core/deep-equal").use(sinonMatch);
 var functionName = require("./util/core/function-name");
 var createInstance = require("./util/core/create");
 var sinonFormat = require("./util/core/format");
+var valueToString = require("./util/core/value-to-string");
 var slice = Array.prototype.slice;
 
 function throwYieldError(proxy, text, args) {
@@ -143,7 +144,7 @@ var callProto = {
                 return;
             }
         }
-        throwYieldError(this.proxy, " cannot yield to '" + String(prop) +
+        throwYieldError(this.proxy, " cannot yield to '" + valueToString(prop) +
             "' since no callback was passed.", args);
     },
 

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -143,7 +143,7 @@ var callProto = {
                 return;
             }
         }
-        throwYieldError(this.proxy, " cannot yield to '" + prop +
+        throwYieldError(this.proxy, " cannot yield to '" + String(prop) +
             "' since no callback was passed.", args);
     },
 

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -85,14 +85,14 @@ var collection = {
         if (property) {
             if (!object) {
                 var type = object === null ? "null" : "undefined";
-                throw new Error("Trying to stub property '" + property + "' of " + type);
+                throw new Error("Trying to stub property '" + String(property) + "' of " + type);
             }
 
             var original = object[property];
 
             if (typeof original !== "function") {
                 if (!hasOwnProperty.call(object, property)) {
-                    throw new TypeError("Cannot stub non-existent own property " + property);
+                    throw new TypeError("Cannot stub non-existent own property " + String(property));
                 }
 
                 object[property] = value;

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -12,6 +12,7 @@ var sinon = require("./util/core");
 var sinonSpy = require("./spy");
 var walk = require("./util/core/walk");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
+var valueToString = require("./util/core/value-to-string");
 
 var push = [].push;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -85,14 +86,14 @@ var collection = {
         if (property) {
             if (!object) {
                 var type = object === null ? "null" : "undefined";
-                throw new Error("Trying to stub property '" + String(property) + "' of " + type);
+                throw new Error("Trying to stub property '" + valueToString(property) + "' of " + type);
             }
 
             var original = object[property];
 
             if (typeof original !== "function") {
                 if (!hasOwnProperty.call(object, property)) {
-                    throw new TypeError("Cannot stub non-existent own property " + String(property));
+                    throw new TypeError("Cannot stub non-existent own property " + valueToString(property));
                 }
 
                 object[property] = value;

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -226,5 +226,6 @@ match.func = match.typeOf("function");
 match.array = match.typeOf("array");
 match.regexp = match.typeOf("regexp");
 match.date = match.typeOf("date");
+match.symbol = match.typeOf("symbol");
 
 module.exports = match;

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -194,7 +194,7 @@ function createPropertyMatcher(propertyTest, messagePrefix) {
         var onlyProperty = arguments.length === 1;
         var message = messagePrefix + "(\"" + property + "\"";
         if (!onlyProperty) {
-            message += ", " + value;
+            message += ", " + String(value);
         }
         message += ")";
         return match(function (actual) {

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -80,7 +80,7 @@ var TYPE_MAP = {
 
         for (key in expectation) {
             if (expectation.hasOwnProperty(key)) {
-                array.push(key + ": " + expectation[key]);
+                array.push(key + ": " + String(expectation[key]));
             }
         }
         m.test = function (actual) {
@@ -114,7 +114,7 @@ function match(expectation, message) {
     }
 
     if (!m.message) {
-        m.message = "match(" + expectation + ")";
+        m.message = "match(" + String(expectation) + ")";
     }
 
     return m;

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -12,6 +12,7 @@ var create = require("./util/core/create");
 var deepEqual = require("./util/core/deep-equal").use(match); // eslint-disable-line no-use-before-define
 var functionName = require("./util/core/function-name");
 var typeOf = require("./typeOf");
+var valueToString = require("./util/core/value-to-string");
 
 function assertType(value, type, name) {
     var actual = typeOf(value);
@@ -80,7 +81,7 @@ var TYPE_MAP = {
 
         for (key in expectation) {
             if (expectation.hasOwnProperty(key)) {
-                array.push(key + ": " + String(expectation[key]));
+                array.push(key + ": " + valueToString(expectation[key]));
             }
         }
         m.test = function (actual) {
@@ -114,7 +115,7 @@ function match(expectation, message) {
     }
 
     if (!m.message) {
-        m.message = "match(" + String(expectation) + ")";
+        m.message = "match(" + valueToString(expectation) + ")";
     }
 
     return m;
@@ -171,7 +172,7 @@ match.falsy = match(function (actual) {
 match.same = function (expectation) {
     return match(function (actual) {
         return expectation === actual;
-    }, "same(" + String(expectation) + ")");
+    }, "same(" + valueToString(expectation) + ")");
 };
 
 match.typeOf = function (type) {
@@ -194,7 +195,7 @@ function createPropertyMatcher(propertyTest, messagePrefix) {
         var onlyProperty = arguments.length === 1;
         var message = messagePrefix + "(\"" + property + "\"";
         if (!onlyProperty) {
-            message += ", " + String(value);
+            message += ", " + valueToString(value);
         }
         message += ")";
         return match(function (actual) {

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -171,7 +171,7 @@ match.falsy = match(function (actual) {
 match.same = function (expectation) {
     return match(function (actual) {
         return expectation === actual;
-    }, "same(" + expectation + ")");
+    }, "same(" + String(expectation) + ")");
 };
 
 match.typeOf = function (type) {

--- a/lib/sinon/mock-expectation.js
+++ b/lib/sinon/mock-expectation.js
@@ -17,6 +17,7 @@ var stub = require("./stub");
 var assert = require("./assert");
 var deepEqual = require("./util/core/deep-equal").use(match);
 var format = require("./util/core/format");
+var valueToString = require("./util/core/value-to-string");
 
 var slice = Array.prototype.slice;
 var push = Array.prototype.push;
@@ -89,7 +90,7 @@ var mockExpectation = {
 
     atLeast: function atLeast(num) {
         if (typeof num !== "number") {
-            throw new TypeError("'" + String(num) + "' is not number");
+            throw new TypeError("'" + valueToString(num) + "' is not number");
         }
 
         if (!this.limitsSet) {
@@ -104,7 +105,7 @@ var mockExpectation = {
 
     atMost: function atMost(num) {
         if (typeof num !== "number") {
-            throw new TypeError("'" + String(num) + "' is not number");
+            throw new TypeError("'" + valueToString(num) + "' is not number");
         }
 
         if (!this.limitsSet) {
@@ -135,7 +136,7 @@ var mockExpectation = {
 
     exactly: function exactly(num) {
         if (typeof num !== "number") {
-            throw new TypeError("'" + String(num) + "' is not a number");
+            throw new TypeError("'" + valueToString(num) + "' is not a number");
         }
 
         this.atLeast(num);
@@ -153,8 +154,8 @@ var mockExpectation = {
         }
 
         if ("expectedThis" in this && this.expectedThis !== thisValue) {
-            mockExpectation.fail(this.method + " called with " + String(thisValue) +
-                " as thisValue, expected " + String(this.expectedThis));
+            mockExpectation.fail(this.method + " called with " + valueToString(thisValue) +
+                " as thisValue, expected " + valueToString(this.expectedThis));
         }
 
         if (!("expectedArguments" in this)) {

--- a/lib/sinon/mock-expectation.js
+++ b/lib/sinon/mock-expectation.js
@@ -89,7 +89,7 @@ var mockExpectation = {
 
     atLeast: function atLeast(num) {
         if (typeof num !== "number") {
-            throw new TypeError("'" + num + "' is not number");
+            throw new TypeError("'" + String(num) + "' is not number");
         }
 
         if (!this.limitsSet) {
@@ -104,7 +104,7 @@ var mockExpectation = {
 
     atMost: function atMost(num) {
         if (typeof num !== "number") {
-            throw new TypeError("'" + num + "' is not number");
+            throw new TypeError("'" + String(num) + "' is not number");
         }
 
         if (!this.limitsSet) {
@@ -135,7 +135,7 @@ var mockExpectation = {
 
     exactly: function exactly(num) {
         if (typeof num !== "number") {
-            throw new TypeError("'" + num + "' is not a number");
+            throw new TypeError("'" + String(num) + "' is not a number");
         }
 
         this.atLeast(num);

--- a/lib/sinon/mock-expectation.js
+++ b/lib/sinon/mock-expectation.js
@@ -153,8 +153,8 @@ var mockExpectation = {
         }
 
         if ("expectedThis" in this && this.expectedThis !== thisValue) {
-            mockExpectation.fail(this.method + " called with " + thisValue + " as thisValue, expected " +
-                this.expectedThis);
+            mockExpectation.fail(this.method + " called with " + String(thisValue) +
+                " as thisValue, expected " + String(this.expectedThis));
         }
 
         if (!("expectedArguments" in this)) {

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -399,7 +399,7 @@ delegateToCalls("yieldTo", false, "yieldTo", function (property) {
         "' since it was not yet invoked.");
 });
 delegateToCalls("yieldToOn", false, "yieldToOn", function (property) {
-    throw new Error(this.toString() + " cannot yield to '" + property +
+    throw new Error(this.toString() + " cannot yield to '" + String(property) +
         "' since it was not yet invoked.");
 });
 

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -18,6 +18,7 @@ var spyCall = require("./call");
 var timesInWords = require("./util/core/times-in-words");
 var wrapMethod = require("./util/core/wrap-method");
 var sinonFormat = require("./util/core/format");
+var valueToString = require("./util/core/value-to-string");
 
 var push = Array.prototype.push;
 var slice = Array.prototype.slice;
@@ -395,11 +396,11 @@ delegateToCalls("yieldOn", false, "yieldOn", function () {
     throw new Error(this.toString() + " cannot yield since it was not yet invoked.");
 });
 delegateToCalls("yieldTo", false, "yieldTo", function (property) {
-    throw new Error(this.toString() + " cannot yield to '" + String(property) +
+    throw new Error(this.toString() + " cannot yield to '" + valueToString(property) +
         "' since it was not yet invoked.");
 });
 delegateToCalls("yieldToOn", false, "yieldToOn", function (property) {
-    throw new Error(this.toString() + " cannot yield to '" + String(property) +
+    throw new Error(this.toString() + " cannot yield to '" + valueToString(property) +
         "' since it was not yet invoked.");
 });
 

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -395,7 +395,7 @@ delegateToCalls("yieldOn", false, "yieldOn", function () {
     throw new Error(this.toString() + " cannot yield since it was not yet invoked.");
 });
 delegateToCalls("yieldTo", false, "yieldTo", function (property) {
-    throw new Error(this.toString() + " cannot yield to '" + property +
+    throw new Error(this.toString() + " cannot yield to '" + String(property) +
         "' since it was not yet invoked.");
 });
 delegateToCalls("yieldToOn", false, "yieldToOn", function (property) {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -25,7 +25,7 @@ function stub(object, property, func) {
 
     if (property && !object) {
         var type = object === null ? "null" : "undefined";
-        throw new Error("Trying to stub property '" + property + "' of " + type);
+        throw new Error("Trying to stub property '" + String(property) + "' of " + type);
     }
 
     var wrapper;

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -16,6 +16,7 @@ var objectKeys = require("./util/core/object-keys");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var createInstance = require("./util/core/create");
 var functionToString = require("./util/core/function-to-string");
+var valueToString = require("./util/core/value-to-string");
 var wrapMethod = require("./util/core/wrap-method");
 
 function stub(object, property, func) {
@@ -25,7 +26,7 @@ function stub(object, property, func) {
 
     if (property && !object) {
         var type = object === null ? "null" : "undefined";
-        throw new Error("Trying to stub property '" + String(property) + "' of " + type);
+        throw new Error("Trying to stub property '" + valueToString(property) + "' of " + type);
     }
 
     var wrapper;

--- a/lib/sinon/util/core/value-to-string.js
+++ b/lib/sinon/util/core/value-to-string.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = function (value) {
+    if (value && value.toString) {
+        return value.toString();
+    }
+    return String(value);
+};

--- a/lib/sinon/util/core/wrap-method.js
+++ b/lib/sinon/util/core/wrap-method.js
@@ -2,6 +2,7 @@
 
 var getPropertyDescriptor = require("./get-property-descriptor");
 var objectKeys = require("./object-keys");
+var valueToString = require("./value-to-string");
 
 var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -34,12 +35,12 @@ module.exports = function wrapMethod(object, property, method) {
 
         if (!isFunction(wrappedMethod)) {
             error = new TypeError("Attempted to wrap " + (typeof wrappedMethod) + " property " +
-                                property + " as function");
+                                valueToString(property) + " as function");
         } else if (wrappedMethod.restore && wrappedMethod.restore.sinon) {
-            error = new TypeError("Attempted to wrap " + property + " which is already wrapped");
+            error = new TypeError("Attempted to wrap " + valueToString(property) + " which is already wrapped");
         } else if (wrappedMethod.calledBefore) {
             var verb = wrappedMethod.returns ? "stubbed" : "spied on";
-            error = new TypeError("Attempted to wrap " + property + " which is already " + verb);
+            error = new TypeError("Attempted to wrap " + valueToString(property) + " which is already " + verb);
         }
 
         if (error) {

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -671,6 +671,18 @@ describe("sinon.spy.call", function () {
             }
         });
 
+        it("throws understandable error if symbol prop is not found", function () {
+            var call = this.call;
+            var symbol = Symbol();
+
+            assert.exception(function () {
+                call.yieldToOn(symbol, {});
+            }, function (err) {
+                return err.message === "spy cannot yield to 'Symbol()' since no callback was passed.";
+            });
+
+        });
+
         it("includes stub name and actual arguments in error", function () {
             this.proxy.displayName = "somethingAwesome";
             this.args.push(23, 42);

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -672,15 +672,16 @@ describe("sinon.spy.call", function () {
         });
 
         it("throws understandable error if symbol prop is not found", function () {
-            var call = this.call;
-            var symbol = Symbol();
+            if (typeof Symbol === "function") {
+                var call = this.call;
+                var symbol = Symbol();
 
-            assert.exception(function () {
-                call.yieldToOn(symbol, {});
-            }, function (err) {
-                return err.message === "spy cannot yield to 'Symbol()' since no callback was passed.";
-            });
-
+                assert.exception(function () {
+                    call.yieldToOn(symbol, {});
+                }, function (err) {
+                    return err.message === "spy cannot yield to 'Symbol()' since no callback was passed.";
+                });
+            }
         });
 
         it("includes stub name and actual arguments in error", function () {

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -37,6 +37,18 @@ describe("sinon.collection", function () {
             assert.equals(error.message, "Trying to stub property 'prop' of null");
         });
 
+        it("fails if stubbing symbol on null", function () {
+            var error;
+
+            try {
+                this.collection.stub(null, Symbol());
+            } catch (e) {
+                error = e;
+            }
+
+            assert.equals(error.message, "Trying to stub property 'Symbol()' of null");
+        });
+
         it("calls stub", function () {
             var object = { method: function () {} };
             var args;
@@ -156,6 +168,17 @@ describe("sinon.collection", function () {
 
             assert.exception(function () {
                 collection.stub(object, "prop", 1);
+            });
+        });
+
+        it("fails if Symbol does not exist", function () {
+            var collection = this.collection;
+            var object = {};
+
+            assert.exception(function () {
+                collection.stub(object, Symbol(), 1);
+            }, function (err) {
+                return err.message === "Cannot stub non-existent own property Symbol()";
             });
         });
     });

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -38,15 +38,16 @@ describe("sinon.collection", function () {
         });
 
         it("fails if stubbing symbol on null", function () {
-            var error;
+            if (typeof Symbol === "function") {
+                var error;
 
-            try {
-                this.collection.stub(null, Symbol());
-            } catch (e) {
-                error = e;
+                try {
+                    this.collection.stub(null, Symbol());
+                } catch (e) {
+                    error = e;
+                }
+                assert.equals(error.message, "Trying to stub property 'Symbol()' of null");
             }
-
-            assert.equals(error.message, "Trying to stub property 'Symbol()' of null");
         });
 
         it("calls stub", function () {
@@ -172,14 +173,16 @@ describe("sinon.collection", function () {
         });
 
         it("fails if Symbol does not exist", function () {
-            var collection = this.collection;
-            var object = {};
+            if (typeof Symbol === "function") {
+                var collection = this.collection;
+                var object = {};
 
-            assert.exception(function () {
-                collection.stub(object, Symbol(), 1);
-            }, function (err) {
-                return err.message === "Cannot stub non-existent own property Symbol()";
-            });
+                assert.exception(function () {
+                    collection.stub(object, Symbol(), 1);
+                }, function (err) {
+                    return err.message === "Cannot stub non-existent own property Symbol()";
+                });
+            }
         });
     });
 

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -241,28 +241,34 @@ describe("sinon.match", function () {
     });
 
     it("returns true for Symbol match", function () {
-        var symbol = Symbol();
+        if (typeof Symbol === "function") {
+            var symbol = Symbol();
 
-        var match = sinon.match(symbol);
+            var match = sinon.match(symbol);
 
-        assert(match.test(symbol));
+            assert(match.test(symbol));
+        }
     });
 
     it("returns false for Symbol mismatch", function () {
-        var match = sinon.match(Symbol());
+        if (typeof Symbol === "function") {
+            var match = sinon.match(Symbol());
 
-        assert.isFalse(match.test());
-        assert.isFalse(match.test(Symbol(null)));
-        assert.isFalse(match.test(Symbol()));
-        assert.isFalse(match.test(Symbol({})));
+            assert.isFalse(match.test());
+            assert.isFalse(match.test(Symbol(null)));
+            assert.isFalse(match.test(Symbol()));
+            assert.isFalse(match.test(Symbol({})));
+        }
     });
 
     it("returns true for Symbol inside object", function () {
-        var symbol = Symbol();
+        if (typeof Symbol === "function") {
+            var symbol = Symbol();
 
-        var match = sinon.match({ prop: symbol });
+            var match = sinon.match({ prop: symbol });
 
-        assert(match.test({ prop: symbol }));
+            assert(match.test({ prop: symbol }));
+        }
     });
 
     it("returns true if test function in object returns true", function () {
@@ -407,10 +413,12 @@ describe("sinon.match", function () {
         });
 
         it("returns true if test is called with same symbol", function () {
-            var symbol = Symbol();
-            var same = sinon.match.same(symbol);
+            if (typeof Symbol === "function") {
+                var symbol = Symbol();
+                var same = sinon.match.same(symbol);
 
-            assert(same.test(symbol));
+                assert(same.test(symbol));
+            }
         });
 
         it("returns false if test is not called with same argument", function () {
@@ -449,9 +457,11 @@ describe("sinon.match", function () {
         });
 
         it("returns true if test is called with symbol", function () {
-            var typeOf = sinon.match.typeOf("symbol");
+            if (typeof Symbol === "function") {
+                var typeOf = sinon.match.typeOf("symbol");
 
-            assert(typeOf.test(Symbol()));
+                assert(typeOf.test(Symbol()));
+            }
         });
 
         it("returns true if test is called with regexp", function () {
@@ -531,11 +541,13 @@ describe("sinon.match", function () {
         });
 
         it("returns true if object has Symbol", function () {
-            var symbol = Symbol();
+            if (typeof Symbol === "function") {
+                var symbol = Symbol();
 
-            var has = sinon.match.has("prop", symbol);
+                var has = sinon.match.has("prop", symbol);
 
-            assert(has.test({ prop: symbol }));
+                assert(has.test({ prop: symbol }));
+            }
         });
     });
 

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -406,6 +406,13 @@ describe("sinon.match", function () {
             assert(same.test(object));
         });
 
+        it("returns true if test is called with same symbol", function () {
+            var symbol = Symbol();
+            var same = sinon.match.same(symbol);
+
+            assert(same.test(symbol));
+        });
+
         it("returns false if test is not called with same argument", function () {
             var same = sinon.match.same({});
 

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -448,6 +448,12 @@ describe("sinon.match", function () {
             assert.isFalse(typeOf.test(123));
         });
 
+        it("returns true if test is called with symbol", function () {
+            var typeOf = sinon.match.typeOf("symbol");
+
+            assert(typeOf.test(Symbol()));
+        });
+
         it("returns true if test is called with regexp", function () {
             var typeOf = sinon.match.typeOf("regexp");
 
@@ -622,6 +628,15 @@ describe("sinon.match", function () {
 
             assert(sinon.match.isMatcher(date));
             assert.equals(date.toString(), "typeOf(\"date\")");
+        });
+    });
+
+    describe(".symbol", function () {
+        it("is typeOf symbol matcher", function () {
+            var symbol = sinon.match.symbol;
+
+            assert(sinon.match.isMatcher(symbol));
+            assert.equals(symbol.toString(), "typeOf(\"symbol\")");
         });
     });
 

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -240,6 +240,31 @@ describe("sinon.match", function () {
         assert.isFalse(match.test({}));
     });
 
+    it("returns true for Symbol match", function () {
+        var symbol = Symbol();
+
+        var match = sinon.match(symbol);
+
+        assert(match.test(symbol));
+    });
+
+    it("returns false for Symbol mismatch", function () {
+        var match = sinon.match(Symbol());
+
+        assert.isFalse(match.test());
+        assert.isFalse(match.test(Symbol(null)));
+        assert.isFalse(match.test(Symbol()));
+        assert.isFalse(match.test(Symbol({})));
+    });
+
+    it("returns true for Symbol inside object", function () {
+        var symbol = Symbol();
+
+        var match = sinon.match({ prop: symbol });
+
+        assert(match.test({ prop: symbol }));
+    });
+
     it("returns true if test function in object returns true", function () {
         var match = sinon.match({ test: function () {
             return true;

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -523,6 +523,14 @@ describe("sinon.match", function () {
 
             assert(has.test(0));
         });
+
+        it("returns true if object has Symbol", function () {
+            var symbol = Symbol();
+
+            var has = sinon.match.has("prop", symbol);
+
+            assert(has.test({ prop: symbol }));
+        });
     });
 
     describe(".hasOwnSpecial", function () {

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -228,13 +228,15 @@ describe("sinon.mock", function () {
             });
 
             it("throws with Symbol", function () {
-                var expectation = this.expectation;
+                if (typeof Symbol === "function") {
+                    var expectation = this.expectation;
 
-                assert.exception(function () {
-                    expectation.exactly(Symbol());
-                }, function (err) {
-                    return err.message === "'Symbol()' is not a number";
-                });
+                    assert.exception(function () {
+                        expectation.exactly(Symbol());
+                    }, function (err) {
+                        return err.message === "'Symbol()' is not a number";
+                    });
+                }
             });
         });
 
@@ -256,13 +258,15 @@ describe("sinon.mock", function () {
             });
 
             it("throws with Symbol", function () {
-                var expectation = this.expectation;
+                if (typeof Symbol === "function") {
+                    var expectation = this.expectation;
 
-                assert.exception(function () {
-                    expectation.atLeast(Symbol());
-                }, function (err) {
-                    return err.message === "'Symbol()' is not number";
-                });
+                    assert.exception(function () {
+                        expectation.atLeast(Symbol());
+                    }, function (err) {
+                        return err.message === "'Symbol()' is not number";
+                    });
+                }
             });
 
             it("returns expectation for chaining", function () {
@@ -351,13 +355,15 @@ describe("sinon.mock", function () {
             });
 
             it("throws with Symbol", function () {
-                var expectation = this.expectation;
+                if (typeof Symbol === "function") {
+                    var expectation = this.expectation;
 
-                assert.exception(function () {
-                    expectation.atMost(Symbol());
-                }, function (err) {
-                    return err.message === "'Symbol()' is not number";
-                });
+                    assert.exception(function () {
+                        expectation.atMost(Symbol());
+                    }, function (err) {
+                        return err.message === "'Symbol()' is not number";
+                    });
+                }
             });
 
             it("returns expectation for chaining", function () {
@@ -632,14 +638,16 @@ describe("sinon.mock", function () {
             });
 
             it("throws if calls on wrong Symbol", function () {
-                var expectation = sinon.expectation.create("method");
-                expectation.on(Symbol());
+                if (typeof Symbol === "function") {
+                    var expectation = sinon.expectation.create("method");
+                    expectation.on(Symbol());
 
-                assert.exception(function () {
-                    expectation.call(Symbol());
-                }, function (err) {
-                    return err.message === "method called with Symbol() as thisValue, expected Symbol()";
-                });
+                    assert.exception(function () {
+                        expectation.call(Symbol());
+                    }, function (err) {
+                        return err.message === "method called with Symbol() as thisValue, expected Symbol()";
+                    });
+                }
             });
         });
 

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -226,6 +226,16 @@ describe("sinon.mock", function () {
                     expectation.exactly("12");
                 }, "TypeError");
             });
+
+            it("throws with Symbol", function () {
+                var expectation = this.expectation;
+
+                assert.exception(function () {
+                    expectation.exactly(Symbol());
+                }, function (err) {
+                    return err.message === "'Symbol()' is not a number";
+                });
+            });
         });
 
         describe(".atLeast", function () {
@@ -243,6 +253,16 @@ describe("sinon.mock", function () {
                 assert.exception(function () {
                     expectation.atLeast({});
                 }, "TypeError");
+            });
+
+            it("throws with Symbol", function () {
+                var expectation = this.expectation;
+
+                assert.exception(function () {
+                    expectation.atLeast(Symbol());
+                }, function (err) {
+                    return err.message === "'Symbol()' is not number";
+                });
             });
 
             it("returns expectation for chaining", function () {
@@ -328,6 +348,16 @@ describe("sinon.mock", function () {
                 assert.exception(function () {
                     expectation.atMost({});
                 }, "TypeError");
+            });
+
+            it("throws with Symbol", function () {
+                var expectation = this.expectation;
+
+                assert.exception(function () {
+                    expectation.atMost(Symbol());
+                }, function (err) {
+                    return err.message === "'Symbol()' is not number";
+                });
             });
 
             it("returns expectation for chaining", function () {

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -630,6 +630,17 @@ describe("sinon.mock", function () {
                     expectation();
                 }, "ExpectationError");
             });
+
+            it("throws if calls on wrong Symbol", function () {
+                var expectation = sinon.expectation.create("method");
+                expectation.on(Symbol());
+
+                assert.exception(function () {
+                    expectation.call(Symbol());
+                }, function (err) {
+                    return err.message === "method called with Symbol() as thisValue, expected Symbol()";
+                });
+            });
         });
 
         describe(".verify", function () {

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2159,12 +2159,14 @@ describe("spy", function () {
         });
 
         it("throws readable message for symbol when spy was not yet invoked", function () {
-            var spy = createSpy();
+            if (typeof Symbol === "function") {
+                var spy = createSpy();
 
-            try {
-                spy.yieldTo(Symbol());
-            } catch (e) {
-                assert.equals(e.message, "spy cannot yield to 'Symbol()' since it was not yet invoked.");
+                try {
+                    spy.yieldTo(Symbol());
+                } catch (e) {
+                    assert.equals(e.message, "spy cannot yield to 'Symbol()' since it was not yet invoked.");
+                }
             }
         });
 
@@ -2228,13 +2230,15 @@ describe("spy", function () {
         });
 
         it("throws readable message for symbol when spy was not yet invoked", function () {
-            var spy = createSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            if (typeof Symbol === "function") {
+                var spy = createSpy();
+                var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                spy.yieldToOn(Symbol(), thisObj);
-            } catch (e) {
-                assert.equals(e.message, "spy cannot yield to 'Symbol()' since it was not yet invoked.");
+                try {
+                    spy.yieldToOn(Symbol(), thisObj);
+                } catch (e) {
+                    assert.equals(e.message, "spy cannot yield to 'Symbol()' since it was not yet invoked.");
+                }
             }
         });
 

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2158,6 +2158,16 @@ describe("spy", function () {
             }
         });
 
+        it("throws readable message for symbol when spy was not yet invoked", function () {
+            var spy = createSpy();
+
+            try {
+                spy.yieldTo(Symbol());
+            } catch (e) {
+                assert.equals(e.message, "spy cannot yield to 'Symbol()' since it was not yet invoked.");
+            }
+        });
+
         it("pass additional arguments", function () {
             var spy = createSpy();
             var callback = createSpy();

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2227,6 +2227,17 @@ describe("spy", function () {
             }
         });
 
+        it("throws readable message for symbol when spy was not yet invoked", function () {
+            var spy = createSpy();
+            var thisObj = { name1: "value1", name2: "value2" };
+
+            try {
+                spy.yieldToOn(Symbol(), thisObj);
+            } catch (e) {
+                assert.equals(e.message, "spy cannot yield to 'Symbol()' since it was not yet invoked.");
+            }
+        });
+
         it("pass additional arguments", function () {
             var spy = createSpy();
             var callback = createSpy();

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -32,10 +32,12 @@ describe("stub", function () {
     });
 
     it("throws a readable error if stubbing Symbol on null", function () {
-        try {
-            createStub(null, Symbol());
-        } catch (err) {
-            assert.equals(err.message, "Trying to stub property 'Symbol()' of null");
+        if (typeof Symbol === "function") {
+            try {
+                createStub(null, Symbol());
+            } catch (err) {
+                assert.equals(err.message, "Trying to stub property 'Symbol()' of null");
+            }
         }
     });
 
@@ -1124,16 +1126,18 @@ describe("stub", function () {
         });
 
         it("throws understandable error if failing to yield callback by symbol", function () {
-            var symbol = Symbol();
+            if (typeof Symbol === "function") {
+                var symbol = Symbol();
 
-            var stub = createStub().yieldsTo(symbol);
+                var stub = createStub().yieldsTo(symbol);
 
-            assert.exception(function () {
-                stub();
-            }, function (err) {
-                return err.message === "stub expected to yield to 'Symbol()', but no object with " +
-                                       "such a property was passed.";
-            });
+                assert.exception(function () {
+                    stub();
+                }, function (err) {
+                    return err.message === "stub expected to yield to 'Symbol()', but no object with " +
+                                           "such a property was passed.";
+                });
+            }
         });
 
         it("includes stub name and actual arguments in error", function () {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -31,6 +31,14 @@ describe("stub", function () {
         assert.equals(error.message, "Trying to stub property 'prop' of null");
     });
 
+    it("throws a readable error if stubbing Symbol on null", function () {
+        try {
+            createStub(null, Symbol());
+        } catch (err) {
+            assert.equals(err.message, "Trying to stub property 'Symbol()' of null");
+        }
+    });
+
     it("should contain asynchronous versions of callsArg*, and yields* methods", function () {
         var stub = createStub.create();
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1115,6 +1115,19 @@ describe("stub", function () {
             }
         });
 
+        it("throws understandable error if failing to yield callback by symbol", function () {
+            var symbol = Symbol();
+
+            var stub = createStub().yieldsTo(symbol);
+
+            assert.exception(function () {
+                stub();
+            }, function (err) {
+                return err.message === "stub expected to yield to 'Symbol()', but no object with " +
+                                       "such a property was passed.";
+            });
+        });
+
         it("includes stub name and actual arguments in error", function () {
             var myObj = { somethingAwesome: function () {} };
             var stub = createStub(myObj, "somethingAwesome").yieldsTo("success");

--- a/test/util/core/value-to-string-test.js
+++ b/test/util/core/value-to-string-test.js
@@ -1,0 +1,21 @@
+"use strict";
+
+var referee = require("referee");
+var valueToString = require("../../../lib/sinon/util/core/value-to-string");
+var assert = referee.assert;
+
+describe("util/core/valueToString", function () {
+    it("returns string representation of an object", function () {
+        var obj = {};
+
+        assert.equals(valueToString(obj), obj.toString());
+    });
+
+    it("returns 'null' for literal null'", function () {
+        assert.equals(valueToString(null), "null");
+    });
+
+    it("returns 'undefined' for literal undefined", function () {
+        assert.equals(valueToString(undefined), "undefined");
+    });
+});

--- a/test/util/core/wrap-method-test.js
+++ b/test/util/core/wrap-method-test.js
@@ -39,6 +39,18 @@ describe("util/core/wrapMethod", function () {
         }, "TypeError");
     });
 
+    it("throws Symbol() if object defines property but is not function", function () {
+        var symbol = Symbol();
+        var object = {};
+        object[symbol] = 42;
+
+        assert.exception(function () {
+            wrapMethod(object, symbol, function () {});
+        }, function (err) {
+            return err.message === "Attempted to wrap number property Symbol() as function";
+        });
+    });
+
     it("throws if object does not define property", function () {
         var object = this.object;
 
@@ -102,6 +114,19 @@ describe("util/core/wrapMethod", function () {
         }, "TypeError");
     });
 
+    it("throws Symbol if method is already wrapped", function () {
+        var symbol = Symbol();
+        var object = {};
+        object[symbol] = function () {};
+        wrapMethod(object, symbol, function () {});
+
+        assert.exception(function () {
+            wrapMethod(object, symbol, function () {});
+        }, function (err) {
+            return err.message === "Attempted to wrap Symbol() which is already wrapped";
+        });
+    });
+
     it("throws if property descriptor is already wrapped", function () {
         wrapMethod(this.object, "property", { get: function () {} });
 
@@ -116,6 +141,18 @@ describe("util/core/wrapMethod", function () {
         assert.exception(function () {
             wrapMethod(object, "method", function () {});
         }, "TypeError");
+    });
+
+    it("throws if Symbol method is already a spy", function () {
+        var symbol = Symbol();
+        var object = {};
+        object[symbol] = createSpy();
+
+        assert.exception(function () {
+            wrapMethod(object, symbol, function () {});
+        }, function (err) {
+            return err.message === "Attempted to wrap Symbol() which is already spied on";
+        });
     });
 
     var overridingErrorAndTypeError = (function () {

--- a/test/util/core/wrap-method-test.js
+++ b/test/util/core/wrap-method-test.js
@@ -40,15 +40,17 @@ describe("util/core/wrapMethod", function () {
     });
 
     it("throws Symbol() if object defines property but is not function", function () {
-        var symbol = Symbol();
-        var object = {};
-        object[symbol] = 42;
+        if (typeof Symbol === "function") {
+            var symbol = Symbol();
+            var object = {};
+            object[symbol] = 42;
 
-        assert.exception(function () {
-            wrapMethod(object, symbol, function () {});
-        }, function (err) {
-            return err.message === "Attempted to wrap number property Symbol() as function";
-        });
+            assert.exception(function () {
+                wrapMethod(object, symbol, function () {});
+            }, function (err) {
+                return err.message === "Attempted to wrap number property Symbol() as function";
+            });
+        }
     });
 
     it("throws if object does not define property", function () {
@@ -115,16 +117,18 @@ describe("util/core/wrapMethod", function () {
     });
 
     it("throws Symbol if method is already wrapped", function () {
-        var symbol = Symbol();
-        var object = {};
-        object[symbol] = function () {};
-        wrapMethod(object, symbol, function () {});
-
-        assert.exception(function () {
+        if (typeof Symbol === "function") {
+            var symbol = Symbol();
+            var object = {};
+            object[symbol] = function () {};
             wrapMethod(object, symbol, function () {});
-        }, function (err) {
-            return err.message === "Attempted to wrap Symbol() which is already wrapped";
-        });
+
+            assert.exception(function () {
+                wrapMethod(object, symbol, function () {});
+            }, function (err) {
+                return err.message === "Attempted to wrap Symbol() which is already wrapped";
+            });
+        }
     });
 
     it("throws if property descriptor is already wrapped", function () {
@@ -144,15 +148,17 @@ describe("util/core/wrapMethod", function () {
     });
 
     it("throws if Symbol method is already a spy", function () {
-        var symbol = Symbol();
-        var object = {};
-        object[symbol] = createSpy();
+        if (typeof Symbol === "function") {
+            var symbol = Symbol();
+            var object = {};
+            object[symbol] = createSpy();
 
-        assert.exception(function () {
-            wrapMethod(object, symbol, function () {});
-        }, function (err) {
-            return err.message === "Attempted to wrap Symbol() which is already spied on";
-        });
+            assert.exception(function () {
+                wrapMethod(object, symbol, function () {});
+            }, function (err) {
+                return err.message === "Attempted to wrap Symbol() which is already spied on";
+            });
+        }
     });
 
     var overridingErrorAndTypeError = (function () {


### PR DESCRIPTION
Adds explicit cast from value to String, when the value is used in error messages. This is to support the es6 Symbol type in these message. The Symbol type cannot be coerced to string. This causes the existing code throw a TypeError when concatenating the error messages containing Symbols. The explicit casts introduced in this PR solves this issue. 

This PR aims to resolve #1002, and goes a little further in resolving similar issues throughout the codebase. 
In addition it adds a matcher for Symbol located at `sinon.match.symbol`.

Note: There are a few more issues like this in `wrapMethod`. These issues arise when a symbol is used as a property key. As far as I know you need to use the `var obj = { [Symbol()]: function() {} };` syntax to write a test to generate this case. Should I include these cases as well?