### PR TITLE
Add support for React Native window location format Fixes sinonjs/sin…

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -21,31 +21,30 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = getWindowLocation();
-
-var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
-
-function getWindowLocation() {
-    if ( typeof window !== "undefined") {
-        if (typeof window.location !== 'undefined') {
-            // Browsers place location on window
-            return window.location;
-        } else if((typeof window.window !== 'undefined') && (typeof window.window.location !== 'undefined')) {
-            // React Native on Android places location on window.window
-            return window.window.location;
-        } else {
-            return getDefaultWindowLocation();
-        }
-    } else {
-        // Fallback
-        return getDefaultWindowLocation();
-    }
-}
-
 function getDefaultWindowLocation() {
   return { "host": "localhost", "protocol": "http"}
 }
 
+function getWindowLocation() {
+  if ( typeof window !== "undefined") {
+    if (typeof window.location !== 'undefined') {
+      // Browsers place location on window
+      return window.location;
+    } else if((typeof window.window !== 'undefined') && (typeof window.window.location !== 'undefined')) {
+      // React Native on Android places location on window.window
+      return window.window.location;
+    } else {
+      return getDefaultWindowLocation();
+    }
+  } else {
+    // Fallback
+    return getDefaultWindowLocation();
+  }
+}
+
+var wloc = getWindowLocation();
+
+var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {
     var rmeth = response.method;

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -26,19 +26,21 @@ function getDefaultWindowLocation() {
 }
 
 function getWindowLocation() {
-    if ( typeof window !== "undefined") {
-        if (typeof window.location !== "undefined") {
-            // Browsers place location on window
-            return window.location;
-        } else if ((typeof window.window !== "undefined") && (typeof window.window.location !== "undefined")) {
-            // React Native on Android places location on window.window
-            return window.window.location;
-        }
-
+    if (typeof window === "undefined") {
+        // Fallback
         return getDefaultWindowLocation();
     }
 
-    // Fallback
+    if (typeof window.location !== "undefined") {
+        // Browsers place location on window
+        return window.location;
+    }
+
+    if ((typeof window.window !== "undefined") && (typeof window.window.location !== "undefined")) {
+        // React Native on Android places location on window.window
+        return window.window.location;
+    }
+
     return getDefaultWindowLocation();
 }
 

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -22,24 +22,24 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-  return { "host": "localhost", "protocol": "http"}
+    return { "host": "localhost", "protocol": "http" };
 }
 
 function getWindowLocation() {
-  if ( typeof window !== "undefined") {
-    if (typeof window.location !== 'undefined') {
-      // Browsers place location on window
-      return window.location;
-    } else if((typeof window.window !== 'undefined') && (typeof window.window.location !== 'undefined')) {
-      // React Native on Android places location on window.window
-      return window.window.location;
-    } else {
-      return getDefaultWindowLocation();
+    if ( typeof window !== "undefined") {
+        if (typeof window.location !== "undefined") {
+            // Browsers place location on window
+            return window.location;
+        } else if((typeof window.window !== "undefined") && (typeof window.window.location !== "undefined")) {
+            // React Native on Android places location on window.window
+            return window.window.location;
+        } else {
+            return getDefaultWindowLocation();
+        }
     }
-  } else {
+
     // Fallback
     return getDefaultWindowLocation();
-  }
 }
 
 var wloc = getWindowLocation();

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -21,8 +21,31 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
+var wloc = getWindowLocation();
+
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
+
+function getWindowLocation() {
+    if ( typeof window !== "undefined") {
+        if (typeof window.location !== 'undefined') {
+            // Browsers place location on window
+            return window.location;
+        } else if((typeof window.window !== 'undefined') && (typeof window.window.location !== 'undefined')) {
+            // React Native on Android places location on window.window
+            return window.window.location;
+        } else {
+            return getDefaultWindowLocation();
+        }
+    } else {
+        // Fallback
+        return getDefaultWindowLocation();
+    }
+}
+
+function getDefaultWindowLocation() {
+  return { "host": "localhost", "protocol": "http"}
+}
+
 
 function matchOne(response, reqMethod, reqUrl) {
     var rmeth = response.method;

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -30,12 +30,12 @@ function getWindowLocation() {
         if (typeof window.location !== "undefined") {
             // Browsers place location on window
             return window.location;
-        } else if((typeof window.window !== "undefined") && (typeof window.window.location !== "undefined")) {
+        } else if ((typeof window.window !== "undefined") && (typeof window.window.location !== "undefined")) {
             // React Native on Android places location on window.window
             return window.window.location;
-        } else {
-            return getDefaultWindowLocation();
         }
+
+        return getDefaultWindowLocation();
     }
 
     // Fallback


### PR DESCRIPTION
#### Purpose (TL;DR)

Fix issue #1362 and allows sinon to be used with React Native builds (where the location object is not stored directly on window). 

Preserves existing behaviour for all other environments, including fallback object.

#### How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. import sinon into a React Native project and test on Android and iOS that it does not raise the error

    undefined is not an object (evaluating 'wloc.protocol')
