### PR TITLE
Add documentation for .rejects() and .resolves()

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -226,7 +226,7 @@ Causes the stub to return its <code>this</code> value.
 
 Useful for stubbing jQuery-style fluent APIs.
 
-#### `stub.resolves(obj);`
+#### `stub.resolves(value);`
 
 Causes the stub to return a Promise which resolves to the provided value.
 
@@ -268,7 +268,7 @@ Causes the stub to return a Promise which rejects with an exception of the provi
 *Since `sinon@2.0.0`*
 
 
-#### `stub.rejects(obj);`
+#### `stub.rejects(value);`
 
 Causes the stub to return a Promise which rejects with the provided exception object.
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -226,6 +226,15 @@ Causes the stub to return its <code>this</code> value.
 
 Useful for stubbing jQuery-style fluent APIs.
 
+#### `stub.resolves(obj);`
+
+Causes the stub to return a Promise which resolves to the provided value.
+
+When constructing the Promise, sinon uses the `Promise.resolve` method. You are
+responsible for providing a polyfill in environments which do not provide `Promise`.
+
+*Since `sinon@2.0.0`*
+
 
 #### `stub.throws();`
 
@@ -240,6 +249,30 @@ Causes the stub to throw an exception of the provided type.
 #### `stub.throws(obj);`
 
 Causes the stub to throw the provided exception object.
+
+
+#### `stub.rejects();`
+
+Causes the stub to return a Promise which rejects with an exception (`Error`).
+
+When constructing the Promise, sinon uses the `Promise.reject` method. You are
+responsible for providing a polyfill in environments which do not provide `Promise`.
+
+*Since `sinon@2.0.0`*
+
+
+#### `stub.rejects("TypeError");`
+
+Causes the stub to return a Promise which rejects with an exception of the provided type.
+
+*Since `sinon@2.0.0`*
+
+
+#### `stub.rejects(obj);`
+
+Causes the stub to return a Promise which rejects with the provided exception object.
+
+*Since `sinon@2.0.0`*
 
 
 #### `stub.callsArg(index);`


### PR DESCRIPTION
#### Purpose (TL;DR)

This PR adds documentation for the functionality provided by #1211.
It has the mention "since sinon@2.0.0".

#### Background (Problem in detail)  - optional

I completely forgot to document the functionality in the first PR. Sorry =)

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. open `docs/release-source/release/stubs.md`
3. Look for ".resolves" and ".rejects"
