### PR TITLE
Fix old url and add Stack Overflow link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,10 @@
 
 There are several ways of contributing to Sinon.JS
 
-* Help [improve the documentation](https://github.com/sinonjs/sinon-docs) published at [the Sinon.JS website](http://sinonjs.org)
-* Help someone understand and use Sinon.JS on [the mailing list](http://groups.google.com/group/sinonjs)
+* Look into [issues tagged `help-wanted`](https://github.com/sinonjs/sinon/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22)
+* Help [improve the documentation](https://github.com/sinonjs/sinon/tree/master/docs) published
+  at [the Sinon.JS website](http://sinonjs.org). [Documentation issues](https://github.com/sinonjs/sinon/issues?q=is%3Aopen+is%3Aissue+label%3ADocumentation).
+* Help someone understand and use Sinon.JS on [the mailing list](http://groups.google.com/group/sinonjs) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/sinon)
 * Report an issue, please read instructions below
 * Help with triaging the [issues](http://github.com/cjohansen/Sinon.JS/issues). The clearer they are, the more likely they are to be fixed soon.
 * Contribute to the code base.


### PR DESCRIPTION
Link was pointing to old repo. Also, most Sinon issues these days end up on Stack Overflow, so why not point people there? I also track the Sinon tag there.