### PR TITLE
Update changelog page in postversion.sh

### DIFF
--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -7,5 +7,9 @@ echo 'postversion tasks'
 echo 'set new current/next release id in documentation'
 node ./scripts/set-release-id-in-config-yml.js
 
+echo 'update changelog'
+./scripts/update-changelog-page.sh
+
+git add docs/changelog.md
 git add docs/_config.yml
-git commit -m "Update docs/_config.yml with new release id: $PACKAGE_VERSION"
+git commit -m "Update docs/changelog.md and set new release id in docs/_config.yml"

--- a/scripts/update-changelog-page.sh
+++ b/scripts/update-changelog-page.sh
@@ -1,0 +1,9 @@
+cat > docs/changelog.md <<EOL
+---
+layout: default
+title: Changelog
+permalink: /releases/changelog
+---
+# Changelog
+$(<Changelog.txt)
+EOL


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
> Implement task #1219 by creating shell script to copy Changelog.txt into docs directory as a markdown file.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. Run ./scripts/postversion.sh 
3. Run bundle exec jekyll serve
4. Go to http://localhost:4000/sinon/releases/changelog
