### PR TITLE
Fix capturing of stack traces in Phantom.js.

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -207,7 +207,16 @@ var spyApi = {
 
         push.call(this.exceptions, exception);
         push.call(this.returnValues, returnValue);
-        push.call(this.stacks, new Error().stack);
+        var err = new Error();
+        var stack = err.stack;
+        if (!stack) {
+            // PhantomJS does not serialize the stack trace until the error has been thrown:
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack
+            try {
+                throw err;
+            } catch (e) {/* empty */}
+        }
+        push.call(this.stacks, err.stack);
 
         // Make return value and exception available in the calls:
         createCallProperties.call(this);

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -1281,4 +1281,19 @@ describe("sinon.spy.call", function () {
             assert.equals(spy.printf("%λ"), "%λ");
         });
     });
+
+    it("captures a stack trace", function () {
+        var spy = sinon.spy();
+        spy();
+        assert.isString(spy.getCall(0).stack);
+    });
+
+    describe("getStackFrames", function () {
+        it("makes the non-Sinon stack frames available as an array", function () {
+            var spy = sinon.spy();
+            spy();
+
+            assert.isString(spy.getCall(0).getStackFrames()[0]);
+        });
+    });
 });


### PR DESCRIPTION
Apparently Phantom.JS requires an `Error` instance must be thrown before it has its `stack` serialized.