### PR TITLE
Add assertion check for too many args with calledOnce/Twice/Thrice

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -43,6 +43,23 @@ function verifyIsStub() {
     }
 }
 
+function verifyIsValidAssertion(assertionMethod, assertionArgs) {
+    switch (assertionMethod) {
+        case "notCalled":
+        case "called":
+        case "calledOnce":
+        case "calledTwice":
+        case "calledThrice":
+            if (assertionArgs.length !== 0) {
+                assert.fail(assertionMethod +
+                            " takes 1 argument but was called with " + (assertionArgs.length + 1) + " arguments");
+            }
+            break;
+        default:
+            break;
+    }
+}
+
 function failAssertion(object, msg) {
     object = object || global;
     var failMethod = object.fail || assert.fail;
@@ -60,6 +77,8 @@ function mirrorPropAsAssertion(name, method, message) {
 
         var args = slice.call(arguments, 1);
         var failed = false;
+
+        verifyIsValidAssertion(name, args);
 
         if (typeof method === "function") {
             failed = !method(fake);

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -131,6 +131,15 @@ describe("assert", function () {
             assert(sinonAssert.fail.called);
         });
 
+        it("fails when called with more than one argument", function () {
+            var stub = this.stub;
+            stub();
+
+            assert.exception(function () {
+                sinonAssert.called(stub, 1);
+            });
+        });
+
         it("does not fail when method was called", function () {
             var stub = this.stub;
             stub();
@@ -190,6 +199,14 @@ describe("assert", function () {
             assert(sinonAssert.fail.called);
         });
 
+        it("fails when called with more than one argument", function () {
+            var stub = this.stub;
+
+            assert.exception(function () {
+                sinonAssert.notCalled(stub, 1);
+            });
+        });
+
         it("passes when method was not called", function () {
             var stub = this.stub;
 
@@ -243,6 +260,15 @@ describe("assert", function () {
             assert(sinonAssert.fail.called);
         });
 
+        it("fails when called with more than one argument", function () {
+            var stub = this.stub;
+            stub();
+
+            assert.exception(function () {
+                sinonAssert.calledOnce(stub, 1);
+            });
+        });
+
         it("passes when method was called", function () {
             var stub = this.stub;
             stub();
@@ -293,6 +319,16 @@ describe("assert", function () {
             });
         });
 
+        it("fails when called with more than one argument", function () {
+            var stub = this.stub;
+            this.stub();
+            this.stub();
+
+            assert.exception(function () {
+                sinonAssert.calledTwice(stub, 1);
+            });
+        });
+
         it("passes if called twice", function () {
             var stub = this.stub;
             this.stub();
@@ -328,6 +364,17 @@ describe("assert", function () {
 
             assert.exception(function () {
                 sinonAssert.calledThrice(stub);
+            });
+        });
+
+        it("fails when called with more than one argument", function () {
+            var stub = this.stub;
+            this.stub();
+            this.stub();
+            this.stub();
+
+            assert.exception(function () {
+                sinonAssert.calledThrice(stub, 1);
             });
         });
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
> give a concise (one or two short sentences) description of what what problem is being solved by this PR

Add assertion to make sure calledOnce, calledTwice, calledThrice don't get called with any extra arguments. This will prevent the incorrect assumption that calledOnce works like calledWith

Incorrect case that will be prevented:
calledOnce(stub, arg1, agr2); // dev thinks we are asserting with arguments, but this just checks that the stub was called

#### Background (Problem in detail)  - optional
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:

https://github.com/sinonjs/sinon/issues/1093

#### Solution  - optional
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.

This works by adding a check to verify the arguments of an assertion. This goes to a function that could be extended to include other checks for different cases, but for now just includes the single case for the three assertions outlined above. 

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`

running the tests should tell you all you need to know here.

