### PR TITLE
Add docs for the new callsFake behavior

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -211,6 +211,22 @@ stub.called // false
 
 *Since `sinon@2.0.0`*
 
+#### `stub.callsFake(fakeFunction);`
+Makes the stub call the provided `fakeFunction` when invoked.
+
+```javascript
+var myObj = {};
+myObj.prop = function propFn() {
+    return "foo";
+};
+
+sinon.stub(myObj, prop).callsFake(function fakeFn() {
+    return 'bar';
+});
+
+myObj.prop(); // 'bar'
+```
+
 #### `stub.returns(obj);`
 Makes the stub return the provided value.
 


### PR DESCRIPTION
## Purpose (TL;DR) - mandatory

This adds docs also containing an example to the `callsFake` method introduced in #1207.


## Solution

I just added a new entry to the ` docs/release-source/release/stubs.md` file for `stub.callsFake` with an example below its description.

I also made sure it was on top because I think this is one of the most used features for stubs we've got.


## How to verify

1. Check out this branch (see github instructions below)
2. Go to the docs folder by running `cd docs` on Sinon's root folder
3. Ensure you have bundler by running `gem install bundler`
4. Install dependencies by running `bundle install`
5. Run a local server by running `bundle exec jekyll serve`
6. Generate a new version with `npm version`
7. Go to `http://localhost:4000` and check the new docs for the next release
