### PR TITLE
Feature detect function name property in issue 950

### DIFF
--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -123,30 +123,33 @@ describe("issues", function () {
     });
 
     describe("#950 - first execution of a spy as a method renames that spy", function () {
-        it("should not rename spies", function () {
-            var expectedName = "proxy";
+        function bob() {}
 
-            function bob() {}
-            var spy = sinon.spy(bob);
+        // IE 11 does not support the function name property
+        if (bob.name) {
+            it("should not rename spies", function () {
+                var expectedName = "proxy";
+                var spy = sinon.spy(bob);
 
-            assert.equals(spy.name, expectedName);
+                assert.equals(spy.name, expectedName);
 
-            var obj = { methodName: spy };
-            assert.equals(spy.name, expectedName);
+                var obj = { methodName: spy };
+                assert.equals(spy.name, expectedName);
 
-            spy();
-            assert.equals(spy.name, expectedName);
+                spy();
+                assert.equals(spy.name, expectedName);
 
-            obj.methodName.call(null);
-            assert.equals(spy.name, expectedName);
+                obj.methodName.call(null);
+                assert.equals(spy.name, expectedName);
 
-            obj.methodName();
-            assert.equals(spy.name, expectedName);
+                obj.methodName();
+                assert.equals(spy.name, expectedName);
 
-            obj.otherProp = spy;
-            obj.otherProp();
-            assert.equals(spy.name, expectedName);
-        });
+                obj.otherProp = spy;
+                obj.otherProp();
+                assert.equals(spy.name, expectedName);
+            });
+        }
     });
 
     describe("#1026", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix the sauce labs build on master

#### Background (Problem in detail)  - optional

IE 11 does not support the name property on functions.

#### Solution  - optional

The test case for issue #950 is only executed if the name property is supported.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm run test-cloud`