### PR TITLE
Docs: Fix incorrect sandbox configuration documentation.

### DIFF
--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -41,16 +41,32 @@ describe('myAPI.hello method', function () {
 
 #### `var sandbox = sinon.sandbox.create();`
 
-Creates a sandbox object
+Creates a sandbox object with spies, stubs, and mocks.
 
 
 #### `var sandbox = sinon.sandbox.create(config);`
 
-The `sinon.sandbox.create(config)` method is mostly an integration feature, and as an end-user of Sinon.JS you will probably not need it.
+The `sinon.sandbox.create(config)` method is often an integration feature, and can be used for scenarios including a global object to coordinate all fakes through.
 
-Creates a pre-configured sandbox object. The configuration can instruct the sandbox to include fake timers, fake server, and how to interact with these.
+Sandboxes are partially configured by default such that calling:
 
-The default configuration looks like:
+```javascript
+var sandbox = sinon.sandbox.create({});
+```
+
+will merge in extra defaults analogous to:
+
+```javascript
+var sandbox = sinon.sandbox.create({
+    // ...
+    injectInto: null,
+    properties: ["spy", "stub", "mock"],
+    useFakeTimers: false,
+    useFakeServer: false
+});
+```
+
+The `useFakeTimers` and `useFakeServers` are **false** as opposed to the defaults in `sinon.defaultConfig`:
 
 ```javascript
 sinon.defaultConfig = {
@@ -60,6 +76,19 @@ sinon.defaultConfig = {
     useFakeTimers: true,
     useFakeServer: true
 }
+```
+
+To get a full sandbox with stubs, spies, etc. **and** fake timers and servers, you can call:
+
+```javascript
+// Inject the sinon defaults explicitly.
+var sandbox = sinon.sandbox.create(sinon.defaultConfig);
+
+// (OR) Add the extra properties that differ from the sinon defaults.
+var sandbox = sinon.sandbox.create({
+    useFakeTimers: true
+    useFakeServer: true
+});
 ```
 
 ##### injectInto


### PR DESCRIPTION
#### Purpose (TL;DR)

The documentation for `sinon.sandbox` is incorrect and this PR fixes it. The bug was originally identified in #617.

#### Background (Problem in detail)

@divmain identified that the `sinon.sandbox` documentation is wrong in #617 and in a fiddle http://jsfiddle.net/8k0zv6tp/

Here's a concise example:

The documentation says that calling:

```js
var sandbox = sinon.sandbox.create({});
```

essentially means:

```js
var sandbox = sinon.sandbox.create({
    // ...
    injectInto: null,
    properties: ["spy", "stub", "mock", "clock", "server", "requests"],
    useFakeTimers: true,
    useFakeServer: true
});
```

This is wrong. In the shell we have:

```js
> var sandbox = sinon.sandbox.create({})
undefined
> sandbox.clock
undefined
> sandbox.server
undefined
```

What really happens is equivalent to:

```js
var sandbox = sinon.sandbox.create({
    // ...
    injectInto: null,
    properties: ["spy", "stub", "mock"],
    useFakeTimers: false,
    useFakeServer: false
});
```

The upstream #617 issue was closed with https://github.com/sinonjs/sinon/issues/617#issuecomment-304498837 comment of:

> The current documentation shows how to create a sandbox without a config and clearly states that sinon.sandbox.create(config) is an integration feature, that users are likely not to need.
>
> I consider this solved, and am closing this. Feel free to create a PR for the new documentation if you have improvements for this area of the documentation.

As part of the public API, some of our biggest clients use `sandbox` exclusively for large test suites for better fake management and cleanup, we have a vested interest in making sure the documentation and behavior of sandbox is correct.

So, after the issue was closed I asked "is this a bug? or a documentation bug?" and I haven't received a response. So, I took a hint from the closing comment and making the simplifying assumption it's a documentation bug and here's the requested PR!

Enjoy!

#### How to verify

The documentation behavior being wrong can be seen with:

```
$ npm install sinon
$ node
> var sandbox = sinon.sandbox.create({})
undefined

// These **should** be defined.
> sandbox.clock
undefined
> sandbox.server
undefined

// Now, let's do what the PR improved docs say.
> sandbox = sinon.sandbox.create(sinon.defaultConfig)
undefined

// These **should** be defined.
> sandbox.clock
{ now: 0,
  hrNow: 0,
  timeouts: {},
  Date: 
   { [Function: ClockDate]
// ... STUFF ...
> sandbox.server
{ logError: [Function: logError],
  requests: [],
  requestCount: 0,
  queue: [],
  responses: [] }
```
