### PR TITLE
Fix 1445: make stubbing of static function properties possible

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -18,7 +18,7 @@ function stub(object, property, descriptor) {
     var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
     var isCreatingNewStub = !object && typeof property === "undefined";
     var isStubbingDescriptor = object && property && Boolean(descriptor);
-    var isStubbingNonFuncProperty = typeof object === "object"
+    var isStubbingNonFuncProperty = (typeof object === "object" || typeof object === "function")
                                     && typeof property !== "undefined"
                                     && (typeof actualDescriptor === "undefined"
                                     || typeof actualDescriptor.value !== "function")

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2654,5 +2654,23 @@ describe("stub", function () {
 
             assert.equals(getPropertyDescriptor(obj, "nonExisting"), undefined);
         });
+
+        it("allows stubbing function static properties", function () {
+            var myFunc = function () {};
+            myFunc.prop = "rawString";
+
+            createStub(myFunc, "prop").value("newString");
+            assert.equals(myFunc.prop, "newString");
+        });
+
+        it("allows restoring function static properties", function () {
+            var myFunc = function () {};
+            myFunc.prop = "rawString";
+
+            var stub = createStub(myFunc, "prop").value("newString");
+            stub.restore();
+
+            assert.equals(myFunc.prop, "rawString");
+        });
     });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix issue #1445 related to stubbing function static properties by adding an extra check for the `object` type to be a function 