### PR TITLE
Fix Reference to deprecated API

### DIFF
--- a/docs/_releases/v2.1.0/stubs.md
+++ b/docs/_releases/v2.1.0/stubs.md
@@ -76,7 +76,7 @@ Replaces `object.method` with a stub function. An exception is thrown if the pro
 
 The original function can be restored by calling `object.method.restore();` (or `stub.restore();`).
 
-#### `var stub = sinon.stub(object, "method", func);`
+#### `var stub = sinon.stub(object, "method").callsFake(func);`
 
 Replaces `object.method` with a `func`, wrapped in a `spy`.
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix Reference to deprecated API

#### Background (Problem in detail)  - optional
I tried to follow the docs and got the following warning message.
"sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon. Use stub(obj, 'meth').callsFake(fn)."

#### How to verify - mandatory
1. Its pure textual you can just look at it.
