### PR TITLE
ReactNative compatibility. Allow sinon fakeServer to run in React Native

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -32,8 +32,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : {};
-wloc = typeof wloc !== "undefined" ? wloc : { "host": "localhost", "protocol": "http"};
+var wloc = typeof window !== "undefined" ? window.location : { "host" : "localhost", "protocol" : "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -33,6 +33,7 @@ function responseArray(handler) {
 }
 
 var wloc = typeof window !== "undefined" ? window.location : {};
+wloc = typeof wloc !== "undefined" ? wloc : { "host" : "localhost", "protocol" : "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -33,7 +33,7 @@ function responseArray(handler) {
 }
 
 var wloc = typeof window !== "undefined" ? window.location : {};
-wloc = typeof wloc !== "undefined" ? wloc : { "host" : "localhost", "protocol" : "http"};
+wloc = typeof wloc !== "undefined" ? wloc : { "host": "localhost", "protocol": "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -32,7 +32,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : { "host" : "localhost", "protocol" : "http"};
+var wloc = typeof window !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -41,13 +41,14 @@ var supportsBlob = (function () {
         return false;
     }
 })();
+var isReactNative = global.navigator && global.navigator.product === "ReactNative";
 var sinonXhr = { XMLHttpRequest: global.XMLHttpRequest };
 sinonXhr.GlobalXMLHttpRequest = global.XMLHttpRequest;
 sinonXhr.GlobalActiveXObject = global.ActiveXObject;
 sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject !== "undefined";
 sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest !== "undefined";
 sinonXhr.workingXHR = getWorkingXHR(global);
-sinonXhr.supportsCORS = global.navigator.product === "ReactNative" ||
+sinonXhr.supportsCORS =  isReactNative ||
     (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
 var unsafeHeaders = {

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -47,7 +47,8 @@ sinonXhr.GlobalActiveXObject = global.ActiveXObject;
 sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject !== "undefined";
 sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest !== "undefined";
 sinonXhr.workingXHR = getWorkingXHR(global);
-sinonXhr.supportsCORS = global.navigator.product === "ReactNative" || (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
+sinonXhr.supportsCORS = global.navigator.product === "ReactNative" ||
+    (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
 var unsafeHeaders = {
     "Accept-Charset": true,

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -48,7 +48,7 @@ sinonXhr.GlobalActiveXObject = global.ActiveXObject;
 sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject !== "undefined";
 sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest !== "undefined";
 sinonXhr.workingXHR = getWorkingXHR(global);
-sinonXhr.supportsCORS =  isReactNative ||
+sinonXhr.supportsCORS = isReactNative ||
     (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
 var unsafeHeaders = {

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -47,7 +47,7 @@ sinonXhr.GlobalActiveXObject = global.ActiveXObject;
 sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject !== "undefined";
 sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest !== "undefined";
 sinonXhr.workingXHR = getWorkingXHR(global);
-sinonXhr.supportsCORS = sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest());
+sinonXhr.supportsCORS = global.navigator.product === "ReactNative" || (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
 var unsafeHeaders = {
     "Accept-Charset": true,


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
> Enable fakeServer to execute in ReactNative environment - https://github.com/sinonjs/sinon/issues/1051

#### Background (Problem in detail)  - optional
> React Native has xhr support via polyfill but sinon is not detecting it properly
> React Native does not have window.location - it needs to be detected and defaulted properly

#### Solution  - optional
> Proper check for xhr support in ReactNative env
> Default window.location if it is undefined

#### How to verify - mandatory

1. Create react native sample app. Look at RN getting started
2. Add sinon as dependency in package.json, run npm install
3. Require sinon
4. Code fakeServer test cases in RN app
5. Run all normal test cases to verify no regression.
