### PR TITLE
Mock expectation errors are now re-thrown when calling mock.verify()

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -148,11 +148,6 @@ var callProto = {
             "' since no callback was passed.", args);
     },
 
-    getStackFrames: function () {
-        // Omit the error message and the two top stack frames in sinon itself:
-        return this.stack && this.stack.split("\n").slice(3);
-    },
-
     toString: function () {
         var callStr = this.proxy ? this.proxy.toString() + "(" : "";
         var args = [];
@@ -179,8 +174,8 @@ var callProto = {
             }
         }
         if (this.stack) {
-            callStr += this.getStackFrames()[0].replace(/^\s*(?:at\s+|@)?/, " at ");
-
+            // Omit the error message and the two top stack frames in sinon itself:
+            callStr += this.stack.split("\n")[3].replace(/^\s*(?:at\s+|@)?/, " at ");
         }
 
         return callStr;

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -73,6 +73,7 @@ extend(mock, {
         if (!this.expectations) {
             this.expectations = {};
             this.proxies = [];
+            this.failures = [];
         }
 
         if (!this.expectations[method]) {
@@ -104,7 +105,7 @@ extend(mock, {
 
     verify: function verify() {
         var expectations = this.expectations || {};
-        var messages = [];
+        var messages = this.failures ? this.failures.slice() : [];
         var met = [];
 
         each(this.proxies, function (proxy) {
@@ -173,6 +174,19 @@ extend(mock, {
         messages.unshift("Unexpected call: " + spyCallToString.call({
             proxy: method,
             args: args
+        }));
+
+        var err = new Error();
+        if (!err.stack) {
+            // PhantomJS does not serialize the stack trace until the error has been thrown
+            try {
+                throw err;
+            } catch (e) {/* empty */}
+        }
+        this.failures.push("Unexpected call: " + spyCallToString.call({
+            proxy: method,
+            args: args,
+            stack: err.stack
         }));
 
         mockExpectation.fail(messages.join("\n"));

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -1289,13 +1289,4 @@ describe("sinonSpy.call", function () {
         spy();
         assert.isString(spy.getCall(0).stack);
     });
-
-    describe("getStackFrames", function () {
-        it("makes the non-Sinon stack frames available as an array", function () {
-            var spy = sinonSpy();
-            spy();
-
-            assert.isString(spy.getCall(0).getStackFrames()[0]);
-        });
-    });
 });

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -889,6 +889,22 @@ describe("sinonMock", function () {
                           "(never called)");
         });
 
+        it("fails even if the original expectation exception was caught", function () {
+            var mock = this.mock;
+            mock.expects("method").once();
+
+            this.object.method();
+            try {
+                this.object.method();
+            } catch (e) {
+                // Silenced error
+            }
+
+            assert.exception(function () {
+                mock.verify();
+            }, "ExpectationError");
+        });
+
         it("does not call pass if no expectations", function () {
             var pass = sinonStub(sinonExpectation, "pass");
 


### PR DESCRIPTION
#### Purpose (TL;DR)
Fix issue #1166 by re-throwing any "Expectation failed" exceptions when `mock.verify()` is called.

#### Background (Problem in detail)  - optional
See https://github.com/sinonjs/sinon/issues/1166 for more detailed info. Basically, if you had code like this:
```js
try {
  mockedObject.method(unexpected, argument, list);
} catch (e) {
  // Silenced error
} 
```
Even if you call `mockedObject.verify()` after that code (silently) fails, the test would pass. With this change, those expectation failures are stored in the `mock` object and re-thrown again in the `mock.verify()` call, so even if the system under test silences errors, tests can properly fail.

@mroderick About "What to do when there are multiple failures for the same mock". After taking a deep look at the code, I think this is a good solution. With code like this:
```js
it("fails even if the original expectation exception was caught", function() {
    var mock = this.mock;
    mock.expects("method").once();

    this.object.method();

    for (var i = 0; i < 10; i++){
        try {
            this.object.method();
        } catch (e) {
            // Silenced error
        }        
    }

    assert.exception(function() {
        mock.verify();
    }, "ExpectationError");
});
```
The test now fails with this exception:
```
{ ExpectationError: Unexpected call: method() at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:899:33)
Unexpected call: method() at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:899:33)
Unexpected call: method() at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:899:33)
Unexpected call: method() at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:899:33)
Unexpected call: method() at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:899:33)
Unexpected call: method() at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:899:33)
Unexpected call: method() at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:899:33)
Unexpected call: method() at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:899:33)
Unexpected call: method() at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:899:33)
Unexpected call: method() at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:899:33)
Expectation met: method([...]) once
    at Object.fail (C:\Users\Daniel\Projects\sinon\lib\sinon\mock-expectation.js:286:25)
    at Object.verify (C:\Users\Daniel\Projects\sinon\lib\sinon\mock.js:124:29)
    at C:\Users\Daniel\Projects\sinon\test\mock-test.js:907:26
    at captureException (C:\Users\Daniel\Projects\sinon\node_modules\referee\lib\referee.js:540:15)
    at Object.assert (C:\Users\Daniel\Projects\sinon\node_modules\referee\lib\referee.js:559:23)
    at assertion (C:\Users\Daniel\Projects\sinon\node_modules\referee\lib\referee.js:95:23)
    at Function.referee.(anonymous function).(anonymous function) [as exception] (C:\Users\Daniel\Projects\sinon\node_modules\referee\lib\referee.js:118:23)
    at Context.<anonymous> (C:\Users\Daniel\Projects\sinon\test\mock-test.js:905:20)
    at callFn (C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runnable.js:326:21)
    at Test.Runnable.run (C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runnable.js:319:7)
    at Runner.runTest (C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runner.js:422:10)
    at C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runner.js:528:12
    at next (C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runner.js:342:14)
    at C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runner.js:352:7
    at next (C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runner.js:284:14)
    at C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runner.js:315:7
    at done (C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runnable.js:287:5)
    at callFn (C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runnable.js:344:7)
    at Hook.Runnable.run (C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runnable.js:319:7)
    at next (C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runner.js:298:10)
    at Immediate.<anonymous> (C:\Users\Daniel\Projects\sinon\node_modules\mocha\lib\runner.js:320:5)
    at runCallback (timers.js:637:20)
    at tryOnImmediate (timers.js:610:5)
    at processImmediate [as _immediateCallback] (timers.js:582:5) name: 'ExpectationError' }
```
Note that every `Unexpected Call` message has the line where the original call was made (and silenced), and the real exception stacktrace is the location of the `mock.verify()` call. I don't think this is *too much* information, because for each error only the line where it happened is displayed, **not** the full stacktrace. But I'm willing to be convinced otherwise :)

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Check that tests pass (`npm test`)
