### PR TITLE
V1.17 progress event compliance - fixed #1105

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -459,12 +459,20 @@
                 }
 
                 if (this.readyState === FakeXMLHttpRequest.DONE) {
-                    if (this.aborted || this.status === 0) {
-                        progress = {loaded: 0, total: 0};
-                        event = this.aborted ? "abort" : "error";
+                    // ensure loaded and total are numbers
+                    progress = {
+                      loaded: this.progress || 0,
+                      total: this.progress || 0
+                    };
+
+                    // order of checking is important here
+                    if (this.aborted) {
+                        event = "abort";
+                    }
+                    else if (this.status === 0) {
+                        event = "error";
                     }
                     else {
-                        progress = {loaded: 100, total: 100};
                         event = "load";
                     }
 

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -629,6 +629,7 @@
                 } else if (this.responseType === "" && isXmlContentType(contentType)) {
                     this.responseXML = FakeXMLHttpRequest.parseXML(this.responseText);
                 }
+                this.progress = body.length;
                 this.readyStateChange(FakeXMLHttpRequest.DONE);
             },
 

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1887,7 +1887,7 @@
 
             "triggers 'loadend' event at the end": function (done) {
                 this.xhr.addEventListener("loadend", function (e) {
-                    assertProgressEvent(e, 100);
+                    assertProgressEvent(e, 0);
 
                     done();
                 });
@@ -1911,7 +1911,7 @@
 
             "calls #onloadend at the end": function (done) {
                 this.xhr.onloadend = function (e) {
-                    assertProgressEvent(e, 100);
+                    assertProgressEvent(e, 0);
 
                     done();
                 };

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1794,8 +1794,9 @@
                 this.xhr.respond(200, {}, "");
             },
 
-            "triggers 'load' event on for non-200 events": assertEventOrdering("load", 100, function (xhr) {
-                xhr.respond(500, {}, "");
+            "triggers 'load' event on for non-200 events": assertEventOrdering("load", 50, function (xhr) {
+                // error is 50 chars long
+                xhr.respond(500, {}, Array(51).join("x"));
             }),
 
             "triggers 'load' with event target set to the XHR object": function (done) {
@@ -1939,8 +1940,8 @@
             },
 
 
-            "follows request load event steps": assertEventOrdering("load", 100, function (xhr) {
-                xhr.respond(200, {}, "");
+            "follows request load event steps": assertEventOrdering("load", 27, function (xhr) {
+                xhr.respond(200, {}, "This line is 27 chars long.");
             })
         },
 
@@ -1995,7 +1996,8 @@
                     });
 
                     this.xhr.send();
-                    this.xhr.respond(200, {}, "");
+                    // 100 character string
+                    this.xhr.respond(200, {}, Array(101).join("x"));
                 }
             },
 


### PR DESCRIPTION
This changes the data that progress events send to more closely mimic browsers. This fix affects the state and properties of the `ProgressEvent` fired in ready state 4 (done).

### Change Affects the following properties for ProgressEvent

* loaded
* total
* lengthComputable

### State Before this Branch

* `progressEvents` fired with only two progress `loaded`/`total` values -- `0` or `100`
* All `error` and `abort` events triggered a `0` progress event
* All `load` events triggered a `100` progress event

### Changes in this Branch

* `load` events can fire with `0` progress events (no body was returned)
* `error` events can fire with non-0 progress events (error with `lengthComputable`)
* All events can fire with any size body (0+) -- not limited to `0` or `100` like before

This is a major change I believe. This fixes #1105.