### PR TITLE
Implement XHR.overrideMimeType

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -597,7 +597,7 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         verifyRequestSent(this);
         verifyHeadersReceived(this);
         verifyResponseBodyType(body);
-        var contentType = this.getResponseHeader("Content-Type");
+        var contentType = this.overriddenMimeType || this.getResponseHeader("Content-Type");
 
         var isTextResponse = this.responseType === "" || this.responseType === "text";
         clearResponse(this);
@@ -651,6 +651,13 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         if (supportsCustomEvent) {
             this.upload.dispatchEvent(new sinonEvent.CustomEvent("error", {detail: error}));
         }
+    },
+
+    overrideMimeType: function overrideMimeType(type) {
+        if (this.readyState >= FakeXMLHttpRequest.LOADING) {
+            throw new Error("INVALID_STATE_ERR");
+        }
+        this.overriddenMimeType = type;
     }
 });
 

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1528,6 +1528,36 @@ if (typeof window !== "undefined") {
             });
         });
 
+        describe(".overrideMimeType", function () {
+            beforeEach(function () {
+                this.xhr = new FakeXMLHttpRequest();
+            });
+
+            if (supportsBlob) {
+                it("overrides provided MIME-Type", function () {
+                    this.xhr.responseType = "blob";
+                    this.xhr.open("GET", "/");
+                    this.xhr.overrideMimeType("text/plain");
+                    this.xhr.send();
+
+                    this.xhr.respond(200, { "Content-Type": "text/html" }, "");
+
+                    assert.equals(this.xhr.response.type, "text/plain");
+                });
+            }
+
+            it("throws when executed too late", function () {
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+
+                this.xhr.respond(200, {}, "");
+
+                assert.exception(function () {
+                    this.xhr.overrideMimeType("text/plain");
+                });
+            });
+        });
+
         describe("stub XHR", function () {
             beforeEach(fakeXhrSetUp);
             afterEach(fakeXhrTearDown);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Implement missing XMLHttpRequest.overrideMimeType.
#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
