### PR TITLE
Replace `stub(o, 'm', fn)` with `stub(o, 'm').callsFake(fn)`

### DIFF
--- a/docs/api/v2.0.0/stubs/index.md
+++ b/docs/api/v2.0.0/stubs/index.md
@@ -75,12 +75,6 @@ Replaces `object.method` with a stub function. An exception is thrown if the pro
 
 The original function can be restored by calling `object.method.restore();` (or `stub.restore();`).
 
-#### `var stub = sinon.stub(object, \"method\", func);`
-
-Replaces `object.method` with a `func`, wrapped in a `spy`.
-
-As usual, `object.method.restore();` can be used to restore the original method.
-
 #### `var stub = sinon.stub(object, \"property\", fakeDescriptor);`
 
 Replaces the getter/setter of `property` on `object` with stubs created from the fake methods passed in `fakeDescriptor` argument.
@@ -230,6 +224,9 @@ Causes the stub to throw an exception of the provided type.
 
 Causes the stub to throw the provided exception object.
 
+#### `stub.callsFake(fn);`
+
+Causes stub to call `fn` passing through orignal args and `this` value.
 
 #### `stub.callsArg(index);`
 

--- a/docs/current/migrating-to-2.0.md
+++ b/docs/current/migrating-to-2.0.md
@@ -22,6 +22,18 @@ var myFakeServer = sinon.fakeServer.create({
 ## sinon.test, sinon.testCase and sinon.config Removed
 `sinon.test` and `sinon.testCase` have been extracted from the Sinon API and moved into their own node module, [sinon-test](https://www.npmjs.com/package/sinon-test). Please refer to the [sinon-test README](https://github.com/sinonjs/sinon-test/blob/master/README.md) for migration examples.
 
+## stub.callsFake replaces stub(obj, 'meth', fn)
+`sinon.stub(obj, 'meth', fn)` return a spy, not a full stub. Behavior could not be redefined. `stub.callsFake`
+now returns a full stub. Here's a [codemod script](https://github.com/hurrymaplelad/sinon-codemod) to help you migrate.
+See [discussion](https://github.com/sinonjs/sinon/pull/823).
+
+```js
+// Old
+sinon.stub(obj, 'meth', fn);
+// New
+sinon.stub(obj, 'meth').callsFake(fn);
+```
+
 ## Deprecation of internal helpers
 The following utility functions are being marked as deprecated and are planned for removal in Sinon v3.0; please check your codebase for usage to ease future migrations:
 
@@ -45,4 +57,3 @@ The following utility functions are being marked as deprecated and are planned f
 * `sinon.ProgressEvent`
 * `sinon.typeOf`
 * `sinon.extend`
-

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -133,6 +133,7 @@ var proto = {
                 this.exception ||
                 typeof this.returnArgAt === "number" ||
                 this.returnThis ||
+                this.fakeFn ||
                 this.returnValueDefined);
     },
 
@@ -145,8 +146,9 @@ var proto = {
             return args[this.returnArgAt];
         } else if (this.returnThis) {
             return context;
+        } else if (this.fakeFn) {
+            return this.fakeFn.apply(context, args);
         }
-
         return this.returnValue;
     },
 
@@ -172,6 +174,11 @@ var proto = {
             "is not supported. Use \"stub.withArgs(...).onCall(...)\" " +
             "to define sequential behavior for calls with certain arguments."
         );
+    },
+
+    callsFake: function callsFake(fn) {
+        this.fakeFn = fn;
+        return this;
     },
 
     callsArg: function callsArg(pos) {
@@ -287,6 +294,7 @@ var proto = {
         this.returnValue = value;
         this.returnValueDefined = true;
         this.exception = undefined;
+        this.fakeFn = undefined;
 
         return this;
     },

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -15,15 +15,21 @@ var walk = require("./util/core/walk");
 var objectKeys = require("./util/core/object-keys");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var createInstance = require("./util/core/create");
+var deprecated = require("./util/core/deprecated");
 var functionToString = require("./util/core/function-to-string");
 var valueToString = require("./util/core/value-to-string");
 var wrapMethod = require("./util/core/wrap-method");
 
 function stub(object, property, descriptor) {
     if (!!descriptor && typeof descriptor === "function") {
-        throw new Error("stub(obj, 'meth', fn) is no longer supported. Use stub(obj, 'meth').callsFake(fn)");
+        deprecated.wrap(function () {},
+          "sinon.stub(obj, 'meth', fn) is deprecated and will be removed from" +
+          "the public API in a future version of sinon." +
+          "\n Use stub(obj, 'meth').callsFake(fn)." +
+          "\n Codemod available at https://github.com/hurrymaplelad/sinon-codemod"
+        )();
     }
-    if (!!descriptor && typeof descriptor !== "object") {
+    if (!!descriptor && typeof descriptor !== "function" && typeof descriptor !== "object") {
         throw new TypeError("Custom stub should be a property descriptor");
     }
 
@@ -37,13 +43,16 @@ function stub(object, property, descriptor) {
     }
 
     var wrapper;
-
     if (descriptor) {
-        wrapper = descriptor;
-        if (spy && spy.create) {
-            var types = objectKeys(wrapper);
-            for (var i = 0; i < types.length; i++) {
-                wrapper[types[i]] = spy.create(wrapper[types[i]]);
+        if (typeof descriptor === "function") {
+            wrapper = spy && spy.create ? spy.create(descriptor) : descriptor;
+        } else {
+            wrapper = descriptor;
+            if (spy && spy.create) {
+                var types = objectKeys(wrapper);
+                for (var i = 0; i < types.length; i++) {
+                    wrapper[types[i]] = spy.create(wrapper[types[i]]);
+                }
             }
         }
     } else {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -19,12 +19,15 @@ var functionToString = require("./util/core/function-to-string");
 var valueToString = require("./util/core/value-to-string");
 var wrapMethod = require("./util/core/wrap-method");
 
-function stub(object, property, funcOrDescriptor) {
-    if (!!funcOrDescriptor && typeof funcOrDescriptor !== "function" && typeof funcOrDescriptor !== "object") {
-        throw new TypeError("Custom stub should be a function or a property descriptor");
+function stub(object, property, descriptor) {
+    if (!!descriptor && typeof descriptor === "function") {
+        throw new Error("stub(obj, 'meth', fn) is no longer supported. Use stub(obj, 'meth').callsFake(fn)");
+    }
+    if (!!descriptor && typeof descriptor !== "object") {
+        throw new TypeError("Custom stub should be a property descriptor");
     }
 
-    if (typeof funcOrDescriptor === "object" && objectKeys(funcOrDescriptor).length === 0) {
+    if (typeof descriptor === "object" && objectKeys(descriptor).length === 0) {
         throw new TypeError("Expected property descriptor to have at least one key");
     }
 
@@ -35,16 +38,12 @@ function stub(object, property, funcOrDescriptor) {
 
     var wrapper;
 
-    if (funcOrDescriptor) {
-        if (typeof funcOrDescriptor === "function") {
-            wrapper = spy && spy.create ? spy.create(funcOrDescriptor) : funcOrDescriptor;
-        } else {
-            wrapper = funcOrDescriptor;
-            if (spy && spy.create) {
-                var types = objectKeys(wrapper);
-                for (var i = 0; i < types.length; i++) {
-                    wrapper[types[i]] = spy.create(wrapper[types[i]]);
-                }
+    if (descriptor) {
+        wrapper = descriptor;
+        if (spy && spy.create) {
+            var types = objectKeys(wrapper);
+            for (var i = 0; i < types.length; i++) {
+                wrapper[types[i]] = spy.create(wrapper[types[i]]);
             }
         }
     } else {
@@ -134,6 +133,7 @@ var proto = {
 
         delete this.returnValue;
         delete this.returnArgAt;
+        delete this.fakeFn;
         this.returnThis = false;
 
         if (this.fakes) {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -22,12 +22,12 @@ var wrapMethod = require("./util/core/wrap-method");
 
 function stub(object, property, descriptor) {
     if (!!descriptor && typeof descriptor === "function") {
-        deprecated.wrap(function () {},
+        deprecated.printWarning(
           "sinon.stub(obj, 'meth', fn) is deprecated and will be removed from" +
           "the public API in a future version of sinon." +
           "\n Use stub(obj, 'meth').callsFake(fn)." +
           "\n Codemod available at https://github.com/hurrymaplelad/sinon-codemod"
-        )();
+        );
     }
     if (!!descriptor && typeof descriptor !== "function" && typeof descriptor !== "object") {
         throw new TypeError("Custom stub should be a property descriptor");

--- a/lib/sinon/util/core/deprecated.js
+++ b/lib/sinon/util/core/deprecated.js
@@ -5,14 +5,7 @@
 // time it is called.
 exports.wrap = function (func, msg) {
     var wrapped = function () {
-        // Watch out for IE7 and below! :(
-        if (typeof console !== "undefined") {
-            if (console.info) {
-                console.info(msg);
-            } else {
-                console.log(msg);
-            }
-        }
+        exports.printWarning(msg);
         return func.apply(this, arguments);
     };
     if (func.prototype) {
@@ -25,4 +18,15 @@ exports.wrap = function (func, msg) {
 // sinon API has been deprecated.
 exports.defaultMsg = function (funcName) {
     return "sinon." + funcName + " is deprecated and will be removed from the public API in a future version of sinon.";
+};
+
+exports.printWarning = function (msg) {
+    // Watch out for IE7 and below! :(
+    if (typeof console !== "undefined") {
+        if (console.info) {
+            console.info(msg);
+        } else {
+            console.log(msg);
+        }
+    }
 };

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -598,11 +598,17 @@ describe("stub", function () {
             */
         });
 
-        it("throws provided function as stub, recommending callsFake instead", function () {
-            var object = this.object;
-            assert.exception(function () {
-                createStub(object, "method", function () {});
-            }, /callsFake/);
+        it("warns provided function as stub, recommending callsFake instead", function () {
+            var called = false;
+            var infoStub = createStub(console, "info");
+            var stub = createStub(this.object, "method", function () {
+                called = true;
+            });
+
+            stub();
+
+            assert(called);
+            assert(infoStub.called);
         });
 
         it("throws if third argument is provided but not a proprety descriptor", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Replace
```
var stub = sinon.stub(foo, 'bar', myCustomFunc); // does not return a real stub
```
with
```
var stub = sinon.stub(foo, 'bar').callsFake(myCustomFunc); // returns a real stub
```
as discussed [here](https://github.com/sinonjs/sinon/pull/823).

#### Background (Problem in detail)  - optional
Discussed [here](https://github.com/sinonjs/sinon/pull/823).

#### Solution  - optional
Adds a new `callsFake()` behavior, stashed on the internal field `fakeFn` of stubs.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
