### PR TITLE
Don't reset behavior when calling resetHistory()

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -133,7 +133,11 @@ var spyApi = {
         this.errorsWithCallStack = [];
         if (this.fakes) {
             this.fakes.forEach(function (fake) {
-                fake.reset();
+                if (fake.resetHistory) {
+                    fake.resetHistory();
+                } else {
+                    fake.reset();
+                }
             });
         }
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1991,6 +1991,15 @@ describe("stub", function () {
             assert(stub.calledOnce);
             assert.equals(stub.getCall(0).args[0], 2);
         });
+
+        it("doesn't reset behavior defined using withArgs", function () {
+            var stub = createStub();
+            stub.withArgs("test").returns(10);
+
+            stub.resetHistory();
+
+            assert.equals(stub("test"), 10);
+        });
     });
 
     describe(".resetBehavior", function () {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2000,6 +2000,15 @@ describe("stub", function () {
 
             assert.equals(stub("test"), 10);
         });
+
+        it("doesn't reset behavior", function () {
+            var stub = createStub();
+            stub.returns(10);
+
+            stub.resetHistory();
+
+            assert.equals(stub("test"), 10);
+        });
     });
 
     describe(".resetBehavior", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Make `stub.resetHistory()` keep the behavior defined using `stub.withArgs(...).returns`.

#### Background (Problem in detail)  - optional
Fixes #1361

ATM `stub.resetHistory()` delegates to `spy.reset()` but `spy.reset()` resets all
its fakes by calling `reset()` on them. If the fakes were created from a
stub, we want to call `resetHistory()` on them instead to preserve their behavior.

#### How to verify - mandatory
Added a failing test so:

1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
