### PR TITLE
Fix typo in docs: stubs.md example

### DIFF
--- a/docs/_releases/v2.0.0/stubs.md
+++ b/docs/_releases/v2.0.0/stubs.md
@@ -474,11 +474,11 @@ var myObj = {
     prop: 'foo'
 };
 
-createStub(myObj, 'prop').get(function getterFn() {
+sinon.stub(myObj, 'prop').get(function getterFn() {
     return 'bar';
 });
 
-myObj.example; // 'bar'
+myObj.prop; // 'bar'
 ```
 
 #### `stub.set(setterFn)`
@@ -491,7 +491,7 @@ var myObj = {
     prop: 'foo'
 };
 
-createStub(myObj, 'prop').set(function setterFn(val) {
+sinon.stub(myObj, 'prop').set(function setterFn(val) {
     myObj.example = val;
 });
 

--- a/docs/_releases/v2.1.0/stubs.md
+++ b/docs/_releases/v2.1.0/stubs.md
@@ -474,11 +474,11 @@ var myObj = {
     prop: 'foo'
 };
 
-createStub(myObj, 'prop').get(function getterFn() {
+sinon.stub(myObj, 'prop').get(function getterFn() {
     return 'bar';
 });
 
-myObj.example; // 'bar'
+myObj.prop; // 'bar'
 ```
 
 #### `stub.set(setterFn)`
@@ -491,7 +491,7 @@ var myObj = {
     prop: 'foo'
 };
 
-createStub(myObj, 'prop').set(function setterFn(val) {
+sinon.stub(myObj, 'prop').set(function setterFn(val) {
     myObj.example = val;
 });
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -474,11 +474,11 @@ var myObj = {
     prop: 'foo'
 };
 
-createStub(myObj, 'prop').get(function getterFn() {
+sinon.stub(myObj, 'prop').get(function getterFn() {
     return 'bar';
 });
 
-myObj.example; // 'bar'
+myObj.prop; // 'bar'
 ```
 
 #### `stub.set(setterFn)`
@@ -491,7 +491,7 @@ var myObj = {
     prop: 'foo'
 };
 
-createStub(myObj, 'prop').set(function setterFn(val) {
+sinon.stub(myObj, 'prop').set(function setterFn(val) {
     myObj.example = val;
 });
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix typo in docs: stubs.md example.
Releases v2.0.0, v2.1.0 and the next one.

#### How to verify - mandatory
Its pure textual you can just look at it.
