### PR TITLE
Fix restoring unexisting stubbed property

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -45,7 +45,12 @@ function stub(object, property, descriptor) {
     s.rootObj = object;
     s.propName = property;
     s.restore = function restore() {
-        Object.defineProperty(object, property, actualDescriptor);
+        if (actualDescriptor !== undefined) {
+            Object.defineProperty(object, property, actualDescriptor);
+            return;
+        }
+
+        delete object[property];
     };
 
     return isStubbingNonFuncProperty ? s : wrapMethod(object, property, s);

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -94,6 +94,15 @@ describe("stub", function () {
         assert(callback.called);
     });
 
+    it("should allow restoring previously undefined properties", function () {
+        var obj = {};
+        var stub = createStub(obj, "nonExisting").value(2);
+
+        stub.restore();
+
+        assert.isFalse(Object.hasOwnProperty(obj, "nonExisting"));
+    });
+
     describe(".returns", function () {
         it("returns specified value", function () {
             var stub = createStub.create();


### PR DESCRIPTION
## Purpose (TL;DR)

This aims to fix an error that happened when restoring a stubbed property that did not exist before.


## Background (Problem in detail)

This happened because [we were always getting the actualDescriptor of the property being stubbed](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:fix-restoring-unexisting-property#diff-048fb1194de4b43f7f7e45758f900749L17), thus, if this property was not defined, it would be undefined.

This caused the `restore` method to throw an error [when using `Object.defineProperty` to redefine that property back to its old value](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:fix-restoring-unexisting-property#diff-048fb1194de4b43f7f7e45758f900749R49) because `undefined` was passed to it as the descriptor.


## Solution

This fix was really simple. All I did was [adding a check to see if the descriptor we've got inside the `stub` closure is defined](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:fix-restoring-unexisting-property#diff-048fb1194de4b43f7f7e45758f900749R48). If it is not defined we can just delete the stubbed property.

* This PR also includes a test to prove this bug is not present anymore

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
