### PR TITLE
Fix invalid markdown syntax in fake-timers.md

### DIFF
--- a/docs/_releases/v1.17.6/fake-timers.md
+++ b/docs/_releases/v1.17.6/fake-timers.md
@@ -70,7 +70,7 @@ Tick the clock ahead `ms` milliseconds.
 Causes all timers scheduled within the affected time range to be called.
 
 
-#### `clock.restore();"
+#### `clock.restore();`
 
 Restore the faked methods.
 


### PR DESCRIPTION
#### Purpose 

This is the same fix as 7942a15be60a48650e033922172ebc1ecfc13e88 but for 1.17.6 release docs