### PR TITLE
Make better use of eslint-plugin-mocha

### DIFF
--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
     "env": {
         "mocha": true
     },

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,3 +1,7 @@
+const ERROR = "error";
+const WARN = "warn";
+const OFF = "off";
+
 module.exports = {
     "env": {
         "mocha": true
@@ -6,8 +10,20 @@ module.exports = {
         "mocha"
     ],
     "rules": {
-        "mocha/no-exclusive-tests": 2,
-        "max-nested-callbacks": 0,
-        "no-restricted-syntax": [2, "TryStatement"]
+        "max-nested-callbacks": OFF,
+        "no-restricted-syntax": [ERROR, "TryStatement"],
+
+        // Mocha Plugin - https://github.com/lo1tuma/eslint-plugin-mocha
+        "mocha/handle-done-callback": ERROR,
+        "mocha/no-exclusive-tests": ERROR,
+        "mocha/no-global-tests": ERROR,
+        "mocha/no-hooks-for-single-case": OFF,
+        "mocha/no-identical-title": ERROR,
+        "mocha/no-mocha-arrows": ERROR,
+        "mocha/no-nested-tests": ERROR,
+        "mocha/no-return-and-callback": ERROR,
+        "mocha/no-sibling-hooks": ERROR,
+        "mocha/no-skipped-tests": WARN,
+        "mocha/no-top-level-hooks": ERROR
     }
 }

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -23,6 +23,7 @@ function spyCallCallSetup() {
 
 function spyCallCalledTests(method) {
     return function () {
+        // eslint-disable-next-line mocha/no-top-level-hooks
         beforeEach(spyCallSetUp);
 
         it("returns true if all args match", function () {
@@ -63,6 +64,7 @@ function spyCallCalledTests(method) {
 
 function spyCallNotCalledTests(method) {
     return function () {
+        // eslint-disable-next-line mocha/no-top-level-hooks, mocha/no-sibling-hooks
         beforeEach(spyCallSetUp);
 
         it("returns false if all args match", function () {
@@ -1251,22 +1253,22 @@ describe("sinonSpy.call", function () {
 
         describe("calls", function () {
             it("oneLine", function () {
-                function test(arg, expected) {
+                function verify(arg, expected) {
                     var spy = sinonSpy();
                     spy(arg);
                     assert.equals(spy.printf("%C").replace(/ at.*/g, ""), "\n    " + expected);
                 }
 
-                test(true, "spy(true)");
-                test(false, "spy(false)");
-                test(undefined, "spy(undefined)");
-                test(1, "spy(1)");
-                test(0, "spy(0)");
-                test(-1, "spy(-1)");
-                test(-1.1, "spy(-1.1)");
-                test(Infinity, "spy(Infinity)");
-                test(["a"], "spy([\"a\"])");
-                test({ a: "a" }, "spy({ a: \"a\" })");
+                verify(true, "spy(true)");
+                verify(false, "spy(false)");
+                verify(undefined, "spy(undefined)");
+                verify(1, "spy(1)");
+                verify(0, "spy(0)");
+                verify(-1, "spy(-1)");
+                verify(-1.1, "spy(-1.1)");
+                verify(Infinity, "spy(Infinity)");
+                verify(["a"], "spy([\"a\"])");
+                verify({ a: "a" }, "spy({ a: \"a\" })");
             });
 
             it("multiline", function () {

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -55,6 +55,7 @@ describe("issues", function () {
     });
 
     describe("#624", function () {
+        // eslint-disable-next-line mocha/no-skipped-tests
         it.skip("useFakeTimers should be idempotent", function () {
             // Issue #624 shows that useFakeTimers is not idempotent when it comes to
             // using Date.now

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -165,6 +165,7 @@ describe("sinonSandbox", function () {
                 });
         });
 
+        // eslint-disable-next-line mocha/no-identical-title
         it("must set all stubs created from sandbox with mockPromise", function () {
 
             var resolveValue = {};

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -8,6 +8,7 @@ var refute = referee.refute;
 
 function spyCalledTests(method) {
     return function () {
+        // eslint-disable-next-line mocha/no-top-level-hooks
         beforeEach(function () {
             this.spy = createSpy.create();
         });
@@ -97,14 +98,17 @@ function spyCalledTests(method) {
 
 function spyAlwaysCalledTests(method) {
     return function () {
+        // eslint-disable-next-line mocha/no-top-level-hooks, mocha/no-sibling-hooks
         beforeEach(function () {
             this.spy = createSpy.create();
         });
 
+        // eslint-disable-next-line mocha/no-identical-title
         it("returns false if spy was not called", function () {
             assert.isFalse(this.spy[method](1, 2, 3));
         });
 
+        // eslint-disable-next-line mocha/no-identical-title
         it("returns true if spy was called with args", function () {
             this.spy(1, 2, 3);
 
@@ -119,6 +123,7 @@ function spyAlwaysCalledTests(method) {
             assert.isFalse(this.spy[method](1, 2, 3));
         });
 
+        // eslint-disable-next-line mocha/no-identical-title
         it("returns false if not called with args", function () {
             this.spy(1, 3, 3);
             this.spy(2);
@@ -127,6 +132,7 @@ function spyAlwaysCalledTests(method) {
             assert.isFalse(this.spy[method](1, 2, 3));
         });
 
+        // eslint-disable-next-line mocha/no-identical-title
         it("returns true for partial match", function () {
             this.spy(1, 3, 3);
 
@@ -142,6 +148,7 @@ function spyAlwaysCalledTests(method) {
             assert(this.spy[method](1, 3));
         });
 
+        // eslint-disable-next-line mocha/no-identical-title
         it("matchs all arguments individually, not as array", function () {
             this.spy([1, 2, 3]);
 
@@ -152,6 +159,7 @@ function spyAlwaysCalledTests(method) {
 
 function spyNeverCalledTests(method) {
     return function () {
+        // eslint-disable-next-line mocha/no-top-level-hooks, mocha/no-sibling-hooks
         beforeEach(function () {
             this.spy = createSpy.create();
         });
@@ -190,6 +198,7 @@ function spyNeverCalledTests(method) {
             assert.isFalse(this.spy[method](1, 3));
         });
 
+        // eslint-disable-next-line mocha/no-identical-title
         it("matchs all arguments individually, not as array", function () {
             this.spy([1, 2, 3]);
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -834,36 +834,6 @@ describe("stub", function () {
             }
         });
 
-        it.skip("returns function from wrapMethod", function () {
-            /*
-            var wrapper = function () {};
-            sinon.wrapMethod = function () {
-                return wrapper;
-            };
-
-            var result = createStub(this.object, "method");
-
-            assert.same(result, wrapper);
-            */
-        });
-
-        it.skip("passes object and method to wrapMethod", function () {
-            /*
-            var wrapper = function () {};
-            var args;
-
-            sinon.wrapMethod = function () {
-                args = arguments;
-                return wrapper;
-            };
-
-            createStub(this.object, "method");
-
-            assert.same(args[0], this.object);
-            assert.same(args[1], "method");
-            */
-        });
-
         it("warns provided function as stub, recommending callsFake instead", function () {
             deprecated.printWarning.restore();
 

--- a/test/util/core/format-test.js
+++ b/test/util/core/format-test.js
@@ -9,6 +9,7 @@ describe("util/core/format", function () {
         assert.equals(format({ id: 42 }), "{ id: 42 }");
     });
 
+    // eslint-disable-next-line mocha/no-skipped-tests
     it.skip("should configure formatio to use maximum 250 entries", function () {
         // not sure how we can verify this integration with the current setup
         // where sinon.js calls formatio as part of its loading

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1837,6 +1837,7 @@ if (typeof window !== "undefined") {
                 FakeXMLHttpRequest.restore();
             });
 
+            // eslint-disable-next-line mocha/no-skipped-tests
             it.skip("loads resource asynchronously", function (done) {
                 var req = new XMLHttpRequest();
 
@@ -1852,6 +1853,7 @@ if (typeof window !== "undefined") {
                 req.send();
             });
 
+            // eslint-disable-next-line mocha/no-skipped-tests
             it.skip("loads resource synchronously", function () {
                 var req = new XMLHttpRequest();
                 req.open("GET", "/test/resources/xhr_target.txt", false);


### PR DESCRIPTION
This PR enables more rules from [`eslint-plugin-mocha`](https://github.com/lo1tuma/eslint-plugin-mocha)

As you can see from the error report below, there are a number of fixes to be one.

If there's traction for adopting these rules, then I'll fix the outstanding errors before we merge this PR.

```text
/Users/mroderick/code/sinon/test/call-test.js
    26:9   error  Unexpected use of Mocha `beforeEach` hook outside of a test suite  mocha/no-top-level-hooks
    66:9   error  Unexpected use of Mocha `beforeEach` hook outside of a test suite  mocha/no-top-level-hooks
    66:9   error  Unexpected use of duplicate Mocha `beforeEach` hook                mocha/no-sibling-hooks
  1249:17  error  Unexpected test nested within another test                         mocha/no-nested-tests
  1250:17  error  Unexpected test nested within another test                         mocha/no-nested-tests
  1251:17  error  Unexpected test nested within another test                         mocha/no-nested-tests
  1252:17  error  Unexpected test nested within another test                         mocha/no-nested-tests
  1253:17  error  Unexpected test nested within another test                         mocha/no-nested-tests
  1254:17  error  Unexpected test nested within another test                         mocha/no-nested-tests
  1255:17  error  Unexpected test nested within another test                         mocha/no-nested-tests
  1256:17  error  Unexpected test nested within another test                         mocha/no-nested-tests
  1257:17  error  Unexpected test nested within another test                         mocha/no-nested-tests
  1258:17  error  Unexpected test nested within another test                         mocha/no-nested-tests

/Users/mroderick/code/sinon/test/collection-test.js
  105:17  error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  216:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  229:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  323:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  344:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  365:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case

/Users/mroderick/code/sinon/test/issues/issues-test.js
  57:12  error  Unexpected skipped mocha test  mocha/no-skipped-tests

/Users/mroderick/code/sinon/test/sandbox-test.js
  152:9  error  Test title is used multiple times in the same test suite  mocha/no-identical-title

/Users/mroderick/code/sinon/test/spy-test.js
   11:9  error  Unexpected use of Mocha `beforeEach` hook outside of a test suite  mocha/no-top-level-hooks
  100:9  error  Unexpected use of Mocha `beforeEach` hook outside of a test suite  mocha/no-top-level-hooks
  100:9  error  Unexpected use of duplicate Mocha `beforeEach` hook                mocha/no-sibling-hooks
  104:9  error  Test title is used multiple times in the same test suite           mocha/no-identical-title
  108:9  error  Test title is used multiple times in the same test suite           mocha/no-identical-title
  122:9  error  Test title is used multiple times in the same test suite           mocha/no-identical-title
  130:9  error  Test title is used multiple times in the same test suite           mocha/no-identical-title
  145:9  error  Test title is used multiple times in the same test suite           mocha/no-identical-title
  155:9  error  Unexpected use of duplicate Mocha `beforeEach` hook                mocha/no-sibling-hooks
  155:9  error  Unexpected use of Mocha `beforeEach` hook outside of a test suite  mocha/no-top-level-hooks
  193:9  error  Test title is used multiple times in the same test suite           mocha/no-identical-title

/Users/mroderick/code/sinon/test/stub-test.js
   845:12  error  Unexpected skipped mocha test                                     mocha/no-skipped-tests
   858:12  error  Unexpected skipped mocha test                                     mocha/no-skipped-tests
  1668:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  1683:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  1704:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  1727:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  1762:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  1801:9   error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case

/Users/mroderick/code/sinon/test/util/core/format-test.js
  12:8  error  Unexpected skipped mocha test  mocha/no-skipped-tests

/Users/mroderick/code/sinon/test/util/core/wrap-method-test.js
  169:13  error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  180:13  error  Unexpected use of Mocha `afterEach` hook for a single test case   mocha/no-hooks-for-single-case

/Users/mroderick/code/sinon/test/util/fake-server-test.js
  918:13  error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  925:13  error  Unexpected use of Mocha `afterEach` hook for a single test case   mocha/no-hooks-for-single-case

/Users/mroderick/code/sinon/test/util/fake-timers-test.js
  156:9  error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  532:9  error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case

/Users/mroderick/code/sinon/test/util/fake-xml-http-request-test.js
   165:13  error  Unexpected use of Mocha `beforeEach` hook for a single test case  mocha/no-hooks-for-single-case
  1840:16  error  Unexpected skipped mocha test                                     mocha/no-skipped-tests
  1855:16  error  Unexpected skipped mocha test                                     mocha/no-skipped-tests

✖ 50 problems (50 errors, 0 warnings)
```