### PR TITLE
Add missing documentation for spy.getCalls()

### DIFF
--- a/docs/_releases/v1.17.6/spies.md
+++ b/docs/_releases/v1.17.6/spies.md
@@ -351,6 +351,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v1.17.7/spies.md
+++ b/docs/_releases/v1.17.7/spies.md
@@ -351,6 +351,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v2.0.0/spies.md
+++ b/docs/_releases/v2.0.0/spies.md
@@ -349,6 +349,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v2.1.0/spies.md
+++ b/docs/_releases/v2.1.0/spies.md
@@ -349,6 +349,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v2.2.0/spies.md
+++ b/docs/_releases/v2.2.0/spies.md
@@ -361,6 +361,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v2.3.0/spies.md
+++ b/docs/_releases/v2.3.0/spies.md
@@ -361,6 +361,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v2.3.1/spies.md
+++ b/docs/_releases/v2.3.1/spies.md
@@ -361,6 +361,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v2.3.2/spies.md
+++ b/docs/_releases/v2.3.2/spies.md
@@ -361,6 +361,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v2.3.3/spies.md
+++ b/docs/_releases/v2.3.3/spies.md
@@ -361,6 +361,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v2.3.4/spies.md
+++ b/docs/_releases/v2.3.4/spies.md
@@ -361,6 +361,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v2.3.5/spies.md
+++ b/docs/_releases/v2.3.5/spies.md
@@ -361,6 +361,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/_releases/v2.3.6/spies.md
+++ b/docs/_releases/v2.3.6/spies.md
@@ -361,6 +361,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/api/v1.17.3/spies/index.md
+++ b/docs/api/v1.17.3/spies/index.md
@@ -371,6 +371,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -361,6 +361,11 @@ assertEquals("/stuffs", spyCall.args[0]);
 ```
 
 
+#### `var spyCalls = spy.getCalls();`
+
+Returns an `Array` of all [calls](#spycall) recorded by the spy.
+
+
 #### `spy.thisValues`
 
 Array of `this` objects, `spy.thisValues[0]` is the `this` object for the first call.


### PR DESCRIPTION
[`spy.getCalls()`](https://github.com/sinonjs/sinon/blob/833ff2c25f2a6af96b782422c1f1bef068d63bb2/lib/sinon/spy.js#L242-L251) has been part of the codebase since at least 8d69a482, which was
committed on (2013-09-08 15:18:55 +0100)