### PR TITLE
Add chrome to SauceLabs tested browser list

### DIFF
--- a/.min-wd
+++ b/.min-wd
@@ -1,6 +1,8 @@
 {
   "sauceLabs": true,
   "browsers": [{
+    "name": "chrome"
+  }, {
     "name": "firefox"
   }, {
     "name": "internet explorer",


### PR DESCRIPTION
Run the test suite in Chrome on SauceLabs again.

I finally managed to investigate further on the Chrome issue. An attempt to fix the issue was made in [min-webdriver 2.9.1](https://github.com/mantoni/min-webdriver/blob/master/CHANGES.md#291).

This PR should (hopefully) demonstrate that Chrome testing now works as expected.

This will finally allow us to close #912 and #914 