### PR TITLE
Optimize performance of call-stack getting

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -174,10 +174,17 @@ var callProto = {
         return callStr;
     }
 };
+Object.defineProperty(callProto, "stack", {
+    enumerable: true,
+    configurable: true,
+    get: function () {
+        return this.errorWithCallStack && this.errorWithCallStack.stack || "";
+    }
+});
 
 callProto.invokeCallback = callProto.yield;
 
-function createSpyCall(spy, thisValue, args, returnValue, exception, id, stack) {
+function createSpyCall(spy, thisValue, args, returnValue, exception, id, errorWithCallStack) {
     if (typeof id !== "number") {
         throw new TypeError("Call id is not a number");
     }
@@ -188,7 +195,7 @@ function createSpyCall(spy, thisValue, args, returnValue, exception, id, stack) 
     proxyCall.returnValue = returnValue;
     proxyCall.exception = exception;
     proxyCall.callId = id;
-    proxyCall.stack = stack;
+    proxyCall.errorWithCallStack = errorWithCallStack;
 
     return proxyCall;
 }

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -130,7 +130,7 @@ var spyApi = {
         this.thisValues = [];
         this.exceptions = [];
         this.callIds = [];
-        this.stacks = [];
+        this.errorsWithCallStack = [];
         if (this.fakes) {
             this.fakes.forEach(function (fake) {
                 fake.reset();
@@ -203,15 +203,13 @@ var spyApi = {
         push.call(this.exceptions, exception);
         push.call(this.returnValues, returnValue);
         var err = new ErrorConstructor();
-        var stack = err.stack;
-        if (!stack) {
-            // PhantomJS does not serialize the stack trace until the error has been thrown:
-            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack
-            try {
-                throw err;
-            } catch (e) {/* empty */}
-        }
-        push.call(this.stacks, err.stack);
+        // 1. Please do not get stack at this point. It's may be so very slow, and not actually used
+        // 2. PhantomJS does not serialize the stack trace until the error has been thrown:
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack
+        try {
+            throw err;
+        } catch (e) {/* empty */}
+        push.call(this.errorsWithCallStack, err);
 
         // Make return value and exception available in the calls:
         createCallProperties.call(this);
@@ -235,7 +233,7 @@ var spyApi = {
 
         return spyCall(this, this.thisValues[i], this.args[i],
                                 this.returnValues[i], this.exceptions[i],
-                                this.callIds[i], this.stacks[i]);
+                                this.callIds[i], this.errorsWithCallStack[i]);
     },
 
     getCalls: function () {


### PR DESCRIPTION
call stack not actually needed at most cases, but got always
get(actually only first get) call stack from error is so slow operation, and may be moved on-demand getter

#### Purpose (TL;DR) - mandatory
> Optimize work with callstack of stubbing
> Call of stubbed functions was 5-15 times faster

#### Background (Problem in detail)  - optional
> When stubbed function call, that remember hist call stack for use in call.toString()
> But get stack-property from Error-object is so slow in first getting
> Also this very slow with babel, because used source-map convert of stack
> I think, that not actually need get stack, when call-object constructed, but may getted when this really need(at toString() method)

#### Solution  - optional
> I not resolve stack at call-object constructring, but I remeber only generated Error-object
> Only when stack actually needed, I get it from Error-object
> Important: only first getting of stack from Error-object is slow. Repeated get stack is cached(I check this at Chrome)

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. Put in root of repo this file https://gist.github.com/Gvozd/291e4f0adf247ff70ed72150059e4977
4. Run this file with `node` or `babel-node` command
5. Performance of running this example is better, than withount my fix
x5 times at Node.js
x15 times at babel-node
