### PR TITLE
Fix set iterableToString test on IE11

### DIFF
--- a/lib/sinon/typeOf.js
+++ b/lib/sinon/typeOf.js
@@ -8,12 +8,8 @@
  */
 "use strict";
 
+var type = require("type-detect");
+
 module.exports = function typeOf(value) {
-    if (value === null) {
-        return "null";
-    } else if (value === undefined) {
-        return "undefined";
-    }
-    var string = Object.prototype.toString.call(value);
-    return string.substring(8, string.length - 1).toLowerCase();
+    return type(value).toLowerCase();
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "native-promise-only": "^0.8.1",
     "path-to-regexp": "^1.7.0",
     "samsam": "^1.1.3",
-    "text-encoding": "0.6.2"
+    "text-encoding": "0.6.2",
+    "type-detect": "^4.0.0"
   },
   "devDependencies": {
     "browserify": "^13.0.0",

--- a/test/util/core/iterable-to-string-test.js
+++ b/test/util/core/iterable-to-string-test.js
@@ -32,7 +32,13 @@ describe("util/core/iterable-to-string", function () {
 
     if (typeof Set === "function") {
         it("returns an String representation of Set objects", function () {
-            var set = new Set([1, "one", true, undefined, null]);
+            var set = new Set();
+            set.add(1);
+            set.add("one");
+            set.add(true);
+            set.add(undefined);
+            set.add(null);
+
             var expected = "1,'one',true,undefined,null";
 
             assert.equals(iterableToString(set), expected);


### PR DESCRIPTION
#### Purpose (TL;DR)

This fixes the failing tests on IE11 introduced in #1215 .

#### Background

Our implementation of `typeOf` was too simple and didn't handle older implementations of `Map`s and `Set`s.

Even with the `if` clauses guarding the `Map` and `Set` related tests they would fail, because IE11 did implement them, however, IE11's implementation wasn't following the ECMA standard. This caused our type detection to fail without recognizing these object's types correctly.

Also, IE11's `Set` constructor was a bit weird and didn't accept an array of elements as argument, so I had to use multiple `.add` calls to add elements to a `Set`.


#### Solution

I added `type-detect` to solve the `typeOf` related problem.

I'm not sure everyone agrees on that. So, if you don't want that please let me know and I'll dedicate more time to rewrite `typeOf` and make it compatible with older browsers implementations of `Map`s and `Set`s. However, this library is maintained by everyone at `Chai` and other awesome contributors and it's pretty stable and has good performance.

IMO, having less code to maintain is always good and maybe we can join efforts on that library making it better for everyone.

I have also changed the `Set` constructor on a test in order to use an IE11 compliant way of creating Sets.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm run test`

Let me know if you disagree with anything and I'll happily fix it.

PS.: Sorry for breaking your build! 😅 
