### PR TITLE
Refactor stub methods

### DIFF
--- a/lib/sinon/collect-own-methods.js
+++ b/lib/sinon/collect-own-methods.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var walk = require("./util/core/walk");
+var getPropertyDescriptor = require("./util/core/get-property-descriptor");
+
+function collectMethod(methods, object, prop, propOwner) {
+    if (
+        typeof getPropertyDescriptor(propOwner, prop).value === "function" &&
+        object.hasOwnProperty(prop)
+    ) {
+        methods.push(object[prop]);
+    }
+}
+
+// This function returns an array of all the own methods on the passed object
+function collectOwnMethods(object) {
+    var methods = [];
+
+    walk(object, collectMethod.bind(null, methods, object));
+
+    return methods;
+}
+
+module.exports = collectOwnMethods;

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -11,12 +11,11 @@
 var sinonSpy = require("./spy");
 var sinonStub = require("./stub");
 var sinonMock = require("./mock");
-var valueToString = require("./util/core/value-to-string");
 var throwOnFalsyObject = require("./throw-on-falsy-object");
 var collectOwnMethods = require("./collect-own-methods");
+var stubNonFunctionProperty = require("./stub-non-function-property");
 
 var push = [].push;
-var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 function getFakes(fakeCollection) {
     if (!fakeCollection.fakes) {
@@ -91,39 +90,22 @@ var collection = {
         return this.add(sinonSpy.apply(sinonSpy, arguments));
     },
 
-    stub: function stub(object, property, value) {
+    stub: function stub(object, property/*, value*/) {
         throwOnFalsyObject.apply(null, arguments);
 
         var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
-
-        if (property) {
-            var original = object[property];
-
-            if (typeof original !== "function") {
-                if (!hasOwnProperty.call(object, property)) {
-                    throw new TypeError("Cannot stub non-existent own property " + valueToString(property));
-                }
-
-                object[property] = value;
-
-                return this.add({
-                    restore: function () {
-                        object[property] = original;
-                    }
-                });
-            }
-        }
+        var isStubbingNonFunctionProperty = property && typeof object[property] !== "function";
+        var stubbed = isStubbingNonFunctionProperty ?
+                        stubNonFunctionProperty.apply(null, arguments) :
+                        sinonStub.apply(null, arguments);
 
         if (isStubbingEntireObject) {
-            var col = this;
-            var stubbedObj = sinonStub.apply(null, arguments);
-
-            collectOwnMethods(stubbedObj).forEach(col.add.bind(this));
-
-            return stubbedObj;
+            collectOwnMethods(stubbed).forEach(this.add.bind(this));
+        } else {
+            this.add(stubbed);
         }
 
-        return this.add(sinonStub.apply(null, arguments));
+        return stubbed;
     },
 
     mock: function mock() {

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -14,6 +14,7 @@ var sinonMock = require("./mock");
 var walk = require("./util/core/walk");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var valueToString = require("./util/core/value-to-string");
+var throwOnFalsyObject = require("./throw-on-falsy-object");
 
 var push = [].push;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -92,12 +93,9 @@ var collection = {
     },
 
     stub: function stub(object, property, value) {
-        if (property) {
-            if (!object) {
-                var type = object === null ? "null" : "undefined";
-                throw new Error("Trying to stub property '" + valueToString(property) + "' of " + type);
-            }
+        throwOnFalsyObject.apply(null, arguments);
 
+        if (property) {
             var original = object[property];
 
             if (typeof original !== "function") {

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -11,10 +11,9 @@
 var sinonSpy = require("./spy");
 var sinonStub = require("./stub");
 var sinonMock = require("./mock");
-var walk = require("./util/core/walk");
-var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var valueToString = require("./util/core/value-to-string");
 var throwOnFalsyObject = require("./throw-on-falsy-object");
+var collectOwnMethods = require("./collect-own-methods");
 
 var push = [].push;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -95,6 +94,8 @@ var collection = {
     stub: function stub(object, property, value) {
         throwOnFalsyObject.apply(null, arguments);
 
+        var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
+
         if (property) {
             var original = object[property];
 
@@ -112,18 +113,12 @@ var collection = {
                 });
             }
         }
-        if (!property && !!object && typeof object === "object") {
+
+        if (isStubbingEntireObject) {
             var col = this;
             var stubbedObj = sinonStub.apply(null, arguments);
 
-            walk(stubbedObj, function (prop, propOwner) {
-                if (
-                    typeof getPropertyDescriptor(propOwner, prop).value === "function" &&
-                    stubbedObj.hasOwnProperty(prop)
-                ) {
-                    col.add(stubbedObj[prop]);
-                }
-            });
+            collectOwnMethods(stubbedObj).forEach(col.add.bind(this));
 
             return stubbedObj;
         }

--- a/lib/sinon/stub-descriptor.js
+++ b/lib/sinon/stub-descriptor.js
@@ -1,0 +1,43 @@
+"use strict";
+
+var deprecated = require("./util/core/deprecated");
+var objectKeys = require("./util/core/object-keys");
+var spy = require("./spy");
+var wrapMethod = require("./util/core/wrap-method");
+
+// This is deprecated and will be removed in a future version of sinon.
+// We will only consider pull requests that fix serious bugs in the implementation
+function stubDescriptor(object, property, descriptor) {
+    var wrapper;
+
+    deprecated.printWarning(
+      "sinon.stub(obj, 'meth', fn) is deprecated and will be removed from" +
+      "the public API in a future version of sinon." +
+      "\n Use stub(obj, 'meth').callsFake(fn)." +
+      "\n Codemod available at https://github.com/hurrymaplelad/sinon-codemod"
+    );
+
+    if (!!descriptor && typeof descriptor !== "function" && typeof descriptor !== "object") {
+        throw new TypeError("Custom stub should be a property descriptor");
+    }
+
+    if (typeof descriptor === "object" && objectKeys(descriptor).length === 0) {
+        throw new TypeError("Expected property descriptor to have at least one key");
+    }
+
+    if (typeof descriptor === "function") {
+        wrapper = spy && spy.create ? spy.create(descriptor) : descriptor;
+    } else {
+        wrapper = descriptor;
+        if (spy && spy.create) {
+            var types = objectKeys(wrapper);
+            for (var i = 0; i < types.length; i++) {
+                wrapper[types[i]] = spy.create(wrapper[types[i]]);
+            }
+        }
+    }
+
+    return wrapMethod(object, property, wrapper);
+}
+
+module.exports = stubDescriptor;

--- a/lib/sinon/stub-entire-object.js
+++ b/lib/sinon/stub-entire-object.js
@@ -1,0 +1,22 @@
+"use strict";
+
+var getPropertyDescriptor = require("./util/core/get-property-descriptor");
+var walk = require("./util/core/walk");
+
+function stubEntireObject(stub, object) {
+    walk(object || {}, function (prop, propOwner) {
+        // we don't want to stub things like toString(), valueOf(), etc. so we only stub if the object
+        // is not Object.prototype
+        if (
+            propOwner !== Object.prototype &&
+            prop !== "constructor" &&
+            typeof getPropertyDescriptor(propOwner, prop).value === "function"
+        ) {
+            stub(object, prop);
+        }
+    });
+
+    return object;
+}
+
+module.exports = stubEntireObject;

--- a/lib/sinon/stub-non-function-property.js
+++ b/lib/sinon/stub-non-function-property.js
@@ -1,0 +1,22 @@
+"use strict";
+
+var valueToString = require("./util/core/value-to-string");
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
+function stubNonFunctionProperty(object, property, value) {
+    var original = object[property];
+
+    if (!hasOwnProperty.call(object, property)) {
+        throw new TypeError("Cannot stub non-existent own property " + valueToString(property));
+    }
+
+    object[property] = value;
+
+    return {
+        restore: function () {
+            object[property] = original;
+        }
+    };
+}
+
+module.exports = stubNonFunctionProperty;

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -11,35 +11,19 @@
 var behavior = require("./behavior");
 var spy = require("./spy");
 var extend = require("./util/core/extend");
-var objectKeys = require("./util/core/object-keys");
 var createInstance = require("./util/core/create");
-var deprecated = require("./util/core/deprecated");
 var functionToString = require("./util/core/function-to-string");
 var valueToString = require("./util/core/value-to-string");
 var wrapMethod = require("./util/core/wrap-method");
 var stubEntireObject = require("./stub-entire-object");
+var stubDescriptor = require("./stub-descriptor");
 
 function stub(object, property, descriptor) {
     var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
+    var isStubbingDescriptor = Boolean(descriptor);
 
     if (isStubbingEntireObject) {
         return stubEntireObject(stub, object);
-    }
-
-    if (!!descriptor && typeof descriptor === "function") {
-        deprecated.printWarning(
-          "sinon.stub(obj, 'meth', fn) is deprecated and will be removed from" +
-          "the public API in a future version of sinon." +
-          "\n Use stub(obj, 'meth').callsFake(fn)." +
-          "\n Codemod available at https://github.com/hurrymaplelad/sinon-codemod"
-        );
-    }
-    if (!!descriptor && typeof descriptor !== "function" && typeof descriptor !== "object") {
-        throw new TypeError("Custom stub should be a property descriptor");
-    }
-
-    if (typeof descriptor === "object" && objectKeys(descriptor).length === 0) {
-        throw new TypeError("Expected property descriptor to have at least one key");
     }
 
     if (property && !object) {
@@ -51,26 +35,16 @@ function stub(object, property, descriptor) {
         return stub.create();
     }
 
-    var wrapper;
-    if (descriptor) {
-        if (typeof descriptor === "function") {
-            wrapper = spy && spy.create ? spy.create(descriptor) : descriptor;
-        } else {
-            wrapper = descriptor;
-            if (spy && spy.create) {
-                var types = objectKeys(wrapper);
-                for (var i = 0; i < types.length; i++) {
-                    wrapper[types[i]] = spy.create(wrapper[types[i]]);
-                }
-            }
-        }
-    } else {
-        var stubLength = 0;
-        if (typeof object === "object" && typeof object[property] === "function") {
-            stubLength = object[property].length;
-        }
-        wrapper = stub.create(stubLength);
+    if (isStubbingDescriptor) {
+        return stubDescriptor.apply(null, arguments);
     }
+
+    var wrapper;
+    var stubLength = 0;
+    if (typeof object === "object" && typeof object[property] === "function") {
+        stubLength = object[property].length;
+    }
+    wrapper = stub.create(stubLength);
 
     return wrapMethod(object, property, wrapper);
 }

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -11,16 +11,21 @@
 var behavior = require("./behavior");
 var spy = require("./spy");
 var extend = require("./util/core/extend");
-var walk = require("./util/core/walk");
 var objectKeys = require("./util/core/object-keys");
-var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var createInstance = require("./util/core/create");
 var deprecated = require("./util/core/deprecated");
 var functionToString = require("./util/core/function-to-string");
 var valueToString = require("./util/core/value-to-string");
 var wrapMethod = require("./util/core/wrap-method");
+var stubEntireObject = require("./stub-entire-object");
 
 function stub(object, property, descriptor) {
+    var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
+
+    if (isStubbingEntireObject) {
+        return stubEntireObject(stub, object);
+    }
+
     if (!!descriptor && typeof descriptor === "function") {
         deprecated.printWarning(
           "sinon.stub(obj, 'meth', fn) is deprecated and will be removed from" +
@@ -65,22 +70,6 @@ function stub(object, property, descriptor) {
             stubLength = object[property].length;
         }
         wrapper = stub.create(stubLength);
-    }
-
-    if (typeof property === "undefined" && typeof object === "object") {
-        walk(object || {}, function (prop, propOwner) {
-            // we don't want to stub things like toString(), valueOf(), etc. so we only stub if the object
-            // is not Object.prototype
-            if (
-                propOwner !== Object.prototype &&
-                prop !== "constructor" &&
-                typeof getPropertyDescriptor(propOwner, prop).value === "function"
-            ) {
-                stub(object, prop);
-            }
-        });
-
-        return object;
     }
 
     return wrapMethod(object, property, wrapper);

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -13,20 +13,13 @@ var spy = require("./spy");
 var extend = require("./util/core/extend");
 var createInstance = require("./util/core/create");
 var functionToString = require("./util/core/function-to-string");
-var valueToString = require("./util/core/value-to-string");
 var wrapMethod = require("./util/core/wrap-method");
 var stubEntireObject = require("./stub-entire-object");
 var stubDescriptor = require("./stub-descriptor");
-
-function verifyArguments(object, property) {
-    if (property && !object) {
-        var type = object === null ? "null" : "undefined";
-        throw new Error("Trying to stub property '" + valueToString(property) + "' of " + type);
-    }
-}
+var throwOnFalsyObject = require("./throw-on-falsy-object");
 
 function stub(object, property, descriptor) {
-    verifyArguments.apply(null, arguments);
+    throwOnFalsyObject.apply(null, arguments);
 
     var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
     var isCreatingNewStub = !object && typeof property === "undefined";

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -18,17 +18,21 @@ var wrapMethod = require("./util/core/wrap-method");
 var stubEntireObject = require("./stub-entire-object");
 var stubDescriptor = require("./stub-descriptor");
 
+function verifyArguments(object, property) {
+    if (property && !object) {
+        var type = object === null ? "null" : "undefined";
+        throw new Error("Trying to stub property '" + valueToString(property) + "' of " + type);
+    }
+}
+
 function stub(object, property, descriptor) {
     var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
     var isStubbingDescriptor = Boolean(descriptor);
 
+    verifyArguments.apply(null, arguments);
+
     if (isStubbingEntireObject) {
         return stubEntireObject(stub, object);
-    }
-
-    if (property && !object) {
-        var type = object === null ? "null" : "undefined";
-        throw new Error("Trying to stub property '" + valueToString(property) + "' of " + type);
     }
 
     if (!object && typeof property === "undefined") {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -27,6 +27,7 @@ function verifyArguments(object, property) {
 
 function stub(object, property, descriptor) {
     var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
+    var isCreatingNewStub = !object && typeof property === "undefined";
     var isStubbingDescriptor = Boolean(descriptor);
 
     verifyArguments.apply(null, arguments);
@@ -35,7 +36,7 @@ function stub(object, property, descriptor) {
         return stubEntireObject(stub, object);
     }
 
-    if (!object && typeof property === "undefined") {
+    if (isCreatingNewStub) {
         return stub.create();
     }
 

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -26,11 +26,15 @@ function verifyArguments(object, property) {
 }
 
 function stub(object, property, descriptor) {
+    verifyArguments.apply(null, arguments);
+
     var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
     var isCreatingNewStub = !object && typeof property === "undefined";
-    var isStubbingDescriptor = Boolean(descriptor);
-
-    verifyArguments.apply(null, arguments);
+    var isStubbingDescriptor = object && property && Boolean(descriptor);
+    var isStubbingExistingMethod = !isStubbingDescriptor
+                                    && typeof object === "object"
+                                    && typeof object[property] === "function";
+    var arity = isStubbingExistingMethod ? object[property].length : 0;
 
     if (isStubbingEntireObject) {
         return stubEntireObject(stub, object);
@@ -44,14 +48,7 @@ function stub(object, property, descriptor) {
         return stubDescriptor.apply(null, arguments);
     }
 
-    var wrapper;
-    var stubLength = 0;
-    if (typeof object === "object" && typeof object[property] === "function") {
-        stubLength = object[property].length;
-    }
-    wrapper = stub.create(stubLength);
-
-    return wrapMethod(object, property, wrapper);
+    return wrapMethod(object, property, stub.create(arity));
 }
 
 stub.createStubInstance = function (constructor) {

--- a/lib/sinon/throw-on-falsy-object.js
+++ b/lib/sinon/throw-on-falsy-object.js
@@ -1,0 +1,11 @@
+"use strict";
+var valueToString = require("./util/core/value-to-string");
+
+function throwOnFalsyObject(object, property) {
+    if (property && !object) {
+        var type = object === null ? "null" : "undefined";
+        throw new Error("Trying to stub property '" + valueToString(property) + "' of " + type);
+    }
+}
+
+module.exports = throwOnFalsyObject;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -10,6 +10,7 @@ var assert = referee.assert;
 var refute = referee.refute;
 var fail = referee.fail;
 var Promise = require("native-promise-only"); // eslint-disable-line no-unused-vars
+var deprecated = require("../lib/sinon/util/core/deprecated");
 
 describe("stub", function () {
     it("is spy", function () {
@@ -33,11 +34,14 @@ describe("stub", function () {
     });
 
     it("fails if called with an empty property descriptor", function () {
+        var originalPrintWarning = deprecated.printWarning;
         var error;
         var propertyKey = "ea762c6d-16ab-4ded-8bc2-3bc6f2de2925";
         var object = {};
 
         object[propertyKey] = "257b38d8-3c02-4353-82ab-b1b588be6990";
+
+        deprecated.printWarning = function () {};
 
         try {
             createStub(object, propertyKey, {});
@@ -46,6 +50,8 @@ describe("stub", function () {
         }
 
         assert.equals(error.message, "Expected property descriptor to have at least one key");
+
+        deprecated.printWarning = originalPrintWarning;
     });
 
     it("throws a readable error if stubbing Symbol on null", function () {
@@ -749,11 +755,16 @@ describe("stub", function () {
         });
 
         it("throws if third argument is provided but not a proprety descriptor", function () {
+            var originalPrintWarning = deprecated.printWarning;
             var object = this.object;
+
+            deprecated.printWarning = function () {};
 
             assert.exception(function () {
                 createStub(object, "method", 1);
             }, "TypeError");
+
+            deprecated.printWarning = originalPrintWarning;
         });
 
         it("stubbed method should be proper stub", function () {
@@ -912,6 +923,10 @@ describe("stub", function () {
         });
 
         it("does not call getter during restore", function () {
+            var originalPrintWarning = deprecated.printWarning;
+
+            deprecated.printWarning = function () {};
+
             var obj = {
                 get prop() {
                     fail("should not call getter");
@@ -924,6 +939,7 @@ describe("stub", function () {
             assert.equals(obj.prop, 43);
 
             stub.restore();
+            deprecated.printWarning = originalPrintWarning;
         });
     });
 


### PR DESCRIPTION
This PR refactors `sinon.stub()` and `sandbox.stub()` (internally `collection.stub()` methods to improve legibility.

Feedback on naming of files and functions as well as locations of these in the tree is most welcome.

The aim was to not make *any* changes to functionality, but make it easier to understand the `stub` methods and to highlight differences between them for future improvements.

During refactoring this, I discovered an inconsistency in the API.

#### Proposal: fix inconsistency of stubbing non-function properties

As you can see in `collection.stub` and its tests, it supports stubbing non-function properties, which `sinon.stub` does not.

The documentation for `sandbox.stub` reads:

> The sandbox `stub` method can also be used to stub any kind of property. This is useful if you need to override an object's property for the duration of a test, and have it restored when the test completes

In my opinion, stubs should be used for replacing methods and objects with fakes. Instead of stubbing out a property on an object for the duration of a test, the author should use a stub in the right place to return an entirely fake object that has the (fake) methods and properties that is needed for the test.

I propose that we remove stubbing of non-function properties feature from `collection.stub`, so that it's behaviour matches that of `sinon.stub` (since it would then defer everything to `sinon.stub`).

I am happy to do that as part of this PR.

What do you think?