### PR TITLE
Stopped treating non-200 responses as error - fixes #1040

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -557,6 +557,15 @@
                 this.readyState = FakeXMLHttpRequest.UNSENT;
             },
 
+            error: function error() {
+                clearResponse(this);
+                this.errorFlag = true;
+                this.requestHeaders = {};
+                this.responseHeaders = {};
+
+                this.readyStateChange(FakeXMLHttpRequest.DONE);
+            },
+
             getResponseHeader: function getResponseHeader(header) {
                 if (this.readyState < FakeXMLHttpRequest.HEADERS_RECEIVED) {
                     return null;

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -125,7 +125,7 @@
         }
 
         var xhr = this;
-        var events = ["loadstart", "load", "abort", "loadend"];
+        var events = ["loadstart", "load", "abort", "error", "loadend"];
 
         function addEventListener(eventName) {
             xhr.addEventListener(eventName, function (event) {
@@ -459,7 +459,7 @@
                 }
 
                 if (this.readyState === FakeXMLHttpRequest.DONE) {
-                    if (this.status < 200 || this.status > 299) {
+                    if (this.aborted || this.status === 0) {
                         progress = {loaded: 0, total: 0};
                         event = this.aborted ? "abort" : "error";
                     }


### PR DESCRIPTION
* non-200 requests trigger `load` event (fixes regression)
* added `xhr.error()` to simulate network errors

Tests and fixes are ported from `master`.