### PR TITLE
Fix onerror event triggering for fake xhr requests

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -125,7 +125,7 @@ function FakeXMLHttpRequest(config) {
     }
 
     var xhr = this;
-    var events = ["loadstart", "load", "abort", "loadend"];
+    var events = ["loadstart", "load", "abort", "error", "loadend"];
 
     function addEventListener(eventName) {
         xhr.addEventListener(eventName, function (event) {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
The `xhr.onerror` event was not firing at all.

#### Background (Problem in detail)  - optional
I cam across this issue while looking into #1040 and #1031. There are a finite number of `xhr.on__event__` hooks that sinon was checking and `onerror` was not on the list. 

Note: There is talk of errors being triggered at the wrong time in sinon. I did not address that at all. This only makes `xhr.onerror` trigger when an `error` event is triggered. I added additional tests to ensure the order and make sure this stays functional in the future.

#### Solution
Added `error` event to sequence of events looked for on xhr object (`xhr['on' + name]`).

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`