### PR TITLE
Add related libraries section to How To page

### DIFF
--- a/docs/_data/related_libraries.yml
+++ b/docs/_data/related_libraries.yml
@@ -1,0 +1,17 @@
+- title: proxyquire — Proxies nodejs require in order to allow overriding dependencies during testing
+  url: https://github.com/thlorenz/proxyquire
+
+- title: sisyphos — utility to stub modules imported with the System.js module loader
+  url: https://github.com/codazzo/sisyphos
+
+- title: bogus — utility for mocking dependencies when testing RequireJS based projects
+  url: https://github.com/mroderick/bogus
+
+- title: Mock Socket — mocking library for websockets and socket.io
+  url: https://github.com/thoov/mock-socket
+
+- title: wrapple — generic wrapper for browser natives (or other globals) to allow stubbing in unit tests
+  url: https://github.com/mroderick/wrapple
+
+- title: test double — minimal test double library for TDD with JavaScript
+  url: https://github.com/testdouble/testdouble.js

--- a/docs/how-to/index.html
+++ b/docs/how-to/index.html
@@ -17,6 +17,13 @@ permalink: /how-to/
 {% endfor %}
 </ul>
 
+<h2>Related libraries</h2>
+<ul>
+{% for library in site.data.related_libraries %}
+        <li><a href="{{ library.url }}">{{ library.title }}</a></li>
+{% endfor %}
+</ul>
+
 <h2>Articles elsewhere on the web</h2>
 
 <ul>


### PR DESCRIPTION
This PR adds a "Related libraries" section to the How To page.

#### To verify

1. Check out this branch
1. `cd docs`
1. `bundle exec jekyll serve`
1. Navigate to http://localhost:4000/how-to/
1. Observe the new section, see screenshot below

![2017-05-21 at 12 38](https://cloud.githubusercontent.com/assets/20321/26283173/c05ce856-3e22-11e7-840c-381b10a28b5a.png)

Contributions welcome!