### PR TITLE
Make object "has" matcher recursive

### DIFF
--- a/docs/release-source/release/matchers.md
+++ b/docs/release-source/release/matchers.md
@@ -12,6 +12,10 @@ corresponding `sinon.assert` functions as well as `spy.withArgs`. Matchers allow
     var book = {
         pages: 42,
         author: "cjno"
+        id: {
+          isbn10: "0596517742",
+          isbn13: "978-0596517748"
+        }
     };
     var spy = sinon.spy();
 
@@ -19,6 +23,7 @@ corresponding `sinon.assert` functions as well as `spy.withArgs`. Matchers allow
 
     sinon.assert.calledWith(spy, sinon.match({ author: "cjno" }));
     sinon.assert.calledWith(spy, sinon.match.has("pages", 42));
+    sinon.assert.calledWith(spy, sinon.match.has("id", sinon.match.has("isbn13", "978-0596517748")));
 }
 ```
 

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -185,7 +185,7 @@ match.instanceOf = function (type) {
     }, "instanceOf(" + functionName(type) + ")");
 };
 
-function createPropertyMatcher(propertyMatch, messagePrefix) {
+function createPropertyMatcher(propertyTest, messagePrefix) {
     return function (property, value) {
         assertType(property, "string", "property");
         var onlyProperty = arguments.length === 1;
@@ -195,45 +195,24 @@ function createPropertyMatcher(propertyMatch, messagePrefix) {
         }
         message += ")";
         return match(function (actual) {
-            if (actual === undefined || actual === null) {
+            if (actual === undefined || actual === null ||
+                    !propertyTest(actual, property)) {
                 return false;
             }
-            var actualValue = propertyMatch(actual, property);
-            return typeof actualValue !== "undefined" && (onlyProperty || deepEqual(value, actualValue));
+            return onlyProperty || deepEqual(value, actual[property]);
         }, message);
     };
 }
 
 match.has = createPropertyMatcher(function (actual, property) {
-    function recursiveObjectMatcher(recActual, recProperty) {
-        var splitRecProperty = recProperty.split(/\.(.+)/);
-        if (splitRecProperty.length > 1) {
-            if (splitRecProperty[0] in recActual) {
-                return recursiveObjectMatcher(recActual[splitRecProperty[0]], splitRecProperty[1]);
-            }
-            return undefined;
-        }
-        if (recProperty in recActual) {
-            return recActual[recProperty];
-        }
-        return undefined;
-    }
-
     if (typeof actual === "object") {
-        return recursiveObjectMatcher(actual, property);
+        return property in actual;
     }
-
-    if (actual[property] !== undefined) {
-        return actual[property];
-    }
-    return undefined;
+    return actual[property] !== undefined;
 }, "has");
 
 match.hasOwn = createPropertyMatcher(function (actual, property) {
-    if (actual.hasOwnProperty(property)) {
-        return actual[property];
-    }
-    return undefined;
+    return actual.hasOwnProperty(property);
 }, "hasOwn");
 
 match.array = match.typeOf("array");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -185,7 +185,7 @@ match.instanceOf = function (type) {
     }, "instanceOf(" + functionName(type) + ")");
 };
 
-function createPropertyMatcher(propertyTest, messagePrefix) {
+function createPropertyMatcher(propertyMatch, messagePrefix) {
     return function (property, value) {
         assertType(property, "string", "property");
         var onlyProperty = arguments.length === 1;
@@ -195,24 +195,45 @@ function createPropertyMatcher(propertyTest, messagePrefix) {
         }
         message += ")";
         return match(function (actual) {
-            if (actual === undefined || actual === null ||
-                    !propertyTest(actual, property)) {
+            if (actual === undefined || actual === null) {
                 return false;
             }
-            return onlyProperty || deepEqual(value, actual[property]);
+            var actualValue = propertyMatch(actual, property);
+            return typeof actualValue !== "undefined" && (onlyProperty || deepEqual(value, actualValue));
         }, message);
     };
 }
 
 match.has = createPropertyMatcher(function (actual, property) {
-    if (typeof actual === "object") {
-        return property in actual;
+    function recursiveObjectMatcher(recActual, recProperty) {
+        var splitRecProperty = recProperty.split(/\.(.+)/);
+        if (splitRecProperty.length > 1) {
+            if (splitRecProperty[0] in recActual) {
+                return recursiveObjectMatcher(recActual[splitRecProperty[0]], splitRecProperty[1]);
+            }
+            return undefined;
+        }
+        if (recProperty in recActual) {
+            return recActual[recProperty];
+        }
+        return undefined;
     }
-    return actual[property] !== undefined;
+
+    if (typeof actual === "object") {
+        return recursiveObjectMatcher(actual, property);
+    }
+
+    if (actual[property] !== undefined) {
+        return actual[property];
+    }
+    return undefined;
 }, "has");
 
 match.hasOwn = createPropertyMatcher(function (actual, property) {
-    return actual.hasOwnProperty(property);
+    if (actual.hasOwnProperty(property)) {
+        return actual[property];
+    }
+    return undefined;
 }, "hasOwn");
 
 match.array = match.typeOf("array");

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -555,16 +555,6 @@ describe("sinonMatch", function () {
                 assert(has.test({ prop: symbol }));
             }
         });
-
-        it("returns true if embedded object has Symbol", function () {
-            if (typeof Symbol === "function") {
-                var symbol = Symbol();
-
-                var has = sinonMatch.has("prop.embedded", symbol);
-
-                assert(has.test({ prop: { embedded: symbol } }));
-            }
-        });
     });
 
     describe(".hasOwnSpecial", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -555,6 +555,16 @@ describe("sinonMatch", function () {
                 assert(has.test({ prop: symbol }));
             }
         });
+
+        it("returns true if embedded object has Symbol", function () {
+            if (typeof Symbol === "function") {
+                var symbol = Symbol();
+
+                var has = sinonMatch.has("prop", sinonMatch.has("embedded", symbol));
+
+                assert(has.test({ prop: { embedded: symbol }, ignored: 42 }));
+            }
+        });
     });
 
     describe(".hasOwnSpecial", function () {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -555,6 +555,16 @@ describe("sinonMatch", function () {
                 assert(has.test({ prop: symbol }));
             }
         });
+
+        it("returns true if embedded object has Symbol", function () {
+            if (typeof Symbol === "function") {
+                var symbol = Symbol();
+
+                var has = sinonMatch.has("prop.embedded", symbol);
+
+                assert(has.test({ prop: { embedded: symbol } }));
+            }
+        });
     });
 
     describe(".hasOwnSpecial", function () {


### PR DESCRIPTION
#### Purpose (TL;DR)
Enable matching properties of embedded objects using `sinon.match.has` matcher.

#### Background (Problem in detail) 

```
"test should assert fuzzy": function () {
    var book = {
        pages: 42,
        author: {
            name: "cj"
            surname: "no" 
        }
    };
    var spy = sinon.spy();
    spy(book);

    // currently, this will NOT match (entire object has to be passed as value)
    sinon.assert.calledWith(spy, sinon.match.has("author", { name: "cj" } ));

    // this pull request enable this to match
    sinon.assert.calledWith(spy, sinon.match.has("author.name", "cj" ));
}
```

#### Solution 
`createPropertyMatcher` has been modified such that:
* existence of `"dot.separated.embedded.property"` is checked using recursive helper function
* `deepEqual` is run only on the value of the requested property, not on the whole top-level object

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test` (test case for the new functionality has been added)
