### PR TITLE
Added spy APIs to fake server - fixed #1126

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -64,6 +64,22 @@ function match(response, request) {
     return false;
 }
 
+function incrementRequestCount() {
+    var count = ++this.requestCount;
+
+    this.requested = true;
+
+    this.requestedOnce = count === 1;
+    this.requestedTwice = count === 2;
+    this.requestedThrice = count === 3;
+
+    this.firstRequest = this.getRequest(0);
+    this.secondRequest = this.getRequest(1);
+    this.thirdRequest = this.getRequest(2);
+
+    this.lastRequest = this.getRequest(count - 1);
+}
+
 var fakeServer = {
     create: function (config) {
         var server = createInstance(this);
@@ -74,6 +90,7 @@ var fakeServer = {
             this.xhr = sinon.useFakeXMLHttpRequest();
         }
         server.requests = [];
+        server.requestCount = 0;
 
         this.xhr.onCreate = function (xhrObj) {
             server.addRequest(xhrObj);
@@ -104,6 +121,8 @@ var fakeServer = {
     addRequest: function addRequest(xhrObj) {
         var server = this;
         push.call(this.requests, xhrObj);
+
+        incrementRequestCount.call(this);
 
         xhrObj.onSend = function () {
             server.handleRequest(this);
@@ -229,6 +248,35 @@ var fakeServer = {
 
     restore: function restore() {
         return this.xhr.restore && this.xhr.restore.apply(this.xhr, arguments);
+    },
+
+    getRequest: function getRequest(index) {
+        return this.requests[index] || null;
+    },
+
+    reset: function reset() {
+        this.resetBehavior();
+        this.resetHistory();
+    },
+
+    resetBehavior: function resetBehavior() {
+        this.responses.length =
+        this.queue.length = 0;
+    },
+
+    resetHistory: function resetHistory() {
+        this.requests.length =
+        this.requestCount = 0;
+
+        this.requestedOnce =
+        this.requestedTwice =
+        this.requestedThrice =
+        this.requested = false;
+
+        this.firstRequest =
+        this.secondRequest =
+        this.thirdRequest =
+        this.lastRequest = null;
     }
 };
 

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -260,23 +260,15 @@ var fakeServer = {
     },
 
     resetBehavior: function resetBehavior() {
-        this.responses.length =
-        this.queue.length = 0;
+        this.responses.length = this.queue.length = 0;
     },
 
     resetHistory: function resetHistory() {
-        this.requests.length =
-        this.requestCount = 0;
+        this.requests.length = this.requestCount = 0;
 
-        this.requestedOnce =
-        this.requestedTwice =
-        this.requestedThrice =
-        this.requested = false;
+        this.requestedOnce = this.requestedTwice = this.requestedThrice = this.requested = false;
 
-        this.firstRequest =
-        this.secondRequest =
-        this.thirdRequest =
-        this.lastRequest = null;
+        this.firstRequest = this.secondRequest = this.thirdRequest = this.lastRequest = null;
     }
 };
 


### PR DESCRIPTION
Copied some friendly APIs from `sinon.spy` to `fakeServer`:

New server properties:

* `requested[Once|Twice|Thrice]`
* `requested`
* `[first|second|third]Request`
* `lastRequest`
* `requestCount`

New fake server methods:

* `getRequest(index)` - retrieve request at index
* `resetBehavior()` - resets all server behavior (via `respondWith`)
* `resetHistory()` - resets all new properties listed above
* `reset()` - resets behavior and history using the methods above