### PR TITLE
Called in order considers callCount

### DIFF
--- a/lib/sinon/util/core/called-in-order.js
+++ b/lib/sinon/util/core/called-in-order.js
@@ -1,15 +1,34 @@
 "use strict";
 
+var every = Array.prototype.every;
+
 module.exports = function calledInOrder(spies) {
+    var callMap = {};
+
+    function hasCallsLeft(spy) {
+        if (callMap[spy.id] === undefined) {
+            callMap[spy.id] = 0;
+        }
+
+        return callMap[spy.id] < spy.callCount;
+    }
+
     if (arguments.length > 1) {
         spies = arguments;
     }
 
-    for (var i = 1, l = spies.length; i < l; i++) {
-        if (!spies[i - 1].calledBefore(spies[i]) || !spies[i].called) {
-            return false;
-        }
-    }
+    return every.call(spies, function checkAdjacentCalls(spy, i) {
+        var calledBeforeNext = true;
 
-    return true;
+        if (i !== spies.length - 1) {
+            calledBeforeNext = spy.calledBefore(spies[i + 1]);
+        }
+
+        if (hasCallsLeft(spy) && calledBeforeNext) {
+            callMap[spy.id] += 1;
+            return true;
+        }
+
+        return false;
+    });
 };

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -200,4 +200,19 @@ describe("issues", function () {
             assert(firstFake !== secondFake);
         });
     });
+
+    describe("#1398", function () {
+        it("Call order takes into account both calledBefore and callCount", function () {
+            var s1 = sinon.spy();
+            var s2 = sinon.spy();
+
+            s1();
+            s2();
+            s1();
+
+            assert.exception(function () {
+                sinon.assert.callOrder(s2, s1, s2);
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Purpose (TL;DR)

This makes `calledAfter` symetric with `calledBefore`, as I explained in #1398.

## Background (Problem in detail)

Semantically speaking, `calledAfter` does not do what it says it does.

When you say you expect `something` to have been `calledAfter` `anotherThing`, you don't care if `something` has been called last or not, all you care about is if `something` has been called any times **after** `anotherThing`.

This is the way `calledBefore` works. It is not concerned about whether or not the current spy was the first to be called, it just checks if the current spy has been called any times before the passed spy.


## Solution

I just check if the last call to the current spy (`this`) has happened after the first call to the passed spy (`spyFn`) by comparing their `callIds`

[I also fixed a test which had the incorrect spec for this](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:simmetric-callAfter#diff-8b6a8ef53c91611b3781f26049e5d972R1644).


## How to verify

1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test` -> This will run all tests including [the modified one with the correct spec](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:simmetric-callAfter#diff-8b6a8ef53c91611b3781f26049e5d972R1644)


**EDIT: Building is breaking on PhantomJS, I gotta see why. Let me check this...**