### PR TITLE
Add getters/setters stub behaviors new API

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -448,3 +448,38 @@ var stub = sinon.stub().returnsNum(42);
 
 assert.equals(stub(), 42);
 ```
+
+#### `stub.get(getterFn)`
+
+Replaces a new getter for this stub.
+
+```javascript
+var myObj = {
+    prop: 'foo'
+};
+
+createStub(myObj, 'prop').get(function getterFn() {
+    return 'bar';
+});
+
+myObj.example; // 'bar'
+```
+
+#### `stub.set(setterFn)`
+
+Defines a new setter for this stub.
+
+```javascript
+var myObj = {
+    example: 'oldValue',
+    prop: 'foo'
+};
+
+createStub(myObj, 'prop').set(function setterFn(val) {
+    myObj.example = val;
+});
+
+myObj.prop = 'baz';
+
+myObj.example; // 'baz'
+```

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -163,6 +163,26 @@ module.exports = {
 
     callThrough: function callThrough(fake) {
         fake.callsThrough = true;
+    },
+
+    get: function get(fake, getterFunction) {
+        var rootStub = fake.stub || fake;
+
+        Object.defineProperty(rootStub.rootObj, rootStub.propName, {
+            get: getterFunction
+        });
+
+        return fake;
+    },
+
+    set: function set(fake, setterFunction) {
+        var rootStub = fake.stub || fake;
+
+        Object.defineProperty(rootStub.rootObj, rootStub.propName, { // eslint-disable-line accessor-pairs
+            set: setterFunction
+        });
+
+        return fake;
     }
 };
 

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -44,12 +44,11 @@ function stub(object, property, descriptor) {
     var s = stub.create(arity);
     s.rootObj = object;
     s.propName = property;
+    s.restore = function restore() {
+        Object.defineProperty(object, property, actualDescriptor);
+    };
 
-    if (isStubbingNonFuncProperty) {
-        return s;
-    }
-
-    return wrapMethod(object, property, s);
+    return isStubbingNonFuncProperty ? s : wrapMethod(object, property, s);
 }
 
 stub.createStubInstance = function (constructor) {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -5,6 +5,7 @@ var behaviors = require("./default-behaviors");
 var spy = require("./spy");
 var extend = require("./util/core/extend");
 var functionToString = require("./util/core/function-to-string");
+var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var wrapMethod = require("./util/core/wrap-method");
 var stubEntireObject = require("./stub-entire-object");
 var stubDescriptor = require("./stub-descriptor");
@@ -13,24 +14,38 @@ var throwOnFalsyObject = require("./throw-on-falsy-object");
 function stub(object, property, descriptor) {
     throwOnFalsyObject.apply(null, arguments);
 
+    var actualDescriptor = getPropertyDescriptor(object, property);
     var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
     var isCreatingNewStub = !object && typeof property === "undefined";
     var isStubbingDescriptor = object && property && Boolean(descriptor);
+    var isStubbingNonFuncProperty = typeof object === "object"
+                                    && typeof property !== "undefined"
+                                    && (typeof actualDescriptor === "undefined"
+                                    || typeof actualDescriptor.value !== "function")
+                                    && typeof descriptor === "undefined";
     var isStubbingExistingMethod = !isStubbingDescriptor
                                     && typeof object === "object"
-                                    && typeof object[property] === "function";
+                                    && typeof actualDescriptor !== "undefined"
+                                    && typeof actualDescriptor.value === "function";
     var arity = isStubbingExistingMethod ? object[property].length : 0;
 
     if (isStubbingEntireObject) {
         return stubEntireObject(stub, object);
     }
 
+    if (isStubbingDescriptor) {
+        return stubDescriptor.apply(null, arguments);
+    }
+
     if (isCreatingNewStub) {
         return stub.create();
     }
 
-    if (isStubbingDescriptor) {
-        return stubDescriptor.apply(null, arguments);
+    if (isStubbingNonFuncProperty) {
+        var s = stub.create();
+        s.rootObj = object;
+        s.propName = property;
+        return s;
     }
 
     return wrapMethod(object, property, stub.create(arity));

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -41,14 +41,15 @@ function stub(object, property, descriptor) {
         return stub.create();
     }
 
+    var s = stub.create(arity);
+    s.rootObj = object;
+    s.propName = property;
+
     if (isStubbingNonFuncProperty) {
-        var s = stub.create();
-        s.rootObj = object;
-        s.propName = property;
         return s;
     }
 
-    return wrapMethod(object, property, stub.create(arity));
+    return wrapMethod(object, property, s);
 }
 
 stub.createStubInstance = function (constructor) {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2288,7 +2288,7 @@ describe("stub", function () {
                 prop: "foo"
             };
 
-            createStub(myObj, "prop").get(function () {
+            createStub(myObj, "prop").get(function getterFn() {
                 return "bar";
             });
 
@@ -2302,7 +2302,7 @@ describe("stub", function () {
                 }
             };
 
-            createStub(myObj, "prop").get(function () {
+            createStub(myObj, "prop").get(function getterFn() {
                 return "bar";
             });
 
@@ -2316,7 +2316,7 @@ describe("stub", function () {
                 }
             };
 
-            createStub(myObj, "prop").get(function () {
+            createStub(myObj, "prop").get(function getterFn() {
                 return "bar";
             });
 
@@ -2326,7 +2326,7 @@ describe("stub", function () {
         it("can set getters for non-existing properties", function () {
             var myObj = {};
 
-            createStub(myObj, "prop").get(function () {
+            createStub(myObj, "prop").get(function getterFn() {
                 return "bar";
             });
 
@@ -2334,7 +2334,7 @@ describe("stub", function () {
         });
 
         it("can restore stubbed setters for functions", function () {
-            var propFn = function () {
+            var propFn = function propFn() {
                 return "bar";
             };
 
@@ -2344,7 +2344,7 @@ describe("stub", function () {
 
             var stub = createStub(myObj, "prop");
 
-            stub.get(function () {
+            stub.get(function getterFn() {
                 return "baz";
             });
 
@@ -2362,7 +2362,7 @@ describe("stub", function () {
 
             var stub = createStub(myObj, "prop");
 
-            stub.get(function () {
+            stub.get(function getterFn() {
                 return "baz";
             });
 
@@ -2378,7 +2378,7 @@ describe("stub", function () {
                 prop: "foo"
             };
 
-            createStub(myObj, "prop").set(function () {
+            createStub(myObj, "prop").set(function setterFn() {
                 myObj.example = "bar";
             });
 
@@ -2394,7 +2394,7 @@ describe("stub", function () {
                 }
             };
 
-            createStub(myObj, "prop").set(function () {
+            createStub(myObj, "prop").set(function setterFn() {
                 myObj.example = "bar";
             });
 
@@ -2410,7 +2410,7 @@ describe("stub", function () {
                 }
             };
 
-            createStub(myObj, "prop").set(function () {
+            createStub(myObj, "prop").set(function setterFn() {
                 myObj.example = "bar";
             });
 
@@ -2422,7 +2422,7 @@ describe("stub", function () {
         it("can set setters for non-existing properties", function () {
             var myObj = {};
 
-            createStub(myObj, "prop").set(function () {
+            createStub(myObj, "prop").set(function setterFn() {
                 myObj.example = "bar";
             });
 
@@ -2432,7 +2432,7 @@ describe("stub", function () {
         });
 
         it("can restore stubbed setters for functions", function () {
-            var propFn = function () {
+            var propFn = function propFn() {
                 return "bar";
             };
 
@@ -2442,7 +2442,7 @@ describe("stub", function () {
 
             var stub = createStub(myObj, "prop");
 
-            stub.set(function () {
+            stub.set(function setterFn() {
                 myObj.otherProp = "baz";
             });
 
@@ -2461,7 +2461,7 @@ describe("stub", function () {
 
             var stub = createStub(myObj, "prop");
 
-            stub.set(function () {
+            stub.set(function setterFn() {
                 myObj.otherProp = "baz";
             });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2332,6 +2332,44 @@ describe("stub", function () {
 
             assert.equals(myObj.prop, "bar");
         });
+
+        it("can restore stubbed setters for functions", function () {
+            var propFn = function () {
+                return "bar";
+            };
+
+            var myObj = {
+                prop: propFn
+            };
+
+            var stub = createStub(myObj, "prop");
+
+            stub.get(function () {
+                return "baz";
+            });
+
+            stub.restore();
+
+            assert.equals(myObj.prop, propFn);
+        });
+
+        it("can restore stubbed getters for properties", function () {
+            var myObj = {
+                get prop() {
+                    return "bar";
+                }
+            };
+
+            var stub = createStub(myObj, "prop");
+
+            stub.get(function () {
+                return "baz";
+            });
+
+            stub.restore();
+
+            assert.equals(myObj.prop, "bar");
+        });
     });
 
     describe(".set", function () {
@@ -2391,6 +2429,46 @@ describe("stub", function () {
             myObj.prop = "foo";
 
             assert.equals(myObj.example, "bar");
+        });
+
+        it("can restore stubbed setters for functions", function () {
+            var propFn = function () {
+                return "bar";
+            };
+
+            var myObj = {
+                prop: propFn
+            };
+
+            var stub = createStub(myObj, "prop");
+
+            stub.set(function () {
+                myObj.otherProp = "baz";
+            });
+
+            stub.restore();
+
+            assert.equals(myObj.prop, propFn);
+        });
+
+        it("can restore stubbed setters for properties", function () {
+            var myObj = { // eslint-disable-line accessor-pairs
+                set prop(val) {
+                    this.otherProp = "bar";
+                    return "bar";
+                }
+            };
+
+            var stub = createStub(myObj, "prop");
+
+            stub.set(function () {
+                myObj.otherProp = "baz";
+            });
+
+            stub.restore();
+
+            myObj.prop = "foo";
+            assert.equals(myObj.otherProp, "bar");
         });
     });
 });

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2295,6 +2295,20 @@ describe("stub", function () {
             assert.equals(myObj.prop, "bar");
         });
 
+        it("allows users to stub getter functions for functions", function () {
+            var myObj = {
+                prop: function propGetter() {
+                    return "foo";
+                }
+            };
+
+            createStub(myObj, "prop").get(function () {
+                return "bar";
+            });
+
+            assert.equals(myObj.prop, "bar");
+        });
+
         it("replaces old getters", function () {
             var myObj = {
                 get prop() {
@@ -2324,6 +2338,22 @@ describe("stub", function () {
         it("allows users to stub setter functions for properties", function () {
             var myObj = {
                 prop: "foo"
+            };
+
+            createStub(myObj, "prop").set(function () {
+                myObj.example = "bar";
+            });
+
+            myObj.prop = "baz";
+
+            assert.equals(myObj.example, "bar");
+        });
+
+        it("allows users to stub setter functions for functions", function () {
+            var myObj = {
+                prop: function propSetter() {
+                    return "foo";
+                }
             };
 
             createStub(myObj, "prop").set(function () {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -800,16 +800,6 @@ describe("stub", function () {
             assert.isFalse(stub.called);
         });
 
-        it("throws if property is not a function", function () {
-            var obj = { someProp: 42 };
-
-            assert.exception(function () {
-                createStub(obj, "someProp");
-            });
-
-            assert.equals(obj.someProp, 42);
-        });
-
         it("successfully stubs falsey properties", function () {
             var obj = { 0: function () { } };
 
@@ -943,16 +933,6 @@ describe("stub", function () {
     });
 
     describe("stubbed function", function () {
-        it("throws if stubbing non-existent property", function () {
-            var myObj = {};
-
-            assert.exception(function () {
-                createStub(myObj, "ouch");
-            });
-
-            refute.defined(myObj.ouch);
-        });
-
         it("has toString method", function () {
             var obj = { meth: function () {} };
             createStub(obj, "meth");
@@ -2299,6 +2279,88 @@ describe("stub", function () {
             myObj.prop("not foo");
 
             assert.equals(reference, myObj);
+        });
+    });
+
+    describe(".get", function () {
+        it("allows users to stub getter functions for properties", function () {
+            var myObj = {
+                prop: "foo"
+            };
+
+            createStub(myObj, "prop").get(function () {
+                return "bar";
+            });
+
+            assert.equals(myObj.prop, "bar");
+        });
+
+        it("replaces old getters", function () {
+            var myObj = {
+                get prop() {
+                    fail("should not call the old getter");
+                }
+            };
+
+            createStub(myObj, "prop").get(function () {
+                return "bar";
+            });
+
+            assert.equals(myObj.prop, "bar");
+        });
+
+        it("can set getters for non-existing properties", function () {
+            var myObj = {};
+
+            createStub(myObj, "prop").get(function () {
+                return "bar";
+            });
+
+            assert.equals(myObj.prop, "bar");
+        });
+    });
+
+    describe(".set", function () {
+        it("allows users to stub setter functions for properties", function () {
+            var myObj = {
+                prop: "foo"
+            };
+
+            createStub(myObj, "prop").set(function () {
+                myObj.example = "bar";
+            });
+
+            myObj.prop = "baz";
+
+            assert.equals(myObj.example, "bar");
+        });
+
+        it("replaces old setters", function () {
+            var myObj = { // eslint-disable-line accessor-pairs
+                set prop(val) {
+                    fail("should not call the old setter");
+                }
+            };
+
+            createStub(myObj, "prop").set(function () {
+                myObj.example = "bar";
+            });
+
+            myObj.prop = "foo";
+
+            assert.equals(myObj.example, "bar");
+        });
+
+        it("can set setters for non-existing properties", function () {
+            var myObj = {};
+
+            createStub(myObj, "prop").set(function () {
+                myObj.example = "bar";
+            });
+
+            myObj.prop = "foo";
+
+            assert.equals(myObj.example, "bar");
         });
     });
 });


### PR DESCRIPTION
**This pull request is now complete. Please see [this comment](https://github.com/sinonjs/sinon/pull/1297#issuecomment-285877735) to read about the new changes.**

## Purpose (TL;DR)

This aims to add `get/set` stubbing features for #1258.

I also added some tests for it (supporting only the current state of this PR, not the whole feature).

## Background

As I've said in the previous section, given the new API and deprecation of `stubDescriptor` (#1239) we should have a new API for setting getter and setter stubs.

Right now it's only allowing us to define getters and setters for non-function properties. Which I admit is not that useful as if it allowed stubbing getters and setters for functions too.

**The reason I'm opening an incomplete PR is both to have your feedback on the current work and also because I'll be traveling tomorrow so I won't have time to work on this for the next two weeks so I will leave this here in case someone wants to continue this work (sorry for that!).**


## Solution 

Since this solution is partial I'll explain what I've done until now and the problems I've faced.

First of all I needed to store a reference to the root object and the original property name which we're adding this stub to [in this line](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:getters-setters-new-api?expand=1#diff-048fb1194de4b43f7f7e45758f900749R43). I only do that when someone passes a non-function property in order to avoid calling `wrapMethod` which ends up throwing an error when we pass non-function properties to it. We might want to look forward to allow it to wrap non-function properties too in order to fully accomplish this PR's goal.

The reason I needed to import [`getPropertyDescriptor`](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:getters-setters-new-api?expand=1#diff-048fb1194de4b43f7f7e45758f900749R16) is to avoid triggering existing getters when doing our property type checks.

Then finally I have just added two new behaviors which you can see [here](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:getters-setters-new-api?expand=1#diff-90c61de3967bc714354fe10dcfa51b57R353) and [here](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:getters-setters-new-api?expand=1#diff-90c61de3967bc714354fe10dcfa51b57R363). These are the methods responsible for adding the getter/setter replacements to the desired property on the object we're stubbing. It simply gets the reference to the root object and the property's name and defines a new descriptor for it.

#### Known Issues With This Approach:
* We cannot stub getters/setters for functions
* We cannot `restore` these getters/setters

Also, @fatso83 talked to me about not having the stub available anymore when retrieving a property if we stub its property descriptor. I haven't thought about this when I was talking to him, but since the behavior methods return `this.chain()` it would not be a problem, we would just need to assign the result of calling the `get` or `set` method to a variable and then use it to manage our stub.

#### Things we might wanna do for this to be complete:
* Allow `wrapMethod` to wrap non-function properties in order for us to be able to stub them
* Allowing it to wrap non-function properties would also be cool because then we could just call it on our behaviors passing property descriptors and then we would be able to restore them and we also get to reuse more code

In a nutshell: if we make `wrapMethod` work for this use case it would be perfect because then we could use it and accomplish our goal without too much branching.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test` -> This will run the newly created tests

Feel free to clone my fork and continue your work from there if you want to, this is just a proof of concept and a way of sharing what I've thought as I was talking to @fatso83 this morning.

Sorry again for not being able to finish this, I hope this PR helps you deciding what to do.