### PR TITLE
Feature/cjsify typeof extend tests

### DIFF
--- a/test/extend-test.js
+++ b/test/extend-test.js
@@ -1,14 +1,14 @@
 "use strict";
 
 var referee = require("referee");
-var sinon = require("../lib/sinon");
+var extend = require("../lib/sinon/extend");
 var assert = referee.assert;
 
-describe("sinon.extend", function () {
+describe("extend", function () {
     it("should return unaltered target when only one argument", function () {
         var target = { hello: "world" };
 
-        sinon.extend(target);
+        extend(target);
 
         assert.equals(target, { hello: "world" });
     });
@@ -16,7 +16,7 @@ describe("sinon.extend", function () {
     it("should copy all (own) properties into first argument, from all subsequent arguments", function () {
         var target = { hello: "world" };
 
-        sinon.extend(target, { a: "a" }, { b: "b" });
+        extend(target, { a: "a" }, { b: "b" });
 
         assert.equals(target.hello, "world");
         assert.equals(target.a, "a");
@@ -36,7 +36,7 @@ describe("sinon.extend", function () {
             }
         };
 
-        sinon.extend(target, source);
+        extend(target, source);
 
         assert.same(target.toString, source.toString);
     });
@@ -47,7 +47,7 @@ describe("sinon.extend", function () {
         var source2 = { a: 2, b: 2 };
         var source3 = { a: 3 };
 
-        sinon.extend(target, source1, source2, source3);
+        extend(target, source1, source2, source3);
 
         assert.equals(target.a, 3);
         assert.equals(target.b, 2);
@@ -66,7 +66,7 @@ describe("sinon.extend", function () {
             prop4: 4
         };
 
-        var result = sinon.extend({}, object1, object2);
+        var result = extend({}, object1, object2);
 
         var expected = {
             prop1: null,

--- a/test/typeOf-test.js
+++ b/test/typeOf-test.js
@@ -1,47 +1,47 @@
 "use strict";
 
 var referee = require("referee");
-var sinon = require("../lib/sinon");
+var sinonTypeOf = require("../lib/sinon/typeOf");
 var assert = referee.assert;
 
-describe("sinon.typeOf", function () {
+describe("typeOf", function () {
     it("returns boolean", function () {
-        assert.equals(sinon.typeOf(false), "boolean");
+        assert.equals(sinonTypeOf(false), "boolean");
     });
 
     it("returns string", function () {
-        assert.equals(sinon.typeOf("Sinon.JS"), "string");
+        assert.equals(sinonTypeOf("Sinon.JS"), "string");
     });
 
     it("returns number", function () {
-        assert.equals(sinon.typeOf(123), "number");
+        assert.equals(sinonTypeOf(123), "number");
     });
 
     it("returns object", function () {
-        assert.equals(sinon.typeOf({}), "object");
+        assert.equals(sinonTypeOf({}), "object");
     });
 
     it("returns function", function () {
-        assert.equals(sinon.typeOf(function () {}), "function");
+        assert.equals(sinonTypeOf(function () {}), "function");
     });
 
     it("returns undefined", function () {
-        assert.equals(sinon.typeOf(undefined), "undefined");
+        assert.equals(sinonTypeOf(undefined), "undefined");
     });
 
     it("returns null", function () {
-        assert.equals(sinon.typeOf(null), "null");
+        assert.equals(sinonTypeOf(null), "null");
     });
 
     it("returns array", function () {
-        assert.equals(sinon.typeOf([]), "array");
+        assert.equals(sinonTypeOf([]), "array");
     });
 
     it("returns regexp", function () {
-        assert.equals(sinon.typeOf(/.*/), "regexp");
+        assert.equals(sinonTypeOf(/.*/), "regexp");
     });
 
     it("returns date", function () {
-        assert.equals(sinon.typeOf(new Date()), "date");
+        assert.equals(sinonTypeOf(new Date()), "date");
     });
 });


### PR DESCRIPTION
CJSify `extend` and `typeOf` tests

Removes all `sinon.*` references from the test suites
