### PR TITLE
backport hasOwnPropery fix to v1.17.x

### DIFF
--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -220,7 +220,7 @@
             }
 
             for (prop in a) {
-                if (a.hasOwnProperty(prop)) {
+                if (hasOwn.call(a, prop)) {
                     aLength += 1;
 
                     if (!(prop in b)) {
@@ -234,7 +234,7 @@
             }
 
             for (prop in b) {
-                if (b.hasOwnProperty(prop)) {
+                if (hasOwn.call(b, prop)) {
                     bLength += 1;
                 }
             }

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -506,16 +506,47 @@
                 assert(sinon.deepEqual(obj1, obj2));
             },
 
-            "passes objects without a prototype": function () {
-                function Obj() {}
-                Obj.prototype = Object.create(null);
+            "passes object without prototype compared to equal object with prototype": function () {
+                var obj1 = Object.create(null);
+                obj1.a = 1;
+                obj1.b = 2;
+                obj1.c = "hey";
 
-                var obj = new Obj();
-                obj.foo = "bar";
+                var obj2 = { a: 1, b: 2, c: "hey" };
 
-                var pojo = { foo: "bar" };
+                assert(sinon.deepEqual(obj1, obj2));
+            },
 
-                assert(sinon.deepEqual(obj, pojo));
+            "passes object with prototype compared to equal object without prototype": function () {
+                var obj1 = { a: 1, b: 2, c: "hey" };
+
+                var obj2 = Object.create(null);
+                obj2.a = 1;
+                obj2.b = 2;
+                obj2.c = "hey";
+
+                assert(sinon.deepEqual(obj1, obj2));
+            },
+
+            "passes equal objects without prototypes": function () {
+                var obj1 = Object.create(null);
+                obj1.a = 1;
+                obj1.b = 2;
+                obj1.c = "hey";
+
+                var obj2 = Object.create(null);
+                obj2.a = 1;
+                obj2.b = 2;
+                obj2.c = "hey";
+
+                assert(sinon.deepEqual(obj1, obj2));
+            },
+
+            "passes equal objects that override hasOwnProperty": function () {
+                var obj1 = { a: 1, b: 2, c: "hey", hasOwnProperty: "silly" };
+                var obj2 = { a: 1, b: 2, c: "hey", hasOwnProperty: "silly" };
+
+                assert(sinon.deepEqual(obj1, obj2));
             }
         },
 

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -504,6 +504,18 @@
                 };
 
                 assert(sinon.deepEqual(obj1, obj2));
+            },
+
+            "passes objects without a prototype": function () {
+                function Obj() {}
+                Obj.prototype = Object.create(null);
+
+                var obj = new Obj();
+                obj.foo = "bar";
+
+                var pojo = { foo: "bar" };
+
+                assert(sinon.deepEqual(obj, pojo));
             }
         },
 


### PR DESCRIPTION
This fixes `deepEqual()`'s reliance on `hasOwnProperty()` being in all objects (and object having prototypes at all) in 0.17.x.  It's something that has already made it's way into V2, but it's a very small change that un-breaks testing objects created with `Object.create(null)`.