### PR TITLE
Replaced try-catch statements with assertions

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -7,6 +7,7 @@
     ],
     "rules": {
         "mocha/no-exclusive-tests": 2,
-        "max-nested-callbacks": 0
+        "max-nested-callbacks": 0,
+        "no-restricted-syntax": [2, "TryStatement"]
     }
 }

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -30,17 +30,14 @@ describe("assert", function () {
     });
 
     it("supports proxy property", function () {
-        var failed = false;
         var api = { method: function () {} };
         api.method.proxy = function () {};
         sinonSpy(api, "method");
         api.method();
-        try {
+
+        refute.exception(function () {
             sinonAssert.calledOnce(api.method);
-        } catch (e) {
-            failed = true;
-        }
-        assert.isFalse(failed);
+        });
     });
 
     describe(".fail", function () {
@@ -53,18 +50,14 @@ describe("assert", function () {
         });
 
         it("throws exception", function () {
-            var failed = false;
-            var exception;
-
-            try {
-                sinonAssert.fail("Some message");
-                failed = true;
-            } catch (e) {
-                exception = e;
-            }
-
-            assert.isFalse(failed);
-            assert.equals(exception.name, "AssertError");
+            assert.exception(
+                function () {
+                    sinonAssert.fail("Some message");
+                },
+                {
+                    name: "AssertError"
+                }
+            );
         });
 
         it("throws configured exception type", function () {
@@ -1106,11 +1099,14 @@ describe("assert", function () {
                 includeFail: false
             });
 
-            try {
-                assertCalled(sinonSpy()); // eslint-disable-line no-undef
-            } catch (e) {
-                assert.equals(e.message, "expected spy to have been called at least once but was never called");
-            }
+            assert.exception(
+                function () {
+                    assertCalled(sinonSpy()); // eslint-disable-line no-undef
+                },
+                {
+                    message: "expected spy to have been called at least once but was never called"
+                }
+            );
         });
 
         it("exposes asserts into object without prefixes", function () {
@@ -1159,7 +1155,7 @@ describe("assert", function () {
 
             /*eslint consistent-return: "off"*/
             this.message = function (method) {
-                try {
+                try { // eslint-disable-line no-restricted-syntax
                     sinonAssert[method].apply(sinonAssert, [].slice.call(arguments, 1));
                 } catch (e) {
                     return e.message;

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -390,12 +390,14 @@ describe("sinonSpy.call", function () {
         it("throws understandable error if no callback is passed", function () {
             var call = this.call;
 
-            try {
-                call.yield();
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "spy cannot yield since no callback was passed.");
-            }
+            assert.exception(
+                function () {
+                    call.yield();
+                },
+                {
+                    message: "spy cannot yield since no callback was passed."
+                }
+            );
         });
 
         it("includes stub name and actual arguments in error", function () {
@@ -403,13 +405,15 @@ describe("sinonSpy.call", function () {
             this.args.push(23, 42);
             var call = this.call;
 
-            try {
-                call.yield();
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "somethingAwesome cannot yield since no callback was passed. " +
-                              "Received [23, 42]");
-            }
+            assert.exception(
+                function () {
+                    call.yield();
+                },
+                {
+                    message: "somethingAwesome cannot yield since no callback was passed. "
+                             + "Received [23, 42]"
+                }
+            );
         });
 
         it("invokes last argument as callback", function () {
@@ -484,12 +488,14 @@ describe("sinonSpy.call", function () {
             var call = this.call;
             var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                call.yieldOn(thisObj);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "spy cannot yield since no callback was passed.");
-            }
+            assert.exception(
+                function () {
+                    call.yieldOn(thisObj);
+                },
+                {
+                    message: "spy cannot yield since no callback was passed."
+                }
+            );
         });
 
         it("includes stub name and actual arguments in error", function () {
@@ -498,13 +504,15 @@ describe("sinonSpy.call", function () {
             var call = this.call;
             var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                call.yieldOn(thisObj);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "somethingAwesome cannot yield since no callback was passed. " +
-                              "Received [23, 42]");
-            }
+            assert.exception(
+                function () {
+                    call.yieldOn(thisObj);
+                },
+                {
+                    message: "somethingAwesome cannot yield since no callback was passed. " +
+                             "Received [23, 42]"
+                }
+            );
         });
 
         it("invokes last argument as callback", function () {
@@ -575,12 +583,14 @@ describe("sinonSpy.call", function () {
         it("throws understandable error if no callback is passed", function () {
             var call = this.call;
 
-            try {
-                call.yieldTo("success");
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "spy cannot yield to 'success' since no callback was passed.");
-            }
+            assert.exception(
+                function () {
+                    call.yieldTo("success");
+                },
+                {
+                    message: "spy cannot yield to 'success' since no callback was passed."
+                }
+            );
         });
 
         it("includes stub name and actual arguments in error", function () {
@@ -588,15 +598,15 @@ describe("sinonSpy.call", function () {
             this.args.push(23, 42);
             var call = this.call;
 
-            try {
-                call.yieldTo("success");
-                throw new Error();
-            } catch (e) {
-                assert.equals(
-                    e.message,
-                    "somethingAwesome cannot yield to 'success' since no callback was passed. Received [23, 42]"
-                );
-            }
+            assert.exception(
+                function () {
+                    call.yieldTo("success");
+                },
+                {
+                    message: "somethingAwesome cannot yield to 'success' since no callback was passed. "
+                             + "Received [23, 42]"
+                }
+            );
         });
 
         it("invokes property on last argument as callback", function () {
@@ -665,12 +675,14 @@ describe("sinonSpy.call", function () {
             var call = this.call;
             var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                call.yieldToOn("success", thisObj);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "spy cannot yield to 'success' since no callback was passed.");
-            }
+            assert.exception(
+                function () {
+                    call.yieldToOn("success", thisObj);
+                },
+                {
+                    message: "spy cannot yield to 'success' since no callback was passed."
+                }
+            );
         });
 
         it("throws understandable error if symbol prop is not found", function () {
@@ -678,11 +690,14 @@ describe("sinonSpy.call", function () {
                 var call = this.call;
                 var symbol = Symbol();
 
-                assert.exception(function () {
-                    call.yieldToOn(symbol, {});
-                }, function (err) {
-                    return err.message === "spy cannot yield to 'Symbol()' since no callback was passed.";
-                });
+                assert.exception(
+                    function () {
+                        call.yieldToOn(symbol, {});
+                    },
+                    {
+                        message: "spy cannot yield to 'Symbol()' since no callback was passed."
+                    }
+                );
             }
         });
 
@@ -692,15 +707,15 @@ describe("sinonSpy.call", function () {
             var call = this.call;
             var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                call.yieldToOn("success", thisObj);
-                throw new Error();
-            } catch (e) {
-                assert.equals(
-                    e.message,
-                    "somethingAwesome cannot yield to 'success' since no callback was passed. Received [23, 42]"
-                );
-            }
+            assert.exception(
+                function () {
+                    call.yieldToOn("success", thisObj);
+                },
+                {
+                    message: "somethingAwesome cannot yield to 'success' since no callback was passed. "
+                             + "Received [23, 42]"
+                }
+            );
         });
 
         it("invokes property on last argument as callback", function () {
@@ -800,10 +815,9 @@ describe("sinonSpy.call", function () {
         it("includes exception", function () {
             var object = { doIt: sinonStub().throws("TypeError") };
 
-            try {
+            assert.exception(function () {
                 object.doIt();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            });
 
             assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt() !TypeError");
         });
@@ -811,10 +825,9 @@ describe("sinonSpy.call", function () {
         it("includes exception message if any", function () {
             var object = { doIt: sinonStub().throws("TypeError", "Oh noes!") };
 
-            try {
+            assert.exception(function () {
                 object.doIt();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            });
 
             assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt() !TypeError(Oh noes!)");
         });
@@ -1182,17 +1195,16 @@ describe("sinonSpy.call", function () {
                 error.name = y;
                 throw error;
             });
-            /*eslint-disable no-empty*/
-            try {
+
+            assert.exception(function () {
                 spy("a", "1");
-            } catch (ignored) {}
-            try {
+            });
+            assert.exception(function () {
                 spy("b", "2");
-            } catch (ignored) {}
-            try {
+            });
+            assert.exception(function () {
                 spy("b", "3");
-            } catch (ignored) {}
-            /*eslint-enable no-empty*/
+            });
 
             var argSpy1 = spy.withArgs("a");
             var argSpy2 = spy.withArgs("b");
@@ -1222,10 +1234,9 @@ describe("sinonSpy.call", function () {
             // Throwing just to make sure it has no effect.
             var spy = sinonSpy(sinonStub().throws());
             function call() {
-                try {
+                assert.exception(function () {
                     spy();
-                }
-                catch (e) {} // eslint-disable-line no-empty
+                });
             }
 
             call();

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -24,27 +24,30 @@ describe("collection", function () {
         });
 
         it("fails if stubbing property on null", function () {
-            var error;
+            var collection = this.collection;
 
-            try {
-                this.collection.stub(null, "prop");
-            } catch (e) {
-                error = e;
-            }
-
-            assert.equals(error.message, "Trying to stub property 'prop' of null");
+            assert.exception(
+                function () {
+                    collection.stub(null, "prop");
+                },
+                {
+                    message: "Trying to stub property 'prop' of null"
+                }
+            );
         });
 
         it("fails if stubbing symbol on null", function () {
             if (typeof Symbol === "function") {
-                var error;
+                var collection = this.collection;
 
-                try {
-                    this.collection.stub(null, Symbol());
-                } catch (e) {
-                    error = e;
-                }
-                assert.equals(error.message, "Trying to stub property 'Symbol()' of null");
+                assert.exception(
+                    function () {
+                        collection.stub(null, Symbol());
+                    },
+                    {
+                        message: "Trying to stub property 'Symbol()' of null"
+                    }
+                );
             }
         });
 
@@ -307,15 +310,16 @@ describe("collection", function () {
         });
 
         it("calls restore when restore throws", function () {
-            this.collection.verify = sinonSpy();
-            this.collection.restore = sinonStub().throws();
+            var collection = this.collection;
 
-            try {
-                this.collection.verifyAndRestore();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            collection.verify = sinonSpy();
+            collection.restore = sinonStub().throws();
 
-            assert(this.collection.restore.called);
+            assert.exception(function () {
+                collection.verifyAndRestore();
+            });
+
+            assert(collection.restore.called);
         });
     });
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -77,18 +77,24 @@ describe("issues", function () {
 
             // passes
             var err = { name: "TestError", message: "this is a proper exception" };
-            try {
-                logError("#835 test", err);
-            } catch (ex) {
-                assert.equals(ex.name, err.name);
-            }
+            assert.exception(
+                function () {
+                    logError("#835 test", err);
+                },
+                {
+                    name: err.name
+                }
+            );
 
             // fails until this issue is fixed
-            try {
-                logError("#835 test", "this literal string is not a proper exception");
-            } catch (ex) {
-                assert.equals(ex.name, "#835 test");
-            }
+            assert.exception(
+                function () {
+                    logError("#835 test", "this literal string is not a proper exception");
+                },
+                {
+                    name: "#835 test"
+                }
+            );
         });
     });
 
@@ -127,7 +133,7 @@ describe("issues", function () {
                 }
             }
 
-            try {
+            try { // eslint-disable-line no-restricted-syntax
                 var oldWatch = Object.prototype.watch;
 
                 if (typeof Object.prototype.watch !== "function") {

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -70,11 +70,14 @@ describe("sinonMock", function () {
             var anonMock = sinonExpectation.create();
             anonMock.once();
 
-            try {
-                anonMock.verify();
-            } catch (e) {
-                assert.match(e.message, "anonymous mock expectation");
-            }
+            assert.exception(
+                function () {
+                    anonMock.verify();
+                },
+                {
+                    message: "anonymous mock expectation"
+                }
+            );
         });
 
         it("call expectation", function () {
@@ -124,12 +127,9 @@ describe("sinonMock", function () {
                 var expectation = this.expectation;
                 expectation();
 
-                try {
-                    expectation();
-                    referee.fail("Expected to throw");
-                } catch (e) {
-                    assert.equals(e.message, "myMeth already called once");
-                }
+                assert.exception(expectation, {
+                    message: "myMeth already called once"
+                });
             });
         });
 
@@ -465,10 +465,7 @@ describe("sinonMock", function () {
             it("should not be met when called too many times", function () {
                 this.expectation();
 
-                try {
-                    this.expectation();
-                }
-                catch (e) {} // eslint-disable-line no-empty
+                assert.exception(this.expectation);
 
                 assert.isFalse(this.expectation.met());
             });
@@ -689,13 +686,14 @@ describe("sinonMock", function () {
             it("throws readable error", function () {
                 var expectation = this.expectation;
 
-                try {
-                    expectation.verify();
-                    referee.fail("Expected to throw");
-                } catch (e) {
-                    assert.equals(e.message,
-                                  "Expected myMeth([...]) once (never called)");
-                }
+                assert.exception(
+                    function () {
+                        expectation.verify();
+                    },
+                    {
+                        message: "Expected myMeth([...]) once (never called)"
+                    }
+                );
             });
         });
     });
@@ -741,175 +739,181 @@ describe("sinonMock", function () {
             var mock = this.mock;
             mock.expects("method").thrice();
             mock.expects("method").once().withArgs(42);
-            var message;
 
-            try {
-                mock.verify();
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.equals(
-                message,
-                "Expected method([...]) thrice (never called)\nExpected method(42[, ...]) once (never called)"
+            assert.exception(
+                function () {
+                    mock.verify();
+                },
+                {
+                    message: "Expected method([...]) thrice (never called)\n" +
+                             "Expected method(42[, ...]) once (never called)"
+                }
             );
         });
 
         it("includes exact expected arguments in error message", function () {
             var mock = this.mock;
             mock.expects("method").once().withExactArgs(42);
-            var message;
 
-            try {
-                mock.verify();
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.equals(message, "Expected method(42) once (never called)");
+            assert.exception(
+                function () {
+                    mock.verify();
+                },
+                {
+                    message: "Expected method(42) once (never called)"
+                }
+            );
         });
 
         it("includes received call count in error message", function () {
             var mock = this.mock;
             mock.expects("method").thrice().withExactArgs(42);
             this.object.method(42);
-            var message;
 
-            try {
-                mock.verify();
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.equals(message, "Expected method(42) thrice (called once)");
+            assert.exception(
+                function () {
+                    mock.verify();
+                },
+                {
+                    message: "Expected method(42) thrice (called once)"
+                }
+            );
         });
 
         it("includes unexpected calls in error message", function () {
             var mock = this.mock;
+            var object = this.object;
+
             mock.expects("method").thrice().withExactArgs(42);
-            var message;
 
-            try {
-                this.object.method();
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.equals(message,
-                          "Unexpected call: method()\n" +
-                          "    Expected method(42) thrice (never called)");
+            assert.exception(
+                function () {
+                    object.method();
+                },
+                {
+                    message: "Unexpected call: method()\n" +
+                             "    Expected method(42) thrice (never called)"
+                }
+            );
         });
 
         it("includes met expectations in error message", function () {
             var mock = this.mock;
+            var object = this.object;
+
             mock.expects("method").once().withArgs(1);
             mock.expects("method").thrice().withExactArgs(42);
-            this.object.method(1);
-            var message;
+            object.method(1);
 
-            try {
-                this.object.method();
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.equals(message, "Unexpected call: method()\n" +
-                          "    Expectation met: method(1[, ...]) once\n" +
-                          "    Expected method(42) thrice (never called)");
+            assert.exception(
+                function () {
+                    object.method();
+                },
+                {
+                    message: "Unexpected call: method()\n" +
+                             "    Expectation met: method(1[, ...]) once\n" +
+                             "    Expected method(42) thrice (never called)"
+                }
+            );
         });
 
         it("includes met expectations in error message from verify", function () {
             var mock = this.mock;
+
             mock.expects("method").once().withArgs(1);
             mock.expects("method").thrice().withExactArgs(42);
             this.object.method(1);
-            var message;
 
-            try {
-                mock.verify();
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.equals(message, "Expected method(42) thrice (never called)\n" +
-                          "Expectation met: method(1[, ...]) once");
+            assert.exception(
+                function () {
+                    mock.verify();
+                },
+                {
+                    message: "Expected method(42) thrice (never called)\n" +
+                             "Expectation met: method(1[, ...]) once"
+                }
+            );
         });
 
         it("reports min calls in error message", function () {
             var mock = this.mock;
             mock.expects("method").atLeast(1);
-            var message;
 
-            try {
-                mock.verify();
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.equals(message, "Expected method([...]) at least once (never called)");
+            assert.exception(
+                function () {
+                    mock.verify();
+                },
+                {
+                    message: "Expected method([...]) at least once (never called)"
+                }
+            );
         });
 
         it("reports max calls in error message", function () {
             var mock = this.mock;
+            var object = this.object;
+
             mock.expects("method").atMost(2);
-            var message;
 
-            try {
-                this.object.method();
-                this.object.method();
-                this.object.method();
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.equals(message, "Unexpected call: method()\n" +
-                          "    Expectation met: method([...]) at most twice");
+            assert.exception(
+                function () {
+                    object.method();
+                    object.method();
+                    object.method();
+                },
+                {
+                    message: "Unexpected call: method()\n" +
+                             "    Expectation met: method([...]) at most twice"
+                }
+            );
         });
 
         it("reports min calls in met expectation", function () {
             var mock = this.mock;
+            var object = this.object;
+
             mock.expects("method").atLeast(1);
             mock.expects("method").withArgs(2).once();
-            var message;
 
-            try {
-                this.object.method();
-                this.object.method(2);
-                this.object.method(2);
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.equals(message, "Unexpected call: method(2)\n" +
-                          "    Expectation met: method([...]) at least once\n" +
-                          "    Expectation met: method(2[, ...]) once");
+            assert.exception(
+                function () {
+                    object.method();
+                    object.method(2);
+                    object.method(2);
+                },
+                {
+                    message: "Unexpected call: method(2)\n" +
+                             "    Expectation met: method([...]) at least once\n" +
+                             "    Expectation met: method(2[, ...]) once"
+                }
+            );
         });
 
         it("reports max and min calls in error messages", function () {
             var mock = this.mock;
             mock.expects("method").atLeast(1).atMost(2);
-            var message;
 
-            try {
-                mock.verify();
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.equals(message, "Expected method([...]) at least once and at most twice " +
-                          "(never called)");
+            assert.exception(
+                function () {
+                    mock.verify();
+                },
+                {
+                    message: "Expected method([...]) at least once and at most twice (never called)"
+                }
+            );
         });
 
         it("fails even if the original expectation exception was caught", function () {
             var mock = this.mock;
+            var object = this.object;
+
             mock.expects("method").once();
 
-            this.object.method();
-            try {
-                this.object.method();
-            } catch (e) {
-                // Silenced error
-            }
+            object.method();
+
+            assert.exception(function () {
+                object.method();
+            });
 
             assert.exception(function () {
                 mock.verify();
@@ -1082,12 +1086,9 @@ describe("sinonMock", function () {
         it("throws understandable error if no callback is passed", function () {
             var mock = sinonMock().yields();
 
-            try {
-                mock();
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "stub expected to yield, but no callback was passed.");
-            }
+            assert.exception(mock, {
+                message: "stub expected to yield, but no callback was passed."
+            });
         });
     });
 });

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -208,9 +208,7 @@ describe("spy", function () {
     it("does not throw when calling anonymous spy", function () {
         var spy = createSpy.create();
 
-        refute.exception(function () {
-            spy();
-        });
+        refute.exception(spy);
 
         assert(spy.called);
     });
@@ -303,16 +301,20 @@ describe("spy", function () {
         assert(spy.get.calledOnce);
     });
 
-    it("creates a spy for Error", function () {
-        var originalError = global.Error;
-        try {
-            assert(createSpy(global, "Error"));
-            global.Error = originalError;
-        } catch (e) {
-            // so test failure doesn't trickle down
-            global.Error = originalError;
-            referee.fail("Expected spy to be created");
-        }
+    describe("global.Error", function () {
+        beforeEach(function () {
+            this.originalError = global.Error;
+        });
+
+        afterEach(function () {
+            global.Error = this.originalError;
+        });
+
+        it("creates a spy for Error", function () {
+            refute.exception(function () {
+                createSpy(global, "Error");
+            });
+        });
     });
 
     describe(".named", function () {
@@ -384,12 +386,7 @@ describe("spy", function () {
                 throw err;
             });
 
-            try {
-                spy();
-                referee.fail("Expected spy to throw exception");
-            } catch (e) {
-                assert.same(e, err);
-            }
+            assert.exception(spy, err);
         });
 
         it("retains function length 0", function () {
@@ -763,7 +760,7 @@ describe("spy", function () {
         });
 
         var applyableNatives = (function () {
-            try {
+            try { // eslint-disable-line no-restricted-syntax
                 console.log.apply({}, []); // eslint-disable-line no-console
                 return true;
             } catch (e) {
@@ -1156,10 +1153,7 @@ describe("spy", function () {
                 throw err;
             });
 
-            try {
-                spy();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(spy);
 
             assert(spy.threw(err));
         });
@@ -1171,28 +1165,19 @@ describe("spy", function () {
         });
 
         it("returns true if spy threw", function () {
-            try {
-                this.spyWithTypeError();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
             assert(this.spyWithTypeError.threw());
         });
 
         it("returns true if string type matches", function () {
-            try {
-                this.spyWithTypeError();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
             assert(this.spyWithTypeError.threw("TypeError"));
         });
 
         it("returns false if string did not match", function () {
-            try {
-                this.spyWithTypeError();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
             assert.isFalse(this.spyWithTypeError.threw("Error"));
         });
@@ -1204,19 +1189,13 @@ describe("spy", function () {
         });
 
         it("returns true if string matches", function () {
-            try {
-                this.spyWithStringError();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithStringError);
 
             assert(this.spyWithStringError.threw("error"));
         });
 
         it("returns false if strings do not match", function () {
-            try {
-                this.spyWithStringError();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithStringError);
 
             assert.isFalse(this.spyWithStringError.threw("not the error"));
         });
@@ -1238,10 +1217,7 @@ describe("spy", function () {
                 throw err;
             });
 
-            try {
-                spy();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(spy);
 
             assert(spy.alwaysThrew(err));
         });
@@ -1253,28 +1229,19 @@ describe("spy", function () {
         });
 
         it("returns true if spy threw", function () {
-            try {
-                this.spyWithTypeError();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
             assert(this.spyWithTypeError.alwaysThrew());
         });
 
         it("returns true if string type matches", function () {
-            try {
-                this.spyWithTypeError();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
             assert(this.spyWithTypeError.alwaysThrew("TypeError"));
         });
 
         it("returns false if string did not match", function () {
-            try {
-                this.spyWithTypeError();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
             assert.isFalse(this.spyWithTypeError.alwaysThrew("Error"));
         });
@@ -1295,9 +1262,7 @@ describe("spy", function () {
                 }
             });
 
-            try {
-                this.spy();
-            } catch (e) {} // eslint-disable-line no-empty
+            assert.exception(this.spy);
 
             this.spy();
 
@@ -1305,25 +1270,17 @@ describe("spy", function () {
         });
 
         it("returns true if all calls threw", function () {
-            try {
-                this.spyWithTypeError();
-            } catch (e1) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
-            try {
-                this.spyWithTypeError();
-            } catch (e2) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
             assert(this.spyWithTypeError.alwaysThrew());
         });
 
         it("returns true if all calls threw same type", function () {
-            try {
-                this.spyWithTypeError();
-            } catch (e1) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
-            try {
-                this.spyWithTypeError();
-            } catch (e2) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
             assert(this.spyWithTypeError.alwaysThrew("TypeError"));
         });
@@ -1340,9 +1297,7 @@ describe("spy", function () {
         });
 
         it("contains exception thrown by function", function () {
-            try {
-                this.spyWithTypeError();
-            } catch (e) {} // eslint-disable-line no-empty
+            assert.exception(this.spyWithTypeError);
 
             assert.equals(this.spyWithTypeError.exceptions, [this.error]);
         });
@@ -1368,15 +1323,11 @@ describe("spy", function () {
 
             spy();
 
-            try {
-                spy();
-            } catch (e1) {} // eslint-disable-line no-empty
+            assert.exception(spy);
 
             spy();
 
-            try {
-                spy();
-            } catch (e2) {} // eslint-disable-line no-empty
+            assert.exception(spy);
 
             spy();
 
@@ -1495,9 +1446,7 @@ describe("spy", function () {
                 throw new Error();
             });
 
-            try {
-                spy();
-            } catch (e) {} // eslint-disable-line no-empty
+            assert.exception(spy);
 
             assert.equals(spy.returnValues.length, 1);
             refute.defined(spy.returnValues[0]);
@@ -1794,10 +1743,7 @@ describe("spy", function () {
                 throw "an exception";
             });
 
-            try {
-                spy();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(spy);
 
             refute.isNull(spy.firstCall);
         });
@@ -1819,10 +1765,7 @@ describe("spy", function () {
                 throw err;
             });
 
-            try {
-                spy();
-            }
-            catch (e) {} // eslint-disable-line no-empty
+            assert.exception(spy);
 
             assert.same(spy.firstCall.exception, err);
             assert(spy.firstCall.threw(err));
@@ -1998,24 +1941,28 @@ describe("spy", function () {
         it("throws if spy was not yet invoked", function () {
             var spy = createSpy();
 
-            try {
-                spy.callArg(0);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "spy cannot call arg since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.callArg(0);
+                },
+                {
+                    message: "spy cannot call arg since it was not yet invoked."
+                }
+            );
         });
 
         it("includes spy name in error message", function () {
             var api = { someMethod: function () {} };
             var spy = createSpy(api, "someMethod");
 
-            try {
-                spy.callArg(0);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "someMethod cannot call arg since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.callArg(0);
+                },
+                {
+                    message: "someMethod cannot call arg since it was not yet invoked."
+                }
+            );
         });
 
         it("throws if index is not a number", function () {
@@ -2075,12 +2022,14 @@ describe("spy", function () {
             var spy = createSpy();
             var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                spy.callArgOn(0, thisObj);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "spy cannot call arg since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.callArgOn(0, thisObj);
+                },
+                {
+                    message: "spy cannot call arg since it was not yet invoked."
+                }
+            );
         });
 
         it("includes spy name in error message", function () {
@@ -2088,12 +2037,14 @@ describe("spy", function () {
             var spy = createSpy(api, "someMethod");
             var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                spy.callArgOn(0, thisObj);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "someMethod cannot call arg since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.callArgOn(0, thisObj);
+                },
+                {
+                    message: "someMethod cannot call arg since it was not yet invoked."
+                }
+            );
         });
 
         it("throws if index is not a number", function () {
@@ -2159,24 +2110,28 @@ describe("spy", function () {
         it("throws if spy was not yet invoked", function () {
             var spy = createSpy();
 
-            try {
-                spy.yield();
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "spy cannot yield since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.yield();
+                },
+                {
+                    message: "spy cannot yield since it was not yet invoked."
+                }
+            );
         });
 
         it("includes spy name in error message", function () {
             var api = { someMethod: function () {} };
             var spy = createSpy(api, "someMethod");
 
-            try {
-                spy.yield();
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "someMethod cannot yield since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.yield();
+                },
+                {
+                    message: "someMethod cannot yield since it was not yet invoked."
+                }
+            );
         });
 
         it("passs additional arguments", function () {
@@ -2225,12 +2180,14 @@ describe("spy", function () {
             var spy = createSpy();
             var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                spy.yieldOn(thisObj);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "spy cannot yield since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.yieldOn(thisObj);
+                },
+                {
+                    message: "spy cannot yield since it was not yet invoked."
+                }
+            );
         });
 
         it("includes spy name in error message", function () {
@@ -2238,12 +2195,14 @@ describe("spy", function () {
             var spy = createSpy(api, "someMethod");
             var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                spy.yieldOn(thisObj);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "someMethod cannot yield since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.yieldOn(thisObj);
+                },
+                {
+                    message: "someMethod cannot yield since it was not yet invoked."
+                }
+            );
         });
 
         it("pass additional arguments", function () {
@@ -2283,35 +2242,42 @@ describe("spy", function () {
         it("throws if spy was not yet invoked", function () {
             var spy = createSpy();
 
-            try {
-                spy.yieldTo("success");
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "spy cannot yield to 'success' since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.yieldTo("success");
+                },
+                {
+                    message: "spy cannot yield to 'success' since it was not yet invoked."
+                }
+            );
         });
 
         it("includes spy name in error message", function () {
             var api = { someMethod: function () {} };
             var spy = createSpy(api, "someMethod");
 
-            try {
-                spy.yieldTo("success");
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "someMethod cannot yield to 'success' since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.yieldTo("success");
+                },
+                {
+                    message: "someMethod cannot yield to 'success' since it was not yet invoked."
+                }
+            );
         });
 
         it("throws readable message for symbol when spy was not yet invoked", function () {
             if (typeof Symbol === "function") {
                 var spy = createSpy();
 
-                try {
-                    spy.yieldTo(Symbol());
-                } catch (e) {
-                    assert.equals(e.message, "spy cannot yield to 'Symbol()' since it was not yet invoked.");
-                }
+                assert.exception(
+                    function () {
+                        spy.yieldTo(Symbol());
+                    },
+                    {
+                        message: "spy cannot yield to 'Symbol()' since it was not yet invoked."
+                    }
+                );
             }
         });
 
@@ -2353,12 +2319,14 @@ describe("spy", function () {
             var spy = createSpy();
             var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                spy.yieldToOn("success", thisObj);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "spy cannot yield to 'success' since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.yieldToOn("success", thisObj);
+                },
+                {
+                    message: "spy cannot yield to 'success' since it was not yet invoked."
+                }
+            );
         });
 
         it("includes spy name in error message", function () {
@@ -2366,12 +2334,14 @@ describe("spy", function () {
             var spy = createSpy(api, "someMethod");
             var thisObj = { name1: "value1", name2: "value2" };
 
-            try {
-                spy.yieldToOn("success", thisObj);
-                throw new Error();
-            } catch (e) {
-                assert.equals(e.message, "someMethod cannot yield to 'success' since it was not yet invoked.");
-            }
+            assert.exception(
+                function () {
+                    spy.yieldToOn("success", thisObj);
+                },
+                {
+                    message: "someMethod cannot yield to 'success' since it was not yet invoked."
+                }
+            );
         });
 
         it("throws readable message for symbol when spy was not yet invoked", function () {
@@ -2379,11 +2349,14 @@ describe("spy", function () {
                 var spy = createSpy();
                 var thisObj = { name1: "value1", name2: "value2" };
 
-                try {
-                    spy.yieldToOn(Symbol(), thisObj);
-                } catch (e) {
-                    assert.equals(e.message, "spy cannot yield to 'Symbol()' since it was not yet invoked.");
-                }
+                assert.exception(
+                    function () {
+                        spy.yieldToOn(Symbol(), thisObj);
+                    },
+                    {
+                        message: "spy cannot yield to 'Symbol()' since it was not yet invoked."
+                    }
+                );
             }
         });
 
@@ -2468,9 +2441,7 @@ describe("spy", function () {
                 spy.reset();
             });
 
-            assert.exception(function () {
-                spy();
-            }, "InvalidResetException");
+            assert.exception(spy, "InvalidResetException");
         });
     });
 

--- a/test/util/core/walk-test.js
+++ b/test/util/core/walk-test.js
@@ -124,7 +124,7 @@ describe("util/core/walk", function () {
         }
         /* eslint-enable guard-for-in */
 
-        try {
+        try { // eslint-disable-line no-restricted-syntax
             walk(target, iterator, rcvr);
             assert.equals(iterator.callCount, numCalls);
             assert(iterator.alwaysCalledOn(rcvr));

--- a/test/util/core/wrap-method-test.js
+++ b/test/util/core/wrap-method-test.js
@@ -60,13 +60,14 @@ describe("util/core/wrapMethod", function () {
             wrapMethod(object, "prop", function () {});
         });
 
-        try {
-            wrapMethod(object, "prop", function () {});
-            throw new Error("Didn't throw");
-        } catch (e) {
-            assert.match(e.message,
-                /Attempted to wrap .* property .* as function/);
-        }
+        assert.exception(
+            function () {
+                wrapMethod(object, "prop", function () {});
+            },
+            {
+                message: /Attempted to wrap .* property .* as function/
+            }
+        );
     });
 
     it("throws if third argument is missing", function () {
@@ -188,11 +189,14 @@ describe("util/core/wrapMethod", function () {
                     return "original";
                 });
 
-                try {
-                    wrapMethod(object, "method", function () {});
-                } catch (e) {
-                    assert.equals(e.stack, ":STACK2:\n--------------\n:STACK1:");
-                }
+                assert.exception(
+                    function () {
+                        wrapMethod(object, "method", function () {});
+                    },
+                    {
+                        stack: ":STACK2:\n--------------\n:STACK1:"
+                    }
+                );
             });
         });
     }

--- a/test/util/fake-server-test.js
+++ b/test/util/fake-server-test.js
@@ -483,29 +483,29 @@ if (typeof window !== "undefined") {
             });
 
             it("throws understandable error if response is not a string", function () {
-                var error;
+                var server = this.server;
 
-                try {
-                    this.server.respondWith("/", {});
-                } catch (e) {
-                    error = e;
-                }
-
-                assert.isObject(error);
-                assert.equals(error.message, "Fake server response body should be string, but was object");
+                assert.exception(
+                    function () {
+                        server.respondWith("/", {});
+                    },
+                    {
+                        message: "Fake server response body should be string, but was object"
+                    }
+                );
             });
 
             it("throws understandable error if response in array is not a string", function () {
-                var error;
+                var server = this.server;
 
-                try {
-                    this.server.respondWith("/", [200, {}]);
-                } catch (e) {
-                    error = e;
-                }
-
-                assert.isObject(error);
-                assert.equals(error.message, "Fake server response body should be string, but was undefined");
+                assert.exception(
+                    function () {
+                        server.respondWith("/", [200, {}]);
+                    },
+                    {
+                        message: "Fake server response body should be string, but was undefined"
+                    }
+                );
             });
 
             it("is able to pass the same args to respond directly", function () {

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -32,7 +32,7 @@ var fakeXhrTearDown = function () {
 };
 
 var runWithWorkingXHROveride = function (workingXHR, test) {
-    try {
+    try { // eslint-disable-line no-restricted-syntax
         var original = sinonFakeXhr.xhr.workingXHR;
         sinonFakeXhr.xhr.workingXHR = workingXHR;
         test();
@@ -1809,7 +1809,7 @@ if (typeof window !== "undefined") {
 
             it("performs initial readystatechange on opening when filters are being used, but don't match",
                 function () {
-                    try {
+                    try { // eslint-disable-line no-restricted-syntax
                         FakeXMLHttpRequest.useFilters = true;
                         var spy = sinonSpy();
                         this.fakeXhr.addEventListener("readystatechange", spy);

--- a/test/webworker/webworker-support-assessment.js
+++ b/test/webworker/webworker-support-assessment.js
@@ -11,7 +11,7 @@ if (typeof Worker !== "undefined") {
             var worker = new Worker("file://" + __dirname + "/webworker-script.js");
 
             worker.onmessage = function (msg) {
-                try {
+                try { // eslint-disable-line no-restricted-syntax
                     assert.same(msg.data, "worker response");
                     done();
                 } catch (err) {


### PR DESCRIPTION
Replaced try-catch statements with `(assert|refute).exception()` to make them more explicit about their intent. I also added an ESLint rule to disallow `try-catch` in the tests directory.