### PR TITLE
Fix typo in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
-; Needed if doing doing `git add --patch` to edit patches
+; Needed if doing `git add --patch` to edit patches
 [*.diff]
 trim_trailing_whitespace = false


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
The word 'doing' is repeated in comment in .editorconfig

#### Background (Problem in detail)  - optional
Typo fix

#### Solution  - optional
Remove repeated word in comment in .editorconfig

#### How to verify - mandatory
1. Open .editorconfig in a text editor
2. Read comment on line 19