### PR TITLE
[docs] Document calledImmediatelyBefore and calledImmediatelyAfter

### DIFF
--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -229,6 +229,18 @@ Returns `true` if the spy was called before `anotherSpy`
 Returns `true` if the spy was called after `anotherSpy`
 
 
+#### `spy.calledImmediatelyBefore(anotherSpy);`
+
+Returns `true` if `spy` was called before `anotherSpy`, and no spy calls
+occurred between `spy` and `anotherSpy`.
+
+
+#### `spy.calledImmediatelyAfter(anotherSpy);`
+
+Returns `true` if `spy` was called after `anotherSpy`, and no spy calls
+occurred between `anotherSpy` and `spy`.
+
+
 #### `spy.calledOn(obj);`
 
 Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Adds docs for #1337 

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. Serve documentation site locally
4. verify that `calledImmediatelyBefore` and `calledImmediatelyAfter` appear on spies docs page
