### PR TITLE
Fix error on call.toString() where stack has fewer than 4 lines.

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -176,7 +176,7 @@ var callProto = {
         }
         if (this.stack) {
             // Omit the error message and the two top stack frames in sinon itself:
-            callStr += this.stack.split("\n")[3].replace(/^\s*(?:at\s+|@)?/, " at ");
+            callStr += ( this.stack.split("\n")[3] || "unknown" ).replace(/^\s*(?:at\s+|@)?/, " at ");
         }
 
         return callStr;

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -835,6 +835,23 @@ describe("sinonSpy.call", function () {
 
             assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt() => 42");
         });
+
+        // https://github.com/sinonjs/sinon/issues/1066
+        it("does not throw when the call stack is empty", function (done) {
+            var stub1 = sinonStub().resolves(1);
+            var stub2 = sinonStub().returns(1);
+
+            function run() {
+                return stub1().then(stub2);
+            }
+
+            run()
+            .then(function () {
+                assert.equals(stub2.getCall(0).toString().replace(/ at.*/g, ""), "stub(1) => 1");
+                done();
+            })
+            .catch( done );
+        });
     });
 
     describe("constructor", function () {


### PR DESCRIPTION
Fixes #1066

#### Purpose

Fixes #1066 by not calling `String#replace` on `undefined`, which could happen when an error stack had fewer than 4 lines (e.g. when the offending function was called point-free in `Promise#then()`).

#### Background

Here's a very simple reduced test case that reproduces the issue:

```js
let sinon = require('sinon');

function test() {

  let stub1 = sinon.stub().returns( Promise.resolve({}) );
  let stub2 = sinon.stub();

  function run() {
    return stub1().then( stub2 );
  }

  run()
  .then( () => sinon.assert.calledTwice( stub2 ) )
  .catch( console.log );

}

setTimeout( test, 0 );
```

Because `stub2` is invoked *directly by the VM*, it has nothing in its stack. That breaks `call.toString()`, which assumes each stack consists of at least 4 lines (the first 3 of which are Sinon-related, and the 4th being the beginning of the user's call stack).

#### Solution

Simply safe-guard against the `String#replace()` call by providing a default `stack` value of `"unknown"`.

#### How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`

The new test `sinonSpy.call > call.toString > does not throw when the call stack is empty` will pass.

Or try the example under `Background` above.
