### PR TITLE
Add error equality to deepEqual

### DIFF
--- a/lib/sinon/util/core/deep-equal.js
+++ b/lib/sinon/util/core/deep-equal.js
@@ -51,6 +51,10 @@ var deepEqual = module.exports = function deepEqual(a, b) {
             (a.ignoreCase === b.ignoreCase) && (a.multiline === b.multiline);
     }
 
+    if (a instanceof Error && b instanceof Error) {
+        return a === b;
+    }
+
     var aString = Object.prototype.toString.call(a);
     if (aString !== Object.prototype.toString.call(b)) {
         return false;

--- a/test/util/core/deep-equal-test.js
+++ b/test/util/core/deep-equal-test.js
@@ -63,6 +63,12 @@ describe("util/core/deepEqual", function () {
         assert(deepEqual(regexp, regexp));
     });
 
+    it("passes same error", function () {
+        var error = new Error();
+
+        assert(deepEqual(error, error));
+    });
+
     it("passes equal arrays", function () {
         var arr1 = [1, 2, 3, "hey", "there"];
         var arr2 = [1, 2, 3, "hey", "there"];
@@ -163,6 +169,13 @@ describe("util/core/deepEqual", function () {
         var regexp2 = /bar/ig;
 
         assert.isFalse(deepEqual(regexp1, regexp2));
+    });
+
+    it("fails unequal errors", function () {
+        var error1 = new Error();
+        var error2 = new Error();
+
+        assert.isFalse(deepEqual(error1, error2));
     });
 
     it("passes NaN and NaN", function () {


### PR DESCRIPTION
#### Purpose
Add `Error` equality to `deepEqual`. This change allows tests to be written like the below, which currently fail:

```javascript
 it('should throw a specific error', () => {
  const err = new Error('very specific error');
  const notSpecificErr = new Error();

  const func = e => e;
  const funcSpy = sinon.spy(func);
  funcSpy(err);

  expect(funcSpy).to.have.been.calledWithExactly(err);
  expect(funcSpy).not.to.have.been.calledWithExactly(notSpecificErr);
});
```

#### Solution

Modify `deepEqual` such that it identifies error comparisons and uses the `===` operator to check equality.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
