### PR TITLE
Refactor sandbox and allow it to stub getters and setters

### DIFF
--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -106,7 +106,7 @@ Works exactly like `sinon.spy`, only also adds the returned spy to the internal 
 
 Works almost exactly like `sinon.stub`, only also adds the returned stub to the internal collection of fakes for easy restoring through `sandbox.restore()`.
 
-The sandbox `stub` method can also be used to stub any kind of property. This is useful if you need to override an object's property for the duration of a test, and have it restored when the test completes
+The sandbox `stub` method can also be used to stub any kind of property. This is useful if you need to override an object's property for the duration of a test, and have it restored when the test completes.
 
 #### `sandbox.mock();`
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -520,3 +520,31 @@ myObj.prop = 'baz';
 
 myObj.example; // 'baz'
 ```
+
+#### `stub.value(newVal)`
+
+Defines a new value for this stub.
+
+```javascript
+var myObj = {
+    example: 'oldValue',
+};
+
+sinon.stub(myObj, 'example').value('newValue');
+
+myObj.example; // 'newValue'
+```
+
+You can restore values by calling the `restore` method:
+
+```javascript
+var myObj = {
+    example: 'oldValue',
+};
+
+var stub = sinon.stub(myObj, 'example').value('newValue');
+stub.restore()
+
+myObj.example; // 'oldValue'
+```
+

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -3,9 +3,8 @@
 var sinonSpy = require("./spy");
 var sinonStub = require("./stub");
 var sinonMock = require("./mock");
-var throwOnFalsyObject = require("./throw-on-falsy-object");
+var sandboxStub = require("./sandbox-stub");
 var collectOwnMethods = require("./collect-own-methods");
-var stubNonFunctionProperty = require("./stub-non-function-property");
 
 var push = [].push;
 
@@ -81,13 +80,12 @@ var collection = {
     },
 
     stub: function stub(object, property/*, value*/) {
-        throwOnFalsyObject.apply(null, arguments);
+        if (arguments.length > 2) {
+            return sandboxStub.apply(this, arguments);
+        }
 
+        var stubbed = sinonStub.apply(null, arguments);
         var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
-        var isStubbingNonFunctionProperty = property && typeof object[property] !== "function";
-        var stubbed = isStubbingNonFunctionProperty ?
-                        stubNonFunctionProperty.apply(null, arguments) :
-                        sinonStub.apply(null, arguments);
 
         if (isStubbingEntireObject) {
             var ownMethods = collectOwnMethods(stubbed);

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -1,4 +1,5 @@
 "use strict";
+var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 
 var slice = [].slice;
 var useLeftMostCallback = -1;
@@ -185,6 +186,24 @@ module.exports = {
         Object.defineProperty(rootStub.rootObj, rootStub.propName, { // eslint-disable-line accessor-pairs
             set: setterFunction
         });
+
+        return fake;
+    },
+
+    value: function value(fake, newVal) {
+        var rootStub = fake.stub || fake;
+
+        var oldVal = getPropertyDescriptor(rootStub.rootObj, rootStub.propName).value;
+
+        Object.defineProperty(rootStub.rootObj, rootStub.propName, {
+            value: newVal
+        });
+
+        fake.restore = function restore() {
+            Object.defineProperty(rootStub.rootObj, rootStub.propName, {
+                value: oldVal
+            });
+        };
 
         return fake;
     }

--- a/lib/sinon/sandbox-stub.js
+++ b/lib/sinon/sandbox-stub.js
@@ -1,0 +1,51 @@
+"use strict";
+
+var collectOwnMethods = require("./collect-own-methods");
+var deprecated = require("./util/core/deprecated");
+var getPropertyDescriptor = require("./util/core/get-property-descriptor");
+var stubNonFunctionProperty = require("./stub-non-function-property");
+var sinonStub = require("./stub");
+var throwOnFalsyObject = require("./throw-on-falsy-object");
+
+// This is deprecated and will be removed in a future version of sinon.
+// We will only consider pull requests that fix serious bugs in the implementation
+function sandboxStub(object, property/*, value*/) {
+    deprecated.printWarning(
+      "sandbox.stub(obj, 'meth', val) is deprecated and will be removed from " +
+      "the public API in a future version of sinon." +
+      "\n Use sandbox(obj, 'meth').callsFake(fn) instead in order to stub a function." +
+      "\n Use sandbox(obj, 'meth').value(fn) instead in order to stub a non-function value."
+    );
+
+    throwOnFalsyObject.apply(null, arguments);
+
+    var actualDescriptor = getPropertyDescriptor(object, property);
+    var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
+    var isStubbingNonFuncProperty = typeof object === "object"
+                                    && typeof property !== "undefined"
+                                    && (typeof actualDescriptor === "undefined"
+                                    || typeof actualDescriptor.value !== "function");
+
+
+    // When passing a value as third argument it will be applied to stubNonFunctionProperty
+    var stubbed = isStubbingNonFuncProperty ?
+                    stubNonFunctionProperty.apply(null, arguments) :
+                    sinonStub.apply(null, arguments);
+
+    if (isStubbingEntireObject) {
+        var ownMethods = collectOwnMethods(stubbed);
+        ownMethods.forEach(this.add.bind(this));
+        if (this.promiseLibrary) {
+            ownMethods.forEach(this.addUsingPromise.bind(this));
+        }
+    } else {
+        this.add(stubbed);
+        if (this.promiseLibrary) {
+            stubbed.usingPromise(this.promiseLibrary);
+        }
+    }
+
+    return stubbed;
+}
+
+module.exports = sandboxStub;

--- a/lib/sinon/stub-non-function-property.js
+++ b/lib/sinon/stub-non-function-property.js
@@ -13,7 +13,7 @@ function stubNonFunctionProperty(object, property, value) {
     object[property] = value;
 
     return {
-        restore: function () {
+        restore: function restore() {
             object[property] = original;
         }
     };

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -5,6 +5,7 @@ var sinonCollection = require("../lib/sinon/collection");
 var sinonSpy = require("../lib/sinon/spy");
 var sinonStub = require("../lib/sinon/stub");
 var assert = referee.assert;
+var deprecated = require("../lib/sinon/util/core/deprecated");
 
 describe("collection", function () {
     it("creates fake collection", function () {
@@ -106,8 +107,13 @@ describe("collection", function () {
                 });
 
                 it("stubs environment property", function () {
+                    var originalPrintWarning = deprecated.printWarning;
+                    deprecated.printWarning = function () {};
+
                     this.collection.stub(process.env, "HELL", "froze over");
                     assert.equals(process.env.HELL, "froze over");
+
+                    deprecated.printWarning = originalPrintWarning;
                 });
             });
         }
@@ -120,25 +126,40 @@ describe("collection", function () {
         });
 
         it("stubs number property", function () {
+            var originalPrintWarning = deprecated.printWarning;
+            deprecated.printWarning = function () {};
+
             this.collection.stub(this.object, "property", 1);
 
             assert.equals(this.object.property, 1);
+
+            deprecated.printWarning = originalPrintWarning;
         });
 
         it("restores number property", function () {
+            var originalPrintWarning = deprecated.printWarning;
+            deprecated.printWarning = function () {};
+
             this.collection.stub(this.object, "property", 1);
             this.collection.restore();
 
             assert.equals(this.object.property, 42);
+
+            deprecated.printWarning = originalPrintWarning;
         });
 
         it("fails if property does not exist", function () {
+            var originalPrintWarning = deprecated.printWarning;
+            deprecated.printWarning = function () {};
+
             var collection = this.collection;
             var object = {};
 
             assert.exception(function () {
                 collection.stub(object, "prop", 1);
             });
+
+            deprecated.printWarning = originalPrintWarning;
         });
 
         it("fails if Symbol does not exist", function () {
@@ -146,11 +167,16 @@ describe("collection", function () {
                 var collection = this.collection;
                 var object = {};
 
+                var originalPrintWarning = deprecated.printWarning;
+                deprecated.printWarning = function () {};
+
                 assert.exception(function () {
                     collection.stub(object, Symbol(), 1);
                 }, function (err) {
                     return err.message === "Cannot stub non-existent own property Symbol()";
                 });
+
+                deprecated.printWarning = originalPrintWarning;
             }
         });
     });

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -548,4 +548,66 @@ describe("sinonSandbox", function () {
             sandbox.restore();
         });
     });
+
+    describe("getters and setters", function () {
+        it("allows stubbing getters", function () {
+            var object = {
+                foo: "bar"
+            };
+
+            var sandbox = sinonSandbox.create();
+            sandbox.stub(object, "foo").get(function () {
+                return "baz";
+            });
+
+            assert.equals(object.foo, "baz");
+        });
+
+        it("allows restoring getters", function () {
+            var object = {
+                foo: "bar"
+            };
+
+            var sandbox = sinonSandbox.create();
+            sandbox.stub(object, "foo").get(function () {
+                return "baz";
+            });
+
+            sandbox.restore();
+
+            assert.equals(object.foo, "bar");
+        });
+
+        it("allows stubbing setters", function () {
+            var object = {
+                prop: "bar"
+            };
+
+            var sandbox = sinonSandbox.create();
+            sandbox.stub(object, "foo").set(function (val) {
+                object.prop = val + "bla";
+            });
+
+            object.foo = "bla";
+
+            assert.equals(object.prop, "blabla");
+        });
+
+        it("allows restoring setters", function () {
+            var object = {
+                prop: "bar"
+            };
+
+            var sandbox = sinonSandbox.create();
+            sandbox.stub(object, "prop").set(function setterFn(val) {
+                object.prop = val + "bla";
+            });
+
+            sandbox.restore();
+
+            object.prop = "bla";
+
+            assert.equals(object.prop, "bla");
+        });
+    });
 });

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2524,4 +2524,26 @@ describe("stub", function () {
             assert.equals(myObj.otherProp, "bar");
         });
     });
+
+    describe(".value", function () {
+        it("allows stubbing property descriptor values", function () {
+            var myObj = {
+                prop: "rawString"
+            };
+
+            createStub(myObj, "prop").value("newString");
+            assert.equals(myObj.prop, "newString");
+        });
+
+        it("allows restoring stubbed property descriptor values", function () {
+            var myObj = {
+                prop: "rawString"
+            };
+
+            var stub = createStub(myObj, "prop").value("newString");
+            stub.restore();
+
+            assert.equals(myObj.prop, "rawString");
+        });
+    });
 });


### PR DESCRIPTION
## Purpose (TL;DR)

This aims to fix #1401 and #781 by allowing users to stub `getters` and `setters` while using sandboxes.

In order to do this I had to refactor `sandbox.stub` and add new `value` default behavior for the sake of consistency.

*Another side-effect of this PR is adding the `value` default behavior to stubs, allowing users to stub the `value` property on property descriptors.*


## Background (Problem in detail)

As discussed in the two issues linked above, the sandbox API did not allow our users to set `getters` and `setters` for non-function properties they stubbed, because [that meant we were going to call `stubNonFunctionProperty`](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-c66fb904faa27068eb89ea905c3e4d68L89) and [return a raw object with a restore method](https://github.com/sinonjs/sinon/blob/bf2bfbd929b3a21c81d07cf831e8f06b5e2f2a44/lib/sinon/stub-non-function-property.js#L15). Due to this fact, the returned object would not allow us to call the `get` and `set` default behaviors.

Another problem I explained at #781 was that by having `sandbox.stub` to accept a third argument, it was not possible to differentiate this argument from a property descriptor when we wanted to stub non-function-properties, because we would never know whether the user wanted that value to replace that property or if the user wanted that value to be the new property descriptor.

GIven the way `sandbox.stub` was working, it presented a bit of duplication and error prone code, because some of the same checks we have in `sinon.stub` were being made differently in `sandbox.stub`. This could cause unwanted `getter` triggers when checking property values and therefore inconsistent behavior compared to `sinon.stub`.


## Solution

This is how I solved these problems:

1. Allowing **getters** and **setters** (consistent sandbox API)
    I had to create [a separate utility file called `sandbox-stub.js`](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-2362249c6d5cd8ba07d5ee7c94402a56) which does the job of handling calls to the old version of the `sandbox.stub` API. [The function in this file is called whenever a user passes a third argument to `sandbox.stub`](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-c66fb904faa27068eb89ea905c3e4d68L84). [Otherwise, we **always** call the `sinon.stub` function](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-c66fb904faa27068eb89ea905c3e4d68R87) in order to make the behavior of `sandbox.stub` as consistent as we can.
    This allows us to have all the default stub behaviors available on the stub created by `sandbox.stub`.
    Then all we have to do is [add all the stubbed methods (which are more than one if we're stubbing an entire object) to the current collection](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-c66fb904faa27068eb89ea905c3e4d68R90).
2. Allow stubbing non-function values while still allowing `get` and `set` behaviors
    Since there is no way to differentiate a descriptor from a desired property value to replace another when we allow three arguments on the `sandbox.stub` API, I added [a new default behavior called `value`](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-f46d81a3e31504be425e201260dab281R193). This makes the API consistent with stubbing other values on property descriptors, such as `get` and `set`.
    In order to restore a `stubbed` non-function property a user can just call the [`restore` method on the created fake](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-f46d81a3e31504be425e201260dab281R202).

This PR also has:
* [Tests for the new `value` behavior](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-888b5036773bbf553212fad0a7977303R2528)
* [Tests for `sandbox.stub` being able to stub `getters` and `setters`](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-536d6d65592b132d984d4f646cb0448eR552)
* [Updated docs](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-fc7a9e11c0ba5324f14837e385a19d6b)
* [A minor improvement in which I add a name to a previously anonymous function on `stubNonFunctionProperty`](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-0df051cb1e1d912470223f7f38234105L16)
* Fixes to avoid tests for the old `sandbox.stub` API to log deprecation warnings to the console. Like [this](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:refactor-sandbox-stub?expand=1#diff-cce87ff1f83bd217096d5f98bb2ae6f7R130), for example.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test` - This runs both the old tests (proving nothing breaks) and the new ones (proving the new features work properly)


**As always, any feedbacks will be great, specially given it's a long PR.**

Thanks for your time!
