### PR TITLE
Update Gemfile for ruby 2.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       gemoji (~> 2.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.11.1)
     liquid (3.0.6)
     listen (3.0.6)
@@ -199,7 +199,7 @@ DEPENDENCIES
   minima (~> 2.0)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.4.0p0
 
 BUNDLED WITH
-   1.13.5
+   1.13.7


### PR DESCRIPTION
#### Purpose 

Make the new documentation site compatible with ruby@2.4.0

#### Solution  - optional

Update the `json` gem to a compatible version

#### How to verify - mandatory

1. Have ruby 2.4.0 installed (`brew install ruby` on macOS)
1. Check out this branch (see github instructions below)
1. `bundle install`
1. `cd docs`
1. `bundle exec jekyll serve`
1. Navigate to http://127.0.0.1:4000/sinon/
1. Verify that you're not seeing blank pages