### PR TITLE
Support returning promises in sinon.test. Fixes #1119.

### DIFF
--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -51,7 +51,19 @@
                 if (typeof exception !== "undefined") {
                     sandbox.restore();
                     throw exception;
-                } else if (typeof oldDone !== "function") {
+                }
+
+                if (result && typeof result === "object" && typeof result.then === "function") {
+                    return result.then(function sinonHandlePromiseResolve(val) {
+                        sandbox.verifyAndRestore();
+                        return val;
+                    }, function sinonHandlePromiseReject(err) {
+                        sandbox.restore();
+                        throw err;
+                    });
+                }
+
+                if (typeof oldDone !== "function") {
                     sandbox.verifyAndRestore();
                 }
 


### PR DESCRIPTION
#### Purpose (TL;DR) 
Fix issue #1119 by calling thenables if present.

This is a backport of the [accepted solution](https://github.com/sinonjs/sinon-test/commit/c93063c18e33fe064d619f3d9b1d2603cd2c0157) ([issue](https://github.com/sinonjs/sinon-test/issues/6)) in sinon-test into v1. This issue is fixed in v2.

#### Background (Problem in detail)
The problem is fully described in #1119.

Interestingly, this only bit us when https://github.com/petkaantonov/bluebird/issues/1170 was fixed.

#### Solution
This solution is simply a backport with additional tests.

#### How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`.
