### PR TITLE
XHR spec conformance: abort() should not dispatch readystatechange event in DONE state

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -545,7 +545,8 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         this.requestHeaders = {};
         this.responseHeaders = {};
 
-        if (this.readyState > FakeXMLHttpRequest.UNSENT && this.sendFlag) {
+        if (this.readyState !== FakeXMLHttpRequest.UNSENT && this.sendFlag
+            && this.readyState !== FakeXMLHttpRequest.DONE) {
             this.readyStateChange(FakeXMLHttpRequest.DONE);
             this.sendFlag = false;
         }

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1266,6 +1266,17 @@ if (typeof window !== "undefined") {
                 assert.isFalse(this.xhr.onreadystatechange.called);
             });
 
+            it("does not dispatch readystatechange event if readyState is done", function () {
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+                this.xhr.respond();
+
+                this.xhr.onreadystatechange = sinonStub();
+                this.xhr.abort();
+
+                assert.isFalse(this.xhr.onreadystatechange.called);
+            });
+
             assertEventOrdering("abort", 0, function (xhr) {
                 xhr.abort();
             });

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1164,7 +1164,50 @@ if (typeof window !== "undefined") {
                 assert.equals(this.xhr.responseHeaders, {});
             });
 
-            it("sets state to DONE if sent before", function () {
+            it("keeps readyState unsent if called in unsent state", function () {
+                this.xhr.abort();
+
+                assert.equals(this.xhr.readyState, FakeXMLHttpRequest.UNSENT);
+            });
+
+            it("resets readyState to unsent if it was opened", function () {
+                this.xhr.open("GET", "/");
+
+                this.xhr.abort();
+
+                assert.equals(this.xhr.readyState, FakeXMLHttpRequest.UNSENT);
+            });
+
+            it("resets readyState to unsent if it was opened with send() flag sent", function () {
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+
+                this.xhr.abort();
+
+                assert.equals(this.xhr.readyState, FakeXMLHttpRequest.UNSENT);
+            });
+
+            it("resets readyState to unsent if it headers were received", function () {
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+                this.xhr.setResponseHeaders({});
+
+                this.xhr.abort();
+
+                assert.equals(this.xhr.readyState, FakeXMLHttpRequest.UNSENT);
+            });
+
+            it("resets readyState to unsent if it was done", function () {
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+                this.xhr.respond();
+
+                this.xhr.abort();
+
+                assert.equals(this.xhr.readyState, FakeXMLHttpRequest.UNSENT);
+            });
+
+            it("signals onreadystatechange with state set to DONE if sent before", function () {
                 var readyState;
                 this.xhr.open("GET", "/");
                 this.xhr.send();


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix XHR spec conformance by not issuing "load" event if abort() is called on XHR in DONE state.
#### Background (Problem in detail)  - optional

FakeXHR.readyStateChange is issuing "load" event if called on XHR with this.status != 0. FakeXHR.abort() calls FakeXHR.readyStateChange() unconditionally, so don't call it if XHR is in DONE state. This also avoids spurious "progress" and "loadend" events.
#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
