### PR TITLE
Remove nuget

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,93 +1,116 @@
 Christian Johansen <christian@cjohansen.no>
 Morgan Roderick <morgan@roderick.dk>
 Maximilian Antoni <mail@maxantoni.de>
+Carl-Erik Kopseng <carlerik@gmail.com>
+Jonny Reeves <github@jonnyreeves.co.uk>
 Phred <fearphage@gmail.com>
 ben hockey <neonstalwart@gmail.com>
-Jonny Reeves <github@jonnyreeves.co.uk>
-Carl-Erik Kopseng <carlerik@gmail.com>
 Tim Fischbach <mail@timfischbach.de>
-Max Antoni <mail@maxantoni.de>
+Håvard Wormdal Høiby <havardwhoiby@gmail.com>
 Tim Ruffles <timruffles@googlemail.com>
 Jonathan Sokolowski <jonathan.sokolowski@gmail.com>
 Domenic Denicola <domenic@domenicdenicola.com>
 Andreas Lind <andreas@one.com>
-Tim Perry <pimterry@gmail.com>
-Tim Ruffles <timr@picklive.com>
 William Sears <MrBigDog2U@gmail.com>
+Tim Perry <pimterry@gmail.com>
+kpdecker <kpdecker@gmail.com>
 Bryan Donovan <bdondo@gmail.com>
 Felix Geisendörfer <felix@debuggable.com>
-kpdecker <kpdecker@gmail.com>
-pimterry <pimterry@gmail.com>
-Andrew Gurinovich <altmind@gmail.com>
-Christian Johansen <christian.johansen@nrk.no>
-Cory <seeflanigan@gmail.com>
-Keith Cirkel <github@keithcirkel.co.uk>
-Luis Cardoso <luis.cardoso@feedzai.com>
-Martin Sander <forke@uni-bonn.de>
-Tobias Ebnöther <ebi@gorn.ch>
 Tristan Koch <tristan.koch@1und1.de>
-Benjamin Coe <ben@yesware.com>
-Garrick Cheung <garrick@garrickcheung.com>
-Gavin Huang <gravof@gmail.com>
-Konrad Holowinski <konrad.holowinski@gmail.com>
+Keith Cirkel <github@keithcirkel.co.uk>
+Tobias Ebnöther <ebi@gorn.ch>
+Andrew Gurinovich <altmind@gmail.com>
+Martin Sander <forke@uni-bonn.de>
+Cory <seeflanigan@gmail.com>
+Luis Cardoso <luis.cardoso@feedzai.com>
 Marten Lienen <marten.lienen@gmail.com>
-Travis Kaufman <travis.kaufman@gmail.com>
 ben fleis <ben.fleis@gmail.com>
+Travis Kaufman <travis.kaufman@gmail.com>
+Gavin Huang <gravof@gmail.com>
+Garrick Cheung <garrick@garrickcheung.com>
+Konrad Holowinski <konrad.holowinski@gmail.com>
+Benjamin Coe <ben@yesware.com>
 zcicala <zcicala@fitbit.com>
-August Lilleaas <august.lilleaas@gmail.com>
-Cormac Flynn <cormac.flynn@viadeoteam.com>
-Dmitriy Kubyshkin <grassator@gmail.com>
-Duncan Beevers <duncan@dweebd.com>
-Garrick <gcheung@fitbit.com>
-Glen Mailer <glen.mailer@bskyb.com>
-Jmeas <jellyes2@gmail.com>
-Ming Liu <vmliu1@gmail.com>
-Robin Pedersen <robinp@snap.tv>
 Roman Potashow <justgook@gmail.com>
+Ming Liu <vmliu1@gmail.com>
+Islam Sharabash <islam.sharabash@gmail.com>
+Dmitriy Kubyshkin <grassator@gmail.com>
+Dominykas Blyžė <hello@dominykas.com>
+Rae Liu <happyaray@gmail.com>
+Jmeas <jellyes2@gmail.com>
+Robin Pedersen <robinp@snap.tv>
+Duncan Beevers <duncan@dweebd.com>
+Cormac Flynn <cormac.flynn@viadeoteam.com>
 Scott Andrews <scothis@gmail.com>
 Soutaro Matsumoto <matsumoto@soutaro.com>
+Garrick <gcheung@fitbit.com>
 Tamas Szebeni <tamas_szebeni@epam.com>
+August Lilleaas <august.lilleaas@gmail.com>
 Thomas Meyer <meyertee@gmail.com>
+Glen Mailer <glen.mailer@bskyb.com>
 geries <geries.handal@videoplaza.com>
-Alex Urbano <asgaroth.belem@gmail.com>
-Alexander Schmidt <alexanderschmidt1@gmail.com>
-Ben Hockey <neonstalwart@gmail.com>
-Brandon Heyer <brandonheyer@gmail.com>
-Christian Johansen <christian.johansen@finn.no>
-Devin Weaver <suki@tritarget.org>
-Farid Neshat <FaridN_SOAD@yahoo.com>
 G.Serebryanskyi <x5x3x5x@gmail.com>
-Henry Tung <henryptung@gmail.com>
-Irina Dumitrascu <me@dira.ro>
-James Barwell <jb@jamesbarwell.co.uk>
-Jason Karns <jason.karns@gmail.com>
-Jeffrey Falgout <jeffrey.falgout@gmail.com>
-Jeffrey Falgout <jfalgout@bloomberg.net>
-Jonathan Freeman <freethejazz@gmail.com>
-Josh Graham <josh@canva.com>
-Marcus Hüsgen <marcus.huesgen@lusini.com>
-Martin Hansen <martin@martinhansen.no>
-Matt Kern <matt@bloomcrush.com>
-Max Calabrese <max.calabrese@ymail.com>
-Márton Salomváry <salomvary@gmail.com>
-Satoshi Nakamura <snakamura@infoteria.com>
-Simen Bekkhus <sbekkhus91@gmail.com>
-Spencer Elliott <me@elliottsj.com>
-Travis Kaufman <travis.kaufman@refinery29.com>
 Victor Costan <costan@gmail.com>
-gtothesquare <me@gerieshandal.com>
-mohayonao <mohayonao@gmail.com>
-vitalets <vitalets@yandex-team.ru>
-yoshimura-toshihide <toshihide0105yoshimura@gmail.com>
+Irina Dumitrascu <me@dira.ro>
+Brandon Heyer <brandonheyer@gmail.com>
+Spencer Elliott <me@elliottsj.com>
+Simen Bekkhus <sbekkhus91@gmail.com>
+Farid Neshat <FaridN_SOAD@yahoo.com>
+Alexander Schmidt <alexanderschmidt1@gmail.com>
+Marcus Hüsgen <marcus.huesgen@lusini.com>
 なつき <i@ntk.me>
+Jonathan Freeman <freethejazz@gmail.com>
+gtothesquare <me@gerieshandal.com>
+Satoshi Nakamura <snakamura@infoteria.com>
+Mark Stacey <mark.stacey@amecfw.com>
+Henry Tung <henryptung@gmail.com>
+Alex Urbano <asgaroth.belem@gmail.com>
+Jeffrey Falgout <jfalgout@bloomberg.net>
+mohayonao <mohayonao@gmail.com>
+Martin Hansen <martin@martinhansen.no>
+Jason Karns <jason.karns@gmail.com>
+Devin Weaver <suki@tritarget.org>
+James Barwell <jb@jamesbarwell.co.uk>
+Matt Kern <matt@bloomcrush.com>
+Márton Salomváry <salomvary@gmail.com>
+vitalets <vitalets@yandex-team.ru>
+Max Calabrese <max.calabrese@ymail.com>
+yoshimura-toshihide <toshihide0105yoshimura@gmail.com>
+Josh Graham <josh@canva.com>
+T1st3 <contact@tiste.org>
+TEHEK Firefox <tehek@tehek.net>
+Tek Nynja <github@teknynja.com>
+The Gitter Badger <badger@gitter.im>
+Tim Branyen <tim@tabdeveloper.com>
+Tim Wienk <tim@wienk.name>
+Timo Tijhof <krinklemail@gmail.com>
+Volkan Ozcelik <volkan.ozcelik@jivesoftware.com>
+Will Butler <will@butlerhq.com>
+William Meleyal <w.meleyal@wollzelle.com>
 AJ Ortega <ajo@google.com>
-AJ Ortega <ajo@renitservices.com>
+charlierudolph <charles.w.rudolph@gmail.com>
+goligo <ich@malte.de>
+hashchange <heim@zeilenwechsel.de>
+ichthala <alice.mottola@gmail.com>
+jamestalmage <james.talmage@jrtechnical.com>
+kbackowski <kbackowski@gmail.com>
+lucasfcosta <fernandesdacostalucas@gmail.com>
+ngryman <ngryman@gmail.com>
+simonzack <simonzack@gmail.com>
+stevesouth <stephen.south@caplin.com>
+thefourtheye <thefourtheye@users.noreply.github.com>
+till <till@php.net>
+wwalser <waw325@gmail.com>
+Xiao Ma <x@medium.com>
 Adam Hull <adam@hmlad.com>
+AdilKhn <AdilKhn@users.noreply.github.com>
 Adrian Phinney <adrian.phinney@bellaliant.net>
 Alex Kessaris <alex@artsy.ca>
+Alex Tran <alex@Alexs-MacBook-Pro-2.local>
 Alexander Aivars <alex@aivars.se>
 Alfonso Boza <alfonso@cloud.com>
 Ali Shakiba <ali@shakiba.me>
+Andrzej Porebski <fkuciapa@yahoo.com>
 Antonio D'Ettole <antonio@brandwatch.com>
 Aziz Punjani <aziz.punjani@gmail.com>
 Blaine Bublitz <blaine@iceddev.com>
@@ -96,81 +119,67 @@ Blake Israel <blake.israel@gatech.edu>
 Brian M Hunt <brianmhunt@gmail.com>
 Burak Yiğit Kaya <ben@byk.im>
 C. T. Lin <chentsulin@gmail.com>
-Christian Johansen <christian@shortcut.no>
 Daryl Lau <daryl@goodeggs.com>
 Eric Wendelin <ewendelin@twitter.com>
-Felix Geisendörfer <felix@debuggable.com>
+Ericat <erica.salvaneschi@gmail.com>
 Gavin Boulton <gavin.boulton@digital.cabinet-office.gov.uk>
 Gilad Peleg <giladp007@gmail.com>
 Giorgos Giannoutsos <contact@nuc.gr>
-Glen Mailer <glenjamin@gmail.com>
 Gord Tanner <gord@tinyhippos.com>
 Gordon L. Hempton <ghempton@gmail.com>
 Gyandeep Singh <gyandeeps@gmail.com>
 Harry Wolff <hswolff@gmail.com>
 Ian Lewis <IanMLewis@gmail.com>
 Ian Thomas <ian@ian-thomas.net>
+Irving <Irvingb232@gmail.com>
+Jack Brown <jack.brown@mi9.com.au>
 James Beavers <jamesjbeavers@gmail.com>
 Jan Kopriva <jan.kopriva@gooddata.com>
 Jan Suchý <jan.sandokan@gmail.com>
 Jason Anderson <diurnalist@gmail.com>
 Johann Hubert Sonntagbauer <johann.sonntagbauer@gmx.at>
 John Bernardo <jbernardo@linkedin.com>
-John Reeves <github@jonnyreeves.co.uk>
+Jordan Harband <ljharb@gmail.com>
 Jordan Hawker <hawker.jordan@gmail.com>
 Joseph Spens <joseph@workmarket.com>
 Josh Goldberg <josh@fullscreenmario.com>
+Kalisa Falzone <KalisaFalzone@users.noreply.github.com>
+Kelly Selden <kellyselden@gmail.com>
 Kevin Turner <kevin@decipherinc.com>
 Kim Joar Bekkelund <kjbekkelund@gmail.com>
 Kris Kowal <kris.kowal@cixar.com>
 Kurt Ruppel <me@kurtruppel.com>
 Lars Thorup <lars@zealake.com>
 Luchs <Luchs@euirc.eu>
+Maarten Tromp <maarten@nouncy.com>
 Marco Ramirez <marco-ramirez@bankofamerica.com>
 Mario Pareja <mpareja@360incentives.com>
+Mark Banner <standard8@mozilla.com>
 Mark Gibson <mgibson@adaptavist.com>
 Martin Brochhaus <mbrochh@gmail.com>
+Martin Körner <martin.koerner@objectfab.de>
 Max Klymyshyn <klymyshyn@gmail.com>
 Michael Jackson <mjijackson@gmail.com>
 Mikolaj Banasik <d1sover@gmail.com>
 Mustafa Sak <mustafa.sak@1und1.de>
+Nelson Silva <nelson.silva@inevo.pt>
 Nicholas Stephan <nicholas.stephan@gmail.com>
 Nikita Litvin <deltaidea@derpy.ru>
 Niklas Andreasson <eaglus_@hotmail.com>
 Olmo Maldonado <olmo.maldonado@gmail.com>
 Petar Dochev <dotchev@gmail.com>
+Prayag Verma <prayag.verma@gmail.com>
 Rajeesh C V <cvrajeesh@gmail.com>
 Raynos <raynos2@gmail.com>
+ReadmeCritic <frankensteinbot@gmail.com>
 Rodion Vynnychenko <roddiku@gmail.com>
 Ryan Wholey <rjwholey@gmail.com>
+STuFF <nchalleil@gmail.com>
 Sergio Cinos <scinos@atlassian.com>
 Shaine Hatch <shainehatch@overstock.com>
 Shawn Krisman <skrisman@nodelings>
-Shawn Krisman <telaviv@github>
 Shinnosuke Watanabe <snnskwtnb@gmail.com>
 Simone Fonda <fonda@netseven.it>
+Stefan Weil <sw@weilnetz.de>
 Sven Fuchs <svenfuchs@artweb-design.de>
 Søren Enemærke <soren.enemaerke@gmail.com>
-TEHEK Firefox <tehek@tehek.net>
-Tek Nynja <github@teknynja.com>
-The Gitter Badger <badger@gitter.im>
-Tim Branyen <tim@tabdeveloper.com>
-Tim Wienk <tim@wienk.name>
-Timo Tijhof <krinklemail@gmail.com>
-Tristan Koch <tristan@tknetwork.de>
-Volkan Ozcelik <volkan.ozcelik@jivesoftware.com>
-Will Butler <will@butlerhq.com>
-William Meleyal <w.meleyal@wollzelle.com>
-Xiao Ma <x@medium.com>
-brandonheyer <brandonheyer@gmail.com>
-charlierudolph <charles.w.rudolph@gmail.com>
-goligo <ich@malte.de>
-hashchange <heim@zeilenwechsel.de>
-jamestalmage <james.talmage@jrtechnical.com>
-kbackowski <kbackowski@gmail.com>
-ngryman <ngryman@gmail.com>
-simonzack <simonzack@gmail.com>
-stevesouth <stephen.south@caplin.com>
-thefourtheye <thefourtheye@users.noreply.github.com>
-till <till@php.net>
-wwalser <waw325@gmail.com>

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,7 +1,126 @@
 
-2.0.0 / 2015-12-02
+2.0.0-pre.2 / 2016-07-07
 ==================
 
+  * CJSify sinon.call tests (#1079)
+  * CJSify sinon.calledInOrder tests (#1080)
+  * CJSify get-config tests (#1081)
+  * CJSify sinon.assert tests (#1078)
+  * Resolve test failure in node 0.10.x (#1073)
+  * Expose `sinon.assert` on sandbox instances. (#1076)
+  * Add resetBehavior and resetHistory to sandbox API (#1072)
+  * Fix incorrect inline function names
+  * Fix calledOnce on tests for #283. This closes #283.
+  * Add sandbox.reset() docs
+  * Add a line recommending how to pronounce.
+  * Improve tests based on PR feedback
+  * Allow xhr.respond(0) to simulate a network failure and call onerror
+  * Use event loaded instead of error event for code like 403, 500, etc.
+  * Fix invalid markdown in fake-timers.ms (#1054)
+  * Do not invoke getters in walk (#1059)
+  * ReactNative compatibility. Allow sinon fakeServer to run in React Native (#1052)
+  * added timeouts to ensure tests pass
+  * Run tests on stable Node 6 instead of unstable Node 5
+  * added tests to ensure only expected events are fired (#1043)
+  * Fixed formatting of issue template
+  * Added note on using latest version
+  * Fix onerror event triggering for fake xhr requests (#1041)
+  * Add missing mocaccino and phantomic to package.json (#1029)
+  * Pull request and issue templates (#1012)
+  * Fix capturing of stack traces in Phantom.js.
+  * Allow sinon.calledInOrder to be called either with an array of spies or multiple spies as parameters.  Add explicit test cases for sinon.calledInOrder
+  * Fix typos found by codespell
+  * Document faking of setImmediate and clearImmediate
+  * Add feature detection guard for tests containing es6 Symbols
+  * Add support for es6 Symbol to wrapMethod method
+  * Convert values to strings with toString instead of String()
+  * Add typeOf matcher for symbol type
+  * Make expectetation fail as expected when called with wrong Symbol
+  * Make mock report expected TypeError when expecting number and given symbol
+  * Add support for es6 Symbol to match.has method
+  * Make error message when failing to stub method support es6 symbol
+  * Make yieldToOn fail as expected when yielding an es6 Symbol
+  * Add support for es6 Symbol to match.same method
+  * Make yieldTo fail as expected when yielding an es6 Symbol
+  * Add support for es6 Symbol to match method
+  * Work around SauceLabs security limitations
+  * Declare test specific eslint configs in test/.eslintrc
+  * Add test-coverage script
+  * Add eslint-plugin-mocha
+  * Remove browserify-shim
+  * Setup saucelabs tests and adjust travis config
+  * Feature detect __proto__ to exclude a timer test in IE 10
+  * Convert webworker test to mocha
+  * Remove buster
+  * Replace npm test script with mocha / mochify invocations
+  * Fix async fake-xml-http-request tests
+  * Convert issues tests to mocha
+  * Convert util tests to mocha
+  * Convert core tests to mocha
+  * Convert stub tests to mocha
+  * Convert typeof tests to mocha
+  * Convert spy tests to mocha
+  * Convert sandbox tests to mocha
+  * Convert mock tests to mocha
+  * Convert hello world test to mocha
+  * Convert extend tests to mocha
+  * Convert collection tests to mocha
+  * Convert call tests to mocha
+  * Convert assert tests to mocha
+  * Convert matcher tests to mocha
+  * Update docs/TODO.md to reflect plan to Jekyll
+  * CJSify Spy and Stub Tests.
+  * CJSify Core Util Tests.
+  * Migrate Packaged Tests to use a Browserified Build.
+  * fix non enumerable methods stub restore
+  * Improve Blob support detection logics
+  * Fix a typo in Contributing.md
+  * Update Node versions on Travis
+  * Use PhantomJS 2.
+  * Fix #835: make err.message writable
+  * Remove linting errors in switch cases
+  * Add spy.notCalled to documentation
+  * Remove `sinon.test()` and `sinon.testCase`.
+  * Remove `sinon.log` and `sinon.logError`
+  * De-fluff
+  * Remove `sinon-test` module.
+  * Extract `get-config` tests from `sinon-test`.
+  * Extract `function-to-string` tests from `sinon-test`.
+  * Extract `restore` tests from `sinon-test`.
+  * Extract `createStubInstance` tests from `sinon-test`
+  * Extract `deep-equal` tests from `sinon-test`.
+  * Extract `wrap-method` tests from `sinon-test`.
+  * Extract `extend` tests from `sinon-test` to `extend-test`
+  * Move 'lib/util/core' tests into 'test/util/core'
+  * Remove the use of `sinon.format` from the codebase
+  * Require sinon.deepEqual in a more modular way
+  * Fix 648: test for this.proxy before trying toString on it
+  * use the correct sinon.deepEqual to test sinon matcher
+  * add stub test to ensure sinon matcher is recognized within stub.withArgs
+  * update repo link
+  * Remove unused dependency util
+  * Update samsam
+  * Update lolex
+  * Update browserify
+  * Update dependency pre-commit
+  * Update buster-istanbul to 0.1.15
+  * ignore webstorm configs
+  * fix async issues and increase buster timeout
+  * test on node 5
+  * Fixes typo error in docs
+  * fix typo in lib/sinon.js
+  * Fixes typo error in docs
+  * Adding comment to warn against using eval
+  * fix linting
+  * Get rid of eval in sinon spy
+  * Update README URLs based on HTTP redirects
+
+2.0.0-pre / 2015-12-02
+==================
+
+  * 2.0.0 pre-release
+  * Extract `sandbox` into a CommonJS module.
+  * Clarify documentation on creating stubs and spies
   * Extract `util/fake_server_with_clock` into a CommonJS module
   * Extract `util/fake_server` into a CommonJS module.
   * Extract `util/fake_timers` into a CommonJS module.
@@ -85,8 +204,6 @@
   * Fix #851: Do not attempt to re-stub constructors
   * Fix #847: Ensure walk invokes accessors directly on target
   * Run tests in node 4.1.x also
-  * First effort towards moving to CommonJS
-  * Update Changelog.txt
   * stub.reset also resets behavior
 
 1.17.0 / 2015-09-22

--- a/README.md
+++ b/README.md
@@ -12,21 +12,13 @@ via [npm (node package manager)](https://github.com/npm/npm)
 
     $ npm install sinon
 
-via [NuGet (package manager for Microsoft development platform)](https://www.nuget.org/packages/SinonJS)
-
-    Install-Package SinonJS
-
-or install via git by cloning the repository and including sinon.js
-in your project, as you would any other third party library.
-
-Don't forget to include the parts of Sinon.JS that you want to use as well
-(i.e. spy.js).
+or via sinon's browser builds available for download on the [homepage](http://sinonjs.org/download/).
 
 ## Usage
 
 See the [sinon project homepage](http://sinonjs.org/) for documentation on usage.
 
-If you have questions that are not covered by the documentation, please post them to the [Sinon.JS mailing list](http://groups.google.com/group/sinonjs) or drop by <a href="irc://irc.freenode.net:6667/sinon.js">#sinon.js on irc.freenode.net:6667</a>
+If you have questions that are not covered by the documentation, please post them to the [Sinon.JS mailing list](http://groups.google.com/group/sinonjs) or drop by <a href="irc://irc.freenode.net:6667/sinon.js">#sinon.js on irc.freenode.net:6667</a> or the [Gitter channel](https://gitter.im/sinonjs/sinon).
 
 ### Important: AMD needs pre-built version
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sinon",
   "description": "JavaScript test spies, stubs and mocks.",
-  "version": "2.0.0-pre",
+  "version": "2.0.0-pre.2",
   "homepage": "http://sinonjs.org/",
   "author": "Christian Johansen",
   "repository": {


### PR DESCRIPTION
#### Purpose (TL;DR)
Removes a reference to the NuGet repo 

#### Background (Problem in detail)
The NuGet repo has not been updated for ages. I also added a line about using pre-built versions for browsers and removed what I deemed was a line just contributing confusion (about spy.js). Not sure what it meant to say.