### PR TITLE
Allow calling original function from stub. Closes #989

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -152,6 +152,8 @@ var proto = {
             return Promise.resolve(this.returnValue);
         } else if (this.reject) {
             return Promise.reject(this.returnValue);
+        } else if (this.callsThrough) {
+            return this.stub.wrappedMethod.apply(context, args);
         }
         return this.returnValue;
     },
@@ -349,6 +351,11 @@ var proto = {
         this.exception = undefined;
         this.fakeFn = undefined;
 
+        return this;
+    },
+
+    callThrough: function callThrough() {
+        this.callsThrough = true;
         return this;
     }
 };

--- a/lib/sinon/util/core/wrap-method.js
+++ b/lib/sinon/util/core/wrap-method.js
@@ -141,6 +141,8 @@ module.exports = function wrapMethod(object, property, method) {
         }
     };
 
+    method.wrappedMethod = wrappedMethod;
+
     method.restore.sinon = true;
 
     if (!hasES5Support) {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2187,4 +2187,92 @@ describe("stub", function () {
         });
     });
 
+    describe(".callThrough", function () {
+        it("does not call original function when arguments match conditional stub", function () {
+            // We need a function here because we can't wrap properties that are already stubs
+            var callCount = 0;
+            var originalFunc = function increaseCallCount() {
+                callCount++;
+            };
+
+            var myObj = {
+                prop: originalFunc
+            };
+
+            var propStub = createStub(myObj, "prop");
+            propStub.withArgs("foo").returns("bar");
+            propStub.callThrough();
+
+            var result = myObj.prop("foo");
+
+            assert.equals(result, "bar");
+            assert.equals(callCount, 0);
+        });
+
+        it("calls original function when arguments do not match conditional stub", function () {
+            // We need a function here because we can't wrap properties that are already stubs
+            var callCount = 0;
+
+            var originalFunc = function increaseCallCount() {
+                callCount++;
+                return 1337;
+            };
+
+            var myObj = {
+                prop: originalFunc
+            };
+
+            var propStub = createStub(myObj, "prop");
+            propStub.withArgs("foo").returns("bar");
+            propStub.callThrough(propStub);
+
+            var result = myObj.prop("not foo");
+
+            assert.equals(result, 1337);
+            assert.equals(callCount, 1);
+        });
+
+        it("calls original function with same arguments when call does not match conditional stub", function () {
+            // We need a function here because we can't wrap properties that are already stubs
+            var callArgs = [];
+
+            var originalFunc = function increaseCallCount() {
+                callArgs = arguments;
+            };
+
+            var myObj = {
+                prop: originalFunc
+            };
+
+            var propStub = createStub(myObj, "prop");
+            propStub.withArgs("foo").returns("bar");
+            propStub.callThrough();
+
+            myObj.prop("not foo");
+
+            assert.equals(callArgs.length, 1);
+            assert.equals(callArgs[0], "not foo");
+        });
+
+        it("calls original function with same `this` reference when call does not match conditional stub", function () {
+            // We need a function here because we can't wrap properties that are already stubs
+            var reference = {};
+
+            var originalFunc = function increaseCallCount() {
+                reference = this;
+            };
+
+            var myObj = {
+                prop: originalFunc
+            };
+
+            var propStub = createStub(myObj, "prop");
+            propStub.withArgs("foo").returns("bar");
+            propStub.callThrough();
+
+            myObj.prop("not foo");
+
+            assert.equals(reference, myObj);
+        });
+    });
 });


### PR DESCRIPTION
## Purpose (TL;DR)

This aims to add the feature requested in #989 and tests for it.

Here's an example of the new feature's usage:

```js
var obj = {
  method: function foo() {
    return 'bar';
  }
};

var myStub = sinon.stub(object, 'method');

myStub.withArgs(1).returns('baz');
myStub.callThrough();

object.method(1); // 'baz'
object.method('not 1'); // 'bar'
```

Due to #817 it's not working in one-liners, but as soon as #1227 gets merged it will work, since that PR allows chaining.

## Solution

In order to implement this I had to change the `wrapMethod` module in order for it to keep a reference for the old method in the new one. I used the key `wrappedMethod` to hold the old method because I thought it was the most semantically valid name possible.

Then I created a new behavior called `callThrough` which adds a property called `callsThrough` to the behavior with the value `true`. 

Whenever the stub can't find any matching fakes for the provided arguments, it will call behavior's `invoke`, as you can see [here](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/spy.js#L195). The `callsThrough` property will then be used by the behavior's [invoke](https://github.com/sinonjs/sinon/blob/a6d8e1460e21e0b9cc9a28926b8a130c423cd09e/lib/sinon/behavior.js#L140) method in order to determine if it should invoke the original `wrappedMethod`.

Please notice that the `wrappedMethod` is invoked with `.apply` in order to keep bot the `this` reference and the arguments correct.

**The tests ensure that the following requirements are met when using `callThrough()`:**

* The original function should not be called if we've got arguments that match any fakes
* The original function should be invoked if the arguments do not match any fakes
* The original function should be invoked with the same arguments when the arguments do not match any fake
* The original function should be invoked with the same `this` reference when the arguments do not match any fake

## How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm run test`


Please let me know if you desire any further changes or if you disagree with anything. 😄 
Also, after this one I'd also like to solve #956, which is partially related (if you don't mind).

Thanks for reading! ❤️ 