### PR TITLE
Allow running tests in files watch mode, update related docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,34 +79,25 @@ To ensure consistent reporting of lint warnings, you should use the same version
 
 ### Run the tests
 
-This runs linting as well as unit tests in both PhantomJS and node
+Following command runs unit tests in PhantomJS, Node and WebWorker
 
     $ npm test
 
 ##### Testing in development
 
-Sinon.JS uses [Buster.JS](http://busterjs.org), please read those docs if you're unfamiliar with it.
+Sinon.JS uses [Mocha](https://mochajs.org/), please read those docs if you're unfamiliar with it.
 
-If you just want to run tests a few times
+If you're doing more than a one line edit, you'll want to have finer control and less restarting of the Mocha
 
-    $ npm run ci-test
+To start tests in dev mode run 
 
-If you're doing more than a one line edit, you'll want to have finer control and less restarting of the Buster server and PhantomJS process
+    $ npm run test-dev
 
-    # start a server
-    $ $(npm bin)/buster-server
+Dev mode features:
+ * [watching related files](https://mochajs.org/#w---watch) to restart tests once changes are made 
+ * using [Min reporter](https://mochajs.org/#min), which cleans the console each time tests run, so test results are always on top
 
-    # capture a browser by pointing it to http://localhost:1111/capture
-    # run tests (in both browser and node)
-    $ $(npm bin)/buster-test
-
-    # run tests only in browser
-    $ $(npm bin)/buster-test --config-group browser
-
-    # run tests only in node
-    $ $(npm bin)/buster-test --config-group node
-
-If you install `Buster.JS` as a global, you can remove `$(npm-bin)/` from the lines above.
+Note that in dev mode tests run only in Node. Before creating your PR please ensure tests are passing in Phantom and WebWorker as well. To check this please use [Run the tests](#run-the-tests) instructions.
 
 ##### Testing a built version
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "test-node": "mocha --recursive -R dot test/",
+    "test-dev": "npm run test-node -- --watch -R min",
     "test-headless": "mochify --recursive -R dot --grep WebWorker --invert test/",
     "test-coverage": "mochify --recursive -R dot --grep WebWorker --invert --plugin [ mochify-istanbul --report text --report lcovonly --dir ./coverage ] test/",
     "test-cloud": "npm run test-headless -- --wd",

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -284,6 +284,7 @@ describe("spy", function () {
         var originalError = global.Error;
         try {
             assert(createSpy(global, "Error"));
+            global.Error = originalError;
         } catch (e) {
             // so test failure doesn't trickle down
             global.Error = originalError;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -121,6 +121,12 @@ describe("stub", function () {
     });
 
     describe(".resolves", function () {
+        afterEach(function () {
+            if (Promise.resolve.restore) {
+                Promise.resolve.restore();
+            }
+        });
+
         it("returns a promise to the specified value", function () {
             var stub = createStub.create();
             var object = {};
@@ -170,6 +176,12 @@ describe("stub", function () {
     });
 
     describe(".rejects", function () {
+        afterEach(function () {
+            if (Promise.reject.restore) {
+                Promise.reject.restore();
+            }
+        });
+
         it("returns a promise which rejects for the specified reason", function () {
             var stub = createStub.create();
             var reason = new Error();
@@ -685,6 +697,12 @@ describe("stub", function () {
         beforeEach(function () {
             this.method = function () {};
             this.object = { method: this.method };
+        });
+
+        afterEach(function () {
+            if (global.console.info.restore) {
+                global.console.info.restore();
+            }
         });
 
         it.skip("returns function from wrapMethod", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Noticed that possibility to run tests in watch mode was missing. Decided to fix this.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm run test-dev`
