### PR TITLE
Fire .onprogress event handler in fake XHR

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -128,7 +128,7 @@ function FakeXMLHttpRequest(config) {
     }
 
     var xhr = this;
-    var events = ["loadstart", "load", "abort", "error", "loadend"];
+    var events = ["loadstart", "load", "abort", "error", "loadend", "progress"];
 
     function addEventListener(eventName) {
         xhr.addEventListener(eventName, function (event) {

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -2115,6 +2115,24 @@ if (typeof window !== "undefined") {
                 this.xhr.respond(200, {}, "");
             });
 
+            it("calls .onprogess", function (done) {
+                var xhr = this.xhr;
+                this.onprogressCalled = false;
+
+                this.xhr.onprogress = function () {
+                    this.onprogressCalled = true;
+                };
+                this.xhr.addEventListener("readystatechange", function () {
+                    if (xhr.readyState === 4) {
+                        assert.isTrue(this.onprogressCalled);
+                        done();
+                    }
+                });
+
+                this.xhr.send();
+                this.xhr.respond(200, {}, "");
+            });
+
             it("calls 'abort' on cancel", function (done) {
                 var xhr = this.xhr;
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

`xhr.onprogress` was not fired by fake XHR, only `.addEventListener('progress')` handler was. Make it so.
#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
