### PR TITLE
Do not invoke getters in walk

### DIFF
--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -109,7 +109,7 @@ var collection = {
             var col = this;
             var stubbedObj = sinon.stub.apply(sinon, arguments);
 
-            walk(stubbedObj, function (val, prop, propOwner) {
+            walk(stubbedObj, function (prop, propOwner) {
                 if (
                     typeof getPropertyDescriptor(propOwner, prop).value === "function"
                 ) {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -56,7 +56,7 @@ function stub(object, property, func) {
     }
 
     if (typeof property === "undefined" && typeof object === "object") {
-        walk(object || {}, function (value, prop, propOwner) {
+        walk(object || {}, function (prop, propOwner) {
             // we don't want to stub things like toString(), valueOf(), etc. so we only stub if the object
             // is not Object.prototype
             if (

--- a/lib/sinon/util/core/restore.js
+++ b/lib/sinon/util/core/restore.js
@@ -8,7 +8,7 @@ function isRestorable(obj) {
 
 module.exports = function restore(object) {
     if (object !== null && typeof object === "object") {
-        walk(object, function (value, prop) {
+        walk(object, function (prop) {
             if (isRestorable(object[prop])) {
                 object[prop].restore();
             }

--- a/lib/sinon/util/core/walk.js
+++ b/lib/sinon/util/core/walk.js
@@ -20,7 +20,7 @@ function walkInternal(obj, iterator, context, originalObj, seen) {
             seen[k] = true;
             var target = typeof Object.getOwnPropertyDescriptor(obj, k).get === "function" ?
                 originalObj : obj;
-            iterator.call(context, target[k], k, target);
+            iterator.call(context, k, target);
         }
     });
 

--- a/test/util/core/walk-test.js
+++ b/test/util/core/walk-test.js
@@ -19,8 +19,8 @@ describe("util/core/walk", function () {
 
         assert(iterator.calledTwice);
         assert(iterator.alwaysCalledOn(rcvr));
-        assert(iterator.calledWithExactly("world", "hello", target));
-        assert(iterator.calledWithExactly(15, "foo", target));
+        assert(iterator.calledWithExactly("hello", target));
+        assert(iterator.calledWithExactly("foo", target));
     });
 
     it("should work with non-enumerable properties", function () {
@@ -35,8 +35,8 @@ describe("util/core/walk", function () {
         walk(target, iterator);
 
         assert(iterator.calledTwice);
-        assert(iterator.calledWith("world", "hello"));
-        assert(iterator.calledWith(15, "foo"));
+        assert(iterator.calledWith("hello"));
+        assert(iterator.calledWith("foo"));
     });
 
     it("should walk the prototype chain of an object", function () {
@@ -77,30 +77,28 @@ describe("util/core/walk", function () {
         walk(target, iterator);
 
         assert.equals(iterator.callCount, 6);
-        assert(iterator.calledWith("non-enumerable own prop", "nonEnumerableOwnProp", target));
-        assert(iterator.calledWith("enumerable own prop", "enumerableOwnProp", target));
-        assert(iterator.calledWith("non-enumerable prop", "nonEnumerableProp", proto));
-        assert(iterator.calledWith("enumerable prop", "enumerableProp", proto));
-        assert(iterator.calledWith("non-enumerable parent prop", "nonEnumerableParentProp", parentProto));
-        assert(iterator.calledWith("enumerable parent prop", "enumerableParentProp", parentProto));
+        assert(iterator.calledWith("nonEnumerableOwnProp", target));
+        assert(iterator.calledWith("enumerableOwnProp", target));
+        assert(iterator.calledWith("nonEnumerableProp", proto));
+        assert(iterator.calledWith("enumerableProp", proto));
+        assert(iterator.calledWith("nonEnumerableParentProp", parentProto));
+        assert(iterator.calledWith("enumerableParentProp", parentProto));
     });
 
-    it("should always invoke getters on the original receiving object", function () {
-        var Target = function Target() {
-            this.o = { foo: "foo" };
-        };
+    it("should not invoke getters on the original receiving object", function () {
+        var Target = function Target() {};
+        var getter = createSpy();
         Object.defineProperty(Target.prototype, "computedFoo", {
             enumerable: true,
-            get: function () {
-                return "computed " + this.o.foo;
-            }
+            get: getter
         });
         var target = new Target();
         var iterator = createSpy();
 
         walk(target, iterator);
 
-        assert(iterator.calledWith("computed foo", "computedFoo", target));
+        assert(iterator.calledWith("computedFoo", target));
+        assert(getter.notCalled);
     });
 
     it("should fall back to for..in if getOwnPropertyNames is not available", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

When stubbing a prototype, the `walk` implementation accesses getters to obtain the value of each property to pass it to the iterator function. This value is not needed by any of the iterator implementations anymore, but invoking the getter may have side effects or throw exceptions.

#### Solution  - optional

With this change, values are no longer obtained from the objects. It keeps the code to pass a different target object to the iterator which allows to obtain the value in the iterator implementation if necessary.

It turned out that none of the iterator functions passed to `walk` actually used the value.

#### How to verify - mandatory

```js
var redis = require("redis");
var sinon = require("sinon");

sinon.createStubInstance(redis.RedisClient); // throws without this change
```