### PR TITLE
Fixing a Markdown syntax error

### DIFF
--- a/docs/current/sandbox.md
+++ b/docs/current/sandbox.md
@@ -175,6 +175,6 @@ The default configuration looks like:
 If you need the behavior of `sinon.test` for more than one test method in a test case, you can use `sinon.testCase`, which behaves exactly like wrapping each test in `sinon.test` with one exception: `setUp` and
 `tearDown` can share fakes.
 
-#### `var obj = sinon.testCase({});
+#### `var obj = sinon.testCase({});`
 
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fixing a Markdown syntax error

#### Background (Problem in detail)  - optional
The Markdown syntax error results in incorrect rendering

#### Solution  - optional
Fix the syntax error in the Markdown.

#### How to verify - mandatory
View this rendered Markdown file to ensure that the last line is rendered as code.