### PR TITLE
Exclude test and node_modules directories from coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ci-test": "npm run lint && ./scripts/ci-test.sh",
     "test-node": "mocha --recursive -R dot test/",
     "test-headless": "mochify --recursive -R dot --grep WebWorker --invert test/",
-    "test-coverage": "mochify --recursive -R dot --grep WebWorker --invert --plugin [ mochify-istanbul --report text --report lcovonly --dir ./coverage ] test/",
+    "test-coverage": "mochify --recursive -R dot --grep WebWorker --invert --plugin [ mochify-istanbul --exclude '**/+(test|node_modules)/**/*' --report text --report lcovonly --dir ./coverage ] test/",
     "test-cloud": "npm run test-headless -- --wd",
     "test-webworker": "browserify --no-commondir --full-paths -p [ mocaccino -R spec --color ] test/webworker/webworker-support-assessment.js | phantomic --web-security false",
     "test": "npm run test-node && npm run test-headless && npm run test-webworker",


### PR DESCRIPTION
istanbul is currently tracking coverage on the `test` folder. This is causes issues for PR's I think (see #1319). This addresses that by excluding the test and node_modules folders from coverage. 

Bonus: It should speed up tests slightly as well.