### PR TITLE
Throw when sandbox.restore is given arguments (Fixes #1149)

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -95,6 +95,10 @@ extend(sinonSandbox, {
     },
 
     restore: function () {
+        if (arguments.length) {
+            throw new Error("sandbox.restore() does not take any parameters. Perhaps you meant stub.restore()");
+        }
+
         sinonCollection.restore.apply(this, arguments);
         this.restoreContext();
     },

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -243,6 +243,28 @@ describe("sinonSandbox", function () {
         }
     });
 
+    describe(".restore", function () {
+        it("throws when passed arguments", function () {
+            this.sandbox = sinonSandbox.create();
+
+            var failed = false;
+            var exception;
+
+            try {
+                this.sandbox.restore("args");
+                failed = true;
+            } catch (e) {
+                exception = e;
+            }
+
+            assert.isFalse(failed);
+            assert.equals(
+                exception.message,
+                "sandbox.restore() does not take any parameters. Perhaps you meant stub.restore()"
+            );
+        });
+    });
+
     describe("configurable sandbox", function () {
         beforeEach(function () {
             this.requests = [];

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -245,23 +245,13 @@ describe("sinonSandbox", function () {
 
     describe(".restore", function () {
         it("throws when passed arguments", function () {
-            this.sandbox = sinonSandbox.create();
+            var sandbox = sinonSandbox.create();
 
-            var failed = false;
-            var exception;
-
-            try {
-                this.sandbox.restore("args");
-                failed = true;
-            } catch (e) {
-                exception = e;
-            }
-
-            assert.isFalse(failed);
-            assert.equals(
-                exception.message,
-                "sandbox.restore() does not take any parameters. Perhaps you meant stub.restore()"
-            );
+            assert.exception(function () {
+                sandbox.restore("args");
+            }, {
+                message: "sandbox.restore() does not take any parameters. Perhaps you meant stub.restore()"
+            });
         });
     });
 


### PR DESCRIPTION
Fix issue #1149 by throwing when sandbox.restore is given arguments
