### PR TITLE
Add missing error event listener key to the FakeXMLHttpRequest base c…

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -125,7 +125,7 @@ function FakeXMLHttpRequest(config) {
     }
 
     var xhr = this;
-    var events = ["loadstart", "load", "abort", "loadend"];
+    var events = ["loadstart", "load", "abort", "loadend", "error"];
 
     function addEventListener(eventName) {
         xhr.addEventListener(eventName, function (event) {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Add missing "error" event listener key to FakeXmlHttpRequest, which is now not being called as a result of the change referenced in issue #1040 

#### Background (Problem in detail)  - optional
A recent change ( https://github.com/sinonjs/sinon/commit/2cfbacd5cea5b63c014076d3a65b6642b2200793 )  that was merged and pushed in 1.17.4 fixed a previous regression (onerror incorrectly being called when an XmlHttpRequest is aborted by the user) but caused the legitimate error handler for XmlHttpRequests to not be called. This happens because the readyStateChange function was changed to trigger an "error" ProgressEvent instead of relying on the FakeXmlHttpRequest.abort function calling onerror directly (this was incorrect behavior).

The problem is that FakeXmlHttpRequest does not currently have a listener for the newly thrown error event, and thus fails to call error handlers attached to the request when an error happens. This change adds the missing listener key to eventListeners and ensures that xhr.onerror is called if it's defined and is a function.

There is ongoing discussion for this in https://github.com/sinonjs/sinon/issues/1040

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. Run unit tests that verify an error handler for a server response 500 is called after sending the response to the request.

-- I have verified this change with my tests in a private repository. I don't have a clean simple example to provide currently, but can provide one if needed.

-----
Without this, the changes in commit 2cfbacd5cea5b63c014076d3a65b6642b2200793 cause
an onerror function handler on the FakeXMLHttpRequest instance to never be called,
since the "error" event is triggered but there is no event listener listening for
it. This results in regular error handlers not being called for legitimate error
responses (like 500 Internal Server Error).