### PR TITLE
Fix highlighting in matchers.md of v1.17.6 and v1.17.7.

### DIFF
--- a/docs/_releases/v1.17.6/matchers.md
+++ b/docs/_releases/v1.17.6/matchers.md
@@ -4,7 +4,7 @@ title: Matchers - Sinon.JS
 breadcrumb: matchers
 ---
 
-Matchers can be passed as arguments to `spy.calledOn`, spy.calledWith`, `spy.returned` and the
+Matchers can be passed as arguments to `spy.calledOn`, `spy.calledWith`, `spy.returned` and the
 corresponding `sinon.assert` functions as well as `spy.withArgs`. Matchers allow to be either more fuzzy or more specific about the expected value.
 
 ```javascript

--- a/docs/_releases/v1.17.7/matchers.md
+++ b/docs/_releases/v1.17.7/matchers.md
@@ -4,7 +4,7 @@ title: Matchers - Sinon.JS
 breadcrumb: matchers
 ---
 
-Matchers can be passed as arguments to `spy.calledOn`, spy.calledWith`, `spy.returned` and the
+Matchers can be passed as arguments to `spy.calledOn`, `spy.calledWith`, `spy.returned` and the
 corresponding `sinon.assert` functions as well as `spy.withArgs`. Matchers allow to be either more fuzzy or more specific about the expected value.
 
 ```javascript


### PR DESCRIPTION
#### Purpose (TL;DR)
The `matchers.md` files of v1.17.6 and v1.17.7 are missing some `s.

#### Solution
Add the missing `s so the files have the right highlighting.

#### How to verify
View `matchers.md`s at `f2a3f267`.
