### PR TITLE
Redirect /docs and /downloads to /releases

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,6 +15,7 @@ kramdown:
     disable: true
 gems:
   - jekyll-feed
+  - jekyll-redirect-from
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 permalink: /releases/index.html
+redirect_from:
+    - /docs
+    - /downloads
 ---
 
 <h1>Releases</h1>


### PR DESCRIPTION
Ref #1299 Google is currently sending people to our old /docs and /downloads pages.

While creating a better solution this redirect could serve as an interim hotfix that at least will give people something more helpful than a 404 page.