### PR TITLE
Expose readyState constants on XHR instances

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -654,13 +654,16 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
     }
 });
 
-extend(FakeXMLHttpRequest, {
+var states = {
     UNSENT: 0,
     OPENED: 1,
     HEADERS_RECEIVED: 2,
     LOADING: 3,
     DONE: 4
-});
+};
+
+extend(FakeXMLHttpRequest, states);
+extend(FakeXMLHttpRequest.prototype, states);
 
 function useFakeXMLHttpRequest() {
     FakeXMLHttpRequest.restore = function restore(keepOnCreate) {

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -132,11 +132,20 @@ if (typeof window !== "undefined") {
             assert.same(FakeXMLHttpRequest.prototype.constructor, FakeXMLHttpRequest);
         });
 
-        it("implements readyState constants", function () {
+        it("class implements readyState constants", function () {
             assert.same(FakeXMLHttpRequest.OPENED, 1);
             assert.same(FakeXMLHttpRequest.HEADERS_RECEIVED, 2);
             assert.same(FakeXMLHttpRequest.LOADING, 3);
             assert.same(FakeXMLHttpRequest.DONE, 4);
+        });
+
+        it("instance implements readyState constants", function () {
+            var xhr = new FakeXMLHttpRequest();
+
+            assert.same(xhr.OPENED, 1);
+            assert.same(xhr.HEADERS_RECEIVED, 2);
+            assert.same(xhr.LOADING, 3);
+            assert.same(xhr.DONE, 4);
         });
 
         it("calls onCreate if listener is set", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Expose readyState constants on XHR instances to allow mocking code which uses them.
#### Background (Problem in detail)  - optional
- Browsers implement readyState constants on XHR instances.
- XHR spec says to do so too: https://xhr.spec.whatwg.org/#states
- There is code which uses it and it breaks under Sinon's XHR mock.
#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
