### PR TITLE
Docs fixups

### DIFF
--- a/docs/_releases/v1.17.6/mocks.md
+++ b/docs/_releases/v1.17.6/mocks.md
@@ -28,7 +28,7 @@ Thus, they enforce implementation details. The rule of thumb is: if you wouldn't
 
 In general you should have **no more than one** mock (possibly with several expectations) in a single test.
 
-[Expectations](#expectations) implement both the [spies](#spies) and [stubs](#stubs) APIs.
+[Expectations](#expectations) implement both the [spies](../spies) and [stubs](../stubs) APIs.
 
 To see what mocks look like in Sinon.JS, here is one of the [PubSubJS][pubsubjs] tests again, this time using a method as callback and using mocks to verify its behavior
 

--- a/docs/_releases/v1.17.6/mocks.md
+++ b/docs/_releases/v1.17.6/mocks.md
@@ -63,7 +63,7 @@ Creates a mock for the provided object.
 Does not change the object, but returns a mock object to set expectations on the object's methods.
 
 
-#### `var expectation = mock.expects(\"method\");`
+#### `var expectation = mock.expects("method");`
 
 Overrides `obj.method` with a mock function and returns it.
 

--- a/docs/_releases/v1.17.6/sandbox.md
+++ b/docs/_releases/v1.17.6/sandbox.md
@@ -61,7 +61,7 @@ sinon.defaultConfig = {
   <dt><code>useFakeServer</code></dt>
   <dd>If <code>true</code>, <code>server</code> and <code>requests</code> properties are added to the sandbox. Can also be an object to use for fake server. The default one is <code>sinon.fakeServer</code>, but if you're using jQuery 1.3.x or some other library that does not set the XHR's <code>onreadystatechange</code> handler, you might want to do:
 
-<pre class=\"code-snippet\" data-lang=\"javascript\"><code>sinon.config = {
+<pre class="code-snippet" data-lang="javascript"><code>sinon.config = {
     useFakeServer: sinon.fakeServerWithClock
 };</code></pre></dd>
 </dl>

--- a/docs/_releases/v1.17.6/spies.md
+++ b/docs/_releases/v1.17.6/spies.md
@@ -299,7 +299,7 @@ This behaves the same as `spy.neverCalledWith(sinon.match(arg1), sinon.match(arg
 Returns `true` if spy threw an exception at least once.
 
 
-#### `spy.threw(\"TypeError\");`
+#### `spy.threw("TypeError");`
 
 Returns `true` if spy threw an exception of the provided type at least once.
 
@@ -314,7 +314,7 @@ Returns `true` if spy threw the provided exception object at least once.
 Returns `true` if spy always threw an exception.
 
 
-#### `spy.alwaysThrew(\"TypeError\");`
+#### `spy.alwaysThrew("TypeError");`
 
 Returns `true` if spy always threw an exception of the provided type.
 
@@ -462,7 +462,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 Returns `true` if call threw an exception.
 
 
-#### `spyCall.threw(TypeError\");`
+#### `spyCall.threw("TypeError");`
 
 Returns `true` if call threw exception of provided type.
 

--- a/docs/_releases/v1.17.6/stubs.md
+++ b/docs/_releases/v1.17.6/stubs.md
@@ -51,13 +51,13 @@ before one of the other callbacks.
 
 Calling behavior defining methods like `returns` or `throws` multiple times
 overrides the behavior of the stub. As of Sinon version 1.8, you can use the
-[`onCall`]("#stub-onCall) method to make a stub respond differently on
+[`onCall`](#stub-onCall) method to make a stub respond differently on
 consecutive calls.
 
 Note that in Sinon version 1.5 to version 1.7, multiple calls to the `yields*`
 and `callsArg*` family of methods define a sequence of behaviors for consecutive
-calls. As of 1.8, this functionality has been removed in favor of the <a
-href="#stub-onCall"><code>onCall</code></a> API.
+calls. As of 1.8, this functionality has been removed in favor of the
+[`onCall`](#stub-onCall) API.
 
 [pubsubjs]: https://github.com/mroderick/pubsubjs
 
@@ -82,7 +82,7 @@ Replaces `object.method` with a `func`, wrapped in a `spy`.
 
 As usual, `object.method.restore();` can be used to restore the original method.
 
-#### `name "var stub = sinon.stub(obj);`
+#### `var stub = sinon.stub(obj);`
 
 Stubs all the object's methods.
 
@@ -96,7 +96,7 @@ If you want to create a stub object of `MyConstructor`, but don't want the const
 var stub = sinon.createStubInstance(MyConstructor)
 ```
 
-#### `name "stub.withArgs(arg1[, arg2, ...]);`
+#### `stub.withArgs(arg1[, arg2, ...]);`
 
 Stubs the method only for the provided arguments.
 
@@ -114,7 +114,7 @@ This is useful to be more expressive in your assertions, where you can access th
 }
 ```
 
-#### `name "stub.onCall(n);` *Added in v1.8*
+#### <a name="stub-onCall"></a>`"stub.onCall(n);` *Added in v1.8*
 
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 

--- a/docs/_releases/v1.17.6/stubs.md
+++ b/docs/_releases/v1.17.6/stubs.md
@@ -70,13 +70,13 @@ href="#stub-onCall"><code>onCall</code></a> API.
 Creates an anonymous stub function
 
 
-#### `var stub = sinon.stub(object, \"method\");`
+#### `var stub = sinon.stub(object, "method");`
 
 Replaces `object.method` with a stub function. An exception is thrown if the property is not already a function.
 
 The original function can be restored by calling `object.method.restore();` (or `stub.restore();`).
 
-#### `var stub = sinon.stub(object, \"method\", func);`
+#### `var stub = sinon.stub(object, "method", func);`
 
 Replaces `object.method` with a `func`, wrapped in a `spy`.
 
@@ -103,7 +103,7 @@ Stubs the method only for the provided arguments.
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
 ```javascript
-"test should stub method differently based on arguments\": function () {
+"test should stub method differently based on arguments": function () {
     var callback = sinon.stub();
     callback.withArgs(42).returns(1);
     callback.withArgs(1).throws("TypeError");
@@ -119,7 +119,7 @@ This is useful to be more expressive in your assertions, where you can access th
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 
 ```javascript
-"test should stub method differently on consecutive calls\": function () {
+"test should stub method differently on consecutive calls": function () {
     var callback = sinon.stub();
     callback.onCall(0).returns(1);
     callback.onCall(1).returns(2);
@@ -136,7 +136,7 @@ There are methods `onFirstCall`, `onSecondCall`,`onThirdCall` to make stub defin
 `onCall` can be combined with all of the behavior defining methods in this section.  In particular, it can be used together with `withArgs`.
 
 ```javascript
-"test should stub method differently on consecutive calls with certain argument\": function () {
+"test should stub method differently on consecutive calls with certain argument": function () {
     var callback = sinon.stub();
     callback.withArgs(42)
         .onFirstCall().returns(1)
@@ -264,7 +264,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 Like above but with an additional parameter to pass the `this` context."
 
 ```javascript
-"test should fake successful ajax request\": function () {
+"test should fake successful ajax request": function () {
     sinon.stub(jQuery, "ajax").yieldsTo("success", [1, 2, 3]);
 
     jQuery.ajax({

--- a/docs/_releases/v1.17.6/stubs.md
+++ b/docs/_releases/v1.17.6/stubs.md
@@ -261,7 +261,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 
 #### `stub.yieldsToOn(property, context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context."
+Like above but with an additional parameter to pass the `this` context.
 
 ```javascript
 "test should fake successful ajax request": function () {
@@ -285,7 +285,7 @@ If the stub was never called with a function argument, `yield` throws an error.
 Also aliased as `invokeCallback`.
 
 
-#### `stub.yieldTo(callback, [arg1, arg2, ...])``
+#### `stub.yieldTo(callback, [arg1, arg2, ...])`
 
 Invokes callbacks passed as a property of an object to the stub.
 

--- a/docs/_releases/v1.17.6/stubs.md
+++ b/docs/_releases/v1.17.6/stubs.md
@@ -20,7 +20,7 @@ Use a stub when you want to:
 
 1. Control a method's behavior from a test to force the code down a specific path. Examples include forcing a method to throw an error in order to test error handling.
 
-2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest or similar).
+2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest` or similar).
 
 The following example is yet another test from [PubSubJS][pubsubjs] which shows how to create an anonymous stub that throws an exception when called.
 

--- a/docs/_releases/v1.17.6/stubs.md
+++ b/docs/_releases/v1.17.6/stubs.md
@@ -8,7 +8,7 @@ breadcrumb: stubs
 
 Test stubs are functions (spies) with pre-programmed behavior.
 
-They support the full <a href="#spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
+They support the full <a href="../spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
 
 As spies, stubs can be either anonymous, or wrap existing functions. When
 wrapping an existing function with a stub, the original function is not called.

--- a/docs/_releases/v1.17.6/utils.md
+++ b/docs/_releases/v1.17.6/utils.md
@@ -32,7 +32,7 @@ Restores supplied method
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.
 
-The given constructor function is not invoked. See also the [stub API](#stubs).
+The given constructor function is not invoked. See also the [stub API](../stubs).
 
 #### `sinon.format(object);`
 

--- a/docs/_releases/v1.17.7/mocks.md
+++ b/docs/_releases/v1.17.7/mocks.md
@@ -28,7 +28,7 @@ Thus, they enforce implementation details. The rule of thumb is: if you wouldn't
 
 In general you should have **no more than one** mock (possibly with several expectations) in a single test.
 
-[Expectations](#expectations) implement both the [spies](#spies) and [stubs](#stubs) APIs.
+[Expectations](#expectations) implement both the [spies](../spies) and [stubs](../stubs) APIs.
 
 To see what mocks look like in Sinon.JS, here is one of the [PubSubJS][pubsubjs] tests again, this time using a method as callback and using mocks to verify its behavior
 

--- a/docs/_releases/v1.17.7/mocks.md
+++ b/docs/_releases/v1.17.7/mocks.md
@@ -63,7 +63,7 @@ Creates a mock for the provided object.
 Does not change the object, but returns a mock object to set expectations on the object's methods.
 
 
-#### `var expectation = mock.expects(\"method\");`
+#### `var expectation = mock.expects("method");`
 
 Overrides `obj.method` with a mock function and returns it.
 

--- a/docs/_releases/v1.17.7/sandbox.md
+++ b/docs/_releases/v1.17.7/sandbox.md
@@ -61,7 +61,7 @@ sinon.defaultConfig = {
   <dt><code>useFakeServer</code></dt>
   <dd>If <code>true</code>, <code>server</code> and <code>requests</code> properties are added to the sandbox. Can also be an object to use for fake server. The default one is <code>sinon.fakeServer</code>, but if you're using jQuery 1.3.x or some other library that does not set the XHR's <code>onreadystatechange</code> handler, you might want to do:
 
-<pre class=\"code-snippet\" data-lang=\"javascript\"><code>sinon.config = {
+<pre class="code-snippet" data-lang="javascript"><code>sinon.config = {
     useFakeServer: sinon.fakeServerWithClock
 };</code></pre></dd>
 </dl>

--- a/docs/_releases/v1.17.7/spies.md
+++ b/docs/_releases/v1.17.7/spies.md
@@ -299,7 +299,7 @@ This behaves the same as `spy.neverCalledWith(sinon.match(arg1), sinon.match(arg
 Returns `true` if spy threw an exception at least once.
 
 
-#### `spy.threw(\"TypeError\");`
+#### `spy.threw("TypeError");`
 
 Returns `true` if spy threw an exception of the provided type at least once.
 
@@ -314,7 +314,7 @@ Returns `true` if spy threw the provided exception object at least once.
 Returns `true` if spy always threw an exception.
 
 
-#### `spy.alwaysThrew(\"TypeError\");`
+#### `spy.alwaysThrew("TypeError");`
 
 Returns `true` if spy always threw an exception of the provided type.
 
@@ -462,7 +462,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 Returns `true` if call threw an exception.
 
 
-#### `spyCall.threw(TypeError\");`
+#### `spyCall.threw("TypeError");`
 
 Returns `true` if call threw exception of provided type.
 

--- a/docs/_releases/v1.17.7/stubs.md
+++ b/docs/_releases/v1.17.7/stubs.md
@@ -70,13 +70,13 @@ href="#stub-onCall"><code>onCall</code></a> API.
 Creates an anonymous stub function
 
 
-#### `var stub = sinon.stub(object, \"method\");`
+#### `var stub = sinon.stub(object, "method");`
 
 Replaces `object.method` with a stub function. An exception is thrown if the property is not already a function.
 
 The original function can be restored by calling `object.method.restore();` (or `stub.restore();`).
 
-#### `var stub = sinon.stub(object, \"method\", func);`
+#### `var stub = sinon.stub(object, "method", func);`
 
 Replaces `object.method` with a `func`, wrapped in a `spy`.
 
@@ -103,7 +103,7 @@ Stubs the method only for the provided arguments.
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
 ```javascript
-"test should stub method differently based on arguments\": function () {
+"test should stub method differently based on arguments": function () {
     var callback = sinon.stub();
     callback.withArgs(42).returns(1);
     callback.withArgs(1).throws("TypeError");
@@ -119,7 +119,7 @@ This is useful to be more expressive in your assertions, where you can access th
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 
 ```javascript
-"test should stub method differently on consecutive calls\": function () {
+"test should stub method differently on consecutive calls": function () {
     var callback = sinon.stub();
     callback.onCall(0).returns(1);
     callback.onCall(1).returns(2);
@@ -136,7 +136,7 @@ There are methods `onFirstCall`, `onSecondCall`,`onThirdCall` to make stub defin
 `onCall` can be combined with all of the behavior defining methods in this section.  In particular, it can be used together with `withArgs`.
 
 ```javascript
-"test should stub method differently on consecutive calls with certain argument\": function () {
+"test should stub method differently on consecutive calls with certain argument": function () {
     var callback = sinon.stub();
     callback.withArgs(42)
         .onFirstCall().returns(1)
@@ -264,7 +264,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 Like above but with an additional parameter to pass the `this` context."
 
 ```javascript
-"test should fake successful ajax request\": function () {
+"test should fake successful ajax request": function () {
     sinon.stub(jQuery, "ajax").yieldsTo("success", [1, 2, 3]);
 
     jQuery.ajax({

--- a/docs/_releases/v1.17.7/stubs.md
+++ b/docs/_releases/v1.17.7/stubs.md
@@ -261,7 +261,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 
 #### `stub.yieldsToOn(property, context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context."
+Like above but with an additional parameter to pass the `this` context.
 
 ```javascript
 "test should fake successful ajax request": function () {
@@ -285,7 +285,7 @@ If the stub was never called with a function argument, `yield` throws an error.
 Also aliased as `invokeCallback`.
 
 
-#### `stub.yieldTo(callback, [arg1, arg2, ...])``
+#### `stub.yieldTo(callback, [arg1, arg2, ...])`
 
 Invokes callbacks passed as a property of an object to the stub.
 

--- a/docs/_releases/v1.17.7/stubs.md
+++ b/docs/_releases/v1.17.7/stubs.md
@@ -51,13 +51,13 @@ before one of the other callbacks.
 
 Calling behavior defining methods like `returns` or `throws` multiple times
 overrides the behavior of the stub. As of Sinon version 1.8, you can use the
-[`onCall`]("#stub-onCall) method to make a stub respond differently on
+[`onCall`](#stub-onCall) method to make a stub respond differently on
 consecutive calls.
 
 Note that in Sinon version 1.5 to version 1.7, multiple calls to the `yields*`
 and `callsArg*` family of methods define a sequence of behaviors for consecutive
-calls. As of 1.8, this functionality has been removed in favor of the <a
-href="#stub-onCall"><code>onCall</code></a> API.
+calls. As of 1.8, this functionality has been removed in favor of the
+[`onCall`](#stub-onCall) API.
 
 [pubsubjs]: https://github.com/mroderick/pubsubjs
 
@@ -82,7 +82,7 @@ Replaces `object.method` with a `func`, wrapped in a `spy`.
 
 As usual, `object.method.restore();` can be used to restore the original method.
 
-#### `name "var stub = sinon.stub(obj);`
+#### `var stub = sinon.stub(obj);`
 
 Stubs all the object's methods.
 
@@ -96,7 +96,7 @@ If you want to create a stub object of `MyConstructor`, but don't want the const
 var stub = sinon.createStubInstance(MyConstructor)
 ```
 
-#### `name "stub.withArgs(arg1[, arg2, ...]);`
+#### `stub.withArgs(arg1[, arg2, ...]);`
 
 Stubs the method only for the provided arguments.
 
@@ -114,7 +114,7 @@ This is useful to be more expressive in your assertions, where you can access th
 }
 ```
 
-#### `name "stub.onCall(n);` *Added in v1.8*
+#### <a name="stub-onCall"></a>`stub.onCall(n);` *Added in v1.8*
 
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 

--- a/docs/_releases/v1.17.7/stubs.md
+++ b/docs/_releases/v1.17.7/stubs.md
@@ -20,7 +20,7 @@ Use a stub when you want to:
 
 1. Control a method's behavior from a test to force the code down a specific path. Examples include forcing a method to throw an error in order to test error handling.
 
-2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest or similar).
+2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest` or similar).
 
 The following example is yet another test from [PubSubJS][pubsubjs] which shows how to create an anonymous stub that throws an exception when called.
 

--- a/docs/_releases/v1.17.7/stubs.md
+++ b/docs/_releases/v1.17.7/stubs.md
@@ -8,7 +8,7 @@ breadcrumb: stubs
 
 Test stubs are functions (spies) with pre-programmed behavior.
 
-They support the full <a href="#spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
+They support the full <a href="../spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
 
 As spies, stubs can be either anonymous, or wrap existing functions. When
 wrapping an existing function with a stub, the original function is not called.

--- a/docs/_releases/v1.17.7/utils.md
+++ b/docs/_releases/v1.17.7/utils.md
@@ -32,7 +32,7 @@ Restores supplied method
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.
 
-The given constructor function is not invoked. See also the [stub API](#stubs).
+The given constructor function is not invoked. See also the [stub API](../stubs).
 
 #### `sinon.format(object);`
 

--- a/docs/_releases/v2.0.0-pre.4/mocks.md
+++ b/docs/_releases/v2.0.0-pre.4/mocks.md
@@ -28,7 +28,7 @@ Thus, they enforce implementation details. The rule of thumb is: if you wouldn't
 
 In general you should have **no more than one** mock (possibly with several expectations) in a single test.
 
-[Expectations](#expectations) implement both the [spies](#spies) and [stubs](#stubs) APIs.
+[Expectations](#expectations) implement both the [spies](../spies) and [stubs](../stubs) APIs.
 
 To see what mocks look like in Sinon.JS, here is one of the [PubSubJS][pubsubjs] tests again, this time using a method as callback and using mocks to verify its behavior
 

--- a/docs/_releases/v2.0.0-pre.4/mocks.md
+++ b/docs/_releases/v2.0.0-pre.4/mocks.md
@@ -63,7 +63,7 @@ Creates a mock for the provided object.
 Does not change the object, but returns a mock object to set expectations on the object's methods.
 
 
-#### `var expectation = mock.expects(\"method\");`
+#### `var expectation = mock.expects("method");`
 
 Overrides `obj.method` with a mock function and returns it.
 

--- a/docs/_releases/v2.0.0-pre.4/sandbox.md
+++ b/docs/_releases/v2.0.0-pre.4/sandbox.md
@@ -76,7 +76,7 @@ sinon.defaultConfig = {
   <dt><code>useFakeServer</code></dt>
   <dd>If <code>true</code>, <code>server</code> and <code>requests</code> properties are added to the sandbox. Can also be an object to use for fake server. The default one is <code>sinon.fakeServer</code>, but if you're using jQuery 1.3.x or some other library that does not set the XHR's <code>onreadystatechange</code> handler, you might want to do:
 
-<pre class=\"code-snippet\" data-lang=\"javascript\"><code>sinon.config = {
+<pre class="code-snippet" data-lang="javascript"><code>sinon.config = {
     useFakeServer: sinon.fakeServerWithClock
 };</code></pre></dd>
 </dl>

--- a/docs/_releases/v2.0.0-pre.4/spies.md
+++ b/docs/_releases/v2.0.0-pre.4/spies.md
@@ -299,7 +299,7 @@ This behaves the same as `spy.neverCalledWith(sinon.match(arg1), sinon.match(arg
 Returns `true` if spy threw an exception at least once.
 
 
-#### `spy.threw(\"TypeError\");`
+#### `spy.threw("TypeError");`
 
 Returns `true` if spy threw an exception of the provided type at least once.
 
@@ -314,7 +314,7 @@ Returns `true` if spy threw the provided exception object at least once.
 Returns `true` if spy always threw an exception.
 
 
-#### `spy.alwaysThrew(\"TypeError\");`
+#### `spy.alwaysThrew("TypeError");`
 
 Returns `true` if spy always threw an exception of the provided type.
 
@@ -462,7 +462,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 Returns `true` if call threw an exception.
 
 
-#### `spyCall.threw(TypeError\");`
+#### `spyCall.threw("TypeError");`
 
 Returns `true` if call threw exception of provided type.
 

--- a/docs/_releases/v2.0.0-pre.4/stubs.md
+++ b/docs/_releases/v2.0.0-pre.4/stubs.md
@@ -51,13 +51,13 @@ before one of the other callbacks.
 
 Calling behavior defining methods like `returns` or `throws` multiple times
 overrides the behavior of the stub. As of Sinon version 1.8, you can use the
-[`onCall`]("#stub-onCall) method to make a stub respond differently on
+[`onCall`](#stub-onCall) method to make a stub respond differently on
 consecutive calls.
 
 Note that in Sinon version 1.5 to version 1.7, multiple calls to the `yields*`
 and `callsArg*` family of methods define a sequence of behaviors for consecutive
-calls. As of 1.8, this functionality has been removed in favor of the <a
-href="#stub-onCall"><code>onCall</code></a> API.
+calls. As of 1.8, this functionality has been removed in favor of the
+[`onCall`](#stub-onCall) API.
 
 [pubsubjs]: https://github.com/mroderick/pubsubjs
 
@@ -82,7 +82,7 @@ Replaces `object.method` with a `func`, wrapped in a `spy`.
 
 As usual, `object.method.restore();` can be used to restore the original method.
 
-#### `name "var stub = sinon.stub(obj);`
+#### `var stub = sinon.stub(obj);`
 
 Stubs all the object's methods.
 
@@ -96,7 +96,7 @@ If you want to create a stub object of `MyConstructor`, but don't want the const
 var stub = sinon.createStubInstance(MyConstructor)
 ```
 
-#### `name "stub.withArgs(arg1[, arg2, ...]);`
+#### `stub.withArgs(arg1[, arg2, ...]);`
 
 Stubs the method only for the provided arguments.
 
@@ -114,7 +114,7 @@ This is useful to be more expressive in your assertions, where you can access th
 }
 ```
 
-#### `name "stub.onCall(n);` *Added in v1.8*
+#### <a name="stub-onCall"></a>`stub.onCall(n);` *Added in v1.8*
 
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 

--- a/docs/_releases/v2.0.0-pre.4/stubs.md
+++ b/docs/_releases/v2.0.0-pre.4/stubs.md
@@ -20,7 +20,7 @@ Use a stub when you want to:
 
 1. Control a method's behavior from a test to force the code down a specific path. Examples include forcing a method to throw an error in order to test error handling.
 
-2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest or similar).
+2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest` or similar).
 
 The following example is yet another test from [PubSubJS][pubsubjs] which shows how to create an anonymous stub that throws an exception when called.
 

--- a/docs/_releases/v2.0.0-pre.4/stubs.md
+++ b/docs/_releases/v2.0.0-pre.4/stubs.md
@@ -283,7 +283,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 
 #### `stub.yieldsToOn(property, context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context."
+Like above but with an additional parameter to pass the `this` context.
 
 ```javascript
 "test should fake successful ajax request": function () {
@@ -307,7 +307,7 @@ If the stub was never called with a function argument, `yield` throws an error.
 Also aliased as `invokeCallback`.
 
 
-#### `stub.yieldTo(callback, [arg1, arg2, ...])``
+#### `stub.yieldTo(callback, [arg1, arg2, ...])`
 
 Invokes callbacks passed as a property of an object to the stub.
 

--- a/docs/_releases/v2.0.0-pre.4/stubs.md
+++ b/docs/_releases/v2.0.0-pre.4/stubs.md
@@ -8,7 +8,7 @@ breadcrumb: stubs
 
 Test stubs are functions (spies) with pre-programmed behavior.
 
-They support the full <a href="#spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
+They support the full <a href="../spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
 
 As spies, stubs can be either anonymous, or wrap existing functions. When
 wrapping an existing function with a stub, the original function is not called.

--- a/docs/_releases/v2.0.0-pre.4/stubs.md
+++ b/docs/_releases/v2.0.0-pre.4/stubs.md
@@ -70,13 +70,13 @@ href="#stub-onCall"><code>onCall</code></a> API.
 Creates an anonymous stub function
 
 
-#### `var stub = sinon.stub(object, \"method\");`
+#### `var stub = sinon.stub(object, "method");`
 
 Replaces `object.method` with a stub function. An exception is thrown if the property is not already a function.
 
 The original function can be restored by calling `object.method.restore();` (or `stub.restore();`).
 
-#### `var stub = sinon.stub(object, \"method\", func);`
+#### `var stub = sinon.stub(object, "method", func);`
 
 Replaces `object.method` with a `func`, wrapped in a `spy`.
 
@@ -103,7 +103,7 @@ Stubs the method only for the provided arguments.
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
 ```javascript
-"test should stub method differently based on arguments\": function () {
+"test should stub method differently based on arguments": function () {
     var callback = sinon.stub();
     callback.withArgs(42).returns(1);
     callback.withArgs(1).throws("TypeError");
@@ -119,7 +119,7 @@ This is useful to be more expressive in your assertions, where you can access th
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 
 ```javascript
-"test should stub method differently on consecutive calls\": function () {
+"test should stub method differently on consecutive calls": function () {
     var callback = sinon.stub();
     callback.onCall(0).returns(1);
     callback.onCall(1).returns(2);
@@ -136,7 +136,7 @@ There are methods `onFirstCall`, `onSecondCall`,`onThirdCall` to make stub defin
 `onCall` can be combined with all of the behavior defining methods in this section.  In particular, it can be used together with `withArgs`.
 
 ```javascript
-"test should stub method differently on consecutive calls with certain argument\": function () {
+"test should stub method differently on consecutive calls with certain argument": function () {
     var callback = sinon.stub();
     callback.withArgs(42)
         .onFirstCall().returns(1)
@@ -286,7 +286,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 Like above but with an additional parameter to pass the `this` context."
 
 ```javascript
-"test should fake successful ajax request\": function () {
+"test should fake successful ajax request": function () {
     sinon.stub(jQuery, "ajax").yieldsTo("success", [1, 2, 3]);
 
     jQuery.ajax({

--- a/docs/_releases/v2.0.0-pre.4/utils.md
+++ b/docs/_releases/v2.0.0-pre.4/utils.md
@@ -32,7 +32,7 @@ Restores supplied method
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.
 
-The given constructor function is not invoked. See also the [stub API](#stubs).
+The given constructor function is not invoked. See also the [stub API](../stubs).
 
 #### `sinon.format(object);`
 

--- a/docs/_releases/v2.0.0-pre.5/mocks.md
+++ b/docs/_releases/v2.0.0-pre.5/mocks.md
@@ -28,7 +28,7 @@ Thus, they enforce implementation details. The rule of thumb is: if you wouldn't
 
 In general you should have **no more than one** mock (possibly with several expectations) in a single test.
 
-[Expectations](#expectations) implement both the [spies](#spies) and [stubs](#stubs) APIs.
+[Expectations](#expectations) implement both the [spies](../spies) and [stubs](../stubs) APIs.
 
 To see what mocks look like in Sinon.JS, here is one of the [PubSubJS][pubsubjs] tests again, this time using a method as callback and using mocks to verify its behavior
 

--- a/docs/_releases/v2.0.0-pre.5/mocks.md
+++ b/docs/_releases/v2.0.0-pre.5/mocks.md
@@ -63,7 +63,7 @@ Creates a mock for the provided object.
 Does not change the object, but returns a mock object to set expectations on the object's methods.
 
 
-#### `var expectation = mock.expects(\"method\");`
+#### `var expectation = mock.expects("method");`
 
 Overrides `obj.method` with a mock function and returns it.
 

--- a/docs/_releases/v2.0.0-pre.5/sandbox.md
+++ b/docs/_releases/v2.0.0-pre.5/sandbox.md
@@ -76,7 +76,7 @@ sinon.defaultConfig = {
   <dt><code>useFakeServer</code></dt>
   <dd>If <code>true</code>, <code>server</code> and <code>requests</code> properties are added to the sandbox. Can also be an object to use for fake server. The default one is <code>sinon.fakeServer</code>, but if you're using jQuery 1.3.x or some other library that does not set the XHR's <code>onreadystatechange</code> handler, you might want to do:
 
-<pre class=\"code-snippet\" data-lang=\"javascript\"><code>sinon.config = {
+<pre class="code-snippet" data-lang="javascript"><code>sinon.config = {
     useFakeServer: sinon.fakeServerWithClock
 };</code></pre></dd>
 </dl>

--- a/docs/_releases/v2.0.0-pre.5/spies.md
+++ b/docs/_releases/v2.0.0-pre.5/spies.md
@@ -299,7 +299,7 @@ This behaves the same as `spy.neverCalledWith(sinon.match(arg1), sinon.match(arg
 Returns `true` if spy threw an exception at least once.
 
 
-#### `spy.threw(\"TypeError\");`
+#### `spy.threw("TypeError");`
 
 Returns `true` if spy threw an exception of the provided type at least once.
 
@@ -314,7 +314,7 @@ Returns `true` if spy threw the provided exception object at least once.
 Returns `true` if spy always threw an exception.
 
 
-#### `spy.alwaysThrew(\"TypeError\");`
+#### `spy.alwaysThrew("TypeError");`
 
 Returns `true` if spy always threw an exception of the provided type.
 
@@ -462,7 +462,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 Returns `true` if call threw an exception.
 
 
-#### `spyCall.threw(TypeError\");`
+#### `spyCall.threw("TypeError");`
 
 Returns `true` if call threw exception of provided type.
 

--- a/docs/_releases/v2.0.0-pre.5/stubs.md
+++ b/docs/_releases/v2.0.0-pre.5/stubs.md
@@ -51,13 +51,13 @@ before one of the other callbacks.
 
 Calling behavior defining methods like `returns` or `throws` multiple times
 overrides the behavior of the stub. As of Sinon version 1.8, you can use the
-[`onCall`]("#stub-onCall) method to make a stub respond differently on
+[`onCall`](#stub-onCall) method to make a stub respond differently on
 consecutive calls.
 
 Note that in Sinon version 1.5 to version 1.7, multiple calls to the `yields*`
 and `callsArg*` family of methods define a sequence of behaviors for consecutive
-calls. As of 1.8, this functionality has been removed in favor of the <a
-href="#stub-onCall"><code>onCall</code></a> API.
+calls. As of 1.8, this functionality has been removed in favor of the
+[`onCall`](#stub-onCall) API.
 
 [pubsubjs]: https://github.com/mroderick/pubsubjs
 
@@ -82,7 +82,7 @@ Replaces `object.method` with a `func`, wrapped in a `spy`.
 
 As usual, `object.method.restore();` can be used to restore the original method.
 
-#### `name "var stub = sinon.stub(obj);`
+#### `var stub = sinon.stub(obj);`
 
 Stubs all the object's methods.
 
@@ -96,7 +96,7 @@ If you want to create a stub object of `MyConstructor`, but don't want the const
 var stub = sinon.createStubInstance(MyConstructor)
 ```
 
-#### `name "stub.withArgs(arg1[, arg2, ...]);`
+#### `stub.withArgs(arg1[, arg2, ...]);`
 
 Stubs the method only for the provided arguments.
 
@@ -114,7 +114,7 @@ This is useful to be more expressive in your assertions, where you can access th
 }
 ```
 
-#### `name "stub.onCall(n);` *Added in v1.8*
+#### <a name="stub-onCall"></a>`stub.onCall(n);` *Added in v1.8*
 
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 

--- a/docs/_releases/v2.0.0-pre.5/stubs.md
+++ b/docs/_releases/v2.0.0-pre.5/stubs.md
@@ -20,7 +20,7 @@ Use a stub when you want to:
 
 1. Control a method's behavior from a test to force the code down a specific path. Examples include forcing a method to throw an error in order to test error handling.
 
-2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest or similar).
+2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest` or similar).
 
 The following example is yet another test from [PubSubJS][pubsubjs] which shows how to create an anonymous stub that throws an exception when called.
 

--- a/docs/_releases/v2.0.0-pre.5/stubs.md
+++ b/docs/_releases/v2.0.0-pre.5/stubs.md
@@ -283,7 +283,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 
 #### `stub.yieldsToOn(property, context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context."
+Like above but with an additional parameter to pass the `this` context.
 
 ```javascript
 "test should fake successful ajax request": function () {
@@ -307,7 +307,7 @@ If the stub was never called with a function argument, `yield` throws an error.
 Also aliased as `invokeCallback`.
 
 
-#### `stub.yieldTo(callback, [arg1, arg2, ...])``
+#### `stub.yieldTo(callback, [arg1, arg2, ...])`
 
 Invokes callbacks passed as a property of an object to the stub.
 

--- a/docs/_releases/v2.0.0-pre.5/stubs.md
+++ b/docs/_releases/v2.0.0-pre.5/stubs.md
@@ -8,7 +8,7 @@ breadcrumb: stubs
 
 Test stubs are functions (spies) with pre-programmed behavior.
 
-They support the full <a href="#spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
+They support the full <a href="../spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
 
 As spies, stubs can be either anonymous, or wrap existing functions. When
 wrapping an existing function with a stub, the original function is not called.

--- a/docs/_releases/v2.0.0-pre.5/stubs.md
+++ b/docs/_releases/v2.0.0-pre.5/stubs.md
@@ -70,13 +70,13 @@ href="#stub-onCall"><code>onCall</code></a> API.
 Creates an anonymous stub function
 
 
-#### `var stub = sinon.stub(object, \"method\");`
+#### `var stub = sinon.stub(object, "method");`
 
 Replaces `object.method` with a stub function. An exception is thrown if the property is not already a function.
 
 The original function can be restored by calling `object.method.restore();` (or `stub.restore();`).
 
-#### `var stub = sinon.stub(object, \"method\", func);`
+#### `var stub = sinon.stub(object, "method", func);`
 
 Replaces `object.method` with a `func`, wrapped in a `spy`.
 
@@ -103,7 +103,7 @@ Stubs the method only for the provided arguments.
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
 ```javascript
-"test should stub method differently based on arguments\": function () {
+"test should stub method differently based on arguments": function () {
     var callback = sinon.stub();
     callback.withArgs(42).returns(1);
     callback.withArgs(1).throws("TypeError");
@@ -119,7 +119,7 @@ This is useful to be more expressive in your assertions, where you can access th
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 
 ```javascript
-"test should stub method differently on consecutive calls\": function () {
+"test should stub method differently on consecutive calls": function () {
     var callback = sinon.stub();
     callback.onCall(0).returns(1);
     callback.onCall(1).returns(2);
@@ -136,7 +136,7 @@ There are methods `onFirstCall`, `onSecondCall`,`onThirdCall` to make stub defin
 `onCall` can be combined with all of the behavior defining methods in this section.  In particular, it can be used together with `withArgs`.
 
 ```javascript
-"test should stub method differently on consecutive calls with certain argument\": function () {
+"test should stub method differently on consecutive calls with certain argument": function () {
     var callback = sinon.stub();
     callback.withArgs(42)
         .onFirstCall().returns(1)
@@ -286,7 +286,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 Like above but with an additional parameter to pass the `this` context."
 
 ```javascript
-"test should fake successful ajax request\": function () {
+"test should fake successful ajax request": function () {
     sinon.stub(jQuery, "ajax").yieldsTo("success", [1, 2, 3]);
 
     jQuery.ajax({

--- a/docs/_releases/v2.0.0-pre.5/utils.md
+++ b/docs/_releases/v2.0.0-pre.5/utils.md
@@ -32,7 +32,7 @@ Restores supplied method
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.
 
-The given constructor function is not invoked. See also the [stub API](#stubs).
+The given constructor function is not invoked. See also the [stub API](../stubs).
 
 #### `sinon.format(object);`
 

--- a/docs/api/v1.17.3/spies/index.md
+++ b/docs/api/v1.17.3/spies/index.md
@@ -319,7 +319,7 @@ This behaves the same as `spy.neverCalledWith(sinon.match(arg1), sinon.match(arg
 Returns `true` if spy threw an exception at least once.
 
 
-#### `spy.threw(\"TypeError\");`
+#### `spy.threw("TypeError");`
 
 Returns `true` if spy threw an exception of the provided type at least once.
 
@@ -334,7 +334,7 @@ Returns `true` if spy threw the provided exception object at least once.
 Returns `true` if spy always threw an exception.
 
 
-#### `spy.alwaysThrew(\"TypeError\");`
+#### `spy.alwaysThrew("TypeError");`
 
 Returns `true` if spy always threw an exception of the provided type.
 
@@ -405,7 +405,7 @@ Resets the state of a spy.
 Replaces the spy with the original method. Only available if the spy replaced an existing method.
 
 
-#### `spy.printf(format string\", [arg1, arg2, ...])`
+#### `spy.printf("format string", [arg1, arg2, ...])`
 
 Returns the passed format string with the following replacements performed:
 
@@ -482,7 +482,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 Returns `true` if call threw an exception.
 
 
-#### `spyCall.threw(TypeError\");`
+#### `spyCall.threw("TypeError");`
 
 Returns `true` if call threw exception of provided type.
 

--- a/docs/api/v2.0.0/stubs/index.md
+++ b/docs/api/v2.0.0/stubs/index.md
@@ -7,7 +7,7 @@ title: Stubs
 
 Test stubs are functions (spies) with pre-programmed behavior.
 
-They support the full <a href="#spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
+They support the full <a href="../spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
 
 As spies, stubs can be either anonymous, or wrap existing functions. When
 wrapping an existing function with a stub, the original function is not called.

--- a/docs/api/v2.0.0/stubs/index.md
+++ b/docs/api/v2.0.0/stubs/index.md
@@ -50,13 +50,13 @@ before one of the other callbacks.
 
 Calling behavior defining methods like `returns` or `throws` multiple times
 overrides the behavior of the stub. As of Sinon version 1.8, you can use the
-[`onCall`]("#stub-onCall) method to make a stub respond differently on
+[`onCall`](#stub-onCall) method to make a stub respond differently on
 consecutive calls.
 
 Note that in Sinon version 1.5 to version 1.7, multiple calls to the `yields*`
 and `callsArg*` family of methods define a sequence of behaviors for consecutive
-calls. As of 1.8, this functionality has been removed in favor of the <a
-href="#stub-onCall"><code>onCall</code></a> API.
+calls. As of 1.8, this functionality has been removed in favor of the
+[`onCall`](#stub-onCall) API.
 
 [pubsubjs]: https://github.com/mroderick/pubsubjs
 
@@ -110,7 +110,7 @@ console.log(object.myProperty); // => faked myProperty
 console.log(descriptor.get.callCount); // => 1
 ```
 
-#### `name "var stub = sinon.stub(obj);`
+#### `var stub = sinon.stub(obj);`
 
 Stubs all the object's methods.
 
@@ -124,7 +124,7 @@ If you want to create a stub object of `MyConstructor`, but don't want the const
 var stub = sinon.createStubInstance(MyConstructor)
 ```
 
-#### `name "stub.withArgs(arg1[, arg2, ...]);`
+#### `stub.withArgs(arg1[, arg2, ...]);`
 
 Stubs the method only for the provided arguments.
 
@@ -142,7 +142,7 @@ This is useful to be more expressive in your assertions, where you can access th
 }
 ```
 
-#### `name "stub.onCall(n);` *Added in v1.8*
+#### <a name="stub-onCall"></a>`stub.onCall(n);` *Added in v1.8*
 
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 

--- a/docs/api/v2.0.0/stubs/index.md
+++ b/docs/api/v2.0.0/stubs/index.md
@@ -69,13 +69,13 @@ href="#stub-onCall"><code>onCall</code></a> API.
 Creates an anonymous stub function
 
 
-#### `var stub = sinon.stub(object, \"method\");`
+#### `var stub = sinon.stub(object, "method");`
 
 Replaces `object.method` with a stub function. An exception is thrown if the property is not already a function.
 
 The original function can be restored by calling `object.method.restore();` (or `stub.restore();`).
 
-#### `var stub = sinon.stub(object, \"property\", fakeDescriptor);`
+#### `var stub = sinon.stub(object, "property", fakeDescriptor);`
 
 Replaces the getter/setter of `property` on `object` with stubs created from the fake methods passed in `fakeDescriptor` argument.
 
@@ -131,7 +131,7 @@ Stubs the method only for the provided arguments.
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
 ```javascript
-"test should stub method differently based on arguments\": function () {
+"test should stub method differently based on arguments": function () {
     var callback = sinon.stub();
     callback.withArgs(42).returns(1);
     callback.withArgs(1).throws("TypeError");
@@ -147,7 +147,7 @@ This is useful to be more expressive in your assertions, where you can access th
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 
 ```javascript
-"test should stub method differently on consecutive calls\": function () {
+"test should stub method differently on consecutive calls": function () {
     var callback = sinon.stub();
     callback.onCall(0).returns(1);
     callback.onCall(1).returns(2);
@@ -164,7 +164,7 @@ There are methods `onFirstCall`, `onSecondCall`,`onThirdCall` to make stub defin
 `onCall` can be combined with all of the behavior defining methods in this section.  In particular, it can be used together with `withArgs`.
 
 ```javascript
-"test should stub method differently on consecutive calls with certain argument\": function () {
+"test should stub method differently on consecutive calls with certain argument": function () {
     var callback = sinon.stub();
     callback.withArgs(42)
         .onFirstCall().returns(1)
@@ -272,7 +272,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 Like above but with an additional parameter to pass the `this` context."
 
 ```javascript
-"test should fake successful ajax request\": function () {
+"test should fake successful ajax request": function () {
     sinon.stub(jQuery, "ajax").yieldsTo("success", [1, 2, 3]);
 
     jQuery.ajax({

--- a/docs/api/v2.0.0/stubs/index.md
+++ b/docs/api/v2.0.0/stubs/index.md
@@ -19,7 +19,7 @@ Use a stub when you want to:
 
 1. Control a method's behavior from a test to force the code down a specific path. Examples include forcing a method to throw an error in order to test error handling.
 
-2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest or similar).
+2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest` or similar).
 
 The following example is yet another test from [PubSubJS][pubsubjs] which shows how to create an anonymous stub that throws an exception when called.
 

--- a/docs/api/v2.0.0/stubs/index.md
+++ b/docs/api/v2.0.0/stubs/index.md
@@ -269,7 +269,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 
 #### `stub.yieldsToOn(property, context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context."
+Like above but with an additional parameter to pass the `this` context.
 
 ```javascript
 "test should fake successful ajax request": function () {
@@ -293,7 +293,7 @@ If the stub was never called with a function argument, `yield` throws an error.
 Also aliased as `invokeCallback`.
 
 
-#### `stub.yieldTo(callback, [arg1, arg2, ...])``
+#### `stub.yieldTo(callback, [arg1, arg2, ...])`
 
 Invokes callbacks passed as a property of an object to the stub.
 

--- a/docs/release-source/release/mocks.md
+++ b/docs/release-source/release/mocks.md
@@ -28,7 +28,7 @@ Thus, they enforce implementation details. The rule of thumb is: if you wouldn't
 
 In general you should have **no more than one** mock (possibly with several expectations) in a single test.
 
-[Expectations](#expectations) implement both the [spies](#spies) and [stubs](#stubs) APIs.
+[Expectations](#expectations) implement both the [spies](../spies) and [stubs](../stubs) APIs.
 
 To see what mocks look like in Sinon.JS, here is one of the [PubSubJS][pubsubjs] tests again, this time using a method as callback and using mocks to verify its behavior
 

--- a/docs/release-source/release/mocks.md
+++ b/docs/release-source/release/mocks.md
@@ -63,7 +63,7 @@ Creates a mock for the provided object.
 Does not change the object, but returns a mock object to set expectations on the object's methods.
 
 
-#### `var expectation = mock.expects(\"method\");`
+#### `var expectation = mock.expects("method");`
 
 Overrides `obj.method` with a mock function and returns it.
 

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -76,7 +76,7 @@ sinon.defaultConfig = {
   <dt><code>useFakeServer</code></dt>
   <dd>If <code>true</code>, <code>server</code> and <code>requests</code> properties are added to the sandbox. Can also be an object to use for fake server. The default one is <code>sinon.fakeServer</code>, but if you're using jQuery 1.3.x or some other library that does not set the XHR's <code>onreadystatechange</code> handler, you might want to do:
 
-<pre class=\"code-snippet\" data-lang=\"javascript\"><code>sinon.config = {
+<pre class="code-snippet" data-lang="javascript"><code>sinon.config = {
     useFakeServer: sinon.fakeServerWithClock
 };</code></pre></dd>
 </dl>

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -299,7 +299,7 @@ This behaves the same as `spy.neverCalledWith(sinon.match(arg1), sinon.match(arg
 Returns `true` if spy threw an exception at least once.
 
 
-#### `spy.threw(\"TypeError\");`
+#### `spy.threw("TypeError");`
 
 Returns `true` if spy threw an exception of the provided type at least once.
 
@@ -314,7 +314,7 @@ Returns `true` if spy threw the provided exception object at least once.
 Returns `true` if spy always threw an exception.
 
 
-#### `spy.alwaysThrew(\"TypeError\");`
+#### `spy.alwaysThrew("TypeError");`
 
 Returns `true` if spy always threw an exception of the provided type.
 
@@ -462,7 +462,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 Returns `true` if call threw an exception.
 
 
-#### `spyCall.threw(TypeError\");`
+#### `spyCall.threw("TypeError");`
 
 Returns `true` if call threw exception of provided type.
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -70,13 +70,13 @@ href="#stub-onCall"><code>onCall</code></a> API.
 Creates an anonymous stub function
 
 
-#### `var stub = sinon.stub(object, \"method\");`
+#### `var stub = sinon.stub(object, "method");`
 
 Replaces `object.method` with a stub function. An exception is thrown if the property is not already a function.
 
 The original function can be restored by calling `object.method.restore();` (or `stub.restore();`).
 
-#### `var stub = sinon.stub(object, \"method\", func);`
+#### `var stub = sinon.stub(object, "method", func);`
 
 Replaces `object.method` with a `func`, wrapped in a `spy`.
 
@@ -103,7 +103,7 @@ Stubs the method only for the provided arguments.
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
 ```javascript
-"test should stub method differently based on arguments\": function () {
+"test should stub method differently based on arguments": function () {
     var callback = sinon.stub();
     callback.withArgs(42).returns(1);
     callback.withArgs(1).throws("TypeError");
@@ -119,7 +119,7 @@ This is useful to be more expressive in your assertions, where you can access th
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 
 ```javascript
-"test should stub method differently on consecutive calls\": function () {
+"test should stub method differently on consecutive calls": function () {
     var callback = sinon.stub();
     callback.onCall(0).returns(1);
     callback.onCall(1).returns(2);
@@ -136,7 +136,7 @@ There are methods `onFirstCall`, `onSecondCall`,`onThirdCall` to make stub defin
 `onCall` can be combined with all of the behavior defining methods in this section.  In particular, it can be used together with `withArgs`.
 
 ```javascript
-"test should stub method differently on consecutive calls with certain argument\": function () {
+"test should stub method differently on consecutive calls with certain argument": function () {
     var callback = sinon.stub();
     callback.withArgs(42)
         .onFirstCall().returns(1)
@@ -345,7 +345,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 Like above but with an additional parameter to pass the `this` context."
 
 ```javascript
-"test should fake successful ajax request\": function () {
+"test should fake successful ajax request": function () {
     sinon.stub(jQuery, "ajax").yieldsTo("success", [1, 2, 3]);
 
     jQuery.ajax({

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -51,13 +51,13 @@ before one of the other callbacks.
 
 Calling behavior defining methods like `returns` or `throws` multiple times
 overrides the behavior of the stub. As of Sinon version 1.8, you can use the
-[`onCall`]("#stub-onCall) method to make a stub respond differently on
+[`onCall`](#stub-onCall) method to make a stub respond differently on
 consecutive calls.
 
 Note that in Sinon version 1.5 to version 1.7, multiple calls to the `yields*`
 and `callsArg*` family of methods define a sequence of behaviors for consecutive
-calls. As of 1.8, this functionality has been removed in favor of the <a
-href="#stub-onCall"><code>onCall</code></a> API.
+calls. As of 1.8, this functionality has been removed in favor of the
+[`onCall`](#stub-onCall) API.
 
 [pubsubjs]: https://github.com/mroderick/pubsubjs
 
@@ -82,7 +82,7 @@ Replaces `object.method` with a `func`, wrapped in a `spy`.
 
 As usual, `object.method.restore();` can be used to restore the original method.
 
-#### `name "var stub = sinon.stub(obj);`
+#### `var stub = sinon.stub(obj);`
 
 Stubs all the object's methods.
 
@@ -96,7 +96,7 @@ If you want to create a stub object of `MyConstructor`, but don't want the const
 var stub = sinon.createStubInstance(MyConstructor)
 ```
 
-#### `name "stub.withArgs(arg1[, arg2, ...]);`
+#### `stub.withArgs(arg1[, arg2, ...]);`
 
 Stubs the method only for the provided arguments.
 
@@ -114,7 +114,7 @@ This is useful to be more expressive in your assertions, where you can access th
 }
 ```
 
-#### `name "stub.onCall(n);` *Added in v1.8*
+#### <a name="stub-onCall"></a>`stub.onCall(n);` *Added in v1.8*
 
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -20,7 +20,7 @@ Use a stub when you want to:
 
 1. Control a method's behavior from a test to force the code down a specific path. Examples include forcing a method to throw an error in order to test error handling.
 
-2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest or similar).
+2. When you want to prevent a specific method from being called directly (possibly because it triggers undesired behavior, such as a `XMLHttpRequest` or similar).
 
 The following example is yet another test from [PubSubJS][pubsubjs] which shows how to create an anonymous stub that throws an exception when called.
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -8,7 +8,7 @@ breadcrumb: stubs
 
 Test stubs are functions (spies) with pre-programmed behavior.
 
-They support the full <a href="#spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
+They support the full <a href="../spies">test spy API</a> in addition to methods which can be used to alter the stub's behavior.
 
 As spies, stubs can be either anonymous, or wrap existing functions. When
 wrapping an existing function with a stub, the original function is not called.

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -342,7 +342,7 @@ Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback 
 
 #### `stub.yieldsToOn(property, context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context."
+Like above but with an additional parameter to pass the `this` context.
 
 ```javascript
 "test should fake successful ajax request": function () {
@@ -366,7 +366,7 @@ If the stub was never called with a function argument, `yield` throws an error.
 Also aliased as `invokeCallback`.
 
 
-#### `stub.yieldTo(callback, [arg1, arg2, ...])``
+#### `stub.yieldTo(callback, [arg1, arg2, ...])`
 
 Invokes callbacks passed as a property of an object to the stub.
 

--- a/docs/release-source/release/utils.md
+++ b/docs/release-source/release/utils.md
@@ -32,7 +32,7 @@ Restores supplied method
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.
 
-The given constructor function is not invoked. See also the [stub API](#stubs).
+The given constructor function is not invoked. See also the [stub API](../stubs).
 
 #### `sinon.format(object);`
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix some broken formatting and links in the docs.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `cd docs`
3. `bundle`
4. `jekyll serve`
5. View API docs at `http://localhost:4000/releases/v1.17.7/stubs/` and other pages.