### PR TITLE
Remove polyfill for Promise

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -12,7 +12,6 @@
 var extend = require("./extend");
 var functionName = require("./util/core/function-name");
 var valueToString = require("./util/core/value-to-string");
-var Promise = require("native-promise-only");
 
 var slice = Array.prototype.slice;
 var join = Array.prototype.join;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -9,6 +9,7 @@ var createInstance = require("../lib/sinon/util/core/create");
 var assert = referee.assert;
 var refute = referee.refute;
 var fail = referee.fail;
+var Promise = require("native-promise-only"); // eslint-disable-line no-unused-vars
 
 describe("stub", function () {
     it("is spy", function () {


### PR DESCRIPTION
The ramifications of letting the Promise polyfill enter the main Sinon code escaped me at the time I reviewed #1211, but it struck me when reviewing #1215 that had similar issues. In short:

    having the polyfill bundled with Sinon will lead to false
    negatives: running tests using Sinon will then give
    the impression that code works on platforms that does not
    support the features that were polyfilled.

This reverts the introduction of `native-promise-only` in the main
code and moves it to its proper place: the test code.