### PR TITLE
Upgrade text-encoding to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "native-promise-only": "^0.8.1",
     "path-to-regexp": "^1.7.0",
     "samsam": "^1.1.3",
-    "text-encoding": "0.5.2"
+    "text-encoding": "0.6.2"
   },
   "devDependencies": {
     "browserify": "^13.0.0",


### PR DESCRIPTION
Upgrade the text-encoding package to the latest version (0.6.2). It's not possible to bundle the previous versions with Rollup.