### PR TITLE
Resolve test failure in node 0.10.x

### DIFF
--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -106,7 +106,9 @@ describe("sinon.collection", function () {
 
             this.collection.stub(object);
 
-            assert.equals(this.collection.fakes, [object.method, object.method2, object.method3]);
+            assert.contains(this.collection.fakes, object.method);
+            assert.contains(this.collection.fakes, object.method2);
+            assert.contains(this.collection.fakes, object.method3);
             assert.equals(this.collection.fakes.length, 3);
         });
 


### PR DESCRIPTION
The collections stub test "adds all object methods to fake array" fails intermittently for me when I use node 0.10 (I've tried 0.10.32 and 0.10.45). It appears to fail because the order of methods returned by the `walk` function is not guaranteed in 0.10.x - sometimes the non-enumerable properties are moved to the end of the list, and sometimes they aren't.

I'm not exactly sure *why* this happens (some difference in the Object API between Node versions perhaps?), but as far as I can tell, this non-deterministic ordering shouldn't break anything. So, I adjusted the test so that it no longer depends upon the methods being in the same order they were passed in.

Thoughts? Is the order actually important here in some way that I'm missing? If so, this should probably be rejected. Thanks.