### PR TITLE
Fix 1357 missing quoutes in docs

### DIFF
--- a/docs/_releases/v2.0.0/stubs.md
+++ b/docs/_releases/v2.0.0/stubs.md
@@ -217,7 +217,7 @@ Makes the stub call the provided `fakeFunction` when invoked.
 ```javascript
 var myObj = {};
 myObj.prop = function propFn() {
-    return "foo";
+    return 'foo';
 };
 
 sinon.stub(myObj, prop).callsFake(function fakeFn() {

--- a/docs/_releases/v2.0.0/stubs.md
+++ b/docs/_releases/v2.0.0/stubs.md
@@ -220,7 +220,7 @@ myObj.prop = function propFn() {
     return 'foo';
 };
 
-sinon.stub(myObj, prop).callsFake(function fakeFn() {
+sinon.stub(myObj, 'prop').callsFake(function fakeFn() {
     return 'bar';
 });
 

--- a/docs/_releases/v2.1.0/stubs.md
+++ b/docs/_releases/v2.1.0/stubs.md
@@ -219,7 +219,7 @@ myObj.prop = function propFn() {
     return 'foo';
 };
 
-sinon.stub(myObj, prop).callsFake(function fakeFn() {
+sinon.stub(myObj, 'prop').callsFake(function fakeFn() {
     return 'bar';
 });
 

--- a/docs/_releases/v2.1.0/stubs.md
+++ b/docs/_releases/v2.1.0/stubs.md
@@ -216,7 +216,7 @@ Makes the stub call the provided `fakeFunction` when invoked.
 ```javascript
 var myObj = {};
 myObj.prop = function propFn() {
-    return "foo";
+    return 'foo';
 };
 
 sinon.stub(myObj, prop).callsFake(function fakeFn() {

--- a/docs/_releases/v2.2.0/stubs.md
+++ b/docs/_releases/v2.2.0/stubs.md
@@ -217,7 +217,7 @@ Makes the stub call the provided `fakeFunction` when invoked.
 ```javascript
 var myObj = {};
 myObj.prop = function propFn() {
-    return "foo";
+    return 'foo';
 };
 
 sinon.stub(myObj, prop).callsFake(function fakeFn() {

--- a/docs/_releases/v2.2.0/stubs.md
+++ b/docs/_releases/v2.2.0/stubs.md
@@ -220,7 +220,7 @@ myObj.prop = function propFn() {
     return 'foo';
 };
 
-sinon.stub(myObj, prop).callsFake(function fakeFn() {
+sinon.stub(myObj, 'prop').callsFake(function fakeFn() {
     return 'bar';
 });
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -217,7 +217,7 @@ Makes the stub call the provided `fakeFunction` when invoked.
 ```javascript
 var myObj = {};
 myObj.prop = function propFn() {
-    return "foo";
+    return 'foo';
 };
 
 sinon.stub(myObj, prop).callsFake(function fakeFn() {

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -220,7 +220,7 @@ myObj.prop = function propFn() {
     return 'foo';
 };
 
-sinon.stub(myObj, prop).callsFake(function fakeFn() {
+sinon.stub(myObj, 'prop').callsFake(function fakeFn() {
     return 'bar';
 });
 


### PR DESCRIPTION
This PR fixes #1357 by adding the missing quotes to the `callsFake` example 