### PR TITLE
Fix spying on *etter methods

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -31,11 +31,15 @@
             }
 
             if (types) {
+                // A new descriptor is needed here because we can only wrap functions
+                // By passing the original descriptor we would end up trying to spy non-function properties
+                var descriptor = {};
                 var methodDesc = sinon.getPropertyDescriptor(object, property);
+
                 for (var i = 0; i < types.length; i++) {
-                    methodDesc[types[i]] = spy.create(methodDesc[types[i]]);
+                    descriptor[types[i]] = spy.create(methodDesc[types[i]]);
                 }
-                return sinon.wrapMethod(object, property, methodDesc);
+                return sinon.wrapMethod(object, property, descriptor);
             }
 
             return sinon.wrapMethod(object, property, spy.create(object[property]));

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2226,6 +2226,34 @@
 
                 assert.equals(spy.length, 3);
             }
+        },
+
+        "getters and setters": {
+            "it is possible to spy getters": function () {
+                var object = {
+                    get myProperty() {
+                        return "fb41a645-24fb-4580-b4c0-17d71ecc1c74";
+                    }
+                };
+
+                var descriptor = sinon.spy(object, "myProperty", ["get"]);
+                var value = object.myProperty; // eslint-disable-line no-unused-vars
+
+                assert.equals(descriptor.get.callCount, 1);
+            }
+        },
+
+        "it is possible to spy setters": function () {
+            var object = { // eslint-disable-line accessor-pairs
+                set myProperty(val) {
+                    this.otherProperty = val * 2;
+                }
+            };
+
+            var descriptor = sinon.spy(object, "myProperty", ["set"]);
+            object.myProperty = 10; // eslint-disable-line no-unused-vars
+
+            assert.equals(descriptor.set.callCount, 1);
         }
     });
 }(this));

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1796,6 +1796,47 @@
 
                 assert.equals(stub.length, 3);
             }
+        },
+
+        "getters and setters": {
+            "it is possible to stub getters": function () {
+                var object = {
+                    get myProperty() {
+                        return "4fb82903-6222-45e4-bfeb-a536bfc9734a";
+                    }
+                };
+
+                function fakeGet() {
+                    return "faked myProperty";
+                }
+
+                var descriptor = sinon.stub(object, "myProperty", {
+                    get: fakeGet
+                });
+
+                assert.equals(object.myProperty, "faked myProperty");
+                assert.equals(descriptor.get.callCount, 1);
+            },
+
+            "it is possible to stub setters": function () {
+                var object = { // eslint-disable-line accessor-pairs
+                    set myProperty(val) {
+                        this.otherProperty = val * 2;
+                    }
+                };
+
+                function fakeSet() {
+                    this.otherProperty = "faked myProperty";
+                }
+
+                var descriptor = sinon.stub(object, "myProperty", { // eslint-disable-line accessor-pairs
+                    set: fakeSet
+                });
+
+                object.myProperty = 5;
+                assert.equals(object.otherProperty, "faked myProperty");
+                assert.equals(descriptor.set.callCount, 1);
+            }
         }
     });
 }(this));


### PR DESCRIPTION
#### Purpose (TL;DR)
This PR aims to fix #1018 on `v1.17`.
Basically I just needed to pass a new descriptor with only the property from the propDescriptor which is going to be spied on.
I also added tests to prove both stubbing and spying work as @mroderick did on the issue itself.

#### Background (Problem in detail)
The problem happened because the property descriptor being passed to be spied on had non-function property values (because it was a complete property descriptor taken from that property) and then that caused an error.

#### Solution
As I've said above I just needed to passa a property descriptor with only the property which was going to be spied instead of the whole property descriptor

#### How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm run test` -> This will run the new tests I've added

--------------------------------------------

Thanks for the awesome work you have been doing on Sinon, I'm looking forward to contribute more with you, please let me know if you need anything!

**I've read the contribution guidelines but I'm not sure this PR meets your commit/coding patterns, please let me know if I've done anything wrong or missed anything and I'll happily fix it**. You rock ❤️  

EDIT: The build seems to be failing on CI for an unknown reason. I've read the log and I think it might be related to Travis itself and not this PR. Do you have any idea why this is happening?