### PR TITLE
[feature] adds spy.calledImmediatelyBefore and spy.calledImmediatelyAfter

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -88,6 +88,14 @@ var callProto = {
         return this.callId > other.callId;
     },
 
+    calledImmediatelyBefore: function (other) {
+        return this.callId === other.callId - 1;
+    },
+
+    calledImmediatelyAfter: function (other) {
+        return this.callId === other.callId + 1;
+    },
+
     callArg: function (pos) {
         this.args[pos]();
     },

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -267,6 +267,22 @@ var spyApi = {
         return this.callIds[this.callCount - 1] > spyFn.callIds[spyFn.callCount - 1];
     },
 
+    calledImmediatelyBefore: function calledImmediatelyBefore(spyFn) {
+        if (!this.called || !spyFn.called) {
+            return false;
+        }
+
+        return this.callIds[this.callCount - 1] === spyFn.callIds[spyFn.callCount - 1] - 1;
+    },
+
+    calledImmediatelyAfter: function calledImmediatelyAfter(spyFn) {
+        if (!this.called || !spyFn.called) {
+            return false;
+        }
+
+        return this.callIds[this.callCount - 1] === spyFn.callIds[spyFn.callCount - 1] + 1;
+    },
+
     withArgs: function () {
         var args = slice.call(arguments);
 

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -1650,6 +1650,114 @@ describe("spy", function () {
         });
     });
 
+    describe(".calledImmediatelyAfter", function () {
+        beforeEach(function () {
+            this.spy1 = createSpy();
+            this.spy2 = createSpy();
+            this.spy3 = createSpy();
+        });
+
+        it("is function", function () {
+            assert.isFunction(this.spy1.calledImmediatelyAfter);
+        });
+
+        it("returns true if first call to A was immediately after first to B", function () {
+            this.spy2();
+            this.spy1();
+
+            assert(this.spy1.calledImmediatelyAfter(this.spy2));
+        });
+
+        it("compares calls directly", function () {
+            this.spy2();
+            this.spy1();
+
+            assert(this.spy1.getCall(0).calledImmediatelyAfter(this.spy2.getCall(0)));
+        });
+
+        it("returns false if not called", function () {
+            this.spy2();
+
+            assert.isFalse(this.spy1.calledImmediatelyAfter(this.spy2));
+        });
+
+        it("returns false if other not called", function () {
+            this.spy1();
+
+            assert.isFalse(this.spy1.calledImmediatelyAfter(this.spy2));
+        });
+
+        it("returns false if other called last", function () {
+            this.spy2();
+            this.spy1();
+            this.spy2();
+
+            assert.isFalse(this.spy1.calledImmediatelyAfter(this.spy2));
+        });
+
+        it("returns false if another spy called between", function () {
+            this.spy1();
+            this.spy3();
+            this.spy2();
+
+            assert.isFalse(this.spy2.calledImmediatelyAfter(this.spy1));
+        });
+    });
+
+    describe(".calledImmediatelyBefore", function () {
+        beforeEach(function () {
+            this.spy1 = createSpy();
+            this.spy2 = createSpy();
+            this.spy3 = createSpy();
+        });
+
+        it("is function", function () {
+            assert.isFunction(this.spy1.calledImmediatelyBefore);
+        });
+
+        it("returns true if first call to A was immediately after first to B", function () {
+            this.spy2();
+            this.spy1();
+
+            assert(this.spy2.calledImmediatelyBefore(this.spy1));
+        });
+
+        it("compares calls directly", function () {
+            this.spy2();
+            this.spy1();
+
+            assert(this.spy2.getCall(0).calledImmediatelyBefore(this.spy1.getCall(0)));
+        });
+
+        it("returns false if not called", function () {
+            this.spy2();
+
+            assert.isFalse(this.spy1.calledImmediatelyBefore(this.spy2));
+        });
+
+        it("returns false if other not called", function () {
+            this.spy1();
+
+            assert.isFalse(this.spy1.calledImmediatelyBefore(this.spy2));
+        });
+
+        it("returns false if other called last", function () {
+            this.spy2();
+            this.spy1();
+            this.spy2();
+
+            assert.isFalse(this.spy2.calledImmediatelyBefore(this.spy1));
+        });
+
+        it("returns false if another spy called between", function () {
+            this.spy1();
+            this.spy3();
+            this.spy2();
+
+            assert.isFalse(this.spy1.calledImmediatelyBefore(this.spy2));
+        });
+    });
+
     describe(".firstCall", function () {
         it("is undefined by default", function () {
             var spy = createSpy();

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -1562,199 +1562,199 @@ describe("spy", function () {
 
     describe(".calledBefore", function () {
         beforeEach(function () {
-            this.spy1 = createSpy();
-            this.spy2 = createSpy();
+            this.spyA = createSpy();
+            this.spyB = createSpy();
         });
 
         it("is function", function () {
-            assert.isFunction(this.spy1.calledBefore);
+            assert.isFunction(this.spyA.calledBefore);
         });
 
         it("returns true if first call to A was before first to B", function () {
-            this.spy1();
-            this.spy2();
+            this.spyA();
+            this.spyB();
 
-            assert(this.spy1.calledBefore(this.spy2));
+            assert(this.spyA.calledBefore(this.spyB));
         });
 
         it("compares call order of calls directly", function () {
-            this.spy1();
-            this.spy2();
+            this.spyA();
+            this.spyB();
 
-            assert(this.spy1.getCall(0).calledBefore(this.spy2.getCall(0)));
+            assert(this.spyA.getCall(0).calledBefore(this.spyB.getCall(0)));
         });
 
         it("returns false if not called", function () {
-            this.spy2();
+            this.spyB();
 
-            assert.isFalse(this.spy1.calledBefore(this.spy2));
+            assert.isFalse(this.spyA.calledBefore(this.spyB));
         });
 
         it("returns true if other not called", function () {
-            this.spy1();
+            this.spyA();
 
-            assert(this.spy1.calledBefore(this.spy2));
+            assert(this.spyA.calledBefore(this.spyB));
         });
 
         it("returns false if other called first", function () {
-            this.spy2();
-            this.spy1();
-            this.spy2();
+            this.spyB();
+            this.spyA();
+            this.spyB();
 
-            assert(this.spy1.calledBefore(this.spy2));
+            assert(this.spyA.calledBefore(this.spyB));
         });
     });
 
     describe(".calledAfter", function () {
         beforeEach(function () {
-            this.spy1 = createSpy();
-            this.spy2 = createSpy();
+            this.spyA = createSpy();
+            this.spyB = createSpy();
         });
 
         it("is function", function () {
-            assert.isFunction(this.spy1.calledAfter);
+            assert.isFunction(this.spyA.calledAfter);
         });
 
         it("returns true if first call to A was after first to B", function () {
-            this.spy2();
-            this.spy1();
+            this.spyB();
+            this.spyA();
 
-            assert(this.spy1.calledAfter(this.spy2));
+            assert(this.spyA.calledAfter(this.spyB));
         });
 
         it("compares calls directly", function () {
-            this.spy2();
-            this.spy1();
+            this.spyB();
+            this.spyA();
 
-            assert(this.spy1.getCall(0).calledAfter(this.spy2.getCall(0)));
+            assert(this.spyA.getCall(0).calledAfter(this.spyB.getCall(0)));
         });
 
         it("returns false if not called", function () {
-            this.spy2();
+            this.spyB();
 
-            assert.isFalse(this.spy1.calledAfter(this.spy2));
+            assert.isFalse(this.spyA.calledAfter(this.spyB));
         });
 
         it("returns false if other not called", function () {
-            this.spy1();
+            this.spyA();
 
-            assert.isFalse(this.spy1.calledAfter(this.spy2));
+            assert.isFalse(this.spyA.calledAfter(this.spyB));
         });
 
         it("returns false if other called last", function () {
-            this.spy2();
-            this.spy1();
-            this.spy2();
+            this.spyB();
+            this.spyA();
+            this.spyB();
 
-            assert.isFalse(this.spy1.calledAfter(this.spy2));
+            assert.isFalse(this.spyA.calledAfter(this.spyB));
         });
     });
 
     describe(".calledImmediatelyAfter", function () {
         beforeEach(function () {
-            this.spy1 = createSpy();
-            this.spy2 = createSpy();
-            this.spy3 = createSpy();
+            this.spyA = createSpy();
+            this.spyB = createSpy();
+            this.spyC = createSpy();
         });
 
         it("is function", function () {
-            assert.isFunction(this.spy1.calledImmediatelyAfter);
+            assert.isFunction(this.spyA.calledImmediatelyAfter);
         });
 
         it("returns true if first call to A was immediately after first to B", function () {
-            this.spy2();
-            this.spy1();
+            this.spyB();
+            this.spyA();
 
-            assert(this.spy1.calledImmediatelyAfter(this.spy2));
+            assert(this.spyA.calledImmediatelyAfter(this.spyB));
         });
 
         it("compares calls directly", function () {
-            this.spy2();
-            this.spy1();
+            this.spyB();
+            this.spyA();
 
-            assert(this.spy1.getCall(0).calledImmediatelyAfter(this.spy2.getCall(0)));
+            assert(this.spyA.getCall(0).calledImmediatelyAfter(this.spyB.getCall(0)));
         });
 
         it("returns false if not called", function () {
-            this.spy2();
+            this.spyB();
 
-            assert.isFalse(this.spy1.calledImmediatelyAfter(this.spy2));
+            assert.isFalse(this.spyA.calledImmediatelyAfter(this.spyB));
         });
 
         it("returns false if other not called", function () {
-            this.spy1();
+            this.spyA();
 
-            assert.isFalse(this.spy1.calledImmediatelyAfter(this.spy2));
+            assert.isFalse(this.spyA.calledImmediatelyAfter(this.spyB));
         });
 
         it("returns false if other called last", function () {
-            this.spy2();
-            this.spy1();
-            this.spy2();
+            this.spyB();
+            this.spyA();
+            this.spyB();
 
-            assert.isFalse(this.spy1.calledImmediatelyAfter(this.spy2));
+            assert.isFalse(this.spyA.calledImmediatelyAfter(this.spyB));
         });
 
         it("returns false if another spy called between", function () {
-            this.spy1();
-            this.spy3();
-            this.spy2();
+            this.spyA();
+            this.spyC();
+            this.spyB();
 
-            assert.isFalse(this.spy2.calledImmediatelyAfter(this.spy1));
+            assert.isFalse(this.spyB.calledImmediatelyAfter(this.spyA));
         });
     });
 
     describe(".calledImmediatelyBefore", function () {
         beforeEach(function () {
-            this.spy1 = createSpy();
-            this.spy2 = createSpy();
-            this.spy3 = createSpy();
+            this.spyA = createSpy();
+            this.spyB = createSpy();
+            this.spyC = createSpy();
         });
 
         it("is function", function () {
-            assert.isFunction(this.spy1.calledImmediatelyBefore);
+            assert.isFunction(this.spyA.calledImmediatelyBefore);
         });
 
         it("returns true if first call to A was immediately after first to B", function () {
-            this.spy2();
-            this.spy1();
+            this.spyB();
+            this.spyA();
 
-            assert(this.spy2.calledImmediatelyBefore(this.spy1));
+            assert(this.spyB.calledImmediatelyBefore(this.spyA));
         });
 
         it("compares calls directly", function () {
-            this.spy2();
-            this.spy1();
+            this.spyB();
+            this.spyA();
 
-            assert(this.spy2.getCall(0).calledImmediatelyBefore(this.spy1.getCall(0)));
+            assert(this.spyB.getCall(0).calledImmediatelyBefore(this.spyA.getCall(0)));
         });
 
         it("returns false if not called", function () {
-            this.spy2();
+            this.spyB();
 
-            assert.isFalse(this.spy1.calledImmediatelyBefore(this.spy2));
+            assert.isFalse(this.spyA.calledImmediatelyBefore(this.spyB));
         });
 
         it("returns false if other not called", function () {
-            this.spy1();
+            this.spyA();
 
-            assert.isFalse(this.spy1.calledImmediatelyBefore(this.spy2));
+            assert.isFalse(this.spyA.calledImmediatelyBefore(this.spyB));
         });
 
         it("returns false if other called last", function () {
-            this.spy2();
-            this.spy1();
-            this.spy2();
+            this.spyB();
+            this.spyA();
+            this.spyB();
 
-            assert.isFalse(this.spy2.calledImmediatelyBefore(this.spy1));
+            assert.isFalse(this.spyB.calledImmediatelyBefore(this.spyA));
         });
 
         it("returns false if another spy called between", function () {
-            this.spy1();
-            this.spy3();
-            this.spy2();
+            this.spyA();
+            this.spyC();
+            this.spyB();
 
-            assert.isFalse(this.spy1.calledImmediatelyBefore(this.spy2));
+            assert.isFalse(this.spyA.calledImmediatelyBefore(this.spyB));
         });
     });
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Sometimes you need to be sure that you are calling `a().c()` and not `a().b().c()`. When mocking a large library like `knexjs`, being able to ensure the exact order of calls is incredibly helpful.

#### Background (Problem in detail)  - optional
When mocking a large library that chains calls, you may end up writing one large mock in the `beforeEach` of the test library as to not duplicate code within your tests. Unfortunately there is no way to ensure that chained calls do not sneak into calls chains currently, as the `calledBefore` and `calledAfter` implementations simply use `>` or `<`. In order to use a large mock and reduce duplicitous code in test suites when dealing with libraries that chain calls, `calledImmediatelyBefore` and `calledImmediatelyAfter` allow you to ensure that no additional modifiers end up between your chained calls.

#### Solution  - optional
This solution works just like `calledBefore` and `calledAfter`, but uses strict equality to ensure that the calls to the spies did in fact happen sequentially.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test` (includes 100% test coverage)
