### PR TITLE
Fix failing reset() on sandbox with unused fake server

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -100,6 +100,9 @@ var fakeServer = {
         this.xhr = fakeXhr.useFakeXMLHttpRequest();
         server.requests = [];
         server.requestCount = 0;
+        server.queue = [];
+        server.responses = [];
+
 
         this.xhr.onCreate = function (xhrObj) {
             xhrObj.unsafeHeadersEnabled = function () {
@@ -166,10 +169,6 @@ var fakeServer = {
 
     handleRequest: function handleRequest(xhr) {
         if (xhr.async) {
-            if (!this.queue) {
-                this.queue = [];
-            }
-
             push.call(this.queue, xhr);
         } else {
             this.processRequest(xhr);
@@ -197,10 +196,6 @@ var fakeServer = {
         if (arguments.length === 1 && typeof method !== "function") {
             this.response = responseArray(method);
             return;
-        }
-
-        if (!this.responses) {
-            this.responses = [];
         }
 
         if (arguments.length === 1) {

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -56,6 +56,22 @@ describe("sinonSandbox", function () {
         assert.same(sandbox.assert, sinonAssert);
     });
 
+    it("can be reset without failing when pre-configured to use a fake server", function () {
+        var sandbox = sinonSandbox.create({useFakeServer: true});
+        refute.exception(function () {
+            sandbox.reset();
+        });
+    });
+
+    it("can be reset without failing when configured to use a fake server", function () {
+        var sandbox = sinonSandbox.create();
+        sandbox.useFakeServer();
+        refute.exception(function () {
+            sandbox.reset();
+        });
+    });
+
+
     describe(".useFakeTimers", function () {
         beforeEach(function () {
             this.sandbox = Object.create(sinonSandbox);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
`sandbox.reset()` fails when the sandbox has been configured to use a fake server and the server has not been utilized. This is the standard config for `sinon-test` and was revealed to crash in sinonjs/sinon-test#57

#### Background (Problem in detail)  - optional
```javascript
    var sandbox = sinonSandbox.create({useFakeServer: true});
    sandbox.reset();
```

will crash immediately today due to the fields not being initalized.

#### Solution  - optional
Initializes the fields at creation time.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `git reset --hard HEAD~1 && npm test #pre-fix the tests fail`
4. `git merge && npm test #after fix the tests pass`