### PR TITLE
Add resetBehavior and resetHistory to sandbox API

### DIFF
--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -44,7 +44,7 @@ function compact(fakeCollection) {
 }
 
 var collection = {
-    verify: function resolve() {
+    verify: function verify() {
         each(this, "verify");
     },
 
@@ -53,7 +53,7 @@ var collection = {
         compact(this);
     },
 
-    reset: function restore() {
+    reset: function reset() {
         each(this, "reset");
     },
 

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -57,6 +57,14 @@ var collection = {
         each(this, "reset");
     },
 
+    resetBehavior: function resetBehavior() {
+        each(this, "resetBehavior");
+    },
+
+    resetHistory: function resetHistory() {
+        each(this, "resetHistory");
+    },
+
     verifyAndRestore: function verifyAndRestore() {
         var exception;
 

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -378,6 +378,48 @@ describe("sinon.collection", function () {
         });
     });
 
+    describe(".resetBehavior", function () {
+        beforeEach(function () {
+            this.collection = sinon.create(sinon.collection);
+            this.collection.fakes = [{
+                resetBehavior: sinon.spy.create()
+            }, {
+                resetBehavior: sinon.spy.create()
+            }];
+        });
+
+        it("calls resetBehavior on all fakes", function () {
+            var fake0 = this.collection.fakes[0];
+            var fake1 = this.collection.fakes[1];
+
+            this.collection.resetBehavior();
+
+            assert(fake0.resetBehavior.called);
+            assert(fake1.resetBehavior.called);
+        });
+    });
+
+    describe(".resetHistory", function () {
+        beforeEach(function () {
+            this.collection = sinon.create(sinon.collection);
+            this.collection.fakes = [{
+                resetHistory: sinon.spy.create()
+            }, {
+                resetHistory: sinon.spy.create()
+            }];
+        });
+
+        it("calls resetHistory on all fakes", function () {
+            var fake0 = this.collection.fakes[0];
+            var fake1 = this.collection.fakes[1];
+
+            this.collection.resetHistory();
+
+            assert(fake0.resetHistory.called);
+            assert(fake1.resetHistory.called);
+        });
+    });
+
     describe("inject test", function () {
         beforeEach(function () {
             this.collection = sinon.create(sinon.collection);


### PR DESCRIPTION
Adds resetBehavior and resetHistory to the sandbox API. Closes #1072 

I also noticed that a couple of the inline function names were incorrect - probably just accidentally misnamed - so there's a second commit to fix those.