### PR TITLE
Add missing space from deprecated message

### DIFF
--- a/lib/sinon/stub-descriptor.js
+++ b/lib/sinon/stub-descriptor.js
@@ -10,7 +10,7 @@ function stubDescriptor(object, property, descriptor) {
     var wrapper;
 
     deprecated.printWarning(
-      "sinon.stub(obj, 'meth', fn) is deprecated and will be removed from" +
+      "sinon.stub(obj, 'meth', fn) is deprecated and will be removed from " +
       "the public API in a future version of sinon." +
       "\n Use stub(obj, 'meth').callsFake(fn)." +
       "\n Codemod available at https://github.com/hurrymaplelad/sinon-codemod"


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
> I noticed that the deprecated message for stub was missing a space
>

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. Call `sinon.stub(obj, 'meth', fn)`
3. Observe that the missing space is not missing anymore
😸 
