### PR TITLE
Fix issue #1332 : little bug in spy.printf "%*" formatter.

### DIFF
--- a/lib/sinon/spy-formatters.js
+++ b/lib/sinon/spy-formatters.js
@@ -95,6 +95,6 @@ module.exports = {
     },
 
     "*": function (spyInstance, args) {
-        return args.map(sinonFormat).join(", ");
+        return args.map(function (arg) { return sinonFormat(arg); }).join(", ");
     }
 };

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -1282,6 +1282,16 @@ describe("sinonSpy.call", function () {
 
             assert.equals(spy.printf("%λ"), "%λ");
         });
+
+        it("*", function () {
+            var spy = sinonSpy();
+
+            assert.equals(
+                spy.printf("%*", 1.4567, "a", true, {}, [], undefined, null),
+                "1.4567, a, true, {  }, [], undefined, null"
+            );
+            assert.equals(spy.printf("%*", "a", "b", "c"), "a, b, c");
+        });
     });
 
     it("captures a stack trace", function () {


### PR DESCRIPTION
Fix  #1332 

When use with a list of strings, only the first one is correctly non-quoted :
spy.printf("%*", "a", "b", "c") -> a, "b", "c"

The formatio.ascii function was called with all the arguments provided by map (value, index, collection).
Just added a wrapper in the map() call to forward only the first argument (value).

1. Check out this branch (see github instructions below)
2. `npm install`
3. node
> const sinon = require("./lib/sinon.js")
> const spy = sinon.spy()
> spy.printf("%*", "a", "b", "c")
'a, b, c'

