### PR TITLE
Added documentation for sinon.restore()

### DIFF
--- a/docs/_releases/v1.17.6/utils.md
+++ b/docs/_releases/v1.17.6/utils.md
@@ -8,6 +8,26 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
+#### `sinon.restore(object);`
+
+Restores all fake methods of supplied object
+
+```javascript
+    sinon.stub(obj);
+
+    // run tests...
+
+    sinon.restore(obj);
+```
+
+#### `sinon.restore(method);`
+
+Restores supplied method
+
+```javascript
+    sinon.restore(obj.someMethod);
+```
+
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v2.0.0-pre.4/utils.md
+++ b/docs/_releases/v2.0.0-pre.4/utils.md
@@ -8,6 +8,26 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
+#### `sinon.restore(object);`
+
+Restores all fake methods of supplied object
+
+```javascript
+    sinon.stub(obj);
+
+    // run tests...
+
+    sinon.restore(obj);
+```
+
+#### `sinon.restore(method);`
+
+Restores supplied method
+
+```javascript
+    sinon.restore(obj.someMethod);
+```
+
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/release-source/release/utils.md
+++ b/docs/release-source/release/utils.md
@@ -8,6 +8,26 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
+#### `sinon.restore(object);`
+
+Restores all fake methods of supplied object
+
+```javascript
+    sinon.stub(obj);
+
+    // run tests...
+
+    sinon.restore(obj);
+```
+
+#### `sinon.restore(method);`
+
+Restores supplied method
+
+```javascript
+    sinon.restore(obj.someMethod);
+```
+
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.


### PR DESCRIPTION
Fix issue #810 by adding docs for `sinon.restore()`

Couldn't find this in the docs, really need to be in there!

- Added in all 3 files, hope that's correct
- Not sure if I've added it to the right section
- Not sure if you want the examples