### PR TITLE
Add external links to sinon.js related articles

### DIFF
--- a/docs/_data/external_howtos.yml
+++ b/docs/_data/external_howtos.yml
@@ -1,0 +1,15 @@
+- title: How to test an Ajax request using Sinon's fake XMLHttpRequest
+  url: https://codeutopia.net/blog/2015/03/21/unit-testing-ajax-requests-with-mocha/
+
+- title: How to stub or mock complex objects, such as DOM objects
+  url: https://codeutopia.net/blog/2016/05/23/sinon-js-quick-tip-how-to-stubmock-complex-objects-such-as-dom-objects/
+
+- title: Using Sinon.js with Promises
+  url: https://www.sitepoint.com/promises-in-javascript-unit-tests-the-definitive-guide/
+
+- title: Best practices for spies, stubs and mocks
+  url: https://semaphoreci.com/community/tutorials/best-practices-for-spies-stubs-and-mocks-in-sinon-js
+
+- title: Using Sinon.js to help test Mongoose models
+  url: https://codeutopia.net/blog/2016/06/10/mongoose-models-and-unit-tests-the-definitive-guide/
+

--- a/docs/how-to/index.html
+++ b/docs/how-to/index.html
@@ -15,3 +15,11 @@ permalink: /how-to/
         <li><a href="{{site.baseurl}}{{ article.url }}">{{ article.title }}</a></li>
 {% endfor %}
 </ul>
+
+<h2>Articles elsewhere on the web</h2>
+
+<ul>
+{% for article in site.data.external_howtos %}
+        <li><a href="{{ article.url }}">{{ article.title }}</a></li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
#### Purpose

Add links to useful Sinon.js related articles (as discussed on #1304)

#### Solution

I added links into a datafile in `_data/external-howtos.yml`, and updated the howto page to include a section with "articles elsewhere on the web".

I noticed the other articles were being sorted - I tried sorting the external ones, but it was causing an error with Jekyll and I couldn't really figure out how to fix it.

I'm the author of the articles linked, and I've received a lot of positive feedback on them. I think it would be good to include more (I've had a lot of people ask me about async tests in particular), but I'm not familiar with any good articles beyond these.