### PR TITLE
Remove SSL part of base url

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,7 +2,7 @@ title: Sinon.JS
 description: |
   Standalone test spies, stubs and mocks for JavaScript.
     Works with any unit testing framework.
-url: 'https://sinonjs.org'
+url: 'http://sinonjs.org'
 github_username: sinonjs
 sinon:
   current_release: v1.17.7


### PR DESCRIPTION
Attempt at removing the redirect sending visitors to https. ref [discussion](https://twitter.com/kopseng/status/836326874947158017)

Not possible to test this without deploying, apparently, as it works in either case locally.

refs #1299