### PR TITLE
Use event loaded instead of error event for HTTP error codes

### DIFF
--- a/docs/current/fake-xhr-and-server.md
+++ b/docs/current/fake-xhr-and-server.md
@@ -174,6 +174,9 @@ Calls the above two methods and sets the `status` and `statusText` properties.
 
 Status should be a number, the status text is looked up from `sinon.FakeXMLHttpRequest.statusCodes`.
 
+#### `request.error();`
+
+Simulates a network error on the request. The `onerror` handler will be called and the `status` will be `0`.
 
 #### `Boolean request.autoRespond`
 

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -449,9 +449,9 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         }
 
         if (this.readyState === FakeXMLHttpRequest.DONE) {
-            if (this.aborted) {
+            if (this.aborted || this.status === 0) {
                 progress = {loaded: 0, total: 0};
-                event = "abort";
+                event = this.aborted ? "abort" : "error";
             } else {
                 progress = {loaded: 100, total: 100};
                 event = "load";
@@ -544,6 +544,15 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         }
 
         this.readyState = FakeXMLHttpRequest.UNSENT;
+    },
+
+    error: function () {
+        clearResponse(this);
+        this.errorFlag = true;
+        this.requestHeaders = {};
+        this.responseHeaders = {};
+
+        this.readyStateChange(FakeXMLHttpRequest.DONE);
     },
 
     getResponseHeader: function getResponseHeader(header) {

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -449,11 +449,10 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         }
 
         if (this.readyState === FakeXMLHttpRequest.DONE) {
-            if (this.status < 200 || this.status > 299) {
+            if (this.aborted) {
                 progress = {loaded: 0, total: 0};
-                event = this.aborted ? "abort" : "error";
-            }
-            else {
+                event = "abort";
+            } else {
                 progress = {loaded: 100, total: 100};
                 event = "load";
             }

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1119,14 +1119,6 @@ if (typeof window !== "undefined") {
             assertEventOrdering("abort", 0, function (xhr) {
                 xhr.abort();
             });
-
-            assertEventOrdering("error", 0, function (xhr) {
-                xhr.respond(500, {}, "");
-            });
-
-            assertEventOrdering("load", 100, function (xhr) {
-                xhr.respond(200, {}, "");
-            });
         });
 
         describe(".response", function () {
@@ -1709,6 +1701,20 @@ if (typeof window !== "undefined") {
                 this.xhr.respond(200, {}, "");
             });
 
+            it("triggers 'load' event on for non-200 events", function (done) {
+                var xhr = this.xhr;
+
+                this.xhr.addEventListener("load", function () {
+                    assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.DONE);
+                    assert.equals(xhr.status, 500);
+
+                    done();
+                });
+
+                this.xhr.send();
+                this.xhr.respond(500, {}, "");
+            });
+
             it("triggers 'load' with event target set to the XHR object", function (done) {
                 var xhr = this.xhr;
 
@@ -1736,40 +1742,12 @@ if (typeof window !== "undefined") {
                 this.xhr.respond(200, {}, "");
             });
 
-            it("triggers 'error' event on failure", function (done) {
+            it("calls #onload for non-200 events", function (done) {
                 var xhr = this.xhr;
 
-                this.xhr.addEventListener("error", function () {
+                this.xhr.onload = function () {
                     assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.DONE);
-                    refute.equals(xhr.status, 0);
-
-                    done();
-                });
-
-                this.xhr.send();
-                this.xhr.respond(500, {}, "");
-            });
-
-            it("triggers 'error' with event target set to the XHR object", function (done) {
-                var xhr = this.xhr;
-
-                this.xhr.addEventListener("error", function (event) {
-                    assert.same(xhr, event.target);
-
-                    done();
-                });
-
-                this.xhr.send();
-                this.xhr.respond(500, {}, "");
-            });
-
-
-            it("calls #onerror on failure", function (done) {
-                var xhr = this.xhr;
-
-                this.xhr.onerror = function () {
-                    assert.equals(xhr.readyState, sinon.FakeXMLHttpRequest.DONE);
-                    refute.equals(xhr.status, 0);
+                    assert.equals(xhr.status, 500);
 
                     done();
                 };
@@ -1843,7 +1821,7 @@ if (typeof window !== "undefined") {
 
             it("triggers 'loadend' event at the end", function (done) {
                 this.xhr.addEventListener("loadend", function (e) {
-                    assertProgressEvent(e, 0);
+                    assertProgressEvent(e, 100);
                     assert(true);
 
                     done();
@@ -1869,7 +1847,7 @@ if (typeof window !== "undefined") {
 
             it("calls #onloadend at the end", function (done) {
                 this.xhr.onloadend = function (e) {
-                    assertProgressEvent(e, 0);
+                    assertProgressEvent(e, 100);
                     assert(true);
 
                     done();
@@ -1893,6 +1871,10 @@ if (typeof window !== "undefined") {
                     });
                 });
             }
+
+            assertEventOrdering("load", 100, function (xhr) {
+                xhr.respond(200, {}, "");
+            });
         });
 
         describe("xhr.upload", function () {

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1121,6 +1121,81 @@ if (typeof window !== "undefined") {
             });
         });
 
+        describe(".error", function () {
+            beforeEach(function () {
+                this.xhr = new sinon.FakeXMLHttpRequest();
+            });
+
+            it("sets response to empty string", function () {
+                this.xhr.response = "Partial data";
+
+                this.xhr.error();
+
+                assert.same(this.xhr.response, "");
+            });
+
+            it("sets responseText to empty string", function () {
+                this.xhr.responseText = "Partial data";
+
+                this.xhr.error();
+
+                assert.same(this.xhr.responseText, "");
+            });
+
+            it("sets errorFlag to true", function () {
+                this.xhr.error();
+
+                assert.isTrue(this.xhr.errorFlag);
+            });
+
+            it("nulls request headers", function () {
+                this.xhr.open("GET", "/");
+                this.xhr.setRequestHeader("X-Test", "Sumptn");
+
+                this.xhr.error();
+
+                assert.equals(this.xhr.requestHeaders, {});
+            });
+
+            it("does not have undefined response headers", function () {
+                this.xhr.open("GET", "/");
+
+                this.xhr.error();
+
+                assert.defined(this.xhr.responseHeaders);
+            });
+
+            it("nulls response headers", function () {
+                this.xhr.open("GET", "/");
+
+                this.xhr.error();
+
+                assert.equals(this.xhr.responseHeaders, {});
+            });
+
+            it("dispatches readystatechange event if sent before", function () {
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+                this.xhr.onreadystatechange = sinon.stub();
+
+                this.xhr.error();
+
+                assert(this.xhr.onreadystatechange.called);
+            });
+
+            it("sets readyState to DONE", function () {
+                this.xhr.open("GET", "/");
+
+                this.xhr.error();
+
+                assert.equals(this.xhr.readyState, sinon.FakeXMLHttpRequest.DONE);
+            });
+
+            assertEventOrdering("error", 0, function (xhr) {
+                xhr.error();
+            });
+        });
+
         describe(".response", function () {
             beforeEach(function () {
                 this.xhr = new sinon.FakeXMLHttpRequest();

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1143,6 +1143,7 @@ if (typeof window !== "undefined") {
             });
 
             it("sets errorFlag to true", function () {
+                this.xhr.errorFlag = false;
                 this.xhr.error();
 
                 assert.isTrue(this.xhr.errorFlag);
@@ -1155,14 +1156,6 @@ if (typeof window !== "undefined") {
                 this.xhr.error();
 
                 assert.equals(this.xhr.requestHeaders, {});
-            });
-
-            it("does not have undefined response headers", function () {
-                this.xhr.open("GET", "/");
-
-                this.xhr.error();
-
-                assert.defined(this.xhr.responseHeaders);
             });
 
             it("nulls response headers", function () {


### PR DESCRIPTION
This is #1031, Vietnogi's loaded fix, re-submitted after fixing the (very minor) remaining issues. Full discussion can be found in that PR.

The original PR has been cleaned up a bit, squashing commits and rephrased somewhat.
