### PR TITLE
Array matchers

### DIFF
--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -14,6 +14,9 @@ var functionName = require("./util/core/function-name");
 var typeOf = require("./typeOf");
 var valueToString = require("./util/core/value-to-string");
 
+var every = Array.prototype.every;
+var arrayToString = Array.prototype.toString;
+
 function assertType(value, type, name) {
     var actual = typeOf(value);
     if (actual !== type) {
@@ -225,11 +228,12 @@ match.array = match.typeOf("array");
 
 match.array.deepEquals = function (expectation) {
     return match(function (actual) {
-        // Comparing the length of both is the fastest way to spot a difference before iterating through every item
-        return actual.length === expectation.length && actual.every(function (element, index) {
+        // Comparing lengths is the fastest way to spot a difference before iterating through every item
+        var sameLength = actual.length === expectation.length;
+        return sameLength && every.call(actual, function (element, index) {
             return expectation[index] === element;
         });
-    }, "deepEquals([" + Array.prototype.toString.call(expectation) + "])");
+    }, "deepEquals([" + arrayToString.call(expectation) + "])");
 };
 
 match.array.startsWith = function (expectation) {
@@ -259,6 +263,8 @@ match.array.contains = function (expectation) {
     }, "contains([" + Array.prototype.toString.call(expectation) + "])");
 };
 
+=======
+>>>>>>> Add deepEquals array matcher
 match.bool = match.typeOf("boolean");
 match.number = match.typeOf("number");
 match.string = match.typeOf("string");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -238,33 +238,12 @@ match.array.deepEquals = function (expectation) {
 
 match.array.startsWith = function (expectation) {
     return match(function (actual) {
-        return expectation.every(function (expectedElement, index) {
+        return every.call(expectation, function (expectedElement, index) {
             return actual[index] === expectedElement;
         });
-    }, "startsWith([" + Array.prototype.toString.call(expectation) + "])");
+    }, "startsWith([" + arrayToString.call(expectation) + "])");
 };
 
-match.array.endsWith = function (expectation) {
-    return match(function (actual) {
-        // This indicates the index in which we should start matching
-        var offset = actual.length - expectation.length;
-
-        return expectation.every(function (expectedElement, index) {
-            return actual[offset + index] === expectedElement;
-        });
-    }, "endsWith([" + Array.prototype.toString.call(expectation) + "])");
-};
-
-match.array.contains = function (expectation) {
-    return match(function (actual) {
-        return expectation.every(function (expectedElement) {
-            return actual.indexOf(expectedElement) !== -1;
-        });
-    }, "contains([" + Array.prototype.toString.call(expectation) + "])");
-};
-
-=======
->>>>>>> Add deepEquals array matcher
 match.bool = match.typeOf("boolean");
 match.number = match.typeOf("number");
 match.string = match.typeOf("string");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -15,6 +15,7 @@ var typeOf = require("./typeOf");
 var valueToString = require("./util/core/value-to-string");
 
 var every = Array.prototype.every;
+var indexOf = Array.prototype.indexOf;
 var arrayToString = Array.prototype.toString;
 
 function assertType(value, type, name) {
@@ -253,6 +254,14 @@ match.array.endsWith = function (expectation) {
             return actual[offset + index] === expectedElement;
         });
     }, "endsWith([" + arrayToString.call(expectation) + "])");
+};
+
+match.array.contains = function (expectation) {
+    return match(function (actual) {
+        return every.call(expectation, function (expectedElement) {
+            return indexOf.call(actual, expectedElement) !== -1;
+        });
+    }, "contains([" + arrayToString.call(expectation) + "])");
 };
 
 match.bool = match.typeOf("boolean");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -221,12 +221,49 @@ match.hasOwn = createPropertyMatcher(function (actual, property) {
     return actual.hasOwnProperty(property);
 }, "hasOwn");
 
+match.array = match.typeOf("array");
+
+match.array.deepEquals = function (expectation) {
+    return match(function (actual) {
+        // Comparing the length of both is the fastest way to spot a difference before iterating through every item
+        return actual.length === expectation.length && actual.every(function (element, index) {
+            return expectation[index] === element;
+        });
+    }, "deepEquals([" + Array.prototype.toString.call(expectation) + "])");
+};
+
+match.array.startsWith = function (expectation) {
+    return match(function (actual) {
+        return expectation.every(function (expectedElement, index) {
+            return actual[index] === expectedElement;
+        });
+    }, "startsWith([" + Array.prototype.toString.call(expectation) + "])");
+};
+
+match.array.endsWith = function (expectation) {
+    return match(function (actual) {
+        // This indicates the index in which we should start matching
+        var offset = actual.length - expectation.length;
+
+        return expectation.every(function (expectedElement, index) {
+            return actual[offset + index] === expectedElement;
+        });
+    }, "endsWith([" + Array.prototype.toString.call(expectation) + "])");
+};
+
+match.array.contains = function (expectation) {
+    return match(function (actual) {
+        return expectation.every(function (expectedElement) {
+            return actual.indexOf(expectedElement) !== -1;
+        });
+    }, "contains([" + Array.prototype.toString.call(expectation) + "])");
+};
+
 match.bool = match.typeOf("boolean");
 match.number = match.typeOf("number");
 match.string = match.typeOf("string");
 match.object = match.typeOf("object");
 match.func = match.typeOf("function");
-match.array = match.typeOf("array");
 match.regexp = match.typeOf("regexp");
 match.date = match.typeOf("date");
 match.symbol = match.typeOf("symbol");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -244,6 +244,17 @@ match.array.startsWith = function (expectation) {
     }, "startsWith([" + arrayToString.call(expectation) + "])");
 };
 
+match.array.endsWith = function (expectation) {
+    return match(function (actual) {
+        // This indicates the index in which we should start matching
+        var offset = actual.length - expectation.length;
+
+        return every.call(expectation, function (expectedElement, index) {
+            return actual[offset + index] === expectedElement;
+        });
+    }, "endsWith([" + arrayToString.call(expectation) + "])");
+};
+
 match.bool = match.typeOf("boolean");
 match.number = match.typeOf("number");
 match.string = match.typeOf("string");

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -671,6 +671,22 @@ describe("sinonMatch", function () {
                 assert.isFalse(sinonMatch.array.endsWith([3]).test([1, 2]));
             });
         });
+
+        describe("array.contains", function () {
+            it("has a .contains matcher", function () {
+                var contains = sinonMatch.array.contains([2, 3]);
+
+                assert(sinonMatch.isMatcher(contains));
+                assert.equals(contains.toString(), "contains([2,3])");
+            });
+
+            it("matches arrays containing all the expected elements", function () {
+                assert(sinonMatch.array.contains([2]).test([1, 2, 3]));
+                assert(sinonMatch.array.contains([1, 2]).test([1, 2]));
+                assert.isFalse(sinonMatch.array.contains([1, 2, 3]).test([1, 2]));
+                assert.isFalse(sinonMatch.array.contains([3]).test([1, 2]));
+            });
+        });
     });
 
     describe(".regexp", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -623,6 +623,70 @@ describe("sinonMatch", function () {
             assert(sinonMatch.isMatcher(array));
             assert.equals(array.toString(), "typeOf(\"array\")");
         });
+
+        describe("array.deepEquals", function () {
+            it("has a .deepEquals matcher", function () {
+                var deepEquals = sinonMatch.array.deepEquals([1, 2, 3]);
+
+                assert(sinonMatch.isMatcher(deepEquals));
+                assert.equals(deepEquals.toString(), "deepEquals([1,2,3])");
+            });
+
+            it("matches arrays with the same elements", function () {
+                var deepEquals = sinonMatch.array.deepEquals([1, 2, 3]);
+                assert(deepEquals.test([1, 2, 3]));
+                assert(!deepEquals.test([1, 2]));
+                assert(!deepEquals.test([3]));
+            });
+        });
+
+        describe("array.startsWith", function () {
+            it("has a .startsWith matcher", function () {
+                var startsWith = sinonMatch.array.startsWith([1, 2]);
+
+                assert(sinonMatch.isMatcher(startsWith));
+                assert.equals(startsWith.toString(), "startsWith([1,2])");
+            });
+
+            it("matches arrays starting with the same elements", function () {
+                assert(sinonMatch.array.startsWith([1]).test([1, 2]));
+                assert(sinonMatch.array.startsWith([1, 2]).test([1, 2]));
+                assert(!sinonMatch.array.startsWith([1, 2, 3]).test([1, 2]));
+                assert(!sinonMatch.array.startsWith([2]).test([1, 2]));
+            });
+        });
+
+        describe("array.endsWith", function () {
+            it("has an .endsWith matcher", function () {
+                var endsWith = sinonMatch.array.endsWith([2, 3]);
+
+                assert(sinonMatch.isMatcher(endsWith));
+                assert.equals(endsWith.toString(), "endsWith([2,3])");
+            });
+
+            it("matches arrays ending with the same elements", function () {
+                assert(sinonMatch.array.endsWith([2]).test([1, 2]));
+                assert(sinonMatch.array.endsWith([1, 2]).test([1, 2]));
+                assert(!sinonMatch.array.endsWith([1, 2, 3]).test([1, 2]));
+                assert(!sinonMatch.array.endsWith([3]).test([1, 2]));
+            });
+        });
+
+        describe("array.contains", function () {
+            it("has a .contains matcher", function () {
+                var contains = sinonMatch.array.contains([2, 3]);
+
+                assert(sinonMatch.isMatcher(contains));
+                assert.equals(contains.toString(), "contains([2,3])");
+            });
+
+            it("matches arrays ending with the same elements", function () {
+                assert(sinonMatch.array.contains([2]).test([1, 2, 3]));
+                assert(sinonMatch.array.contains([1, 2]).test([1, 2]));
+                assert(!sinonMatch.array.contains([1, 2, 3]).test([1, 2]));
+                assert(!sinonMatch.array.contains([3]).test([1, 2]));
+            });
+        });
     });
 
     describe(".regexp", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -632,11 +632,11 @@ describe("sinonMatch", function () {
                 assert.equals(deepEquals.toString(), "deepEquals([1,2,3])");
             });
 
-            it("matches arrays with the same elements", function () {
+            it("matches arrays with the exact same elements", function () {
                 var deepEquals = sinonMatch.array.deepEquals([1, 2, 3]);
                 assert(deepEquals.test([1, 2, 3]));
-                assert(!deepEquals.test([1, 2]));
-                assert(!deepEquals.test([3]));
+                assert.isFalse(deepEquals.test([1, 2]));
+                assert.isFalse(deepEquals.test([3]));
             });
         });
 
@@ -687,6 +687,8 @@ describe("sinonMatch", function () {
                 assert(!sinonMatch.array.contains([3]).test([1, 2]));
             });
         });
+=======
+>>>>>>> Add deepEquals array matcher
     });
 
     describe(".regexp", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -651,44 +651,10 @@ describe("sinonMatch", function () {
             it("matches arrays starting with the same elements", function () {
                 assert(sinonMatch.array.startsWith([1]).test([1, 2]));
                 assert(sinonMatch.array.startsWith([1, 2]).test([1, 2]));
-                assert(!sinonMatch.array.startsWith([1, 2, 3]).test([1, 2]));
-                assert(!sinonMatch.array.startsWith([2]).test([1, 2]));
+                assert.isFalse(sinonMatch.array.startsWith([1, 2, 3]).test([1, 2]));
+                assert.isFalse(sinonMatch.array.startsWith([2]).test([1, 2]));
             });
         });
-
-        describe("array.endsWith", function () {
-            it("has an .endsWith matcher", function () {
-                var endsWith = sinonMatch.array.endsWith([2, 3]);
-
-                assert(sinonMatch.isMatcher(endsWith));
-                assert.equals(endsWith.toString(), "endsWith([2,3])");
-            });
-
-            it("matches arrays ending with the same elements", function () {
-                assert(sinonMatch.array.endsWith([2]).test([1, 2]));
-                assert(sinonMatch.array.endsWith([1, 2]).test([1, 2]));
-                assert(!sinonMatch.array.endsWith([1, 2, 3]).test([1, 2]));
-                assert(!sinonMatch.array.endsWith([3]).test([1, 2]));
-            });
-        });
-
-        describe("array.contains", function () {
-            it("has a .contains matcher", function () {
-                var contains = sinonMatch.array.contains([2, 3]);
-
-                assert(sinonMatch.isMatcher(contains));
-                assert.equals(contains.toString(), "contains([2,3])");
-            });
-
-            it("matches arrays ending with the same elements", function () {
-                assert(sinonMatch.array.contains([2]).test([1, 2, 3]));
-                assert(sinonMatch.array.contains([1, 2]).test([1, 2]));
-                assert(!sinonMatch.array.contains([1, 2, 3]).test([1, 2]));
-                assert(!sinonMatch.array.contains([3]).test([1, 2]));
-            });
-        });
-=======
->>>>>>> Add deepEquals array matcher
     });
 
     describe(".regexp", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -655,6 +655,22 @@ describe("sinonMatch", function () {
                 assert.isFalse(sinonMatch.array.startsWith([2]).test([1, 2]));
             });
         });
+
+        describe("array.endsWith", function () {
+            it("has an .endsWith matcher", function () {
+                var endsWith = sinonMatch.array.endsWith([2, 3]);
+
+                assert(sinonMatch.isMatcher(endsWith));
+                assert.equals(endsWith.toString(), "endsWith([2,3])");
+            });
+
+            it("matches arrays ending with the same elements", function () {
+                assert(sinonMatch.array.endsWith([2]).test([1, 2]));
+                assert(sinonMatch.array.endsWith([1, 2]).test([1, 2]));
+                assert.isFalse(sinonMatch.array.endsWith([1, 2, 3]).test([1, 2]));
+                assert.isFalse(sinonMatch.array.endsWith([3]).test([1, 2]));
+            });
+        });
     });
 
     describe(".regexp", function () {


### PR DESCRIPTION
#### Purpose (TL;DR)
This adds the following array matchers as indicated by @mroderick at #1113:

> * `match.array.equals()`: matches when the arrays are equal (unstrict)
> * `match.array.startWith()`: matches sequence against start of array
> * `match.array.endsWith()`: matches sequence against end of array
> * `match.array.contains()`: matches sequence anywhere in the array

The `equals` matcher has also been renamed to `deepEquals`, because as @fearphage suggested the `deepEquals` name is more explicit since we're not doing a `strict` comparison between array elements.

#### Solution

I added a new matcher for each one of the suggested items and tests for each one of them too.

Here go a few considerations about the implementation:

* At the [deepEquals](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:array-matchers?expand=1#diff-562e004061f0ab49a70d3728469de642R229) matcher I've added a `length` check to avoid iterating through array items in case they don't have the same length. This makes it faster to spot differences in most cases and also allows me to iterate through every item in `actual` later to finish the check
* At the [endsWith](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:array-matchers?expand=1#diff-562e004061f0ab49a70d3728469de642R246) matcher I've used an offset in order to know from where we should start comparing items in order to match the last items in the `actual` array. I've added a comment to make that clear but let me know if you think that comment is unnecessary
* At the [contains](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:array-matchers?expand=1#diff-562e004061f0ab49a70d3728469de642R254) matcher I'm using a simple `indexOf` call to find items into the `actual` array. I thought about mapping the `actual` array's items using an object (`O(n)`) in order to traverse it only once since we would then be able to find each element by an `O(1)` factor. Since we would also have to traverse the whole `expectation` array I believe that would be `O(n * m)` where `n` is `actual`'s length and `m` is `expectation`'s length. Let me know if I said anything wrong or if I'm overthinking. I avoided that solution because I was not sure it would be too much over engineering.
* When creating a `message` for each one of the new matchers I've just used `<nameOfMatcher>([x,y,z])`, please let me know if you don't like that output format.
* I also invoked `Array.prototype`'s methods by using `call` to avoid incompatibilities with fake arrays or overwritten methods

#### How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm run test` will run the tests I added to `test/match-test.js`.

Please let me know if I missed anything or if you disagree with any of these changes and I'll be more than happy to fix this PR.

Thanks everyone for reading this. You rock, thanks for maintaining this awesome project ❤️ 