### PR TITLE
moving assertion from 2x to 1x, resolving conflicts

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -45,6 +45,24 @@
             }
         }
 
+        function verifyIsValidAssertion(assertionMethod, assertionArgs) {
+            switch (assertionMethod) {
+                case "notCalled":
+                case "called":
+                case "calledOnce":
+                case "calledTwice":
+                case "calledThrice":
+                    if (assertionArgs.length !== 0) {
+                        assert.fail(assertionMethod +
+                                    " takes 1 argument but was called with " +
+                                    (assertionArgs.length + 1) + " arguments");
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
         function failAssertion(object, msg) {
             object = object || global;
             var failMethod = object.fail || assert.fail;
@@ -61,6 +79,8 @@
                 verifyIsStub(fake);
 
                 var args = slice.call(arguments, 1);
+                verifyIsValidAssertion(name, args);
+
                 var failed = false;
 
                 if (typeof method === "function") {

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -129,6 +129,15 @@
                 assert(sinon.assert.fail.called);
             },
 
+            "fails when called with more than one argument": function () {
+                var stub = this.stub;
+                stub();
+
+                assert.exception(function () {
+                    sinon.assert.called(stub, 1);
+                });
+            },
+
             "does not fail when method was called": function () {
                 var stub = this.stub;
                 stub();
@@ -188,6 +197,14 @@
                 assert(sinon.assert.fail.called);
             },
 
+            "fails when called with more than one argument": function () {
+                var stub = this.stub;
+
+                assert.exception(function () {
+                    sinon.assert.notCalled(stub, 1);
+                });
+            },
+
             "passes when method was not called": function () {
                 var stub = this.stub;
 
@@ -229,6 +246,15 @@
                 });
 
                 assert(sinon.assert.fail.called);
+            },
+
+            "fails when called with more than one argument": function () {
+                var stub = this.stub;
+                stub();
+
+                assert.exception(function () {
+                    sinon.assert.calledOnce(stub, 1);
+                });
             },
 
             "fails when method was not called": function () {
@@ -291,6 +317,16 @@
                 });
             },
 
+            "fails when called with more than one argument": function () {
+                var stub = this.stub;
+                this.stub();
+                this.stub();
+
+                assert.exception(function () {
+                    sinon.assert.calledTwice(stub, 1);
+                });
+            },
+
             "passes if called twice": function () {
                 var stub = this.stub;
                 this.stub();
@@ -326,6 +362,17 @@
 
                 assert.exception(function () {
                     sinon.assert.calledThrice(stub);
+                });
+            },
+
+            "fails when called with more than one argument": function () {
+                var stub = this.stub;
+                this.stub();
+                this.stub();
+                this.stub();
+
+                assert.exception(function () {
+                    sinon.assert.calledThrice(stub, 1);
                 });
             },
 


### PR DESCRIPTION
same as: https://github.com/sinonjs/sinon/pull/1097

but for a 1.x
