### PR TITLE
Add expectation diff logs

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -199,7 +199,7 @@ mirrorPropAsAssertion(
 );
 mirrorPropAsAssertion("calledWithNew", "expected %n to be called with new");
 mirrorPropAsAssertion("alwaysCalledWithNew", "expected %n to always be called with new");
-mirrorPropAsAssertion("calledWith", "expected %n to be called with arguments %*%C");
+mirrorPropAsAssertion("calledWith", "expected %n to be called with arguments %D");
 mirrorPropAsAssertion("calledWithMatch", "expected %n to be called with match %*%C");
 mirrorPropAsAssertion("alwaysCalledWith", "expected %n to always be called with arguments %*%C");
 mirrorPropAsAssertion("alwaysCalledWithMatch", "expected %n to always be called with match %*%C");

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -79,6 +79,7 @@ function mirrorPropAsAssertion(name, method, message) {
         var failed = false;
 
         verifyIsValidAssertion(name, args);
+
         if (typeof method === "function") {
             failed = !method(fake);
         } else {
@@ -199,11 +200,11 @@ mirrorPropAsAssertion(
 mirrorPropAsAssertion("calledWithNew", "expected %n to be called with new");
 mirrorPropAsAssertion("alwaysCalledWithNew", "expected %n to always be called with new");
 mirrorPropAsAssertion("calledWith", "expected %n to be called with arguments %D");
-mirrorPropAsAssertion("calledWithMatch", "expected %n to be called with match %*%C");
-mirrorPropAsAssertion("alwaysCalledWith", "expected %n to always be called with arguments %*%C");
-mirrorPropAsAssertion("alwaysCalledWithMatch", "expected %n to always be called with match %*%C");
-mirrorPropAsAssertion("calledWithExactly", "expected %n to be called with exact arguments %*%C");
-mirrorPropAsAssertion("alwaysCalledWithExactly", "expected %n to always be called with exact arguments %*%C");
+mirrorPropAsAssertion("calledWithMatch", "expected %n to be called with match %D");
+mirrorPropAsAssertion("alwaysCalledWith", "expected %n to always be called with arguments %D");
+mirrorPropAsAssertion("alwaysCalledWithMatch", "expected %n to always be called with match %D");
+mirrorPropAsAssertion("calledWithExactly", "expected %n to be called with exact arguments %D");
+mirrorPropAsAssertion("alwaysCalledWithExactly", "expected %n to always be called with exact arguments %D");
 mirrorPropAsAssertion("neverCalledWith", "expected %n to never be called with arguments %*%C");
 mirrorPropAsAssertion("neverCalledWithMatch", "expected %n to never be called with match %*%C");
 mirrorPropAsAssertion("threw", "%n did not throw exception%C");

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -78,13 +78,7 @@ function mirrorPropAsAssertion(name, method, message) {
         var args = slice.call(arguments, 1);
         var failed = false;
 
-        // Hack to be replaced
-        if (args[0] && args[0].test) {
-            message = message.replace("%D", "%*%C");
-        }
-
         verifyIsValidAssertion(name, args);
-
         if (typeof method === "function") {
             failed = !method(fake);
         } else {

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -78,6 +78,11 @@ function mirrorPropAsAssertion(name, method, message) {
         var args = slice.call(arguments, 1);
         var failed = false;
 
+        // Hack to be replaced
+        if (args[0] && args[0].test) {
+            message = message.replace("%D", "%*%C");
+        }
+
         verifyIsValidAssertion(name, args);
 
         if (typeof method === "function") {

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -7,6 +7,7 @@
   * Copyright (c) 2010-2013 Christian Johansen
   */
 "use strict";
+require("colors");
 
 var extend = require("./extend");
 var functionName = require("./util/core/function-name");
@@ -19,6 +20,7 @@ var timesInWords = require("./util/core/times-in-words");
 var wrapMethod = require("./util/core/wrap-method");
 var sinonFormat = require("./util/core/format");
 var valueToString = require("./util/core/value-to-string");
+var jsDiff = require("diff");
 
 var push = Array.prototype.push;
 var slice = Array.prototype.slice;
@@ -327,6 +329,9 @@ var spyApi = {
         var spyInstance = this;
         var args = slice.call(arguments, 1);
         var formatter;
+        if (format.includes("%D") && args[0] && args[0].test) {
+            format = format.replace("%D", "%*%C");
+        }
 
         return (format || "").replace(/%(.)/g, function (match, specifyer) {
             formatter = spyApi.formatters[specifyer];
@@ -415,6 +420,22 @@ delegateToCalls("yieldToOn", false, "yieldToOn", function (property) {
         "' since it was not yet invoked.");
 });
 
+function colorDiffText(diff) {
+    var objects = diff.map(function (part) {
+        var text = part.value;
+        if (part.added) {
+            text = text.green;
+        } else if (part.removed) {
+            text = text.red;
+        }
+        if (!text.includes("\n")) {
+            text += " "; // format simple types
+        }
+        return text;
+    });
+    return objects.join("");
+}
+
 spyApi.formatters = {
     c: function (spyInstance) {
         return timesInWords(spyInstance.callCount);
@@ -422,6 +443,25 @@ spyApi.formatters = {
 
     n: function (spyInstance) {
         return spyInstance.toString();
+    },
+
+    D: function (spyInstance, args) {
+        if (!spyInstance.getCall || !spyInstance.getCall(0)) {
+            return "";
+        }
+
+        var calledArgs = spyInstance.getCall(0).args;
+        var message = "";
+
+        for (var i = 0; i < calledArgs.length || i < args.length; i++) {
+            message += "\n";
+            var calledArg = i < calledArgs.length ? sinonFormat(calledArgs[i]) : "";
+            var expectedArg = i < args.length ? sinonFormat(args[i]) : "";
+            var diff = jsDiff.diffJson(calledArg, expectedArg);
+            message += colorDiffText(diff);
+        }
+
+        return message;
     },
 
     C: function (spyInstance) {

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -433,6 +433,16 @@ function colorDiffText(diff) {
     return objects.join("");
 }
 
+function colorSinonMatchText(matcher, calledArg, calledArgMessage) {
+    if (!matcher.test(calledArg)) {
+        matcher.message = matcher.message.red;
+        if (calledArgMessage) {
+            calledArgMessage = calledArgMessage.green;
+        }
+    }
+    return calledArgMessage + " " + matcher.message;
+}
+
 spyApi.formatters = {
     c: function (spyInstance) {
         return timesInWords(spyInstance.callCount);
@@ -456,10 +466,14 @@ spyApi.formatters = {
             var calledArgs = spyInstance.getCall(i).args;
             for (var j = 0; j < calledArgs.length || j < args.length; ++j) {
                 message += "\n";
-                var calledArg = j < calledArgs.length ? sinonFormat(calledArgs[j]) : "";
-                var expectedArg = j < args.length ? sinonFormat(args[j]) : "";
-                var diff = jsDiff.diffJson(calledArg, expectedArg);
-                message += colorDiffText(diff);
+                var calledArgMessage = j < calledArgs.length ? sinonFormat(calledArgs[j]) : "";
+                var expectedArgMessage = j < args.length ? sinonFormat(args[j]) : "";
+                if (sinonMatch.isMatcher(args[j])) {
+                    message += colorSinonMatchText(args[j], calledArgs[j], calledArgMessage);
+                } else {
+                    var diff = jsDiff.diffJson(calledArgMessage, expectedArgMessage);
+                    message += colorDiffText(diff);
+                }
             }
         }
 

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -329,9 +329,6 @@ var spyApi = {
         var spyInstance = this;
         var args = slice.call(arguments, 1);
         var formatter;
-        if (format.includes("%D") && args[0] && args[0].test) {
-            format = format.replace("%D", "%*%C");
-        }
 
         return (format || "").replace(/%(.)/g, function (match, specifyer) {
             formatter = spyApi.formatters[specifyer];
@@ -428,8 +425,8 @@ function colorDiffText(diff) {
         } else if (part.removed) {
             text = text.red;
         }
-        if (!text.includes("\n")) {
-            text += " "; // format simple types
+        if (diff.length === 2) {
+            text += " "; // format simple diffs
         }
         return text;
     });
@@ -446,19 +443,24 @@ spyApi.formatters = {
     },
 
     D: function (spyInstance, args) {
-        if (!spyInstance.getCall || !spyInstance.getCall(0)) {
-            return "";
-        }
-
-        var calledArgs = spyInstance.getCall(0).args;
         var message = "";
 
-        for (var i = 0; i < calledArgs.length || i < args.length; i++) {
-            message += "\n";
-            var calledArg = i < calledArgs.length ? sinonFormat(calledArgs[i]) : "";
-            var expectedArg = i < args.length ? sinonFormat(args[i]) : "";
-            var diff = jsDiff.diffJson(calledArg, expectedArg);
-            message += colorDiffText(diff);
+        for (var i = 0, l = spyInstance.callCount; i < l; ++i) {
+            // describe multiple calls
+            if (l > 1) {
+                if (i > 0) {
+                    message += "\n";
+                }
+                message += "Call " + i + ":";
+            }
+            var calledArgs = spyInstance.getCall(i).args;
+            for (var j = 0; j < calledArgs.length || j < args.length; ++j) {
+                message += "\n";
+                var calledArg = j < calledArgs.length ? sinonFormat(calledArgs[j]) : "";
+                var expectedArg = j < args.length ? sinonFormat(args[j]) : "";
+                var diff = jsDiff.diffJson(calledArg, expectedArg);
+                message += colorDiffText(diff);
+            }
         }
 
         return message;

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -461,16 +461,16 @@ spyApi.formatters = {
                 if (i > 0) {
                     message += "\n";
                 }
-                message += "Call " + i + ":";
+                message += "Call " + (i + 1) + ":";
             }
             var calledArgs = spyInstance.getCall(i).args;
             for (var j = 0; j < calledArgs.length || j < args.length; ++j) {
                 message += "\n";
                 var calledArgMessage = j < calledArgs.length ? sinonFormat(calledArgs[j]) : "";
-                var expectedArgMessage = j < args.length ? sinonFormat(args[j]) : "";
                 if (sinonMatch.isMatcher(args[j])) {
                     message += colorSinonMatchText(args[j], calledArgs[j], calledArgMessage);
                 } else {
+                    var expectedArgMessage = j < args.length ? sinonFormat(args[j]) : "";
                     var diff = jsDiff.diffJson(calledArgMessage, expectedArgMessage);
                     message += colorDiffText(diff);
                 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "eslint-pre-commit"
   ],
   "dependencies": {
+    "colors": "^1.1.2",
+    "diff": "^3.1.0",
     "formatio": "1.1.1",
     "lolex": "^1.4.0",
     "samsam": "^1.1.3",

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1375,11 +1375,11 @@ describe("assert", function () {
 
             assert.equals(this.message("calledWith", this.obj.doSomething, 1, 3, "hey").replace(/ at.*/g, ""),
                         "expected doSomething to be called with arguments " +
-                        "Call 0:\n" +
+                        "Call 1:\n" +
                         "4".red + " " + "1".green + " \n" +
                         "3\n" +
                         "hey\n" +
-                        "Call 1:\n" +
+                        "Call 2:\n" +
                         "1\n" +
                         "3\n" +
                         "not".red + " " + "hey".green + " ");
@@ -1552,8 +1552,10 @@ describe("assert", function () {
             this.obj.doSomething(1, 3, "hey");
 
             assert.equals(this.message("calledWithMatch", this.obj.doSomething, 4, 3, "hey").replace(/ at.*/g, ""),
-                          "expected doSomething to be called with match 4, 3, " +
-                          "hey\n    doSomething(1, 3, hey)");
+                          "expected doSomething to be called with match \n" +
+                          "1".red + " " + "4".green + " \n" +
+                          "3\n" +
+                          "hey");
         });
 
         it("assert.alwaysCalledWith exception message", function () {
@@ -1561,8 +1563,13 @@ describe("assert", function () {
             this.obj.doSomething(1, "hey");
 
             assert.equals(this.message("alwaysCalledWith", this.obj.doSomething, 1, "hey").replace(/ at.*/g, ""),
-                          "expected doSomething to always be called with arguments 1" +
-                          ", hey\n    doSomething(1, 3, hey)\n    doSomething(1, hey)");
+                         "expected doSomething to always be called with arguments Call 1:\n" +
+                          "1\n" +
+                          "3".red + " " + "hey".green + " \n" +
+                          "hey".red + "\n" +
+                          "Call 2:\n" +
+                          "1\n" +
+                          "hey");
         });
 
         it("assert.alwaysCalledWithMatch exception message", function () {
@@ -1571,17 +1578,23 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("alwaysCalledWithMatch", this.obj.doSomething, 1, "hey").replace(/ at.*/g, ""),
-                "expected doSomething to always be called with match 1" +
-                    ", hey\n    doSomething(1, 3, hey)\n    doSomething(1, hey)"
-            );
+                "expected doSomething to always be called with match Call 1:\n" +
+                          "1\n" +
+                          "3".red + " " + "hey".green + " \n" +
+                          "hey".red + "\n" +
+                          "Call 2:\n" +
+                          "1\n" +
+                          "hey");
         });
 
         it("assert.calledWithExactly exception message", function () {
             this.obj.doSomething(1, 3, "hey");
 
             assert.equals(this.message("calledWithExactly", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
-                          "expected doSomething to be called with exact arguments 1" +
-                          ", 3\n    doSomething(1, 3, hey)");
+                          "expected doSomething to be called with exact arguments \n" +
+                          "1\n" +
+                          "3\n" +
+                          "hey".red);
         });
 
         it("assert.alwaysCalledWithExactly exception message", function () {
@@ -1589,9 +1602,13 @@ describe("assert", function () {
             this.obj.doSomething(1, 3);
 
             assert.equals(this.message("alwaysCalledWithExactly", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
-                          "expected doSomething to always be called with exact " +
-                          "arguments 1, 3\n    doSomething(1, 3, hey)\n    " +
-                          "doSomething(1, 3)");
+                          "expected doSomething to always be called with exact arguments Call 1:\n" +
+                          "1\n" +
+                          "3\n" +
+                          "hey".red + "\n" +
+                          "Call 2:\n" +
+                          "1\n" +
+                          "3");
         });
 
         it("assert.neverCalledWith exception message", function () {

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1359,12 +1359,71 @@ describe("assert", function () {
                           "expected doSomething to always be called with new");
         });
 
-        it("assert.calledWith exception message", function () {
-            this.obj.doSomething(1, 3, "hey");
+        // test multiple calls, test matchers
 
-            assert.equals(this.message("calledWith", this.obj.doSomething, 4, 3, "hey").replace(/ at.*/g, ""),
-                          "expected doSomething to be called with arguments 4, 3, " +
-                          "hey\n    doSomething(1, 3, hey)");
+        it("assert.calledWith exception message", function () {
+            this.obj.doSomething(4, 3, "hey");
+
+            assert.equals(this.message("calledWith", this.obj.doSomething, 1, 3, "hey").replace(/ at.*/g, ""),
+                        "expected doSomething to be called with arguments \n" +
+                        "4".red + " " + "1".green + " \n" +
+                        "3 \n" +
+                        "hey ");
+        });
+
+        it("assert.calledWith exception message with large object arguments", function () {
+            var calledArg = [
+                {
+                    first: "a",
+                    second: {nest: true},
+                    third: [
+                        {fourth: {nest: true}}
+                    ],
+                    mismatchKey: true
+                },
+                "fifth"
+            ];
+            this.obj.doSomething(calledArg);
+
+            var expectedArg = [
+                {
+                    first: "a",
+                    second: {nest: true},
+                    third: [
+                        {fourth: {nest: false}}
+                    ],
+                    mismatchKeyX: true
+                },
+                "fifth"
+            ];
+            assert.equals(this.message("calledWith", this.obj.doSomething, expectedArg).replace(/ at.*/g, ""),
+                        "expected doSomething to be called with arguments \n" +
+                        "[{\n" +
+                        "  first: \"a\",\n" +
+                        "  mismatchKey: true,\n".red +
+                        "  mismatchKeyX: true,\n".green +
+                        "  second: { nest: true },\n" +
+                        "  third: [{ fourth: { nest: true } }]\n".red +
+                        "  third: [{ fourth: { nest: false } }]\n".green +
+                        "}, \"fifth\"] ");
+        });
+
+        it("assert.calledWith exception message with a missing argument", function () {
+            this.obj.doSomething(4);
+
+            assert.equals(this.message("calledWith", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
+                        "expected doSomething to be called with arguments \n" +
+                        "4".red + " " + "1".green + " \n" +
+                        "3".green + " ");
+        });
+
+        it("assert.calledWith exception message with an excess argument", function () {
+            this.obj.doSomething(4, 3);
+
+            assert.equals(this.message("calledWith", this.obj.doSomething, 1).replace(/ at.*/g, ""),
+                        "expected doSomething to be called with arguments \n" +
+                        "4".red + " " + "1".green + " \n" +
+                        "3".red + " ");
         });
 
         it("assert.calledWith match.any exception message", function () {

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1445,8 +1445,9 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, sinonMatch.any, false).replace(/ at.*/g, ""),
-                "expected doSomething to be called with arguments any, false\n    doSomething(true, true)"
-            );
+                "expected doSomething to be called with arguments \n" +
+                "true any\n" +
+                "true".red + " " + "false".green + " ");
         });
 
         it("assert.calledWith match.defined exception message", function () {
@@ -1454,8 +1455,7 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, sinonMatch.defined).replace(/ at.*/g, ""),
-                "expected doSomething to be called with arguments defined\n    doSomething()"
-            );
+                "expected doSomething to be called with arguments \n " + "defined".red);
         });
 
         it("assert.calledWith match.truthy exception message", function () {
@@ -1463,16 +1463,15 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, sinonMatch.truthy).replace(/ at.*/g, ""),
-                "expected doSomething to be called with arguments truthy\n    doSomething()"
-            );
+                "expected doSomething to be called with arguments \n " + "truthy".red);
         });
 
         it("assert.calledWith match.falsy exception message", function () {
             this.obj.doSomething(true);
 
             assert.equals(this.message("calledWith", this.obj.doSomething, sinonMatch.falsy).replace(/ at.*/g, ""),
-                          "expected doSomething to be called with arguments " +
-                          "falsy\n    doSomething(true)");
+                          "expected doSomething to be called with arguments \n" +
+                          "true".green + " " + "falsy".red);
         });
 
         it("assert.calledWith match.same exception message", function () {
@@ -1480,8 +1479,7 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, sinonMatch.same(1)).replace(/ at.*/g, ""),
-                "expected doSomething to be called with arguments same(1)\n    doSomething()"
-            );
+                "expected doSomething to be called with arguments \n " + "same(1)".red);
         });
 
         it("assert.calledWith match.typeOf exception message", function () {
@@ -1490,8 +1488,7 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, matcher).replace(/ at.*/g, ""),
-                "expected doSomething to be called with arguments typeOf(\"string\")\n    doSomething()"
-            );
+                "expected doSomething to be called with arguments \n " + "typeOf(\"string\")".red);
         });
 
         it("assert.calledWith match.instanceOf exception message", function () {
@@ -1500,8 +1497,7 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, matcher).replace(/ at.*/g, ""),
-                "expected doSomething to be called with arguments instanceOf(CustomType)\n    doSomething()"
-            );
+                "expected doSomething to be called with arguments \n " + "instanceOf(CustomType)".red);
         });
 
         it("assert.calledWith match object exception message", function () {
@@ -1510,24 +1506,21 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, matcher).replace(/ at.*/g, ""),
-                "expected doSomething to be called with arguments match(some: value, and: 123)\n    doSomething()"
-            );
+                "expected doSomething to be called with arguments \n " + "match(some: value, and: 123)".red);
         });
 
         it("assert.calledWith match boolean exception message", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("calledWith", this.obj.doSomething, sinonMatch(true)).replace(/ at.*/g, ""),
-                          "expected doSomething to be called with arguments " +
-                          "match(true)\n    doSomething()");
+                          "expected doSomething to be called with arguments \n " + "match(true)".red);
         });
 
         it("assert.calledWith match number exception message", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("calledWith", this.obj.doSomething, sinonMatch(123)).replace(/ at.*/g, ""),
-                          "expected doSomething to be called with arguments " +
-                          "match(123)\n    doSomething()");
+                          "expected doSomething to be called with arguments \n " + "match(123)".red);
         });
 
         it("assert.calledWith match string exception message", function () {
@@ -1535,8 +1528,7 @@ describe("assert", function () {
             var matcher = sinonMatch("Sinon");
 
             assert.equals(this.message("calledWith", this.obj.doSomething, matcher).replace(/ at.*/g, ""),
-                          "expected doSomething to be called with arguments " +
-                          "match(\"Sinon\")\n    doSomething()");
+                          "expected doSomething to be called with arguments \n " + "match(\"Sinon\")".red);
         });
 
         it("assert.calledWith match regexp exception message", function () {
@@ -1544,8 +1536,7 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, sinonMatch(/[a-z]+/)).replace(/ at.*/g, ""),
-                "expected doSomething to be called with arguments match(/[a-z]+/)\n    doSomething()"
-            );
+                "expected doSomething to be called with arguments \n " + "match(/[a-z]+/)".red);
         });
 
         it("assert.calledWith match test function exception message", function () {
@@ -1554,8 +1545,7 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, matcher).replace(/ at.*/g, ""),
-                "expected doSomething to be called with arguments match(custom)\n    doSomething()"
-            );
+                "expected doSomething to be called with arguments \n " + "match(custom)".red);
         });
 
         it("assert.calledWithMatch exception message", function () {

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1359,16 +1359,30 @@ describe("assert", function () {
                           "expected doSomething to always be called with new");
         });
 
-        // test multiple calls, test matchers
-
         it("assert.calledWith exception message", function () {
             this.obj.doSomething(4, 3, "hey");
 
             assert.equals(this.message("calledWith", this.obj.doSomething, 1, 3, "hey").replace(/ at.*/g, ""),
                         "expected doSomething to be called with arguments \n" +
                         "4".red + " " + "1".green + " \n" +
-                        "3 \n" +
-                        "hey ");
+                        "3\n" +
+                        "hey");
+        });
+
+        it("assert.calledWith exception message with multiple calls", function () {
+            this.obj.doSomething(4, 3, "hey");
+            this.obj.doSomething(1, 3, "not");
+
+            assert.equals(this.message("calledWith", this.obj.doSomething, 1, 3, "hey").replace(/ at.*/g, ""),
+                        "expected doSomething to be called with arguments " +
+                        "Call 0:\n" +
+                        "4".red + " " + "1".green + " \n" +
+                        "3\n" +
+                        "hey\n" +
+                        "Call 1:\n" +
+                        "1\n" +
+                        "3\n" +
+                        "not".red + " " + "hey".green + " ");
         });
 
         it("assert.calledWith exception message with large object arguments", function () {
@@ -1405,7 +1419,7 @@ describe("assert", function () {
                         "  second: { nest: true },\n" +
                         "  third: [{ fourth: { nest: true } }]\n".red +
                         "  third: [{ fourth: { nest: false } }]\n".green +
-                        "}, \"fifth\"] ");
+                        "}, \"fifth\"]");
         });
 
         it("assert.calledWith exception message with a missing argument", function () {
@@ -1414,7 +1428,7 @@ describe("assert", function () {
             assert.equals(this.message("calledWith", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
                         "expected doSomething to be called with arguments \n" +
                         "4".red + " " + "1".green + " \n" +
-                        "3".green + " ");
+                        "3".green);
         });
 
         it("assert.calledWith exception message with an excess argument", function () {
@@ -1423,7 +1437,7 @@ describe("assert", function () {
             assert.equals(this.message("calledWith", this.obj.doSomething, 1).replace(/ at.*/g, ""),
                         "expected doSomething to be called with arguments \n" +
                         "4".red + " " + "1".green + " \n" +
-                        "3".red + " ");
+                        "3".red);
         });
 
         it("assert.calledWith match.any exception message", function () {


### PR DESCRIPTION
#### Purpose

Addresses issue #1179 by using npm libraries "diff" and "colors" to display colored diffs when arguments to `sinonSpy.calledWith` do not match the expectation.

#### Background
Took a stab at implementing diffs for the base case of calledWith. In order to limit changes in this PR, there's a temporary hack to use the original formatting when arguments include sinon matchers. Would appreciate feedback on a better way to implement this, and any other architectural improvements.

#### Solution  

Creates a new formatting type `%D` on spyApi.formatters in  `spy.js` to take the diff of expected and called arguments and created a useful colored message.

Example:

```diff
expected doSomething to be called with arguments 
[{
  first: "a",
-  mismatchKey: true,
+  mismatchKeyX: true,
  second: { nest: true },
-  third: [{ fourth: { nest: true } }]
+  third: [{ fourth: { nest: false } }]
}, "fifth"] 
```
#### How to verify -
Check the added tests in assert-test.js
1. Check out this branch 
2. `npm install`
3. mocha test/assert-test.js 

