### PR TITLE
Sets matchers

### DIFF
--- a/docs/release-source/release/matchers.md
+++ b/docs/release-source/release/matchers.md
@@ -147,6 +147,21 @@ Requires a `Map` to be deep equal another one.
 Requires a `Map` to contain each one of the items the given map has.
 
 
+#### `sinon.match.set"
+
+Requires the value to be a `Set`.
+
+
+#### `sinon.match.set.deepEquals(set)`
+
+Requires a `Set` to be deep equal another one.
+
+
+#### `sinon.match.set.contains(set)`
+
+Requires a `Set` to contain each one of the items the given set has.
+
+
 #### `sinon.match.regexp"
 
 Requires the value to be a regular expression.

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -296,6 +296,14 @@ match.set.deepEquals = function setDeepEquals(expectation) {
     }, "deepEquals(Set[" + iterableToString(expectation) + "])");
 };
 
+match.set.contains = function setContains(expectation) {
+    return match(function (actual) {
+        return typeOf(actual) === "set" && every(expectation, function (element) {
+            return actual.has(element);
+        });
+    }, "contains(Set[" + iterableToString(expectation) + "])");
+};
+
 match.bool = match.typeOf("boolean");
 match.number = match.typeOf("number");
 match.string = match.typeOf("string");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -286,6 +286,16 @@ match.map.contains = function mapContains(expectation) {
 
 match.set = match.typeOf("set");
 
+match.set.deepEquals = function setDeepEquals(expectation) {
+    return match(function (actual) {
+        // Comparing lengths is the fastest way to spot a difference before iterating through every item
+        var sameLength = actual.size === expectation.size;
+        return typeOf(actual) === "set" && sameLength && every(actual, function (element) {
+            return expectation.has(element);
+        });
+    }, "deepEquals(Set[" + iterableToString(expectation) + "])");
+};
+
 match.bool = match.typeOf("boolean");
 match.number = match.typeOf("number");
 match.string = match.typeOf("string");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -284,6 +284,8 @@ match.map.contains = function mapContains(expectation) {
     }, "contains(Map[" + iterableToString(expectation) + "])");
 };
 
+match.set = match.typeOf("set");
+
 match.bool = match.typeOf("boolean");
 match.number = match.typeOf("number");
 match.string = match.typeOf("string");

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -855,6 +855,48 @@ describe("sinonMatch", function () {
             assert(sinonMatch.isMatcher(set));
             assert.equals(set.toString(), "typeOf(\"set\")");
         });
+
+        describe("set.deepEquals", function () {
+            if (typeof Set === "function") {
+                it("has a .deepEquals matcher", function () {
+                    var setOne = new Set();
+                    setOne.add("one");
+                    setOne.add("two");
+                    setOne.add("three");
+
+                    var deepEquals = sinonMatch.set.deepEquals(setOne);
+                    assert(sinonMatch.isMatcher(deepEquals));
+                    assert.equals(deepEquals.toString(), "deepEquals(Set['one','two','three'])");
+                });
+
+                it("matches sets with the exact same elements", function () {
+                    var setOne = new Set();
+                    setOne.add("one");
+                    setOne.add("two");
+                    setOne.add("three");
+
+                    var setTwo = new Set();
+                    setTwo.add("one");
+                    setTwo.add("two");
+                    setTwo.add("three");
+
+                    var setThree = new Set();
+                    setThree.add("one");
+                    setThree.add("two");
+
+                    var deepEquals = sinonMatch.set.deepEquals(setOne);
+                    assert(deepEquals.test(setTwo));
+                    assert.isFalse(deepEquals.test(setThree));
+                    assert.isFalse(deepEquals.test(new Set()));
+                });
+
+                it("fails when passed a non-set object", function () {
+                    var deepEquals = sinonMatch.array.deepEquals(new Set());
+                    assert.isFalse(deepEquals.test({}));
+                    assert.isFalse(deepEquals.test([]));
+                });
+            }
+        });
     });
 
     describe(".regexp", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -897,6 +897,51 @@ describe("sinonMatch", function () {
                 });
             }
         });
+
+        describe("set.contains", function () {
+            if (typeof Set === "function") {
+                it("has a .contains matcher", function () {
+                    var setOne = new Set();
+                    setOne.add("one");
+                    setOne.add("two");
+                    setOne.add("three");
+
+                    var contains = sinonMatch.set.contains(setOne);
+                    assert(sinonMatch.isMatcher(contains));
+                    assert.equals(contains.toString(), "contains(Set['one','two','three'])");
+                });
+
+                it("matches sets containing the given elements", function () {
+                    var setOne = new Set();
+                    setOne.add("one");
+                    setOne.add("two");
+                    setOne.add("three");
+
+                    var setTwo = new Set();
+                    setTwo.add("one");
+                    setTwo.add("two");
+                    setTwo.add("three");
+
+                    var setThree = new Set();
+                    setThree.add("one");
+                    setThree.add("two");
+
+                    var setFour = new Set();
+                    setFour.add("one");
+                    setFour.add("four");
+
+                    assert(sinonMatch.set.contains(setTwo).test(setOne));
+                    assert(sinonMatch.set.contains(setThree).test(setOne));
+                    assert.isFalse(sinonMatch.set.contains(setFour).test(setOne));
+                });
+
+                it("fails when passed a non-set object", function () {
+                    var contains = sinonMatch.set.contains(new Set());
+                    assert.isFalse(contains.test({}));
+                    assert.isFalse(contains.test([]));
+                });
+            }
+        });
     });
 
     describe(".regexp", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -848,6 +848,15 @@ describe("sinonMatch", function () {
         });
     });
 
+    describe(".set", function () {
+        it("is typeOf set matcher", function () {
+            var set = sinonMatch.set;
+
+            assert(sinonMatch.isMatcher(set));
+            assert.equals(set.toString(), "typeOf(\"set\")");
+        });
+    });
+
     describe(".regexp", function () {
         it("is typeOf regexp matcher", function () {
             var regexp = sinonMatch.regexp;


### PR DESCRIPTION
## Purpose (TL;DR) - mandatory

As discussed on #1210 and #1215, this adds the following matchers for the `Set` type:

* `sinon.match.set(set)` - Requires an object to be a `Set`
* `sinon.match.set.deepEquals(set)` - Requires a `Set` to be deep equal another one
* `sinon.match.set.contains(set)` - Requires a `Set` to contain each one of the items the given `set` has.

**This also adds tests for each matcher and updates the docs.**

## Background (Problem in detail)

As it happens with `Map` elements, the `order` of elements does not mean anything in a `Set` and there's no way to know an item's index. This is why this PR does not include `startsWith` and `endsWith` matchers.

As we discussed on the PRs linked on the top of this description each one of these matchers work only for `Set` types and there are tests to ensure this.

The docs follow the same pattern as the docs for `Maps` and `Arrays` matchers in order for it to be consistent.

### **These tests were all ran in IE11 to make sure they would pass**.

## How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm run test` - This will run the newly created tests

If you desire any further changes please let me know and I'll happily commit them as soon as I can.
Once again, thanks for the awesome job you've been doing ❤️  
