### PR TITLE
ESLint upgrade to version 3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,7 @@ trim_trailing_whitespace = true
 [{package.json, .travis.yml}]
 indent_style = space
 indent_size = 2
+
+; Needed if doing doing `git add --patch` to edit patches
+[*.diff]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
     "env": {
         "browser": true,
         "node": true,
-        "amd": true
+        "amd": true,
+        "es6": true
     },
     "rules": {
         "no-alert": 2,
@@ -25,7 +26,7 @@
         "no-else-return": 2,
         "no-empty": 2,
         "no-empty-character-class": 2,
-        "no-empty-label": 2,
+        "no-labels": 2,
         "no-eq-null": 0,
         "no-eval": 2,
         "no-ex-assign": 2,
@@ -43,8 +44,6 @@
         "no-invalid-regexp": 2,
         "no-irregular-whitespace": 2,
         "no-iterator": 2,
-        "no-label-var": 2,
-        "no-labels": 2,
         "no-lone-blocks": 2,
         "no-lonely-if": 0,
         "no-loop-func": 2,
@@ -161,14 +160,13 @@
         "semi": 2,
         "semi-spacing": [2, {"before": false, "after": true}],
         "sort-vars": 0,
-        "space-after-keywords": [2, "always"],
+        "keyword-spacing": ["error", { "after": true }],
         "space-before-blocks": [2, "always"],
         "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
         "space-before-function-parentheses": [0, "always"],
         "space-in-brackets": [0, "never"],
         "space-in-parens": [0, "never"],
         "space-infix-ops": 2,
-        "space-return-throw-case": 2,
         "space-unary-ops": [2, { "words": true, "nonwords": false }],
         "spaced-comment": 0,
         "spaced-line-comment": [0, "always"],

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ before_install:
 
 before_script:
   # these build targets only need to run once per build, so let's conserve a few resources
-  - if [ "x$TRAVIS_NODE_VERSION" = "x0.12" ]; then npm run lint; fi
+  # ESLint only supports Node >=4
+  - if [ "x$TRAVIS_NODE_VERSION" = "x6" ]; then npm run lint; fi
   # run these on node 6 to have npm 3 with flat dependencies
   - if [ "x$TRAVIS_NODE_VERSION" = "x6" ]; then npm run test-headless; fi
   - if [ "x$TRAVIS_NODE_VERSION" = "x6" ]; then npm run test-webworker; fi

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -88,6 +88,8 @@ var TYPE_MAP = {
             return matchObject(expectation, actual);
         };
         m.message = "match(" + array.join(", ") + ")";
+
+        return m;
     },
     regexp: function (m, expectation) {
         m.test = function (actual) {

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -129,6 +129,9 @@ extend(mock, {
     },
 
     invokeMethod: function invokeMethod(method, thisValue, args) {
+        /* if we cannot find any matching files we will explicitly call mockExpection#fail with error messages */
+        /* eslint consistent-return: "off" */
+
         var expectations = this.expectations && this.expectations[method] ? this.expectations[method] : [];
         var expectationsWithMatchingArgs = [];
         var currentArgs = args || [];

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -58,6 +58,8 @@ function matchingFake(fakes, args, strict) {
             return fakes[i];
         }
     }
+
+    return undefined;
 }
 
 function incrementCallCount() {
@@ -319,6 +321,8 @@ var spyApi = {
             deepEqual(margs, args.slice(0, margs.length))) {
             return !strict || margs.length === args.length;
         }
+
+        return undefined;
     },
 
     printf: function (format) {

--- a/lib/sinon/util/event.js
+++ b/lib/sinon/util/event.js
@@ -65,7 +65,8 @@ var EventTarget = {
 
         for (var i = 0, l = listeners.length; i < l; ++i) {
             if (listeners[i] === listener) {
-                return listeners.splice(i, 1);
+                listeners.splice(i, 1);
+                return;
             }
         }
     },

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -95,7 +95,8 @@ UploadProgress.prototype.removeEventListener = function removeEventListener(even
 
     for (var i = 0, l = listeners.length; i < l; ++i) {
         if (listeners[i] === listener) {
-            return listeners.splice(i, 1);
+            listeners.splice(i, 1);
+            return;
         }
     }
 };
@@ -428,7 +429,8 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
                 return filter.apply(this, xhrArgs);
             });
             if (defake) {
-                return FakeXMLHttpRequest.defake(this, arguments);
+                FakeXMLHttpRequest.defake(this, arguments);
+                return;
             }
         }
         this.readyStateChange(FakeXMLHttpRequest.OPENED);

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "devDependencies": {
     "browserify": "^13.0.0",
-    "eslint": "^1.7.1",
-    "eslint-config-defaults": "^2.1.0",
-    "eslint-plugin-mocha": "^1.1.0",
+    "eslint": "^3.1.1",
+    "eslint-config-defaults": "^9.0.0",
+    "eslint-plugin-mocha": "^4.2.0",
     "mocaccino": "^1.8.2",
     "mocha": "^2.4.5",
     "mochify": "^2.17.0",

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1156,6 +1156,7 @@ describe("assert", function () {
 
             sinonSpy(this.obj, "doSomething");
 
+            /*eslint consistent-return: "off"*/
             this.message = function (method) {
                 try {
                     sinonAssert[method].apply(sinonAssert, [].slice.call(arguments, 1));

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -1500,6 +1500,7 @@ describe("spy", function () {
         it("stacks up return values", function () {
             var calls = 0;
 
+            /*eslint consistent-return: "off"*/
             var spy = createSpy.create(function () {
                 calls += 1;
 


### PR DESCRIPTION
#### Purpose
Updates ESLint to current major version

Had to change code in a few places to avoid failing the `consistent-return` rule. Turned out we deviated a tiny bit from W3C spec on EventTarget#removeEventListener by returning the listeners instead of void. Disabled the rule in the two cases it was intentional. Added explicit returns elsewhere.