### PR TITLE
Fix minor typos

### DIFF
--- a/docs/_releases/v2.3.4/spies.md
+++ b/docs/_releases/v2.3.4/spies.md
@@ -419,7 +419,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`
@@ -499,4 +499,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix two minor typos in the [Spies documentation](http://sinonjs.org/releases/v2.3.4/spies/).