### PR TITLE
Fix #1061: add configurable unsafe header checks

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -93,6 +93,9 @@ var fakeServer = {
         server.requestCount = 0;
 
         this.xhr.onCreate = function (xhrObj) {
+            xhrObj.unsafeHeadersEnabled = function () {
+                return !(server.unsafeHeadersEnabled === false);
+            };
             server.addRequest(xhrObj);
         };
 
@@ -105,7 +108,8 @@ var fakeServer = {
             "autoRespondAfter": true,
             "respondImmediately": true,
             "fakeHTTPMethods": true,
-            "logger": true
+            "logger": true,
+            "unsafeHeadersEnabled": true
         };
         var setting;
 

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -54,22 +54,22 @@ sinonXhr.supportsCORS = isReactNative ||
 var unsafeHeaders = {
     "Accept-Charset": true,
     "Accept-Encoding": true,
-    Connection: true,
+    "Connection": true,
     "Content-Length": true,
-    Cookie: true,
-    Cookie2: true,
+    "Cookie": true,
+    "Cookie2": true,
     "Content-Transfer-Encoding": true,
-    Date: true,
-    Expect: true,
-    Host: true,
+    "Date": true,
+    "Expect": true,
+    "Host": true,
     "Keep-Alive": true,
-    Referer: true,
-    TE: true,
-    Trailer: true,
+    "Referer": true,
+    "TE": true,
+    "Trailer": true,
     "Transfer-Encoding": true,
-    Upgrade: true,
+    "Upgrade": true,
     "User-Agent": true,
-    Via: true
+    "Via": true
 };
 
 // An upload object is created for each
@@ -476,7 +476,12 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
     setRequestHeader: function setRequestHeader(header, value) {
         verifyState(this);
 
-        if (unsafeHeaders[header] || /^(Sec-|Proxy-)/.test(header)) {
+        var checkUnsafeHeaders = true;
+        if (typeof this.unsafeHeadersEnabled === "function") {
+            checkUnsafeHeaders = this.unsafeHeadersEnabled();
+        }
+
+        if (checkUnsafeHeaders && (unsafeHeaders[header] || /^(Sec-|Proxy-)/.test(header))) {
             throw new Error("Refused to set unsafe header \"" + header + "\"");
         }
 

--- a/test/util/fake-server-test.js
+++ b/test/util/fake-server-test.js
@@ -71,6 +71,18 @@ if (typeof window !== "undefined") {
                     "fakeServer.create should accept 'fakeHTTPMethods' setting"
                 );
             });
+            it("allows the 'unsafeHeadersEnabled' setting", function () {
+                var server = sinon.fakeServer.create({
+                    unsafeHeadersEnabled: false
+                });
+                assert.defined(
+                    server.unsafeHeadersEnabled,
+                    "'unsafeHeadersEnabled' expected to be defined at server level");
+                assert(
+                    !server.unsafeHeadersEnabled,
+                    "fakeServer.create should accept 'unsafeHeadersEnabled' setting"
+                );
+            });
             it("does not assign a non-whitelisted setting", function () {
                 var server = sinonFakeServer.create({
                     foo: true

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -6,6 +6,7 @@ var sinonSpy = require("../../lib/sinon/spy");
 var sinonExtend = require("../../lib/sinon/extend");
 var sinonSandbox = require("../../lib/sinon/sandbox");
 var sinonFakeXhr = require("../../lib/sinon/util/fake_xml_http_request");
+var sinon = require("../../lib/sinon");
 
 var TextDecoder = global.TextDecoder || require("text-encoding").TextDecoder;
 var FakeXMLHttpRequest = sinonFakeXhr.FakeXMLHttpRequest;
@@ -282,7 +283,7 @@ if (typeof window !== "undefined") {
                 });
             });
 
-            it("disallows unsafe headers", function () {
+            it("disallows unsafe headers by default", function () {
                 var xhr = this.xhr;
 
                 assert.exception(function () {
@@ -364,6 +365,97 @@ if (typeof window !== "undefined") {
                 assert.exception(function () {
                     xhr.setRequestHeader("Sec-Oops", "");
                 });
+            });
+
+            it("allows unsafe headers when fake server unsafeHeadersEnabled option is turned off", function () {
+                var server = sinon.fakeServer.create({
+                    unsafeHeadersEnabled: false
+                });
+
+                var xhr = new sinon.FakeXMLHttpRequest();
+                xhr.open("GET", "/");
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Accept-Charset", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Accept-Encoding", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Connection", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Content-Length", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Cookie", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Cookie2", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Content-Transfer-Encoding", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Date", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Expect", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Host", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Keep-Alive", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Referer", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("TE", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Trailer", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Transfer-Encoding", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Upgrade", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("User-Agent", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Via", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Proxy-Oops", "");
+                });
+
+                refute.exception(function () {
+                    xhr.setRequestHeader("Sec-Oops", "");
+                });
+
+                server.restore();
             });
 
             it("sets header and value", function () {


### PR DESCRIPTION
This is just a rebase of #1063 - see discussion there.
---

#### Fix Issue #1061 - Allow unsafe headers check in fake server using http request to be optional.

#### Background (Problem in detail)

There are times when developer wants to test the app with the fake server without it enforcing any cookie rules with regard to their safety. Currently, this is not possible and in such situations sinon becomes unusable because it blindly checks for unsafe headers and rejects any requests that carry them.

#### Solution

-     Make the unsafe headers optionals/configurable
-     Limit the change to local scope - fake server and fake xmlhttprequest
-     Make the change backward compatible i.e. unless overwritten by user, behavior is the same as before

```
let server = sinon.fakeServer.create()
server.unsafeHeadersEnabled = false
```

#### How to verify - mandatory

1. Check out this branch (see github instructions below)
2.     npm install
3.     run all standard tests - none should fail
4.     create a new basic http request test case and set "cookie" header in the request.
5.     config the fakeServer with unsafeHeaderEnabled = false . test should succeed.
6.     config the fakeServer with unsafeHeaderEnabled = true . test should fail with unsafe header rejection.