### PR TITLE
Remove warning about v1 as source with bundlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ See the [sinon project homepage](http://sinonjs.org/) for documentation on usage
 
 If you have questions that are not covered by the documentation, please post them to the [Sinon.JS mailing list](http://groups.google.com/group/sinonjs) or drop by <a href="irc://irc.freenode.net:6667/sinon.js">#sinon.js on irc.freenode.net:6667</a> or the [Gitter channel](https://gitter.im/sinonjs/sinon).
 
-### Important: Sinon v1.x does not work with AMD/CommonJS Bundlers!
-
-Sinon.JS v1.x *as source* **doesn't work with AMD loaders / RequireJS / Webpack / Browserify**. For that you will have to use a pre-built version. You can either [build it yourself](CONTRIBUTING.md#testing-a-built-version) or get a numbered version from http://sinonjs.org.
-
-This has been resolved in Sinon v2.x; Please don't report this as a bug.
-
 ## Goals
 
 * No global pollution


### PR DESCRIPTION
This is obsolete by now, and just adds noise and might scare people off because of an issue that has been addressed.