### PR TITLE
Remove confusing .withArgs from spy documentation

### DIFF
--- a/docs/_releases/v2.0.0/spies.md
+++ b/docs/_releases/v2.0.0/spies.md
@@ -157,8 +157,6 @@ Creates a spy that only records calls when the received arguments match those pa
 "should call method once with each argument": function () {
     var object = { method: function () {} };
     var spy = sinon.spy(object, "method");
-    spy.withArgs(42);
-    spy.withArgs(1);
 
     object.method(42);
     object.method(1);

--- a/docs/_releases/v2.1.0/spies.md
+++ b/docs/_releases/v2.1.0/spies.md
@@ -157,8 +157,6 @@ Creates a spy that only records calls when the received arguments match those pa
 "should call method once with each argument": function () {
     var object = { method: function () {} };
     var spy = sinon.spy(object, "method");
-    spy.withArgs(42);
-    spy.withArgs(1);
 
     object.method(42);
     object.method(1);

--- a/docs/_releases/v2.2.0/spies.md
+++ b/docs/_releases/v2.2.0/spies.md
@@ -157,8 +157,6 @@ Creates a spy that only records calls when the received arguments match those pa
 "should call method once with each argument": function () {
     var object = { method: function () {} };
     var spy = sinon.spy(object, "method");
-    spy.withArgs(42);
-    spy.withArgs(1);
 
     object.method(42);
     object.method(1);

--- a/docs/_releases/v2.3.0/spies.md
+++ b/docs/_releases/v2.3.0/spies.md
@@ -157,8 +157,6 @@ Creates a spy that only records calls when the received arguments match those pa
 "should call method once with each argument": function () {
     var object = { method: function () {} };
     var spy = sinon.spy(object, "method");
-    spy.withArgs(42);
-    spy.withArgs(1);
 
     object.method(42);
     object.method(1);

--- a/docs/_releases/v2.3.1/spies.md
+++ b/docs/_releases/v2.3.1/spies.md
@@ -157,8 +157,6 @@ Creates a spy that only records calls when the received arguments match those pa
 "should call method once with each argument": function () {
     var object = { method: function () {} };
     var spy = sinon.spy(object, "method");
-    spy.withArgs(42);
-    spy.withArgs(1);
 
     object.method(42);
     object.method(1);

--- a/docs/_releases/v2.3.2/spies.md
+++ b/docs/_releases/v2.3.2/spies.md
@@ -157,8 +157,6 @@ Creates a spy that only records calls when the received arguments match those pa
 "should call method once with each argument": function () {
     var object = { method: function () {} };
     var spy = sinon.spy(object, "method");
-    spy.withArgs(42);
-    spy.withArgs(1);
 
     object.method(42);
     object.method(1);


### PR DESCRIPTION
This is a followup to  #1437, that only fixed this issue for `release-soruce`.
