### PR TITLE
Accept route DSLs

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -16,6 +16,7 @@ var sinon = require("../../sinon");
 var createInstance = require("./core/create");
 var format = require("./core/format");
 var configureLogError = require("./core/log_error");
+var pathToRegexp = require("path-to-regexp");
 
 function responseArray(handler) {
     var response = handler;
@@ -205,7 +206,7 @@ var fakeServer = {
 
         push.call(this.responses, {
             method: method,
-            url: url,
+            url: typeof url === "string" && url !== "" ? pathToRegexp(url) : url,
             response: typeof body === "function" ? body : responseArray(body)
         });
     },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "diff": "^3.1.0",
     "formatio": "1.1.1",
     "lolex": "^1.4.0",
+    "path-to-regexp": "^1.7.0",
     "samsam": "^1.1.3",
     "text-encoding": "0.5.2"
   },

--- a/test/util/fake-server-test.js
+++ b/test/util/fake-server-test.js
@@ -459,6 +459,34 @@ if (typeof window !== "undefined") {
                 assert.equals(xhr.respond.args[0], [200, {}, "Yep"]);
             });
 
+            it("accepts URLS which are common route DSLs", function () {
+                this.server.respondWith("/foo/*", [200, {}, "Yep"]);
+
+                var xhr = new FakeXMLHttpRequest();
+                xhr.respond = sinonSpy();
+                xhr.open("GET", "/foo/bla/boo", true);
+                xhr.send();
+
+                this.server.respond();
+
+                assert.equals(xhr.respond.args[0], [200, {}, "Yep"]);
+            });
+
+            it("yields URL capture groups to response handler when using DSLs", function () {
+                var handler = sinonSpy();
+                this.server.respondWith("GET", "/thing/:id", handler);
+
+                var xhr = new FakeXMLHttpRequest();
+                xhr.respond = sinonSpy();
+                xhr.open("GET", "/thing/1337", true);
+                xhr.send();
+
+                this.server.respond();
+
+                assert(handler.called);
+                assert.equals(handler.args[0], [xhr, "1337"]);
+            });
+
             it("throws understandable error if response is not a string", function () {
                 var error;
 


### PR DESCRIPTION
#### Purpose (TL;DR)

This pull request adds support for common route DSLs as requested in #1107.

In a nutshell, now we are able to do this:

* `server.respondWith('/books/:bookId/', ...)`
* `server.respondWith('/foo*', ...)`

#### Solution 

In order to solve this I've added the [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp) module as a dependency as suggested by @fatso83 to avoid reinventing the wheel and adding more code to maintain (I totally agree with it).

Then I always convert any non-empty strings to regular expressions using the `path-to-regexp` module.

Since it already deals with capture groups it worked right out of the box and the old tests still passed with zero changes.

I also added tests for both simple URL matching and for checking route parameters.

#### How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm run test-headless`

---------------------------------

I'd also like to thank @fatso83 for the help with the browser testing environment. Sorry for not noticing how it worked before 😅 

Let me know if I missed anything or if you disagree with the coding style or anything else and I'll happily fix it. Thanks for reading this.
