### PR TITLE
Fix restoring getters/setters/values for previously unexisting props

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -193,7 +193,8 @@ module.exports = {
         var rootStub = fake.stub || fake;
 
         Object.defineProperty(rootStub.rootObj, rootStub.propName, { // eslint-disable-line accessor-pairs
-            set: setterFunction
+            set: setterFunction,
+            configurable: true
         });
 
         return fake;

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -1,6 +1,4 @@
 "use strict";
-var getPropertyDescriptor = require("./util/core/get-property-descriptor");
-
 var slice = [].slice;
 var useLeftMostCallback = -1;
 var useRightMostCallback = -2;
@@ -203,17 +201,11 @@ module.exports = {
     value: function value(fake, newVal) {
         var rootStub = fake.stub || fake;
 
-        var oldVal = getPropertyDescriptor(rootStub.rootObj, rootStub.propName).value;
-
         Object.defineProperty(rootStub.rootObj, rootStub.propName, {
-            value: newVal
+            value: newVal,
+            enumerable: true,
+            configurable: true
         });
-
-        fake.restore = function restore() {
-            Object.defineProperty(rootStub.rootObj, rootStub.propName, {
-                value: oldVal
-            });
-        };
 
         return fake;
     }

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -182,7 +182,8 @@ module.exports = {
         var rootStub = fake.stub || fake;
 
         Object.defineProperty(rootStub.rootObj, rootStub.propName, {
-            get: getterFunction
+            get: getterFunction,
+            configurable: true
         });
 
         return fake;

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -45,7 +45,12 @@ function stub(object, property, descriptor) {
     s.rootObj = object;
     s.propName = property;
     s.restore = function restore() {
-        Object.defineProperty(object, property, actualDescriptor);
+        if (actualDescriptor !== undefined) {
+            Object.defineProperty(object, property, actualDescriptor);
+            return;
+        }
+
+        delete object[property];
     };
 
     return isStubbingNonFuncProperty ? s : wrapMethod(object, property, s);

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2670,5 +2670,14 @@ describe("stub", function () {
 
             assert.equals(myObj.prop, "rawString");
         });
+
+        it("allows restoring previously undefined properties", function () {
+            var obj = {};
+            var stub = createStub(obj, "nonExisting").value(2);
+
+            stub.restore();
+
+            assert.equals(getPropertyDescriptor(obj, "nonExisting"), undefined);
+        });
     });
 });

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -5,11 +5,12 @@ var createStub = require("../lib/sinon/stub");
 var createStubInstance = require("../lib/sinon/stub").createStubInstance;
 var createSpy = require("../lib/sinon/spy");
 var sinonMatch = require("../lib/sinon/match");
+var getPropertyDescriptor = require("../lib/sinon/util/core/get-property-descriptor");
+var deprecated = require("../lib/sinon/util/core/deprecated");
 var assert = referee.assert;
 var refute = referee.refute;
 var fail = referee.fail;
 var Promise = require("native-promise-only"); // eslint-disable-line no-unused-vars
-var deprecated = require("../lib/sinon/util/core/deprecated");
 
 describe("stub", function () {
     it("is spy", function () {
@@ -2518,6 +2519,20 @@ describe("stub", function () {
             stub.restore();
 
             assert.equals(myObj.prop, "bar");
+        });
+
+        it("can restore stubbed getters for previously undefined properties", function () {
+            var myObj = {};
+
+            var stub = createStub(myObj, "nonExisting");
+
+            stub.get(function getterFn() {
+                return "baz";
+            });
+
+            stub.restore();
+
+            assert.equals(getPropertyDescriptor(myObj, "nonExisting"), undefined);
         });
     });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2634,6 +2634,20 @@ describe("stub", function () {
             myObj.prop = "foo";
             assert.equals(myObj.otherProp, "bar");
         });
+
+        it("can restore stubbed setters for previously undefined properties", function () {
+            var myObj = {};
+
+            var stub = createStub(myObj, "nonExisting");
+
+            stub.set(function setterFn() {
+                myObj.otherProp = "baz";
+            });
+
+            stub.restore();
+
+            assert.equals(getPropertyDescriptor(myObj, "nonExisting"), undefined);
+        });
     });
 
     describe(".value", function () {


### PR DESCRIPTION
## Purpose (TL;DR)

This allows our users to restore `getters`, `setters` and `values` (property descriptor's properties) for properties that were previously undefined.

It also removes [the unnecessary `restore` method inside the `value` behavior](https://github.com/sinonjs/sinon/blob/64d51bef80b20bcab4559aad94e6221d64120d52/lib/sinon/default-behaviors.js#L210) introduced in #1416 since we can use the stub's own restore method to accomplish the goal of restoring a `value`.

This is a remake of #1418 because of further problems I discovered while playing with that solution.


## Background (Problem in detail)

This happened because [we were always getting the actualDescriptor of the property being stubbed](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:fix-restoring-unexisting-props?expand=1#diff-048fb1194de4b43f7f7e45758f900749R17), thus, if this property was not defined, `actualDescriptor` would be undefined.

This caused the `restore` method to throw an error [when using `Object.defineProperty` to redefine that property back to its old value](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:fix-restoring-unexisting-props?expand=1#diff-048fb1194de4b43f7f7e45758f900749R49) because `undefined` was passed to it as the descriptor.


## Solution

In order to solve this I [added a check to see if the descriptor we've got inside the `stub` closure is defined](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:fix-restoring-unexisting-props?expand=1#diff-048fb1194de4b43f7f7e45758f900749R48). If it is not defined we can just delete the stubbed property.

In order to be able to delete it, that property must be [`configurable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Configurable_attribute) so I had to add a `configurable: true` property to the property descriptors passed when defining [a new getter](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:fix-restoring-unexisting-props?expand=1#diff-f46d81a3e31504be425e201260dab281R183), a [new setter](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:fix-restoring-unexisting-props?expand=1#diff-f46d81a3e31504be425e201260dab281R194) and a [new value](https://github.com/sinonjs/sinon/compare/master...lucasfcosta:fix-restoring-unexisting-props?expand=1#diff-f46d81a3e31504be425e201260dab281R207) for a property.

Also, noew the `value` behavior also defines an `enumerable` property, because that way it behaves more like a property defined using an assignment operator (`=`).

**This PR also includes tests for all those changes, one for each default behavior that has been modified**.

## How to verify
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`

PS: Sorry for opening that other unuseful PR before this one. 😓 
