### PR TITLE
Fix: check configurable on a prop before creating (fixes #1456)

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -1,4 +1,7 @@
 "use strict";
+
+var getPropertyDescriptor = require("./util/core/get-property-descriptor");
+
 var slice = [].slice;
 var useLeftMostCallback = -1;
 var useRightMostCallback = -2;
@@ -12,6 +15,12 @@ function throwsException(fake, error, message) {
     } else {
         fake.exception = error;
     }
+}
+
+function isPropertyConfigurable(obj, propName) {
+    var propertyDescriptor = getPropertyDescriptor(obj, propName);
+
+    return propertyDescriptor ? propertyDescriptor.configurable : true;
 }
 
 module.exports = {
@@ -181,7 +190,7 @@ module.exports = {
 
         Object.defineProperty(rootStub.rootObj, rootStub.propName, {
             get: getterFunction,
-            configurable: true
+            configurable: isPropertyConfigurable(rootStub.rootObj, rootStub.propName)
         });
 
         return fake;
@@ -192,7 +201,7 @@ module.exports = {
 
         Object.defineProperty(rootStub.rootObj, rootStub.propName, { // eslint-disable-line accessor-pairs
             set: setterFunction,
-            configurable: true
+            configurable: isPropertyConfigurable(rootStub.rootObj, rootStub.propName)
         });
 
         return fake;
@@ -204,7 +213,7 @@ module.exports = {
         Object.defineProperty(rootStub.rootObj, rootStub.propName, {
             value: newVal,
             enumerable: true,
-            configurable: true
+            configurable: isPropertyConfigurable(rootStub.rootObj, rootStub.propName)
         });
 
         return fake;

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -2,6 +2,7 @@
 
 var referee = require("referee");
 var sinon = require("../../lib/sinon");
+var sinonSandbox = require("../../lib/sinon/sandbox");
 var configureLogError = require("../../lib/sinon/util/core/log_error.js");
 var assert = referee.assert;
 var refute = referee.refute;
@@ -248,4 +249,24 @@ describe("issues", function () {
             });
         });
     });
+
+    if (typeof window !== "undefined") {
+        describe("#1456", function () {
+            var sandbox;
+
+            beforeEach(function () {
+                sandbox = sinonSandbox.create();
+            });
+
+            afterEach(function () {
+                sandbox.restore();
+            });
+
+            it("stub window innerHeight", function () {
+                sandbox.stub(window, "innerHeight").value(111);
+
+                assert.equals(window.innerHeight, 111);
+            });
+        });
+    }
 });

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -626,4 +626,24 @@ describe("sinonSandbox", function () {
             assert.equals(object.prop, "bla");
         });
     });
+
+    if (typeof window !== "undefined") {
+        describe("window properties", function () {
+            var sandbox;
+
+            beforeEach(function () {
+                sandbox = sinonSandbox.create();
+            });
+
+            afterEach(function () {
+                sandbox.restore();
+            });
+
+            it("stub window innerHeight", function () {
+                sandbox.stub(window, "innerHeight").value(111);
+
+                assert.equals(window.innerHeight, 111);
+            });
+        });
+    }
 });

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -626,24 +626,4 @@ describe("sinonSandbox", function () {
             assert.equals(object.prop, "bla");
         });
     });
-
-    if (typeof window !== "undefined") {
-        describe("window properties", function () {
-            var sandbox;
-
-            beforeEach(function () {
-                sandbox = sinonSandbox.create();
-            });
-
-            afterEach(function () {
-                sandbox.restore();
-            });
-
-            it("stub window innerHeight", function () {
-                sandbox.stub(window, "innerHeight").value(111);
-
-                assert.equals(window.innerHeight, 111);
-            });
-        });
-    }
 });

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2672,5 +2672,18 @@ describe("stub", function () {
 
             assert.equals(myFunc.prop, "rawString");
         });
+
+        it("allows stubbing object props with configurable false", function () {
+            var myObj = {};
+            Object.defineProperty(myObj, "prop", {
+                configurable: false,
+                enumerable: true,
+                writable: true,
+                value: "static"
+            });
+
+            createStub(myObj, "prop").value("newString");
+            assert.equals(myObj.prop, "newString");
+        });
     });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fixes #1456 by making sure propert is made `configurable` based on the object props.

@lucasfcosta  have created a fix with my beast understanding of your proposal. Feedback is welcome. Thanks