### PR TITLE
Add docs for stub.callThrough()

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -280,6 +280,32 @@ Causes the stub to return a Promise which rejects with the provided exception ob
 Causes the stub to call the argument at the provided index as a callback function. `stub.callsArg(0);` causes the stub to call the first argument as a callback.
 
 
+#### `stub.callThrough();`
+
+Causes the original method wrapped into the stub to be called when none of the conditional stubs are matched.
+
+```javascript
+var stub = sinon.stub();
+
+var obj = {};
+
+obj.sum = function sum(a, b) {
+    return a + b;
+};
+
+stub(obj, 'sum');
+
+obj.sum.withArgs(2, 2).callsFake(function foo() {
+    return 'bar';
+});
+
+obj.sum.callThrough();
+
+obj.sum(2, 2); // 'bar'
+obj.sum(1, 2); // 3
+```
+
+
 #### `stub.callsArgOn(index, context);`
 
 Like `stub.callsArg(index);` but with an additional parameter to pass the `this` context.


### PR DESCRIPTION
### Purpose (TL;DR) - mandatory

This aims to add docs for the `callThrough` method added to the `stub` object in #1234. This closes #1280.

It allows users to call the original wrapped method when none of the conditional stubs are matched.

### Solution

I just added a new entry into the markdown file for stubs and a small example.

Let me know if I missed anything.

### How to verify

1. Check out this branch (see github instructions below)
2. Go to the docs folder by running `cd docs` on Sinon's root folder
3. Ensure you have bundler by running `gem install bundler`
4. Install dependencies by running `bundle install`
5. Run a local server by running `bundle exec jekyll serve`
6. Go to `http://localhost:4000/releases/v2.0.0-pre.4/stubs/` and check the new docs
