### PR TITLE
Fix #1476: stub#firstCall seems broken on sinon v2.3.6

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -179,6 +179,9 @@ var spyApi = {
 
         // Make call properties available from within the spied function:
         createCallProperties.call(this);
+        matchings.forEach(function (matching) {
+            createCallProperties.call(matching);
+        });
 
         try {
             this.invoking = true;

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -327,7 +327,7 @@ describe("spy", function () {
     });
 
     it("should work with combination of withArgs arguments and order of calling withArgs", function () {
-        var assertSpy = function (spy) {
+        function assertSpy(spy) {
             // assert callCount
             assert.equals(spy.callCount, 4);
             assert.equals(spy.withArgs(1).callCount, 3);
@@ -335,15 +335,15 @@ describe("spy", function () {
             assert.equals(spy.withArgs(1, 2).callCount, 1);
 
             // assert call
-            assert.equals(spy.getCall(0).args[0], undefined);
+            refute.defined(spy.getCall(0).args[0]);
             assert.equals(spy.getCall(1).args[0], 1);
-            assert.equals(spy.getCall(1).args[1], undefined);
+            refute.defined(spy.getCall(1).args[1]);
             assert.equals(spy.getCall(2).args[0], 1);
             assert.equals(spy.getCall(2).args[1], 1);
-            assert.equals(spy.getCall(2).args[2], undefined);
+            refute.defined(spy.getCall(2).args[2]);
             assert.equals(spy.getCall(3).args[0], 1);
             assert.equals(spy.getCall(3).args[1], 2);
-            assert.equals(spy.getCall(3).args[2], undefined);
+            refute.defined(spy.getCall(3).args[2]);
             ["args", "callCount", "callId"].forEach(function (propName) {
                 assert.equals(spy.withArgs(1).getCall(0)[propName],
                               spy.getCall(1)[propName]);
@@ -351,16 +351,13 @@ describe("spy", function () {
                               spy.getCall(2)[propName]);
                 assert.equals(spy.withArgs(1).getCall(2)[propName],
                               spy.getCall(3)[propName]);
-                assert.equals(spy.withArgs(1).getCall(3),
-                              null);
+                assert.isNull(spy.withArgs(1).getCall(3));
                 assert.equals(spy.withArgs(1, 1).getCall(0)[propName],
                               spy.getCall(2)[propName]);
-                assert.equals(spy.withArgs(1, 1).getCall(1),
-                              null);
+                assert.isNull(spy.withArgs(1, 1).getCall(1));
                 assert.equals(spy.withArgs(1, 2).getCall(0)[propName],
                               spy.getCall(3)[propName]);
-                assert.equals(spy.withArgs(1, 2).getCall(1),
-                              null);
+                assert.isNull(spy.withArgs(1, 2).getCall(1));
             });
 
             // assert firstCall, secondCall, thirdCall, and lastCall
@@ -373,14 +370,14 @@ describe("spy", function () {
             assert.equals(spy.withArgs(1).thirdCall.callId, spy.withArgs(1).getCall(2).callId);
             assert.equals(spy.withArgs(1).lastCall.callId, spy.withArgs(1).getCall(2).callId);
             assert.equals(spy.withArgs(1, 1).firstCall.callId, spy.withArgs(1, 1).getCall(0).callId);
-            assert.equals(spy.withArgs(1, 1).secondCall, null);
-            assert.equals(spy.withArgs(1, 1).thirdCall, null);
+            assert.isNull(spy.withArgs(1, 1).secondCall);
+            assert.isNull(spy.withArgs(1, 1).thirdCall);
             assert.equals(spy.withArgs(1, 1).lastCall.callId, spy.withArgs(1, 1).getCall(0).callId);
             assert.equals(spy.withArgs(1, 2).firstCall.callId, spy.withArgs(1, 2).getCall(0).callId);
-            assert.equals(spy.withArgs(1, 2).secondCall, null);
-            assert.equals(spy.withArgs(1, 2).thirdCall, null);
+            assert.isNull(spy.withArgs(1, 2).secondCall);
+            assert.isNull(spy.withArgs(1, 2).thirdCall);
             assert.equals(spy.withArgs(1, 2).lastCall.callId, spy.withArgs(1, 2).getCall(0).callId);
-        };
+        }
 
         var object = {
             f1: function () {},

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -326,7 +326,62 @@ describe("spy", function () {
         });
     });
 
-    it("counts with combination of withArgs arguments and order of calling withArgs", function () {
+    it("should work with combination of withArgs arguments and order of calling withArgs", function () {
+        var assertSpy = function (spy) {
+            // assert callCount
+            assert.equals(spy.callCount, 4);
+            assert.equals(spy.withArgs(1).callCount, 3);
+            assert.equals(spy.withArgs(1, 1).callCount, 1);
+            assert.equals(spy.withArgs(1, 2).callCount, 1);
+
+            // assert call
+            assert.equals(spy.getCall(0).args[0], undefined);
+            assert.equals(spy.getCall(1).args[0], 1);
+            assert.equals(spy.getCall(1).args[1], undefined);
+            assert.equals(spy.getCall(2).args[0], 1);
+            assert.equals(spy.getCall(2).args[1], 1);
+            assert.equals(spy.getCall(2).args[2], undefined);
+            assert.equals(spy.getCall(3).args[0], 1);
+            assert.equals(spy.getCall(3).args[1], 2);
+            assert.equals(spy.getCall(3).args[2], undefined);
+            ["args", "callCount", "callId"].forEach(function (propName) {
+                assert.equals(spy.withArgs(1).getCall(0)[propName],
+                              spy.getCall(1)[propName]);
+                assert.equals(spy.withArgs(1).getCall(1)[propName],
+                              spy.getCall(2)[propName]);
+                assert.equals(spy.withArgs(1).getCall(2)[propName],
+                              spy.getCall(3)[propName]);
+                assert.equals(spy.withArgs(1).getCall(3),
+                              null);
+                assert.equals(spy.withArgs(1, 1).getCall(0)[propName],
+                              spy.getCall(2)[propName]);
+                assert.equals(spy.withArgs(1, 1).getCall(1),
+                              null);
+                assert.equals(spy.withArgs(1, 2).getCall(0)[propName],
+                              spy.getCall(3)[propName]);
+                assert.equals(spy.withArgs(1, 2).getCall(1),
+                              null);
+            });
+
+            // assert firstCall, secondCall, thirdCall, and lastCall
+            assert.equals(spy.firstCall.callId, spy.getCall(0).callId);
+            assert.equals(spy.secondCall.callId, spy.getCall(1).callId);
+            assert.equals(spy.thirdCall.callId, spy.getCall(2).callId);
+            assert.equals(spy.lastCall.callId, spy.getCall(3).callId);
+            assert.equals(spy.withArgs(1).firstCall.callId, spy.withArgs(1).getCall(0).callId);
+            assert.equals(spy.withArgs(1).secondCall.callId, spy.withArgs(1).getCall(1).callId);
+            assert.equals(spy.withArgs(1).thirdCall.callId, spy.withArgs(1).getCall(2).callId);
+            assert.equals(spy.withArgs(1).lastCall.callId, spy.withArgs(1).getCall(2).callId);
+            assert.equals(spy.withArgs(1, 1).firstCall.callId, spy.withArgs(1, 1).getCall(0).callId);
+            assert.equals(spy.withArgs(1, 1).secondCall, null);
+            assert.equals(spy.withArgs(1, 1).thirdCall, null);
+            assert.equals(spy.withArgs(1, 1).lastCall.callId, spy.withArgs(1, 1).getCall(0).callId);
+            assert.equals(spy.withArgs(1, 2).firstCall.callId, spy.withArgs(1, 2).getCall(0).callId);
+            assert.equals(spy.withArgs(1, 2).secondCall, null);
+            assert.equals(spy.withArgs(1, 2).thirdCall, null);
+            assert.equals(spy.withArgs(1, 2).lastCall.callId, spy.withArgs(1, 2).getCall(0).callId);
+        };
+
         var object = {
             f1: function () {},
             f2: function () {}
@@ -337,32 +392,32 @@ describe("spy", function () {
         assert.equals(spy1.callCount, 0);
         assert.equals(spy1.withArgs(1).callCount, 0);
         assert.equals(spy1.withArgs(1, 1).callCount, 0);
+        assert.isNull(spy1.getCall(0));
+        assert.isNull(spy1.getCall(1));
+        assert.isNull(spy1.getCall(2));
+        assert.isNull(spy1.getCall(3));
 
         object.f1();
         object.f1(1);
         object.f1(1, 1);
         object.f1(1, 2);
-
-        assert.equals(spy1.callCount, 4);
-        assert.equals(spy1.withArgs(1).callCount, 3);
-        assert.equals(spy1.withArgs(1, 1).callCount, 1);
-        assert.equals(spy1.withArgs(1, 2).callCount, 1);
+        assertSpy(spy1);
 
         // f2: the order of withArgs(1, 1), withArgs(1)
         var spy2 = createSpy(object, "f2");
         assert.equals(spy2.callCount, 0);
         assert.equals(spy2.withArgs(1, 1).callCount, 0);
         assert.equals(spy2.withArgs(1).callCount, 0);
+        assert.isNull(spy2.getCall(0));
+        assert.isNull(spy2.getCall(1));
+        assert.isNull(spy2.getCall(2));
+        assert.isNull(spy2.getCall(3));
 
         object.f2();
         object.f2(1);
         object.f2(1, 1);
         object.f2(1, 2);
-
-        assert.equals(spy2.callCount, 4);
-        assert.equals(spy2.withArgs(1).callCount, 3);
-        assert.equals(spy2.withArgs(1, 1).callCount, 1);
-        assert.equals(spy2.withArgs(1, 2).callCount, 1);
+        assertSpy(spy2);
     });
 
     describe(".named", function () {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -121,7 +121,7 @@ describe("stub", function () {
         stub.withArgs(1).returns(42);
         stub(1);
 
-        assert.isObject(stub.withArgs(1).firstCall);
+        refute.isNull(stub.withArgs(1).firstCall);
     });
 
     describe(".returns", function () {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -115,6 +115,15 @@ describe("stub", function () {
         assert.equals(stub(2), 0);
     });
 
+    it("should work with combination of withArgs arguments", function () {
+        var stub = createStub();
+
+        stub.withArgs(1).returns(42);
+        stub(1);
+
+        assert.isObject(stub.withArgs(1).firstCall);
+    });
+
     describe(".returns", function () {
         it("returns specified value", function () {
             var stub = createStub.create();


### PR DESCRIPTION
Fix issue #1476 
The cause of this bug is that `createCallProperties(matching)` is never called in spy.js.