### PR TITLE
Fix hardcoded current version in docs root page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,11 @@
 ---
 {% assign current_release = site.sinon.current_release %}
 
-## Get Started  
+## Get Started
 
 ### Install using `npm`
 
-To install the current release (`v2.0.0`) of Sinon:
+To install the current release (`{{current_release}}`) of Sinon:
 
 ```shell
 npm install sinon


### PR DESCRIPTION
This PR fixes a hardcoded current version in the documentation root page, introduced in https://github.com/sinonjs/sinon/commit/6a7c801193e6cd1cb277fc2d96b84fd544d03887#diff-1a523bd9fa0dbf998008b37579210e12

I discovered this because`_config.yml` has been updated to `v2.1.0` as `current_version`, but the website still specifies `v2.0.0` as current version.

#### Before

![2017-03-21 at 10 43](https://cloud.githubusercontent.com/assets/20321/24141286/4c09caf2-0e23-11e7-8911-49b73773c8c4.png)

#### After
 
![2017-03-21 at 10 44](https://cloud.githubusercontent.com/assets/20321/24141319/67aa603c-0e23-11e7-8523-db2f3e0f0464.png)
