### PR TITLE
Expose XHR.setStatus to simplify asynchronous answers

### DIFF
--- a/docs/current/fake-xhr-and-server.md
+++ b/docs/current/fake-xhr-and-server.md
@@ -156,6 +156,12 @@ The filter will be called when `xhr.open` is called, with the exact same argumen
 
 ### Simulating server responses
 
+#### `request.setStatus(status);``
+
+Sets response status (`status` and `statusText` properties).
+
+Status should be a number, the status text is looked up from `sinon.FakeXMLHttpRequest.statusCodes`.
+
 #### `request.setResponseHeaders(object);``
 
 Sets response headers (e.g. `{ "Content-Type": "text/html", /* ... */ }`, updates the `readyState` property and fires `onreadystatechange`.
@@ -170,9 +176,7 @@ Additionally, populates `responseXML` with a parsed document if [response header
 
 #### `request.respond(status, headers, body);``
 
-Calls the above two methods and sets the `status` and `statusText` properties.
-
-Status should be a number, the status text is looked up from `sinon.FakeXMLHttpRequest.statusCodes`.
+Calls the above three methods.
 
 #### `request.error();`
 

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -492,6 +492,14 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         }
     },
 
+    setStatus: function setStatus(status) {
+        var sanitizedStatus = typeof status === "number" ? status : 200;
+
+        verifyRequestOpened(this);
+        this.status = sanitizedStatus;
+        this.statusText = FakeXMLHttpRequest.statusCodes[sanitizedStatus];
+    },
+
     // Helps testing
     setResponseHeaders: function setResponseHeaders(headers) {
         verifyRequestOpened(this);
@@ -629,8 +637,7 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
     },
 
     respond: function respond(status, headers, body) {
-        this.status = typeof status === "number" ? status : 200;
-        this.statusText = FakeXMLHttpRequest.statusCodes[this.status];
+        this.setStatus(status);
         this.setResponseHeaders(headers || {});
         this.setResponseBody(body || "");
     },

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -705,6 +705,58 @@ if (typeof window !== "undefined") {
             });
         });
 
+        describe(".setStatus", function () {
+            beforeEach(function () {
+                this.xhr = new FakeXMLHttpRequest();
+            });
+
+            it("cannot be set on closed request", function () {
+                assert.exception(function () {
+                    this.xhr.setStatus();
+                });
+            });
+
+            it("cannot be set on unsent request", function () {
+                this.xhr.open("GET", "/");
+
+                assert.exception(function () {
+                    this.xhr.setStatus();
+                });
+            });
+
+            it("by default sets status to 200", function () {
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+                this.xhr.setStatus();
+
+                assert.equals(this.xhr.status, 200);
+                assert.equals(this.xhr.statusText, "OK");
+            });
+
+            it("sets status", function () {
+                var expectedStatus = 206;
+                var xhr = this.xhr;
+
+                xhr.open("GET", "/");
+                xhr.send();
+                xhr.setStatus(expectedStatus);
+
+                assert.equals(xhr.status, expectedStatus);
+            });
+
+            it("sets status text to the value from FakeXMLHttpRequest.statusCodes", function () {
+                var status = 206;
+                var expectedStatusText = FakeXMLHttpRequest.statusCodes[status];
+                var xhr = this.xhr;
+
+                xhr.open("GET", "/");
+                xhr.send();
+                xhr.setStatus(status);
+
+                assert.equals(xhr.statusText, expectedStatusText);
+            });
+        });
+
         describe(".setResponseBodyAsync", function () {
             beforeEach(function () {
                 this.xhr = new FakeXMLHttpRequest();


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Previously the only way to do a two-stage XHR response (first headers, then body) was by setting `.status`/`.statusText` manually, as the only method which sets them is `.respond`, which also sets body.

This patch adds `.setStatus`, which allow scenarios like

    xhr.setStatus(200);
    xhr.setResponseHeaders(...);
    // ... sleep for a specified amount of time
    xhr.setResponseBody(...)

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
