### PR TITLE
Fix invalid release number in v1.17.7.md front matter

### DIFF
--- a/docs/_releases/v1.17.7.md
+++ b/docs/_releases/v1.17.7.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: API documentation
-release_id: v1.17.6
+release_id: v1.17.7
 ---
 
 # {{page.title}} - {{page.release_id}}


### PR DESCRIPTION
#### Purpose

Fix invalid release number on `/releases`

![2017-02-25 at 18 15](https://cloud.githubusercontent.com/assets/20321/23333124/7fa83e66-fb86-11e6-9385-6e8cd3f12065.png)

This was due to a copy operation in https://github.com/sinonjs/sinon/pull/1288/commits/52a9e8479285f4b15a24837df18cfe4737d02255