### PR TITLE
fix some printf typos

### DIFF
--- a/docs/current/spies.md
+++ b/docs/current/spies.md
@@ -399,7 +399,7 @@ Returns the passed format string with the following replacements performed:
     <dt><code>%t</code></dt>
     <dd>a comma-delimited list of <code>this</code> values the spy was called on</dd>
 
-    <dt><code>%</code><var>n</var></dt>
+    <dt><code>%</code><var><code>n</code></var></dt>
     <dd>the formatted value of the <var>n</var>th argument passed to <code>printf</code> <br/>FIXME: needs example</dd>
 
     <dt><code>%*</code></dt>

--- a/docs/current/spies.md
+++ b/docs/current/spies.md
@@ -383,7 +383,7 @@ Resets the state of a spy.
 Replaces the spy with the original method. Only available if the spy replaced an existing method.
 
 
-#### `spy.printf(format string\", [arg1, arg2, ...])`
+#### `spy.printf(\"format string\", [arg1, arg2, ...])`
 
 Returns the passed format string with the following replacements performed:
 
@@ -399,7 +399,7 @@ Returns the passed format string with the following replacements performed:
     <dt><code>%t</code></dt>
     <dd>a comma-delimited list of <code>this</code> values the spy was called on</dd>
 
-    <dt><code>%<var>n</var></code></dt>
+    <dt><code>%</code><var>n</var></dt>
     <dd>the formatted value of the <var>n</var>th argument passed to <code>printf</code> <br/>FIXME: needs example</dd>
 
     <dt><code>%*</code></dt>


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This fixes some issues with the `printf` docs
- missing opening `"`
- visible `<var>` tags
