### PR TITLE
Fix being able to spy Error

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -23,6 +23,7 @@ var valueToString = require("./util/core/value-to-string");
 var push = Array.prototype.push;
 var slice = Array.prototype.slice;
 var callId = 0;
+var ErrorConstructor = Error.prototype.constructor;
 
 function spy(object, property, types) {
     var descriptor, i, methodDesc;
@@ -207,7 +208,7 @@ var spyApi = {
 
         push.call(this.exceptions, exception);
         push.call(this.returnValues, returnValue);
-        var err = new Error();
+        var err = new ErrorConstructor();
         var stack = err.stack;
         if (!stack) {
             // PhantomJS does not serialize the stack trace until the error has been thrown:

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -280,6 +280,17 @@ describe("spy", function () {
         assert(spy.get.calledOnce);
     });
 
+    it("creates a spy for Error", function () {
+        var originalError = global.Error;
+        try {
+            assert(createSpy(global, "Error"));
+        } catch (e) {
+            // so test failure doesn't trickle down
+            global.Error = originalError;
+            referee.fail("Expected spy to be created");
+        }
+    });
+
     describe(".named", function () {
         it("sets displayName", function () {
             var spy = createSpy();


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
`node -e "require('sinon').spy(global, 'Error');"` caused a recursion.

#### Background (Problem in detail)  - optional
When simulating a PhantomJS/QtWebKit environment, Error's behave differently. To achieve this simulated environment when testing, Error could be stubbed.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `node -e "require('sinon').spy(global, 'Error');"`
Should return as expected, also see tests.

