### PR TITLE
restoring etters does not invoke the getter #1124

### DIFF
--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -167,9 +167,17 @@
                     Object.defineProperty(object, property, wrappedMethodDesc);
                 }
 
+                // this only supports ES5 getter/setter, for ES3.1 and lower
+                // __lookupSetter__ / __lookupGetter__ should be integrated
+                if (hasES5Support) {
+                    var checkDesc = sinon.getPropertyDescriptor(object, property);
+                    if (checkDesc.value === method) {
+                        object[property] = wrappedMethod;
+                    }
+
                 // Use strict equality comparison to check failures then force a reset
                 // via direct assignment.
-                if (object[property] === method) {
+                } else if (object[property] === method) {
                     object[property] = wrappedMethod;
                 }
             };

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -193,6 +193,38 @@
                 sinon.stub(object, "method");
 
                 assert.isFalse(object.method.called);
+            },
+
+            "does not invoke getter on restore": function () {
+                var object = {};
+                var getterCount = 0;
+                var getter = function () {
+                    getterCount++;
+                };
+                Object.defineProperty(object, "g", {
+                    configurable: true,
+                    get: getter
+                });
+
+                sinon.stub(object, "g", { get: function () {} }).restore();
+
+                assert.equals(getterCount, 0);
+            },
+
+            "does not invoke setter on restore": function () {
+                var object = {};
+                var setterCount = 0;
+                var setter = function () {
+                    setterCount++;
+                };
+                Object.defineProperty(object, "g", { // eslint-disable-line accessor-pairs
+                    configurable: true,
+                    set: setter
+                });
+
+                sinon.stub(object, "g", { set: function () {} }).restore(); // eslint-disable-line accessor-pairs
+
+                assert.equals(setterCount, 0);
             }
         },
 


### PR DESCRIPTION
#### Purpose
Fix issue #1124 "Stubbing and then restoring `getters` causes the wrapped method to be invoked" by reading the "value" descriptor property for equality comparison when checking if the property has been restored. Originally a direct comparison was made which would invoke the getter; this is an alternate way to compare that mitigates the problem, albeit slower.  Only supports ES5; further work with __lookupSetter__ / __lookupGetter__ should be implemented to support lower ECMAScript versions.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

The following unit tests were added to `test/sinon-test.js`:
- "does not invoke getter on restore"
- "does not invoke setter on restore"

#### Warning
I'm not entirely convinced this fixes all scenarios. I was not able to test the logic branch if the comparison is truthy, i.e. `object[property] = wrappedMethod`, but this is a step in the right direction and addresses the immediate need.
