### PR TITLE
Fire onload event on non-2xx HTTP statuses in FakeXDomainRequest - fixes #1259

### DIFF
--- a/lib/sinon/util/fake_xdomain_request.js
+++ b/lib/sinon/util/fake_xdomain_request.js
@@ -82,7 +82,7 @@ extend(FakeXDomainRequest.prototype, event.EventTarget, {
             case FakeXDomainRequest.DONE:
                 if (this.isTimeout) {
                     eventName = "ontimeout";
-                } else if (this.errorFlag || (this.status < 200 || this.status > 299)) {
+                } else if (this.errorFlag || this.status === 0) {
                     eventName = "onerror";
                 } else {
                     eventName = "onload";

--- a/test/util/fake-xdomain-request-test.js
+++ b/test/util/fake-xdomain-request-test.js
@@ -272,6 +272,11 @@ if (typeof window !== "undefined") {
                 xdr.send();
                 xdr.respond(200, {}, "");
             });
+            it("fire onload event on a non-2xx HTTP status", function () {
+                this.xdr.onload = sinon.spy();
+                this.xdr.respond(500, {}, "");
+                assert.equals(this.xdr.onload.callCount, 1);
+            });
             it("calls readystate handler with readyState DONE once", function () {
                 this.xdr.respond(200, {}, "");
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fixes #1259 by triggering load event on non-2xx HTTP statuses in FakeXDomainRequest.

#### Background (Problem in detail)  - optional
 - The issue of when to trigger error vs. load events was originally brought up in #1040. 
 - #1102 fixed the original issue, but FakeXDomainRequest wasn't updated to reflect the decision.
 - This adds a test to ensure that the load event is fired, and updates FakeXDomainRequest.

#### Solution  - optional
See line: https://github.com/JoshuaCWebDeveloper/sinon/blob/802cee6a9c71cef35d7a0d543c5aab670289dda2/lib/sinon/util/fake_xdomain_request.js#L85

Only a status of 0 or a set errorFlag will trigger an error, any other condition will result in a load event during a DONE transition. This is similar to changes introduced in #1102.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test` (the new test should pass; it will fail if added and run outside of this PR)
