### PR TITLE
Add prepublish steps to avoid including extra files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
   - "0.12"
-  - "4.1"
+  - "4.4"
 
 sudo: false
 
 before_install:
   - npm config set strict-ssl false
-  # use a more modern npm than ships with 0.8
-  - 'if [ "x$TRAVIS_NODE_VERSION" = "x0.8" ]; then npm install -g npm@1.4; fi'
   # Workaround for intermittent build failures
   # install buster separately from `npm install`, as it uses the C compiler, which might cause the
   #   npm ERR! cb() never called!

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
+    "build": "./build",
+    "check-clean-wd": "./scripts/is-clean-wd.sh",
+    "clean": "rimraf pkg",
     "ci-test": "npm run lint && ./scripts/ci-test.sh",
     "test": "./scripts/ci-test.sh",
-    "lint": "$(npm bin)/eslint .",
-    "prepublish": "./build",
+    "lint": "eslint .",
+    "prepublish": "npm-run-all check-clean-wd clean build",
     "eslint-pre-commit": "./scripts/eslint-pre-commit"
   },
   "pre-commit": [
@@ -36,7 +39,9 @@
     "eslint": "0.24.0",
     "eslint-config-defaults": "^2.1.0",
     "jscs": "1.13.1",
-    "pre-commit": "1.0.10"
+    "npm-run-all": "^2.3.0",
+    "pre-commit": "1.0.10",
+    "rimraf": "^2.5.4"
   },
   "files": [
     "lib",

--- a/scripts/is-clean-wd.sh
+++ b/scripts/is-clean-wd.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+OUTPUT=$(git status --porcelain)
+if [[ "$OUTPUT" ]]; then
+    echo "The index and/or working directory is unclean. Commit, delete or stash any uncommitted changes before continuing the release process."
+    echo $OUTPUT
+    exit 1
+fi
+


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Avoid including files that are not in the index by cleaning the build directory and refusing to publish to NPM when `git status` detects any changes. This should avoid release problems of the past where older built versions sometimes were bundled along new versions by mistake when publishing to NPM.

#### How to verify - mandatory
1. `touch f`
2. `npm run prepublish #should fail`
3. `rm f`
4. `npm run prepublish #should execute without error`