### PR TITLE
Fix regression in #692 when stubbing browser natives

### DIFF
--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -94,6 +94,13 @@
 
             var error, wrappedMethod, i;
 
+            function simplePropertyAssignment() {
+                wrappedMethod = object[property];
+                checkWrappedMethod(wrappedMethod);
+                object[property] = method;
+                method.displayName = property;
+            }
+
             // IE 8 does not support hasOwnProperty on the window object and Firefox has a problem
             // when using hasOwn.call on objects from other frames.
             var owned = object.hasOwnProperty ? object.hasOwnProperty(property) : hasOwn.call(object, property);
@@ -126,11 +133,17 @@
                     mirrorProperties(methodDesc[types[i]], wrappedMethodDesc[types[i]]);
                 }
                 Object.defineProperty(object, property, methodDesc);
+
+                // catch failing assignment
+                // this is the converse of the check in `.restore` below
+                if ( typeof method === "function" && object[property] !== method ) {
+                    // correct any wrongdoings caused by the defineProperty call above,
+                    // such as adding new items (if object was a Storage object)
+                    delete object[property];
+                    simplePropertyAssignment();
+                }
             } else {
-                wrappedMethod = object[property];
-                checkWrappedMethod(wrappedMethod);
-                object[property] = method;
-                method.displayName = property;
+                simplePropertyAssignment();
             }
 
             method.displayName = property;


### PR DESCRIPTION
#### Purpose
Fix regression in #692 by falling back to simple property assignment.

#### Background
Spying and stubbing of localStorage in Chrome started failing when a regression was introduced in #692. This issue was reported in #1046.

Spying on the methods of the localStorage object failed to work in Chrome when Sinon started using `Object.defineProperty`. Instead, the effect was to add a key with the name of the method
(say `"getItem"`) to the disk storage, instead of on the actual `localStorage` object.

This seems to only affect Chrome.

#### Solution 
Falls back to the ES3 simple assignment method when the assignment fails.

#### How to verify
New tests were added, so just run `npm test`.

You can also verify that it works through this external script used to find the regression:
```sh
# first checkout this branch ... of course
curl -o test-script.sh https://rawgit.com/fatso83/7f135d2de168a07582b075b0fa46e9a9/raw/ceedbd7694c93aef52e146bc9701125f67e34730/test-script.sh
./test-script.sh
```