### PR TITLE
Return fake to support chaining

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -13,6 +13,8 @@ function throwsException(fake, error, message) {
     } else {
         fake.exception = error;
     }
+
+    return fake;
 }
 
 module.exports = {
@@ -30,6 +32,8 @@ module.exports = {
         fake.callbackContext = undefined;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
+
+        return fake;
     },
 
     callsArgOn: function callsArgOn(fake, pos, context) {
@@ -42,6 +46,8 @@ module.exports = {
         fake.callbackContext = context;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
+
+        return fake;
     },
 
     callsArgWith: function callsArgWith(fake, pos) {
@@ -54,6 +60,8 @@ module.exports = {
         fake.callbackContext = undefined;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
+
+        return fake;
     },
 
     callsArgOnWith: function callsArgWith(fake, pos, context) {
@@ -66,6 +74,8 @@ module.exports = {
         fake.callbackContext = context;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
+
+        return fake;
     },
 
     yields: function (fake) {
@@ -74,6 +84,8 @@ module.exports = {
         fake.callbackContext = undefined;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
+
+        return fake;
     },
 
     yieldsRight: function (fake) {
@@ -82,6 +94,8 @@ module.exports = {
         fake.callbackContext = undefined;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
+
+        return fake;
     },
 
     yieldsOn: function (fake, context) {
@@ -90,6 +104,8 @@ module.exports = {
         fake.callbackContext = context;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
+
+        return fake;
     },
 
     yieldsTo: function (fake, prop) {
@@ -98,6 +114,8 @@ module.exports = {
         fake.callbackContext = undefined;
         fake.callArgProp = prop;
         fake.callbackAsync = false;
+
+        return fake;
     },
 
     yieldsToOn: function (fake, prop, context) {
@@ -106,6 +124,8 @@ module.exports = {
         fake.callbackContext = context;
         fake.callArgProp = prop;
         fake.callbackAsync = false;
+
+        return fake;
     },
 
     throws: throwsException,
@@ -118,6 +138,8 @@ module.exports = {
         fake.returnValueDefined = true;
         fake.exception = undefined;
         fake.fakeFn = undefined;
+
+        return fake;
     },
 
     returnsArg: function returnsArg(fake, pos) {
@@ -126,10 +148,14 @@ module.exports = {
         }
 
         fake.returnArgAt = pos;
+
+        return fake;
     },
 
     returnsThis: function returnsThis(fake) {
         fake.returnThis = true;
+
+        return fake;
     },
 
     resolves: function resolves(fake, value) {
@@ -139,6 +165,8 @@ module.exports = {
         fake.returnValueDefined = true;
         fake.exception = undefined;
         fake.fakeFn = undefined;
+
+        return fake;
     },
 
     rejects: function rejects(fake, error, message) {
@@ -163,6 +191,8 @@ module.exports = {
 
     callThrough: function callThrough(fake) {
         fake.callsThrough = true;
+
+        return fake;
     },
 
     get: function get(fake, getterFunction) {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Support chaining and more comfortable mock object creation (my case)

#### Background (Problem in detail)  - optional
Without this pr there is no clean way to create object with stubs
```javascript
const mock = {
  method1: sinon.stub().resolves(123),
  method2: sinon.stub().rejects(new Error()),
  // etc
}
```
you need first create stubs and only then set their behavior
```javascript
const mock = {
  method1: sinon.stub(),
  method2: sinon.stub(),
  // etc
}
mock.method1.resolves(123)
mock.method2.rejects(new Error())
// etc
```

#### Solution  - optional
Return ```fake``` from behavior method

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. 
```javascript
const stubMethod = sinon.stub().returns(123) // stubMethod is undefined
```
