### PR TITLE
Help coveralls separate the code from the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
 
 after_success:
   - npm run test-coverage
-  - cat ./coverage/lcov.info | coveralls
+  - cat ./coverage/lcov.info | coveralls lib
 
 git:
   depth: 10


### PR DESCRIPTION
Just flagging the `lib` dir as code.