### PR TITLE
CJSify collection tests

### DIFF
--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -8,8 +8,9 @@
  */
 "use strict";
 
-var sinon = require("./util/core");
 var sinonSpy = require("./spy");
+var sinonStub = require("./stub");
+var sinonMock = require("./mock");
 var walk = require("./util/core/walk");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var valueToString = require("./util/core/value-to-string");
@@ -115,7 +116,7 @@ var collection = {
         }
         if (!property && !!object && typeof object === "object") {
             var col = this;
-            var stubbedObj = sinon.stub.apply(sinon, arguments);
+            var stubbedObj = sinonStub.apply(null, arguments);
 
             walk(stubbedObj, function (prop, propOwner) {
                 if (
@@ -128,11 +129,11 @@ var collection = {
             return stubbedObj;
         }
 
-        return this.add(sinon.stub.apply(sinon, arguments));
+        return this.add(sinonStub.apply(null, arguments));
     },
 
     mock: function mock() {
-        return this.add(sinon.mock.apply(sinon, arguments));
+        return this.add(sinonMock.apply(null, arguments));
     },
 
     inject: function inject(obj) {


### PR DESCRIPTION
Removes all `sinon.*` references from both the tests and the collection module itself.  A bunch of tests around stubbing and mocking had to be rewritten as it's no longer possible to monkeypatch `mock` and `stub` - the replacement tests are now based on the expected behaviors.