### PR TITLE
Allow some ES6 globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,14 @@
     "rimraf": "^2.5.3"
   },
   "eslintConfig": {
-    "extends": "eslint-config-sinon"
+    "extends": "eslint-config-sinon",
+    "globals": {
+      "ArrayBuffer": false,
+      "Map": false,
+      "Promise": false,
+      "Set": false,
+      "Symbol": false
+    }
   },
   "files": [
     "lib",


### PR DESCRIPTION
This is in preparation of updating `eslint-config-sinon` to set ES5 syntax, which will remove the globals.

See https://github.com/sinonjs/eslint-config-sinon/pull/1

This PR should be merged first!

