### PR TITLE
Avoid running test for #1456 on Safari

### DIFF
--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -7,7 +7,6 @@ var configureLogError = require("../../lib/sinon/util/core/log_error.js");
 var assert = referee.assert;
 var refute = referee.refute;
 
-
 describe("issues", function () {
     beforeEach(function () {
         this.sandbox = sinon.sandbox.create();
@@ -210,10 +209,10 @@ describe("issues", function () {
             var argsB = match(suffixB);
 
             var firstFake = readFile
-              .withArgs(argsA);
+                .withArgs(argsA);
 
             var secondFake = readFile
-              .withArgs(argsB);
+                .withArgs(argsB);
 
             assert(firstFake !== secondFake);
         });
@@ -282,23 +281,37 @@ describe("issues", function () {
         });
     });
 
-    if (typeof window !== "undefined") {
-        describe("#1456", function () {
-            var sandbox;
 
-            beforeEach(function () {
-                sandbox = sinonSandbox.create();
-            });
+    describe("#1456", function () {
+        var sandbox;
 
-            afterEach(function () {
-                sandbox.restore();
-            });
+        function throwsOnUnconfigurableProperty() {
+            /* eslint-disable no-restricted-syntax */
+            try {
+                var preDescriptor = Object.getOwnPropertyDescriptor(window, "innerHeight"); //backup val
+                Object.defineProperty(window, "innerHeight", { value: 10, configureable: true, writeable: true });
+                Object.defineProperty(window, "innerHeight", preDescriptor); //restore
+                return false;
+            } catch (err) {
+                return true;
+            }
+            /* eslint-enable no-restricted-syntax */
+        }
 
-            it("stub window innerHeight", function () {
-                sandbox.stub(window, "innerHeight").value(111);
+        beforeEach(function () {
+            if (typeof window === "undefined" || throwsOnUnconfigurableProperty()) { this.skip(); }
 
-                assert.equals(window.innerHeight, 111);
-            });
+            sandbox = sinonSandbox.create();
         });
-    }
+
+        afterEach(function () {
+            sandbox.restore();
+        });
+
+        it("stub window innerHeight", function () {
+            sandbox.stub(window, "innerHeight").value(111);
+
+            assert.equals(window.innerHeight, 111);
+        });
+    });
 });


### PR DESCRIPTION
#### Purpose
This avoids [breaking the build](https://travis-ci.org/sinonjs/sinon/jobs/249565441) by avoiding running the breaking test on Safari. See background in #1462.

#### Background (Problem in detail)  - optional
Safari throws an error when trying to configure properties on `window` that are not configurable. AFAIK this is not a problem Sinon can solve: if the prop cannot be stubbed, then we shouldn't suppress the error or avoid trying to stub it.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Configure Sauce Labs:
```bash
export SAUCE_USERNAME=sinon-sauce-name
export SAUCE_ACCESS_KEY=abcd3-12345-...
```
4. `npm run test-cloud`

BTW, the code is not so nice ATM. I was just so annoyed by the errors from Travis, so just needed to put a fix out there ... Not totally sure where to put the runtime detection of how this breaks and I am not so sure about how I skip the test. Maybe a simple `return` would suffice?
