### PR TITLE
Ensures different matchers won't be called against each other. Closes…

### DIFF
--- a/lib/sinon/util/core/deep-equal.js
+++ b/lib/sinon/util/core/deep-equal.js
@@ -94,7 +94,13 @@ var deepEqual = module.exports = function deepEqual(a, b) {
 
 deepEqual.use = function (match) {
     return function deepEqual$matcher(a, b) {
+        // If both are matchers they must be the same instance in order to be considered equal
+        // If we didn't do that we would end up running one matcher against the other
         if (match.isMatcher(a)) {
+            if (match.isMatcher(b)) {
+                return a === b;
+            }
+
             return a.test(b);
         }
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -169,4 +169,35 @@ describe("issues", function () {
             restore(oldWatch);
         });
     });
+
+    describe("#1154", function () {
+        it("Ensures different matchers will not be tested against each other", function () {
+            var match = sinon.match;
+            var stub = sinon.stub;
+            var readFile = stub();
+
+            function endsWith(str, suffix) {
+                return str.indexOf(suffix) + suffix.length === str.length;
+            }
+
+            function suffixA(fileName) {
+                return endsWith(fileName, "suffixa");
+            }
+
+            function suffixB(fileName) {
+                return endsWith(fileName, "suffixb");
+            }
+
+            var argsA = match(suffixA);
+            var argsB = match(suffixB);
+
+            var firstFake = readFile
+              .withArgs(argsA);
+
+            var secondFake = readFile
+              .withArgs(argsB);
+
+            assert(firstFake !== secondFake);
+        });
+    });
 });

--- a/test/util/core/deep-equal-test.js
+++ b/test/util/core/deep-equal-test.js
@@ -2,6 +2,8 @@
 
 var referee = require("referee");
 var deepEqual = require("../../../lib/sinon/util/core/deep-equal");
+var match = require("../../../lib/sinon/match");
+var createSpy = require("../../../lib/sinon/spy").create;
 var assert = referee.assert;
 
 describe("util/core/deepEqual", function () {
@@ -306,4 +308,35 @@ describe("util/core/deepEqual", function () {
         assert(deepEqual(obj1, obj2));
     });
 
+    it("does not run matchers against each other when using a matcher library", function () {
+        var matchDeepEqual = deepEqual.use(match);
+
+        var spyA = createSpy();
+        var matchA = match(spyA);
+
+        var spyB = createSpy();
+        var matchB = match(spyB);
+
+        matchDeepEqual(matchA, matchB);
+
+        assert.equals(spyA.callCount, 0);
+        assert.equals(spyB.callCount, 0);
+    });
+
+    it("strictly compares instances when passed two matchers and using a matcher library", function () {
+        var matchDeepEqual = deepEqual.use(match);
+
+        var matchA = match(function a() {
+            return "a";
+        });
+
+        var matchB = match(function b() {
+            return "b";
+        });
+
+        var duplicateA = matchA;
+
+        assert(matchDeepEqual(matchA, duplicateA));
+        assert.isFalse(matchDeepEqual(matchA, matchB));
+    });
 });


### PR DESCRIPTION
## Purpose (TL;DR)

This aims to fix issue #1154. Which ended up causing `Errors` to be thrown when setting up multiple `stub` behavior using matchers.

**This adds both the fix to that and [a test](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:fix-deepEqual-for-matchers?expand=1#diff-844b9be064615d4e686325869d57fb9dR173) which has exactly the same code as the one in the related issue. I also added two new tests to the `deep-equal-test.js` file to ensure the implementation was working as expected.**

## Background (Problem in detail)

When using `.withArgs` for the first time an array of fake implementations get created because none fake implementations existed before, so [this if clause](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/spy.js#L290) is entered.

The second time `.withArgs` gets called we already have fake implementations registered for this so we end up falling in [this if clause right here](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/spy.js#L283). 

Inside that clause we've got [this line](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/spy.js#L284) which is responsible for [verifying if the arguments provided to `.withArgs` match any registered `fakes`](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/spy.js#L60).

In order to see if the provided arguments match any `fake`, [the `deepEqual` function gets called](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/spy.js#L322). Since [it has been told to use the `match` library](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/spy.js#L17) then [this function](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/util/core/deep-equal.js#L96) is what will be called when using `deepEqual` inside the `spy` module.

That returned `deepEqual` function will eventually end up entering [this `if` clause](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/util/core/deep-equal.js#L97), because it will iterate over items passed to it in order to unwrap them, as you can see [here](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/util/core/deep-equal.js#L80).

(TL;DR) **So, finally, in order to see if the arguments passed to `withArgs` already existed or not, the `suffixA` function will be called with `argsB` as an argument. Since `argsB` does not have an `indexOf` function the following error will be thrown:**

```
return str.indexOf(suffix) + suffix.length === str.length;
               ^
TypeError: str.indexOf is not a function
```


## Solution

In order to fix this problem I added a check into the version of deep equals which runs using `matcher` libraries.

When calling [`deepEqual.use`](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/util/core/deep-equal.js#L95) we're able to pass it a `matcher` library to use and then it will return a function which uses that library when comparing two values.

It makes no sense to run a matcher against each other, so I've just made it return the `strict` comparison between two matchers, since the correct behavior here is for this function to say they're equal only when they're the same. That's the whole point of having the `use` function here.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test` will run the newly added tests. One of them runs the code which was failing before as described in the issue linked. The other two ensure the `deepEqual` implementation works as expected when passed two matchers and using a `matcher` library.

Let me know if you disagree with anything or if you desire any further changes. Thanks for reading this 😄
