### PR TITLE
Avoid unnecessary empty stub creation

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -289,7 +289,7 @@ var spyApi = {
 
         var original = this;
         var fake = this.instantiateFake();
-        fake.matchingAguments = args;
+        fake.matchingArguments = args;
         fake.parent = this;
         push.call(this.fakes, fake);
 
@@ -313,7 +313,7 @@ var spyApi = {
     },
 
     matches: function (args, strict) {
-        var margs = this.matchingAguments;
+        var margs = this.matchingArguments;
 
         if (margs.length <= args.length &&
             deepEqual(margs, args.slice(0, margs.length))) {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -29,6 +29,10 @@ function stub(object, property, func) {
         throw new Error("Trying to stub property '" + valueToString(property) + "' of " + type);
     }
 
+    if (!object && typeof property === "undefined") {
+        return stub.create();
+    }
+
     var wrapper;
 
     if (func) {
@@ -49,10 +53,6 @@ function stub(object, property, func) {
             stubLength = object[property].length;
         }
         wrapper = stub.create(stubLength);
-    }
-
-    if (!object && typeof property === "undefined") {
-        return stub.create();
     }
 
     if (typeof property === "undefined" && typeof object === "object") {


### PR DESCRIPTION
#### Purpose (TL;DR)
While investigating #817 I found a little typo and I also found out that whenever we don't have neither an `object` nor a `property` we were still invoking `stub.create` unnecessarily due to the `else` clause of the `if (func)` statement.

#### Solution
In order to avoid that I moved the empty stub creation immediately before that `if` statement.

#### How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm run test` all tests will still be passing

Please let me know if I missed anything and therefore this improvement is not valid.