### PR TITLE
Use phantomjs-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mochify": "^3.0.0",
     "mochify-istanbul": "^2.4.1",
     "phantomic": "^1.4.0",
-    "phantomjs": "^2.1.7",
+    "phantomjs-prebuilt": "^2.1.14",
     "pre-commit": "^1.1.2",
     "referee": "^1.2.0",
     "rimraf": "^2.5.3"


### PR DESCRIPTION
#### Purpose 

The npm package `phantomjs` has been deprecated and has been replaced with
`phantomjs-prebuilt`

https://github.com/Medium/phantomjs
