### PR TITLE
Has Own Property Check in Core now compares vs Object prototype.

### DIFF
--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -103,7 +103,8 @@
 
             // IE 8 does not support hasOwnProperty on the window object and Firefox has a problem
             // when using hasOwn.call on objects from other frames.
-            var owned = object.hasOwnProperty ? object.hasOwnProperty(property) : hasOwn.call(object, property);
+            var owned = (object.hasOwnProperty && object.hasOwnProperty === hasOwn) ?
+                object.hasOwnProperty(property) : hasOwn.call(object, property);
 
             if (hasES5Support) {
                 var methodDesc = (typeof method === "function") ? {value: method} : method;

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -906,6 +906,31 @@
             }
         },
 
+        "mock object with hasOwnProperty": {
+            setUp: function () {
+                this.method = function () {};
+                this.hasOwn = function () {
+                    throw Error("overridden method hasOwnProperty invoked");
+                };
+                this.object = { method: this.method, hasOwnProperty: this.hasOwn };
+                this.mock = sinon.mock.create(this.object);
+            },
+
+            "mocks object method": function () {
+                this.mock.expects("method");
+
+                assert.isFunction(this.object.method);
+                refute.same(this.object.method, this.method);
+            },
+
+            "reverts mocked method": function () {
+                this.mock.expects("method");
+                this.object.method.restore();
+
+                assert.same(this.object.method, this.method);
+            }
+        },
+
         "mock method multiple times": {
             setUp: function () {
                 this.thisValue = {};


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix Issue #1138 Mocked objects which override method 'hasOwnProperty' fail to restore(). Methods were being deleted instead.
#### Background (Problem in detail)  - optional

Issue arises because of a conflict between browser needs. IE does not implement hasOwnProperty, but Firefox cannot blindly rely on Object.prototype.hasOwnProperty.call.
#### Solution  - optional

Not enough to check that hasOwnProperty is implemented. Necessary to also check that it matches Object.prototype.hasOwnProperty
#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. Run testing suite.
