### PR TITLE
Remove unused chain behavior

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -160,14 +160,6 @@ var proto = {
             "is not supported. Use \"stub.withArgs(...).onCall(...)\" " +
             "to define sequential behavior for calls with certain arguments."
         );
-    },
-
-    chain: function chain() {
-        /**
-         * "this" is stub when method is called directly on stub, e.g. stub.returns(123);
-         * "this.stub" exists when method is called from onCall chaining, e.g. stub.onCall(0).returns(123)
-         */
-        return this.stub || this;
     }
 };
 


### PR DESCRIPTION
## Purpose (TL;DR)

This PR removes the old `chain` behavior method introduced in #1227 since we're not using it anymore.

This is also related to #817 and #1100.

## Background (Problem in detail)

Since #1302, most of the old behaviors were moved to a file called `defaultBehaviors` and now we're using the `addBehavior` method to add behavior methods to the `stub`. This method assigns a new function to the stub's `proto` and this method both runs the behavior method and then [returns `this.stub` or `this` if `this.stub` is falsy](https://github.com/sinonjs/sinon/pull/1302/files#diff-90c61de3967bc714354fe10dcfa51b57R201), which is exactly [the same thing the `chain` behavior did](https://github.com/sinonjs/sinon/blob/e0cfccc718d3ba038a8d16a077e60186e5751eb1/lib/sinon/behavior.js#L170).

Due to this fact, the `chain` method is not useful anymore because we're not using it internally anymore and no user needs to call it, since every behavior will return exactly the same value (the stub itself). Another point that backs up this assumption is that we have no tests that test `chain` specifically, which means this isn't something meant to be used by our end-users.

## Solution

Given the explanation above, I simply removed the `chain` behavior and all tests still pass.

## How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test` -> All tests still pass

Let me know if I missed anything and I'll be more than happy to fix it. Thanks!