### PR TITLE
Define window.location when running in jsdom

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -21,7 +21,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" && window.location !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
+var wloc = (typeof window !== "undefined" && typeof window.location !== "undefined") ? window.location : { "host": "localhost", "protocol": "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -21,7 +21,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
+var wloc = typeof window !== "undefined" && window.location !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {


### PR DESCRIPTION
When using jsdom (think Jest), window is defined but `window.location` is not. So we need to return a default object in that case.