### PR TITLE
Revert #1017 fix-fake-xhr-compliance-again"

### DIFF
--- a/lib/sinon/util/event.js
+++ b/lib/sinon/util/event.js
@@ -41,8 +41,8 @@ if (typeof sinon === "undefined") {
 
         sinon.ProgressEvent = function ProgressEvent(type, progressEventRaw, target) {
             this.initEvent(type, false, false, target);
-            this.loaded = typeof progressEventRaw.loaded === "number" ? progressEventRaw.loaded : null;
-            this.total = typeof progressEventRaw.total === "number" ? progressEventRaw.total : null;
+            this.loaded = progressEventRaw.loaded || null;
+            this.total = progressEventRaw.total || null;
             this.lengthComputable = !!progressEventRaw.total;
         };
 

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -77,11 +77,10 @@
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            abort: [],
-            error: [],
+            progress: [],
             load: [],
-            loadend: [],
-            progress: []
+            abort: [],
+            error: []
         };
     }
 
@@ -448,7 +447,6 @@
                 this.readyState = state;
 
                 var readyStateChangeEvent = new sinon.Event("readystatechange", false, false, this);
-                var event, progress;
 
                 if (typeof this.onreadystatechange === "function") {
                     try {
@@ -458,25 +456,16 @@
                     }
                 }
 
-                if (this.readyState === FakeXMLHttpRequest.DONE) {
-                    if (this.status < 200 || this.status > 299) {
-                        progress = {loaded: 0, total: 0};
-                        event = this.aborted ? "abort" : "error";
-                    }
-                    else {
-                        progress = {loaded: 100, total: 100};
-                        event = "load";
-                    }
-
-                    if (supportsProgress) {
-                        this.upload.dispatchEvent(new sinon.ProgressEvent("progress", progress, this));
-                        this.upload.dispatchEvent(new sinon.ProgressEvent(event, progress, this));
-                        this.upload.dispatchEvent(new sinon.ProgressEvent("loadend", progress, this));
-                    }
-
-                    this.dispatchEvent(new sinon.ProgressEvent("progress", progress, this));
-                    this.dispatchEvent(new sinon.ProgressEvent(event, progress, this));
-                    this.dispatchEvent(new sinon.ProgressEvent("loadend", progress, this));
+                switch (this.readyState) {
+                    case FakeXMLHttpRequest.DONE:
+                        if (supportsProgress) {
+                            this.upload.dispatchEvent(new sinon.ProgressEvent("progress", {loaded: 100, total: 100}));
+                            this.dispatchEvent(new sinon.ProgressEvent("progress", {loaded: 100, total: 100}));
+                        }
+                        this.upload.dispatchEvent(new sinon.Event("load", false, false, this));
+                        this.dispatchEvent(new sinon.Event("load", false, false, this));
+                        this.dispatchEvent(new sinon.Event("loadend", false, false, this));
+                        break;
                 }
 
                 this.dispatchEvent(readyStateChangeEvent);
@@ -555,6 +544,14 @@
                 }
 
                 this.readyState = FakeXMLHttpRequest.UNSENT;
+
+                this.dispatchEvent(new sinon.Event("abort", false, false, this));
+
+                this.upload.dispatchEvent(new sinon.Event("abort", false, false, this));
+
+                if (typeof this.onerror === "function") {
+                    this.onerror();
+                }
             },
 
             getResponseHeader: function getResponseHeader(header) {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Revert the networking changes introduced in #1017 for the v1.17 branch

#### Background 
The changes in the networking api introduced in #1017 proved to be too big of a change for version 1.17, and was decided to be kept only for the upcoming version 2 in the master branch to lower the noise and not introduce major breaking changes, even though the implementation predating this was incorrect per the spec.

See [this discussion](https://github.com/sinonjs/sinon/issues/1040#issuecomment-231727271) for more background info.

#### How to verify
Hmm ... well the tests still pass, so ... 