### PR TITLE
Fix invalid markdown in fake-timers.ms

### DIFF
--- a/docs/current/fake-timers.md
+++ b/docs/current/fake-timers.md
@@ -66,7 +66,7 @@ Tick the clock ahead `ms` milliseconds.
 Causes all timers scheduled within the affected time range to be called.
 
 
-#### `clock.restore();"
+#### `clock.restore();`
 
 Restore the faked methods.
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix the markdown to make sure the documentation renders the same way for all methods documented.

#### How to verify - mandatory
1. View the complete file in the markdown view, and observe that the `clock.restore()` method is rendered with a monospace font.