### PR TITLE
Add docs for new array matchers

### DIFF
--- a/docs/release-source/release/matchers.md
+++ b/docs/release-source/release/matchers.md
@@ -112,6 +112,26 @@ Requires the value to be a `Function`.
 Requires the value to be an `Array`.
 
 
+#### `sinon.match.array.deepEquals(arr)`
+
+Requires an `Array` to be deep equal another one.
+
+
+#### `sinon.match.array.startsWith(arr)`
+
+Requires an `Array` to start with the same values as another one.
+
+
+#### `sinon.match.array.endsWith(arr)`
+
+Requires an `Array` to end with the same values as another one.
+
+
+#### `sinon.match.array.contains(arr)`
+
+Requires an `Array` to contain each one of the values the given array has.
+
+
 #### `sinon.match.regexp"
 
 Requires the value to be a regular expression.

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -239,7 +239,7 @@ match.array.deepEquals = function (expectation) {
 
 match.array.startsWith = function (expectation) {
     return match(function (actual) {
-        return every.call(expectation, function (expectedElement, index) {
+        return typeOf(actual) === "array" && every.call(expectation, function (expectedElement, index) {
             return actual[index] === expectedElement;
         });
     }, "startsWith([" + arrayToString.call(expectation) + "])");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -250,7 +250,7 @@ match.array.endsWith = function (expectation) {
         // This indicates the index in which we should start matching
         var offset = actual.length - expectation.length;
 
-        return every.call(expectation, function (expectedElement, index) {
+        return typeOf(actual) === "array" && every.call(expectation, function (expectedElement, index) {
             return actual[offset + index] === expectedElement;
         });
     }, "endsWith([" + arrayToString.call(expectation) + "])");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -258,7 +258,7 @@ match.array.endsWith = function (expectation) {
 
 match.array.contains = function (expectation) {
     return match(function (actual) {
-        return every.call(expectation, function (expectedElement) {
+        return typeOf(actual) === "array" && every.call(expectation, function (expectedElement) {
             return indexOf.call(actual, expectedElement) !== -1;
         });
     }, "contains([" + arrayToString.call(expectation) + "])");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -231,7 +231,7 @@ match.array.deepEquals = function (expectation) {
     return match(function (actual) {
         // Comparing lengths is the fastest way to spot a difference before iterating through every item
         var sameLength = actual.length === expectation.length;
-        return sameLength && every.call(actual, function (element, index) {
+        return typeOf(actual) === "array" && sameLength && every.call(actual, function (element, index) {
             return expectation[index] === element;
         });
     }, "deepEquals([" + arrayToString.call(expectation) + "])");

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -638,6 +638,11 @@ describe("sinonMatch", function () {
                 assert.isFalse(deepEquals.test([1, 2]));
                 assert.isFalse(deepEquals.test([3]));
             });
+
+            it("fails when passed a non-array object", function () {
+                var deepEquals = sinonMatch.array.deepEquals(["one", "two", "three"]);
+                assert.isFalse(deepEquals.test({0: "one", 1: "two", 2: "three", length: 3}));
+            });
         });
 
         describe("array.startsWith", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -659,6 +659,11 @@ describe("sinonMatch", function () {
                 assert.isFalse(sinonMatch.array.startsWith([1, 2, 3]).test([1, 2]));
                 assert.isFalse(sinonMatch.array.startsWith([2]).test([1, 2]));
             });
+
+            it("fails when passed a non-array object", function () {
+                var startsWith = sinonMatch.array.startsWith(["one", "two"]);
+                assert.isFalse(startsWith.test({0: "one", 1: "two", 2: "three", length: 3}));
+            });
         });
 
         describe("array.endsWith", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -702,6 +702,12 @@ describe("sinonMatch", function () {
                 assert.isFalse(sinonMatch.array.contains([1, 2, 3]).test([1, 2]));
                 assert.isFalse(sinonMatch.array.contains([3]).test([1, 2]));
             });
+
+            it("fails when passed a non-array object", function () {
+                var contains = sinonMatch.array.contains(["one", "three"]);
+
+                assert.isFalse(contains.test({0: "one", 1: "two", 2: "three", length: 3}));
+            });
         });
     });
 

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -680,6 +680,12 @@ describe("sinonMatch", function () {
                 assert.isFalse(sinonMatch.array.endsWith([1, 2, 3]).test([1, 2]));
                 assert.isFalse(sinonMatch.array.endsWith([3]).test([1, 2]));
             });
+
+            it("fails when passed a non-array object", function () {
+                var endsWith = sinonMatch.array.endsWith(["two", "three"]);
+
+                assert.isFalse(endsWith.test({0: "one", 1: "two", 2: "three", length: 3}));
+            });
         });
 
         describe("array.contains", function () {


### PR DESCRIPTION
#### Purpose (TL;DR)

This aims to add docs for each one of the changes made at #1208 (which adds new Array Matchers).

#### Solution

I've read [the `CONTRIBUTING.md` file in the `docs` folder](https://github.com/sinonjs/sinon/blob/master/docs/CONTRIBUTING.md) and I think this is the correct place to add the new docs, but I'm not 100% sure, so please correct me if I'm wrong and I'll add these pieces of information to the right place.

Also, I'm not a native english speaker so please let me know if you find any spelling/grammar mistakes. It would be much appreciated 😄 

PS: I've made this in a single commit, but I can split it up into multiple commits, one for each matcher, if you find it to be better.

#### How to verify

1. Check out this branch (see github instructions below)
2. Go to the docs folder by running `cd docs` on Sinon's root folder
3. Ensure you have bundler by running `gem install bundler`
4. Install dependencies by running `bundle install`
5. Run a local server by running `bundle exec jekyll serve`
6. Go to `http://localhost:4000/releases/v2.0.0-pre.4/matchers/` and check the new docs
