### PR TITLE
Make calledAfter symetric with calledBefore

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -264,7 +264,7 @@ var spyApi = {
             return false;
         }
 
-        return this.callIds[this.callCount - 1] > spyFn.callIds[spyFn.callCount - 1];
+        return this.callIds[this.callCount - 1] > spyFn.callIds[0];
     },
 
     calledImmediatelyBefore: function calledImmediatelyBefore(spyFn) {

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -1641,12 +1641,12 @@ describe("spy", function () {
             assert.isFalse(this.spyA.calledAfter(this.spyB));
         });
 
-        it("returns false if other called last", function () {
+        it("returns true if called anytime after other", function () {
             this.spyB();
             this.spyA();
             this.spyB();
 
-            assert.isFalse(this.spyA.calledAfter(this.spyB));
+            assert.isTrue(this.spyA.calledAfter(this.spyB));
         });
     });
 


### PR DESCRIPTION
## Purpose (TL;DR)

This makes `calledAfter` symetric with `calledBefore`, as I explained in #1398.

## Background (Problem in detail)

Semantically speaking, `calledAfter` does not do what it says it does.

When you say you expect `something` to have been `calledAfter` `anotherThing`, you don't care if `something` has been called last or not, all you care about is if `something` has been called any times **after** `anotherThing`.

This is the way `calledBefore` works. It is not concerned about whether or not the current spy was the first to be called, it just checks if the current spy has been called any times before the passed spy.


## Solution

I just check if the last call to the current spy (`this`) has happened after the first call to the passed spy (`spyFn`) by comparing their `callIds`

[I also fixed a test which had the incorrect spec for this](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:simmetric-callAfter#diff-8b6a8ef53c91611b3781f26049e5d972R1644).


## How to verify

1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test` -> This will run all tests including [the modified one with the correct spec](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:simmetric-callAfter#diff-8b6a8ef53c91611b3781f26049e5d972R1644)
