### PR TITLE
Update build instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,11 +121,11 @@ Note that in dev mode tests run only in Node. Before creating your PR please ens
 
 ### Compiling a built version
 
-Build requires [Ruby](https://www.ruby-lang.org/en/). Under the hood [Browserify](http://browserify.org/) is used.
+Build requires Node. Under the hood [Browserify](http://browserify.org/) is used.
 
 To build simply run
 
-    $ ./build
+    $ node build.js
 
 
 [ES5]: http://www.ecma-international.org/ecma-262/5.1/


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix issue #1412 by updating the build instructions in CONTRIBUTING.md.

#### Solution  - optional

Update build instructions in CONTRIBUTING.md to reflect that Node is used to run the build script instead of Ruby.

#### How to verify - mandatory
1. Use updated instructions in CONTRIBUTING.md to build the project
2. See that the build is successful
