### PR TITLE
Fix issue 283 tests

### DIFF
--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -16,7 +16,7 @@ describe("issues", function () {
         this.sandbox.restore();
     });
 
-    it.skip("#283", function () {
+    it("#283", function () {
         function testSinonFakeTimersWith(interval, ticks) {
             var clock = sinon.useFakeTimers();
 
@@ -24,28 +24,17 @@ describe("issues", function () {
             var id = setInterval(spy, interval);
             assert(!spy.calledOnce);
             clock.tick(ticks);
-            assert(spy.calledOnce);
+            assert(spy.callCount === Math.floor(ticks / interval));
 
             clearInterval(id);
             clock.restore();
         }
 
-        // FAILS
         testSinonFakeTimersWith(10, 101);
-
-        // PASS
         testSinonFakeTimersWith(99, 101);
-
-        // FAILS
         testSinonFakeTimersWith(100, 200);
-
-        // PASS
         testSinonFakeTimersWith(199, 200);
-
-        // FAILS
         testSinonFakeTimersWith(500, 1001);
-
-        // PASS
         testSinonFakeTimersWith(1000, 1001);
     });
 


### PR DESCRIPTION
#### Purpose
This fixes #283.
Basically the tests were wrong, we expect `calledOnce` to be true only if something got called exactly once, but with `setInterval` we will trigger the callback function multiple times if the `ticks` are more than double the interval set.

[**Please see this post for more details and a complete explanation**](https://github.com/sinonjs/sinon/issues/283#issuecomment-227921227)

#### How to verify
To check this out you can:
* Replace the spy by any function with a `console.log`, for example, and see it getting called multiple times (`ticks / interval`)
* Use `console.log` to show `callCount`
* Take a look at [this line](https://github.com/sinonjs/sinon/blob/master/lib/sinon/spy.js#L67) and confirm `calledOnce` will be true only if the spy was called exactly once
