### PR TITLE
Throw when sandbox.restore is given arguments (Fixes #1149)

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -93,6 +93,10 @@
             },
 
             restore: function () {
+                if (arguments.length) {
+                    throw new Error("sandbox.restore() does not take any parameters. Perhaps you meant stub.restore()");
+                }
+
                 sinon.collection.restore.apply(this, arguments);
                 this.restoreContext();
             },

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -254,6 +254,18 @@
             }
         },
 
+        ".restore": {
+            "throws when passed arguments": function () {
+                var sandbox = sinon.sandbox.create();
+
+                assert.exception(function () {
+                    sandbox.restore("args");
+                }, {
+                    message: "sandbox.restore() doess not take any parameters. Perhaps you meant stub.restore()"
+                });
+            }
+        },
+
         "configurable sandbox": {
             setUp: function () {
                 this.requests = [];

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -261,7 +261,7 @@
                 assert.exception(function () {
                     sandbox.restore("args");
                 }, {
-                    message: "sandbox.restore() doess not take any parameters. Perhaps you meant stub.restore()"
+                    message: "sandbox.restore() does not take any parameters. Perhaps you meant stub.restore()"
                 });
             }
         },


### PR DESCRIPTION
Backporting https://github.com/sinonjs/sinon/pull/1150 to the 1.17 branch as specified in #1149.

@fatso83 