### PR TITLE
expose wrappedMethod on the wrapped method (#988)

### DIFF
--- a/lib/sinon/util/core/wrap-method.js
+++ b/lib/sinon/util/core/wrap-method.js
@@ -76,7 +76,7 @@ module.exports = function wrapMethod(object, property, method) {
 
         var types = objectKeys(methodDesc);
         for (i = 0; i < types.length; i++) {
-            wrappedMethod = wrappedMethodDesc[types[i]];
+            method.wrappedMethod = wrappedMethod = wrappedMethodDesc[types[i]];
             checkWrappedMethod(wrappedMethod);
         }
 
@@ -86,7 +86,7 @@ module.exports = function wrapMethod(object, property, method) {
         }
         Object.defineProperty(object, property, methodDesc);
     } else {
-        wrappedMethod = object[property];
+        method.wrappedMethod = wrappedMethod = object[property];
         checkWrappedMethod(wrappedMethod);
         object[property] = method;
         method.displayName = property;


### PR DESCRIPTION
#### Purpose

Add #988 which asks for the `wrappedMethod` variable to be exposed as a property
#### Background

All relevant background is in #988 
#### Solution

This solution works by exposing the `wrappedMethod` property on the sinon method object.
#### How to verify

``` js
var API = {
    foo: function() {}
};
var func = API.foo;
console.log(sinon.stub(API, 'foo').wrappedMethod === func); // prints true
```
