### PR TITLE
Allow checks for unsafe headers to be optional

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -32,8 +32,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : {};
-wloc = typeof wloc !== "undefined" ? wloc : { "host": "localhost", "protocol": "http"};
+var wloc = typeof window !== "undefined" ? window.location : { "host" : "localhost", "protocol" : "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -75,6 +75,10 @@ var fakeServer = {
         }
         server.requests = [];
 
+        this.xhr.unsafeHeadersEnabled = function () {
+            return !(server.unsafeHeadersEnabled === false)
+        };
+
         this.xhr.onCreate = function (xhrObj) {
             server.addRequest(xhrObj);
         };
@@ -88,7 +92,8 @@ var fakeServer = {
             "autoRespondAfter": true,
             "respondImmediately": true,
             "fakeHTTPMethods": true,
-            "logger": true
+            "logger": true,
+            "unsafeHeadersEnabled": true
         };
         var setting;
 

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -33,6 +33,7 @@ function responseArray(handler) {
 }
 
 var wloc = typeof window !== "undefined" ? window.location : {};
+wloc = typeof wloc !== "undefined" ? wloc : { "host" : "localhost", "protocol" : "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -33,7 +33,7 @@ function responseArray(handler) {
 }
 
 var wloc = typeof window !== "undefined" ? window.location : {};
-wloc = typeof wloc !== "undefined" ? wloc : { "host" : "localhost", "protocol" : "http"};
+wloc = typeof wloc !== "undefined" ? wloc : { "host": "localhost", "protocol": "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -32,7 +32,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : { "host" : "localhost", "protocol" : "http"};
+var wloc = typeof window !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -41,13 +41,14 @@ var supportsBlob = (function () {
         return false;
     }
 })();
+var isReactNative = global.navigator && global.navigator.product === "ReactNative";
 var sinonXhr = { XMLHttpRequest: global.XMLHttpRequest };
 sinonXhr.GlobalXMLHttpRequest = global.XMLHttpRequest;
 sinonXhr.GlobalActiveXObject = global.ActiveXObject;
 sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject !== "undefined";
 sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest !== "undefined";
 sinonXhr.workingXHR = getWorkingXHR(global);
-sinonXhr.supportsCORS = global.navigator.product === "ReactNative" ||
+sinonXhr.supportsCORS =  isReactNative ||
     (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
 var unsafeHeaders = {

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -54,22 +54,22 @@ sinonXhr.supportsCORS = isReactNative ||
 var unsafeHeaders = {
     "Accept-Charset": true,
     "Accept-Encoding": true,
-    Connection: true,
+    "Connection": true,
     "Content-Length": true,
-    Cookie: true,
-    Cookie2: true,
+    "Cookie": true,
+    "Cookie2": true,
     "Content-Transfer-Encoding": true,
-    Date: true,
-    Expect: true,
-    Host: true,
+    "Date": true,
+    "Expect": true,
+    "Host": true,
     "Keep-Alive": true,
-    Referer: true,
-    TE: true,
-    Trailer: true,
+    "Referer": true,
+    "TE": true,
+    "Trailer": true,
     "Transfer-Encoding": true,
-    Upgrade: true,
+    "Upgrade": true,
     "User-Agent": true,
-    Via: true
+    "Via": true
 };
 
 // An upload object is created for each
@@ -475,7 +475,12 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
     setRequestHeader: function setRequestHeader(header, value) {
         verifyState(this);
 
-        if (unsafeHeaders[header] || /^(Sec-|Proxy-)/.test(header)) {
+        var checkUnsafeHeaders = true;
+        if (typeof this.unsafeHeadersEnabled === "function") {
+            checkUnsafeHeaders = this.unsafeHeadersEnabled();
+        }
+
+        if (checkUnsafeHeaders && (unsafeHeaders[header] || /^(Sec-|Proxy-)/.test(header))) {
             throw new Error("Refused to set unsafe header \"" + header + "\"");
         }
 

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -47,7 +47,8 @@ sinonXhr.GlobalActiveXObject = global.ActiveXObject;
 sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject !== "undefined";
 sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest !== "undefined";
 sinonXhr.workingXHR = getWorkingXHR(global);
-sinonXhr.supportsCORS = global.navigator.product === "ReactNative" || (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
+sinonXhr.supportsCORS = global.navigator.product === "ReactNative" ||
+    (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
 var unsafeHeaders = {
     "Accept-Charset": true,

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -48,7 +48,7 @@ sinonXhr.GlobalActiveXObject = global.ActiveXObject;
 sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject !== "undefined";
 sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest !== "undefined";
 sinonXhr.workingXHR = getWorkingXHR(global);
-sinonXhr.supportsCORS =  isReactNative ||
+sinonXhr.supportsCORS = isReactNative ||
     (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
 var unsafeHeaders = {

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -47,7 +47,7 @@ sinonXhr.GlobalActiveXObject = global.ActiveXObject;
 sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject !== "undefined";
 sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest !== "undefined";
 sinonXhr.workingXHR = getWorkingXHR(global);
-sinonXhr.supportsCORS = sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest());
+sinonXhr.supportsCORS = global.navigator.product === "ReactNative" || (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
 var unsafeHeaders = {
     "Accept-Charset": true,


### PR DESCRIPTION
#### Fix Issue #1061 - Allow unsafe headers check in fake server using http request to be optional.

#### Background (Problem in detail)  
There are times when developer wants to test the app with the fake server without it enforcing any cookie rules with regard to their safety. Currently, this is not possible and in such situations sinon becomes unusable because it blindly checks for unsafe headers and rejects any requests that carry them.

#### Solution 
- Make the unsafe headers optionals/configurable 
- Limit the change to local scope - fake server and fake xmlhttprequest
- Make the change backward compatible i.e. unless overwritten by user, behavior is the same as before

let server = sinon.fakeServer.create()
server.unsafeHeadersEnabled = false

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. run all standard tests - none should fail
4. create a new basic http request test case and set "cookie" header in the request. 
5. config the fakeServer with unsafeHeaderEnabled = false . test should succeed.
6. config the fakeServer with unsafeHeaderEnabled = true . test should fail with unsafe header rejection.
