### PR TITLE
Add missing mocaccino and phantomic to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
     "eslint": "^1.7.1",
     "eslint-config-defaults": "^2.1.0",
     "eslint-plugin-mocha": "^1.1.0",
+    "mocaccino": "^1.8.2",
     "mocha": "^2.4.5",
     "mochify": "^2.17.0",
     "mochify-istanbul": "^2.4.1",
+    "phantomic": "^1.4.0",
     "pre-commit": "^1.1.2",
     "referee": "^1.2.0"
   },


### PR DESCRIPTION
#### Purpose
This is a PR for **master**, it adds two missing development dependencies

#### Background
When running `npm test` from `master`, the tests for web workers do not run.

#### How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
4. Verify that the command exits with zero: `echo $?`