### PR TITLE
forEach() requires 'this' argument

### DIFF
--- a/lib/sinon/mock-expectation.js
+++ b/lib/sinon/mock-expectation.js
@@ -182,7 +182,7 @@ var mockExpectation = {
                 mockExpectation.fail(this.method + " received wrong arguments " + format(args) +
                     ", expected " + format(expectedArguments));
             }
-        });
+        }, this);
     },
 
     allowsCall: function allowsCall(thisValue, args) {

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -475,6 +475,17 @@ describe("sinonMock", function () {
         });
 
         describe(".withArgs", function () {
+            var expectedException = function (name) {
+                return {
+                    test: function (actual) {
+                        return actual.name === name;
+                    },
+                    toString: function () {
+                        return name;
+                    }
+                };
+            };
+
             it("returns expectation for chaining", function () {
                 assert.same(this.expectation.withArgs(1), this.expectation);
             });
@@ -510,7 +521,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation(2, 2, 3);
-                }, "ExpectationError");
+                }, expectedException("ExpectationError"));
             });
 
             it("allows excessive args", function () {


### PR DESCRIPTION
Otherwise, this is evaluated to undefined, which causes cryptic errors like:

`Cannot read property 'method' of undefined`

instead of:

`writeFileSync received wrong arguments(...)`

#### Purpose (TL;DR) - mandatory
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`

#### Background (Problem in detail)  - optional
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution

#### Solution  - optional
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example: 
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. <your-steps-here>
