### PR TITLE
Add v2.0 Migration Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# Sinon.JS
-
-[![Join the chat at https://gitter.im/sinonjs/sinon](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sinonjs/sinon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-[![Build status](https://secure.travis-ci.org/sinonjs/sinon.svg?branch=master)](http://travis-ci.org/sinonjs/sinon) [![bitHound Score](https://www.bithound.io/github/sinonjs/sinon/badges/score.svg)](https://www.bithound.io/github/sinonjs/sinon)
+# Sinon.JS [![npm version](https://img.shields.io/npm/v/sinon.svg?style=flat)](https://www.npmjs.com/package/sinon) [![Join the chat at https://gitter.im/sinonjs/sinon](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sinonjs/sinon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build status](https://secure.travis-ci.org/sinonjs/sinon.svg?branch=master)](http://travis-ci.org/sinonjs/sinon) [![bitHound Score](https://www.bithound.io/github/sinonjs/sinon/badges/score.svg)](https://www.bithound.io/github/sinonjs/sinon) [![Sauce Test Status](https://saucelabs.com/buildstatus/sinonjs)](https://saucelabs.com/u/sinonjs)
 
 Standalone and test framework agnostic JavaScript test spies, stubs and mocks (pronounced "sigh-non").
+
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/sinonjs.svg)](https://saucelabs.com/u/sinonjs)
 
 ## Installation
 
@@ -20,11 +18,11 @@ See the [sinon project homepage](http://sinonjs.org/) for documentation on usage
 
 If you have questions that are not covered by the documentation, please post them to the [Sinon.JS mailing list](http://groups.google.com/group/sinonjs) or drop by <a href="irc://irc.freenode.net:6667/sinon.js">#sinon.js on irc.freenode.net:6667</a> or the [Gitter channel](https://gitter.im/sinonjs/sinon).
 
-### Important: AMD needs pre-built version
+### Important: Sinon v1.x does not work with AMD/CommonJS Bundlers!
 
-Sinon.JS *as source* **doesn't work with AMD loaders** (when they're asynchronous, like loading via script tags in the browser). For that you will have to use a pre-built version. You can either [build it yourself](CONTRIBUTING.md#testing-a-built-version) or get a numbered version from http://sinonjs.org.
+Sinon.JS v1.x *as source* **doesn't work with AMD loaders / RequireJS / Webpack / Browserify**. For that you will have to use a pre-built version. You can either [build it yourself](CONTRIBUTING.md#testing-a-built-version) or get a numbered version from http://sinonjs.org.
 
-This might or might not change in future versions, depending of outcome of investigations. Please don't report this as a bug, just use pre-built versions.
+This has been resolved in Sinon v2.x; Please don't report this as a bug.
 
 ## Goals
 

--- a/docs/current/migrating-to-2.0.md
+++ b/docs/current/migrating-to-2.0.md
@@ -1,0 +1,48 @@
+# Migrating to v2.0
+
+Sinon v2.0 is the second major release, we have made several breaking changes in this release as a result of modernising the internals of Sinon.  This guide is intended to walk you through the changes.
+
+## sinon.log and sinon.logError Removed
+`sinon.log` and `sinon.logError` were used in Sinon v1.x to globally configure `FakeServer`, `FakeXMLHttpRequest` and `FakeXDomainRequest`; these three functions now allow the logger to be configured on a per-use basis.  In v1.x you may have written:
+
+```js
+sinon.log = function (msg) { // your logging impl };
+```
+
+You would now individually import and configure the utility upon creation:
+
+```js
+var sinon = require("sinon");
+
+var myFakeServer = sinon.fakeServer.create({
+ logger: function (msg) { // your logging impl }
+});
+```
+
+## sinon.test, sinon.testCase and sinon.config Removed
+`sinon.test` and `sinon.testCase` have been extracted from the Sinon API and moved into their own node module, [sinon-test](https://www.npmjs.com/package/sinon-test). Please refer to the [sinon-test README](https://github.com/sinonjs/sinon-test/blob/master/README.md) for migration examples.
+
+## Deprecation of internal helpers
+The following utility functions are being marked as deprecated and are planned for removal in Sinon v3.0; please check your codebase for usage to ease future migrations:
+
+* `sinon.calledInOrder`
+* `sinon.create`
+* `sinon.deepEqual`
+* `sinon.format`
+* `sinon.functionName`
+* `sinon.functionToString`
+* `sinon.getConfig`
+* `sinon.getPropertyDescriptor`
+* `sinon.objectKeys`
+* `sinon.orderByFirstCall`
+* `sinon.timesInWorlds`
+* `sinon.valueToString`
+* `sinon.walk`
+* `sinon.wrapMethod`
+* `sinon.Event`
+* `sinon.CustomEvent`
+* `sinon.EventTarget`
+* `sinon.ProgressEvent`
+* `sinon.typeOf`
+* `sinon.extend`
+

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -9,12 +9,45 @@
 "use strict";
 
 var match = require("./sinon/match");
+var deepEqual = require("./sinon/util/core/deep-equal");
+var deprecated = require("./sinon/util/core/deprecated");
+var objectKeys = require("./sinon/util/core/object-keys");
 
-module.exports = exports = require("./sinon/util/core");
+function exposeCoreUtils(target, utils) {
+    var keys = objectKeys(utils);
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        var value = utils[key];
+
+        // allow deepEqual to check equality of matchers through dependency injection. Otherwise we get a circular
+        // dependency
+        if (key === "deepEqual") {
+            value = deepEqual.use(match);
+        }
+        if (typeof value === "function") {
+            value = deprecated.wrap(value, deprecated.defaultMsg(key));
+        }
+        target[key] = value;
+    }
+}
+
+function exposeEventTarget(target, eventTarget) {
+    var keys = objectKeys(eventTarget);
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        target[key] = deprecated.wrap(eventTarget[key], deprecated.defaultMsg("EventTarget"));
+    }
+}
+
+// Expose internal utilities on `sinon` global for backwards compatability.
+exposeCoreUtils(exports, require("./sinon/util/core/index"));
+
+// TODO move these two into util/core.
+exports.extend = deprecated.wrap(require("./sinon/extend"), deprecated.defaultMsg("extend"));
+exports.typeOf = deprecated.wrap(require("./sinon/typeOf"), deprecated.defaultMsg("typeOf"));
 
 exports.assert = require("./sinon/assert");
 exports.collection = require("./sinon/collection");
-exports.extend = require("./sinon/extend");
 exports.match = match;
 exports.spy = require("./sinon/spy");
 exports.spyCall = require("./sinon/call");
@@ -23,18 +56,18 @@ exports.mock = require("./sinon/mock");
 exports.sandbox = require("./sinon/sandbox");
 exports.expectation = require("./sinon/mock-expectation");
 exports.createStubInstance = require("./sinon/stub").createStubInstance;
-exports.typeOf = require("./sinon/typeOf");
-
-var event = require("./sinon/util/event");
-exports.Event = event.Event;
-exports.CustomEvent = event.CustomEvent;
-exports.ProgressEvent = event.ProgressEvent;
-exports.EventTarget = event.EventTarget;
 
 var fakeTimers = require("./sinon/util/fake_timers");
 exports.useFakeTimers = fakeTimers.useFakeTimers;
 exports.clock = fakeTimers.clock;
 exports.timers = fakeTimers.timers;
+
+var event = require("./sinon/util/event");
+exports.Event = deprecated.wrap(event.Event, deprecated.defaultMsg("Event"));
+exports.CustomEvent = deprecated.wrap(event.CustomEvent, deprecated.defaultMsg("CustomEvent"));
+exports.ProgressEvent = deprecated.wrap(event.ProgressEvent, deprecated.defaultMsg("ProgressEvent"));
+exports.EventTarget = {};
+exposeEventTarget(exports.EventTarget, event.EventTarget);
 
 var fakeXdr = require("./sinon/util/fake_xdomain_request");
 exports.xdr = fakeXdr.xdr;
@@ -48,11 +81,4 @@ exports.useFakeXMLHttpRequest = fakeXhr.useFakeXMLHttpRequest;
 
 exports.fakeServer = require("./sinon/util/fake_server");
 exports.fakeServerWithClock = require("./sinon/util/fake_server_with_clock");
-
-/*
- * allow deepEqual to check equality of matchers through
- * dependency injection. Otherwise we get a circular
- * dependency
- */
-exports.deepEqual = exports.deepEqual.use(match);
 

--- a/lib/sinon/util/core/deprecated.js
+++ b/lib/sinon/util/core/deprecated.js
@@ -1,0 +1,28 @@
+/*eslint no-console: 0 */
+"use strict";
+
+// wrap returns a function that will invoke the supplied function and print a deprecation warning to the console each
+// time it is called.
+exports.wrap = function (func, msg) {
+    var wrapped = function () {
+        // Watch out for IE7 and below! :(
+        if (typeof console !== "undefined") {
+            if (console.info) {
+                console.info(msg);
+            } else {
+                console.log(msg);
+            }
+        }
+        return func.apply(this, arguments);
+    };
+    if (func.prototype) {
+        wrapped.prototype = func.prototype;
+    }
+    return wrapped;
+};
+
+// defaultMsg returns a string which can be supplied to `wrap()` to notify the user that a particular part of the
+// sinon API has been deprecated.
+exports.defaultMsg = function (funcName) {
+    return "sinon." + funcName + " is deprecated and will be removed from the public API in a future version of sinon.";
+};

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -12,7 +12,7 @@
 "use strict";
 
 var push = [].push;
-var sinon = require("./core");
+var sinon = require("../../sinon");
 var createInstance = require("./core/create");
 var format = require("./core/format");
 var configureLogError = require("./core/log_error");


### PR DESCRIPTION
- [x] Add deprecation guide.
- [x] Mark core utils as deprecated.
- [x] Mark `sinon.Event` and friends as deprecated.
- [x] Call out deprecation of legacy browsers

----

Went through all the pull requests opened since the initial kick off of the CJSify work and tried to reason about the changes to the public API.

Wasn't 100% where to the put the migration guide, but the `docs` folder felt like a good place :)
