### PR TITLE
Maps matchers

### DIFF
--- a/docs/release-source/release/matchers.md
+++ b/docs/release-source/release/matchers.md
@@ -132,6 +132,21 @@ Requires an `Array` to end with the same values as another one.
 Requires an `Array` to contain each one of the values the given array has.
 
 
+#### `sinon.match.map"
+
+Requires the value to be a `Map`.
+
+
+#### `sinon.match.map.deepEquals(map)`
+
+Requires a `Map` to be deep equal another one.
+
+
+#### `sinon.match.map.contains(map)`
+
+Requires a `Map` to contain each one of the items the given map has.
+
+
 #### `sinon.match.regexp"
 
 Requires the value to be a regular expression.

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -264,6 +264,8 @@ match.array.contains = function (expectation) {
     }, "contains([" + iterableToString(expectation) + "])");
 };
 
+match.map = match.typeOf("map");
+
 match.bool = match.typeOf("boolean");
 match.number = match.typeOf("number");
 match.string = match.typeOf("string");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -12,11 +12,11 @@ var create = require("./util/core/create");
 var deepEqual = require("./util/core/deep-equal").use(match); // eslint-disable-line no-use-before-define
 var every = require("./util/core/every");
 var functionName = require("./util/core/function-name");
+var iterableToString = require("./util/core/iterable-to-string");
 var typeOf = require("./typeOf");
 var valueToString = require("./util/core/value-to-string");
 
 var indexOf = Array.prototype.indexOf;
-var arrayToString = Array.prototype.toString;
 
 function assertType(value, type, name) {
     var actual = typeOf(value);
@@ -234,7 +234,7 @@ match.array.deepEquals = function (expectation) {
         return typeOf(actual) === "array" && sameLength && every(actual, function (element, index) {
             return expectation[index] === element;
         });
-    }, "deepEquals([" + arrayToString.call(expectation) + "])");
+    }, "deepEquals([" + iterableToString(expectation) + "])");
 };
 
 match.array.startsWith = function (expectation) {
@@ -242,7 +242,7 @@ match.array.startsWith = function (expectation) {
         return typeOf(actual) === "array" && every(expectation, function (expectedElement, index) {
             return actual[index] === expectedElement;
         });
-    }, "startsWith([" + arrayToString.call(expectation) + "])");
+    }, "startsWith([" + iterableToString(expectation) + "])");
 };
 
 match.array.endsWith = function (expectation) {
@@ -253,7 +253,7 @@ match.array.endsWith = function (expectation) {
         return typeOf(actual) === "array" && every(expectation, function (expectedElement, index) {
             return actual[offset + index] === expectedElement;
         });
-    }, "endsWith([" + arrayToString.call(expectation) + "])");
+    }, "endsWith([" + iterableToString(expectation) + "])");
 };
 
 match.array.contains = function (expectation) {
@@ -261,7 +261,7 @@ match.array.contains = function (expectation) {
         return typeOf(actual) === "array" && every(expectation, function (expectedElement) {
             return indexOf.call(actual, expectedElement) !== -1;
         });
-    }, "contains([" + arrayToString.call(expectation) + "])");
+    }, "contains([" + iterableToString(expectation) + "])");
 };
 
 match.bool = match.typeOf("boolean");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -276,6 +276,14 @@ match.map.deepEquals = function mapDeepEquals(expectation) {
     }, "deepEquals(Map[" + iterableToString(expectation) + "])");
 };
 
+match.map.contains = function mapContains(expectation) {
+    return match(function (actual) {
+        return typeOf(actual) === "map" && every(expectation, function (element, key) {
+            return actual.has(key) && actual.get(key) === element;
+        });
+    }, "contains(Map[" + iterableToString(expectation) + "])");
+};
+
 match.bool = match.typeOf("boolean");
 match.number = match.typeOf("number");
 match.string = match.typeOf("string");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -10,11 +10,11 @@
 
 var create = require("./util/core/create");
 var deepEqual = require("./util/core/deep-equal").use(match); // eslint-disable-line no-use-before-define
+var every = require("./util/core/every");
 var functionName = require("./util/core/function-name");
 var typeOf = require("./typeOf");
 var valueToString = require("./util/core/value-to-string");
 
-var every = Array.prototype.every;
 var indexOf = Array.prototype.indexOf;
 var arrayToString = Array.prototype.toString;
 
@@ -231,7 +231,7 @@ match.array.deepEquals = function (expectation) {
     return match(function (actual) {
         // Comparing lengths is the fastest way to spot a difference before iterating through every item
         var sameLength = actual.length === expectation.length;
-        return typeOf(actual) === "array" && sameLength && every.call(actual, function (element, index) {
+        return typeOf(actual) === "array" && sameLength && every(actual, function (element, index) {
             return expectation[index] === element;
         });
     }, "deepEquals([" + arrayToString.call(expectation) + "])");
@@ -239,7 +239,7 @@ match.array.deepEquals = function (expectation) {
 
 match.array.startsWith = function (expectation) {
     return match(function (actual) {
-        return typeOf(actual) === "array" && every.call(expectation, function (expectedElement, index) {
+        return typeOf(actual) === "array" && every(expectation, function (expectedElement, index) {
             return actual[index] === expectedElement;
         });
     }, "startsWith([" + arrayToString.call(expectation) + "])");
@@ -250,7 +250,7 @@ match.array.endsWith = function (expectation) {
         // This indicates the index in which we should start matching
         var offset = actual.length - expectation.length;
 
-        return typeOf(actual) === "array" && every.call(expectation, function (expectedElement, index) {
+        return typeOf(actual) === "array" && every(expectation, function (expectedElement, index) {
             return actual[offset + index] === expectedElement;
         });
     }, "endsWith([" + arrayToString.call(expectation) + "])");
@@ -258,7 +258,7 @@ match.array.endsWith = function (expectation) {
 
 match.array.contains = function (expectation) {
     return match(function (actual) {
-        return typeOf(actual) === "array" && every.call(expectation, function (expectedElement) {
+        return typeOf(actual) === "array" && every(expectation, function (expectedElement) {
             return indexOf.call(actual, expectedElement) !== -1;
         });
     }, "contains([" + arrayToString.call(expectation) + "])");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -266,6 +266,16 @@ match.array.contains = function (expectation) {
 
 match.map = match.typeOf("map");
 
+match.map.deepEquals = function mapDeepEquals(expectation) {
+    return match(function (actual) {
+        // Comparing lengths is the fastest way to spot a difference before iterating through every item
+        var sameLength = actual.size === expectation.size;
+        return typeOf(actual) === "map" && sameLength && every(actual, function (element, key) {
+            return expectation.has(key) && expectation.get(key) === element;
+        });
+    }, "deepEquals(Map[" + iterableToString(expectation) + "])");
+};
+
 match.bool = match.typeOf("boolean");
 match.number = match.typeOf("number");
 match.string = match.typeOf("string");

--- a/lib/sinon/util/core/every.js
+++ b/lib/sinon/util/core/every.js
@@ -1,0 +1,19 @@
+"use strict";
+
+// This is an `every` implementation that works for all iterables
+module.exports = function every(obj, fn) {
+    var pass = true;
+
+    try {
+        obj.forEach(function () {
+            if (!fn.apply(this, arguments)) {
+                // Throwing an error is the only way to break `forEach`
+                throw new Error();
+            }
+        });
+    } catch (e) {
+        pass = false;
+    }
+
+    return pass;
+};

--- a/lib/sinon/util/core/index.js
+++ b/lib/sinon/util/core/index.js
@@ -22,6 +22,8 @@ exports.functionName = require("./function-name");
 
 exports.functionToString = require("./function-to-string");
 
+exports.iterableToString = require("./iterable-to-string");
+
 exports.objectKeys = require("./object-keys");
 
 exports.getPropertyDescriptor = require("./get-property-descriptor");

--- a/lib/sinon/util/core/index.js
+++ b/lib/sinon/util/core/index.js
@@ -14,6 +14,8 @@ exports.create = require("./create");
 
 exports.deepEqual = require("./deep-equal");
 
+exports.every = require("./every");
+
 exports.format = require("./format");
 
 exports.functionName = require("./function-name");

--- a/lib/sinon/util/core/iterable-to-string.js
+++ b/lib/sinon/util/core/iterable-to-string.js
@@ -1,0 +1,34 @@
+"use strict";
+var typeOf = require("../../typeOf");
+
+module.exports = function iterableToString(obj) {
+    var representation = "";
+
+    function stringify(item) {
+        return typeof item === "string" ? "'" + item + "'" : String(item);
+    }
+
+    function mapToString(map) {
+        map.forEach(function (value, key) {
+            representation += "[" + stringify(key) + "," + stringify(value) + "],";
+        });
+
+        representation = representation.slice(0, -1);
+        return representation;
+    }
+
+    function genericIterableToString(iterable) {
+        iterable.forEach(function (value) {
+            representation += stringify(value) + ",";
+        });
+
+        representation = representation.slice(0, -1);
+        return representation;
+    }
+
+    if (typeOf(obj) === "map") {
+        return mapToString(obj);
+    }
+
+    return genericIterableToString(obj);
+};

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -781,6 +781,71 @@ describe("sinonMatch", function () {
                 });
             }
         });
+
+        describe("map.contains", function () {
+            if (typeof Map === "function") {
+                it("has a .contains matcher", function () {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var contains = sinonMatch.map.contains(mapOne);
+                    assert(sinonMatch.isMatcher(contains));
+                    assert.equals(contains.toString(), "contains(Map[['one',1],['two',2],['three',3]])");
+                });
+
+                it("matches maps containing the given elements", function () {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var mapTwo = new Map();
+                    mapTwo.set("one", 1);
+                    mapTwo.set("two", 2);
+                    mapTwo.set("three", 3);
+
+                    var mapThree = new Map();
+                    mapThree.set("one", 1);
+                    mapThree.set("two", 2);
+
+                    var mapFour = new Map();
+                    mapFour.set("one", 1);
+                    mapFour.set("four", 4);
+
+                    assert(sinonMatch.map.contains(mapTwo).test(mapOne));
+                    assert(sinonMatch.map.contains(mapThree).test(mapOne));
+                    assert.isFalse(sinonMatch.map.contains(mapFour).test(mapOne));
+                });
+
+                it("fails when maps contain the same keys but different values", function () {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var mapTwo = new Map();
+                    mapTwo.set("one", 2);
+                    mapTwo.set("two", 4);
+                    mapTwo.set("three", 8);
+
+                    var mapThree = new Map();
+                    mapThree.set("one", 1);
+                    mapThree.set("two", 2);
+                    mapThree.set("three", 4);
+
+                    assert.isFalse(sinonMatch.map.contains(mapTwo).test(mapOne));
+                    assert.isFalse(sinonMatch.map.contains(mapThree).test(mapOne));
+                });
+
+                it("fails when passed a non-map object", function () {
+                    var contains = sinonMatch.map.contains(new Map());
+                    assert.isFalse(contains.test({}));
+                    assert.isFalse(contains.test([]));
+                });
+            }
+        });
     });
 
     describe(".regexp", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -718,6 +718,69 @@ describe("sinonMatch", function () {
             assert(sinonMatch.isMatcher(map));
             assert.equals(map.toString(), "typeOf(\"map\")");
         });
+
+        describe("map.deepEquals", function () {
+            if (typeof Map === "function") {
+                it("has a .deepEquals matcher", function () {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var deepEquals = sinonMatch.map.deepEquals(mapOne);
+                    assert(sinonMatch.isMatcher(deepEquals));
+                    assert.equals(deepEquals.toString(), "deepEquals(Map[['one',1],['two',2],['three',3]])");
+                });
+
+                it("matches maps with the exact same elements", function () {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var mapTwo = new Map();
+                    mapTwo.set("one", 1);
+                    mapTwo.set("two", 2);
+                    mapTwo.set("three", 3);
+
+                    var mapThree = new Map();
+                    mapThree.set("one", 1);
+                    mapThree.set("two", 2);
+
+                    var deepEquals = sinonMatch.map.deepEquals(mapOne);
+                    assert(deepEquals.test(mapTwo));
+                    assert.isFalse(deepEquals.test(mapThree));
+                    assert.isFalse(deepEquals.test(new Map()));
+                });
+
+                it("fails when maps have the same keys but different values", function () {
+                    var mapOne = new Map();
+                    mapOne.set("one", 1);
+                    mapOne.set("two", 2);
+                    mapOne.set("three", 3);
+
+                    var mapTwo = new Map();
+                    mapTwo.set("one", 2);
+                    mapTwo.set("two", 4);
+                    mapTwo.set("three", 8);
+
+                    var mapThree = new Map();
+                    mapTwo.set("one", 1);
+                    mapTwo.set("two", 2);
+                    mapTwo.set("three", 4);
+
+                    var deepEquals = sinonMatch.map.deepEquals(mapOne);
+                    assert.isFalse(deepEquals.test(mapTwo));
+                    assert.isFalse(deepEquals.test(mapThree));
+                });
+
+                it("fails when passed a non-map object", function () {
+                    var deepEquals = sinonMatch.array.deepEquals(new Map());
+                    assert.isFalse(deepEquals.test({}));
+                    assert.isFalse(deepEquals.test([]));
+                });
+            }
+        });
     });
 
     describe(".regexp", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -711,6 +711,15 @@ describe("sinonMatch", function () {
         });
     });
 
+    describe(".map", function () {
+        it("is typeOf map matcher", function () {
+            var map = sinonMatch.map;
+
+            assert(sinonMatch.isMatcher(map));
+            assert.equals(map.toString(), "typeOf(\"map\")");
+        });
+    });
+
     describe(".regexp", function () {
         it("is typeOf regexp matcher", function () {
             var regexp = sinonMatch.regexp;

--- a/test/util/core/every-test.js
+++ b/test/util/core/every-test.js
@@ -1,0 +1,42 @@
+"use strict";
+
+var referee = require("referee");
+var createSpy = require("../../../lib/sinon/spy");
+var every = require("../../../lib/sinon/util/core/every");
+var assert = referee.assert;
+
+describe("util/core/every", function () {
+    it("returns true when the callback function returns true for every element in an iterable", function () {
+        var obj = [true, true, true, true];
+        var allTrue = every(obj, function (val) {
+            return val;
+        });
+
+        assert(allTrue);
+    });
+
+    it("returns false when the callback function returns false for any element in an iterable", function () {
+        var obj = [true, true, true, false];
+        var result = every(obj, function (val) {
+            return val;
+        });
+
+        assert.isFalse(result);
+    });
+
+    it("calls the given callback once for each item in an iterable until it returns false", function () {
+        var iterableOne = [true, true, true, true];
+        var iterableTwo = [true, true, false, true];
+        var callback = createSpy(function (val) {
+            return val;
+        });
+
+        every(iterableOne, callback);
+        assert.equals(callback.callCount, 4);
+
+        callback.reset();
+
+        every(iterableTwo, callback);
+        assert.equals(callback.callCount, 3);
+    });
+});

--- a/test/util/core/iterable-to-string-test.js
+++ b/test/util/core/iterable-to-string-test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+var referee = require("referee");
+var iterableToString = require("../../../lib/sinon/util/core/iterable-to-string");
+var assert = referee.assert;
+
+describe("util/core/iterable-to-string", function () {
+    it("returns an String representation of Array objects", function () {
+        var arr = [1, "one", true, undefined, null];
+        var expected = "1,'one',true,undefined,null";
+
+        assert.equals(iterableToString(arr), expected);
+    });
+
+    if (typeof Map === "function") {
+        it("returns an String representation of Map objects", function () {
+            var map = new Map();
+            map.set(1, 1);
+            map.set("one", "one");
+            map.set(true, true);
+            map.set(undefined, undefined);
+            map.set(null, null);
+            var expected = "[1,1]," +
+                "['one','one']," +
+                "[true,true]," +
+                "[undefined,undefined]," +
+                "[null,null]";
+
+            assert.equals(iterableToString(map), expected);
+        });
+    }
+
+    if (typeof Set === "function") {
+        it("returns an String representation of Set objects", function () {
+            var set = new Set([1, "one", true, undefined, null]);
+            var expected = "1,'one',true,undefined,null";
+
+            assert.equals(iterableToString(set), expected);
+        });
+    }
+});


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

As discussed on #1210, this adds the following matchers for the `Map` type:

* `sinon.match.map(map)` - Requires an object to be a `Map`
* `sinon.match.map.deepEquals(map)` - Requires a `Map` to be deep equal another one
* `sinon.match.map.contains(map)` - Requires a `Map` to contain each one of the items the given map has.

**This also adds tests for each matcher and updates the docs.**

#### Background (Problem in detail)

Due to the fact that the `order` of elements should not mean anything in a `Map` (and we can't really have any item's index), I didn't include the `startsWith` and `endsWith` matchers for Maps.

Since the old matchers should work for `Array` objects only, the new ones for `Map` and `Set` objects will be strict as well.

This PR adds matchers for Maps only, I'll be working on the Sets matchers as soon as this gets merged. I'm submitting this one first because I want to make sure we all agree on the spec before going further.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm run test` - This will run the newly created tests


Let me know if I missed something or if there's anything to improve and I'll happily update this PR. It's always great to hear your feedback.

Thanks for reading this 😄 
