### PR TITLE
Fix invalid link in mock documentation

### DIFF
--- a/docs/_releases/v1.17.6/mocks.md
+++ b/docs/_releases/v1.17.6/mocks.md
@@ -67,7 +67,7 @@ Does not change the object, but returns a mock object to set expectations on the
 
 Overrides `obj.method` with a mock function and returns it.
 
-See [expectations](#expectations-api) below.
+See [expectations](#expectations) below.
 
 
 #### `mock.restore();`

--- a/docs/_releases/v1.17.7/mocks.md
+++ b/docs/_releases/v1.17.7/mocks.md
@@ -67,7 +67,7 @@ Does not change the object, but returns a mock object to set expectations on the
 
 Overrides `obj.method` with a mock function and returns it.
 
-See [expectations](#expectations-api) below.
+See [expectations](#expectations) below.
 
 
 #### `mock.restore();`

--- a/docs/_releases/v2.0.0/mocks.md
+++ b/docs/_releases/v2.0.0/mocks.md
@@ -67,7 +67,7 @@ Does not change the object, but returns a mock object to set expectations on the
 
 Overrides `obj.method` with a mock function and returns it.
 
-See [expectations](#expectations-api) below.
+See [expectations](#expectations) below.
 
 
 #### `mock.restore();`

--- a/docs/_releases/v2.1.0/mocks.md
+++ b/docs/_releases/v2.1.0/mocks.md
@@ -67,7 +67,7 @@ Does not change the object, but returns a mock object to set expectations on the
 
 Overrides `obj.method` with a mock function and returns it.
 
-See [expectations](#expectations-api) below.
+See [expectations](#expectations) below.
 
 
 #### `mock.restore();`

--- a/docs/_releases/v2.2.0/mocks.md
+++ b/docs/_releases/v2.2.0/mocks.md
@@ -67,7 +67,7 @@ Does not change the object, but returns a mock object to set expectations on the
 
 Overrides `obj.method` with a mock function and returns it.
 
-See [expectations](#expectations-api) below.
+See [expectations](#expectations) below.
 
 
 #### `mock.restore();`

--- a/docs/_releases/v2.3.0/mocks.md
+++ b/docs/_releases/v2.3.0/mocks.md
@@ -67,7 +67,7 @@ Does not change the object, but returns a mock object to set expectations on the
 
 Overrides `obj.method` with a mock function and returns it.
 
-See [expectations](#expectations-api) below.
+See [expectations](#expectations) below.
 
 
 #### `mock.restore();`

--- a/docs/_releases/v2.3.1/mocks.md
+++ b/docs/_releases/v2.3.1/mocks.md
@@ -67,7 +67,7 @@ Does not change the object, but returns a mock object to set expectations on the
 
 Overrides `obj.method` with a mock function and returns it.
 
-See [expectations](#expectations-api) below.
+See [expectations](#expectations) below.
 
 
 #### `mock.restore();`

--- a/docs/_releases/v2.3.2/mocks.md
+++ b/docs/_releases/v2.3.2/mocks.md
@@ -67,7 +67,7 @@ Does not change the object, but returns a mock object to set expectations on the
 
 Overrides `obj.method` with a mock function and returns it.
 
-See [expectations](#expectations-api) below.
+See [expectations](#expectations) below.
 
 
 #### `mock.restore();`

--- a/docs/release-source/release/mocks.md
+++ b/docs/release-source/release/mocks.md
@@ -67,7 +67,7 @@ Does not change the object, but returns a mock object to set expectations on the
 
 Overrides `obj.method` with a mock function and returns it.
 
-See [expectations](#expectations-api) below.
+See [expectations](#expectations) below.
 
 
 #### `mock.restore();`


### PR DESCRIPTION
#### Purpose 

Fixes invalid link to "Expectations" section in documentation for mocks.

![2017-05-27 at 09 10](https://cloud.githubusercontent.com/assets/20321/26519089/5eae886e-42bc-11e7-9a04-152a4c6c5836.png)

#### How to verify

1. Check out this branch (see github instructions below)
2. `npm install`
3. Navigate to http://localhost:4000/releases/v2.3.2/mocks/
4. Click on the link to expectations (see image above)
5. Observe that you arrive at the expectations section

