### PR TITLE
Resolve/reject promise only upon invoke

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -148,6 +148,10 @@ var proto = {
             return context;
         } else if (this.fakeFn) {
             return this.fakeFn.apply(context, args);
+        } else if (this.resolve) {
+            return Promise.resolve(this.returnValue);
+        } else if (this.reject) {
+            return Promise.reject(this.returnValue);
         }
         return this.returnValue;
     },
@@ -292,6 +296,8 @@ var proto = {
 
     returns: function returns(value) {
         this.returnValue = value;
+        this.resolve = false;
+        this.reject = false;
         this.returnValueDefined = true;
         this.exception = undefined;
         this.fakeFn = undefined;
@@ -316,7 +322,9 @@ var proto = {
     },
 
     resolves: function resolves(value) {
-        this.returnValue = Promise.resolve(value);
+        this.returnValue = value;
+        this.resolve = true;
+        this.reject = false;
         this.returnValueDefined = true;
         this.exception = undefined;
         this.fakeFn = undefined;
@@ -334,7 +342,9 @@ var proto = {
         } else {
             reason = error;
         }
-        this.returnValue = Promise.reject(reason);
+        this.returnValue = reason;
+        this.resolve = false;
+        this.reject = true;
         this.returnValueDefined = true;
         this.exception = undefined;
         this.fakeFn = undefined;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -152,6 +152,21 @@ describe("stub", function () {
 
             return stub().then();
         });
+
+        it("can be superseded by returns", function () {
+            var stub = createStub.create();
+            stub.resolves(2).returns(1);
+
+            assert.equals(stub(), 1);
+        });
+
+        it("does not invoke Promise.resolve when the behavior is added to the stub", function () {
+            var resolveSpy = createSpy(Promise, "resolve");
+            var stub = createStub.create();
+            stub.resolves(2);
+
+            assert.equals(resolveSpy.callCount, 0);
+        });
     });
 
     describe(".rejects", function () {
@@ -205,6 +220,21 @@ describe("stub", function () {
             }).catch(function (reason) {
                 assert.equals(reason.name, "Error");
             });
+        });
+
+        it("can be superseded by returns", function () {
+            var stub = createStub.create();
+            stub.rejects(2).returns(1);
+
+            assert.equals(stub(), 1);
+        });
+
+        it("does not invoke Promise.reject when the behavior is added to the stub", function () {
+            var rejectSpy = createSpy(Promise, "reject");
+            var stub = createStub.create();
+            stub.rejects(2);
+
+            assert.equals(rejectSpy.callCount, 0);
         });
     });
 


### PR DESCRIPTION
### Purpose (TL;DR) - mandatory

This aims to make `Promise` `resolves` and `rejects` happen only when a stub is `invoked` instead of when the behavior is added to the stub.

<img width="1680" alt="Lots of Unhandled Promise Rejection Errors on Tests" src="https://cloud.githubusercontent.com/assets/6868147/21577545/72bf3212-cf45-11e6-8435-d0b3ffcf728a.png">

### Background (Problem in detail)

In order to add `resolves` and `rejects` to the `stub` object the PR #1211 ended up replacing the `returnValue` property of it with `Promise.resolve(val)` and `Promise.reject(err)`. This ended up resolving or rejecting a promise right when the behavior was added to the `stub` instead of only when the `stub` was invoked.

**This was causing `UnhandledPromiseRejection` errors on our tests, even when we were just defining `rejects` and then superseding it with `resolves`. In the future this could have caused our build (and our user's) to fail on newer Node versions, since unhandled promise rejections will be terminating the Node process with non-zero status.**

### Solution

In order to fix this I added the properties `resolve` and `reject`. These properties indicate whether the stub should `resolve` or  `reject` a promise **when invoked**.

I also added tests to prove that these methods from `Promise` were being called only when the stub is `invoked`.

#### How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test` --> This will run the newly added tests

Please let me know if I need anything or if you need any further changes.
Thanks for reading this 😄 