### PR TITLE
Add .resolves and .rejects to stub

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -12,6 +12,7 @@
 var extend = require("./extend");
 var functionName = require("./util/core/function-name");
 var valueToString = require("./util/core/value-to-string");
+var Promise = require("native-promise-only");
 
 var slice = Array.prototype.slice;
 var join = Array.prototype.join;

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -313,6 +313,33 @@ var proto = {
         this.returnThis = true;
 
         return this;
+    },
+
+    resolves: function resolves(value) {
+        this.returnValue = Promise.resolve(value);
+        this.returnValueDefined = true;
+        this.exception = undefined;
+        this.fakeFn = undefined;
+
+        return this;
+    },
+
+    rejects: function rejects(error, message) {
+        var reason;
+        if (typeof error === "string") {
+            reason = new Error(message || "");
+            reason.name = error;
+        } else if (!error) {
+            reason = new Error("Error");
+        } else {
+            reason = error;
+        }
+        this.returnValue = Promise.reject(reason);
+        this.returnValueDefined = true;
+        this.exception = undefined;
+        this.fakeFn = undefined;
+
+        return this;
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "diff": "^3.1.0",
     "formatio": "1.1.1",
     "lolex": "^1.4.0",
+    "native-promise-only": "^0.8.1",
     "path-to-regexp": "^1.7.0",
     "samsam": "^1.1.3",
     "text-encoding": "0.5.2"

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -130,7 +130,7 @@ describe("stub", function () {
             });
         });
 
-        it("should return stub", function () {
+        it("should return the same stub", function () {
             var stub = createStub.create();
 
             assert.same(stub.resolves(""), stub);
@@ -166,7 +166,7 @@ describe("stub", function () {
             });
         });
 
-        it("returns stub", function () {
+        it("should return the same stub", function () {
             var stub = createStub.create();
 
             assert.same(stub.rejects({}), stub);

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -119,6 +119,94 @@ describe("stub", function () {
         });
     });
 
+    describe(".resolves", function () {
+        it("returns a promise to the specified value", function () {
+            var stub = createStub.create();
+            var object = {};
+            stub.resolves(object);
+
+            return stub().then(function (actual) {
+                assert.same(actual, object);
+            });
+        });
+
+        it("should return stub", function () {
+            var stub = createStub.create();
+
+            assert.same(stub.resolves(""), stub);
+        });
+
+        it("supersedes previous throws", function () {
+            var stub = createStub.create();
+            stub.throws().resolves(1);
+
+            refute.exception(function () {
+                stub();
+            });
+        });
+
+        it("supersedes previous rejects", function () {
+            var stub = createStub.create();
+            stub.rejects(Error("should be superseeded")).resolves(1);
+
+            return stub().then();
+        });
+    });
+
+    describe(".rejects", function () {
+        it("returns a promise which rejects for the specified reason", function () {
+            var stub = createStub.create();
+            var reason = new Error();
+            stub.rejects(reason);
+
+            return stub().then(function () {
+                referee.fail("this should not resolve");
+            }).catch(function (actual) {
+                assert.same(actual, reason);
+            });
+        });
+
+        it("returns stub", function () {
+            var stub = createStub.create();
+
+            assert.same(stub.rejects({}), stub);
+        });
+
+        it("specifies exception message", function () {
+            var stub = createStub.create();
+            var message = "Oh no!";
+            stub.rejects("Error", message);
+
+            return stub().then(function () {
+                referee.fail("Expected stub to reject");
+            }).catch(function (reason) {
+                assert.equals(reason.message, message);
+            });
+        });
+
+        it("does not specify exception message if not provided", function () {
+            var stub = createStub.create();
+            stub.rejects("Error");
+
+            return stub().then(function () {
+                referee.fail("Expected stub to reject");
+            }).catch(function (reason) {
+                assert.equals(reason.message, "");
+            });
+        });
+
+        it("rejects for a generic reason", function () {
+            var stub = createStub.create();
+            stub.rejects();
+
+            return stub().then(function () {
+                referee.fail("Expected stub to reject");
+            }).catch(function (reason) {
+                assert.equals(reason.name, "Error");
+            });
+        });
+    });
+
     describe(".returnsArg", function () {
         it("returns argument at specified index", function () {
             var stub = createStub.create();


### PR DESCRIPTION
#### Purpose (TL;DR)
This commit adds the possibility for a stub
to be configured to return a promise which will
either resolve or reject

#### Background (Problem in detail)
This was already possible, but this adds a shorthand for it

##### resolving
```javascript
stub.returns(Promise.resolve({}))`
```
becomes 
```javascript
stub.resolves({})
```

##### rejecting
```javascript
stub.returns(Promise.reject(new Error("bad luck")))
```
becomes
```javascript
stub.rejects("bad luck")
```

Since Promises are now part of the standard ES6 feature set, this
commit does not make use of polyfills or third party library.
This is problematic for some browsers and generally for contexts where
the standard is not implemented.
**EDIT** now it does.

#### Solution  - optional
This solution works by adding a `resolves` and `rejects` method to the possible behaviors.

#### How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
