### PR TITLE
Fix #1372: make sandbox.resetHistory also reset spies

### DIFF
--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -46,7 +46,13 @@ var collection = {
     },
 
     resetHistory: function resetHistory() {
-        each(this, "resetHistory");
+        getFakes(this).forEach(function (fake) {
+            var method = fake.resetHistory || fake.reset;
+
+            if (method) {
+                method.call(fake);
+            }
+        });
     },
 
     verifyAndRestore: function verifyAndRestore() {

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -369,20 +369,28 @@ describe("collection", function () {
         beforeEach(function () {
             this.collection = Object.create(sinonCollection);
             this.collection.fakes = [{
+                // this fake has a resetHistory method
                 resetHistory: sinonSpy()
             }, {
+                // this fake has a resetHistory method
                 resetHistory: sinonSpy()
+            }, {
+                // this fake pretends to be a spy, which does not have resetHistory method
+                // but has a reset method
+                reset: sinonSpy()
             }];
         });
 
-        it("calls resetHistory on all fakes", function () {
+        it("resets the history on all fakes", function () {
             var fake0 = this.collection.fakes[0];
             var fake1 = this.collection.fakes[1];
+            var fake2 = this.collection.fakes[2];
 
             this.collection.resetHistory();
 
             assert(fake0.resetHistory.called);
             assert(fake1.resetHistory.called);
+            assert(fake2.reset.called);
         });
     });
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -187,6 +187,23 @@ describe("issues", function () {
         });
     });
 
+    describe("#1372 - sandbox.resetHistory", function () {
+        it("should reset spies", function () {
+            var spy = this.sandbox.spy();
+
+            spy();
+            assert.equals(spy.callCount, 1);
+
+            spy();
+            assert.equals(spy.callCount, 2);
+
+            this.sandbox.resetHistory();
+
+            spy();
+            assert.equals(spy.callCount, 1);  // should not fail but fails
+        });
+    });
+
     describe("#1398", function () {
         it("Call order takes into account both calledBefore and callCount", function () {
             var s1 = sinon.spy();


### PR DESCRIPTION
This PR fixes #1372, by improving the implementation of `sandbox.resetHistory()` method

#### To verify
1. Check out this branch
2. `npm install`
3. `npm test`
