### PR TITLE
propagates promiseLibrary to new stub behaviors

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -105,6 +105,10 @@ var proto = {
         delete behavior.createBehavior;
         behavior.stub = stub;
 
+        if (stub.defaultBehavior && stub.defaultBehavior.promiseLibrary) {
+            behavior.promiseLibrary = stub.defaultBehavior.promiseLibrary;
+        }
+
         return behavior;
     },
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -251,6 +251,37 @@ describe("issues", function () {
         });
     });
 
+    describe("#1474 - stub.onCall", function () {
+        it("should preserve promise library", function () {
+            var promiseLib = {
+                resolve: function (value) {
+                    var promise = Promise.resolve(value);
+                    promise.tap = function () {
+                        return "tap " + value;
+                    };
+
+                    return promise;
+                }
+            };
+            var stub = sinon.stub().usingPromise(promiseLib);
+
+            stub.resolves("resolved");
+            stub.onSecondCall().resolves("resolved again");
+
+            var first = stub();
+            var second = stub();
+
+            assert.isFunction(first.then);
+            assert.isFunction(first.tap);
+
+            assert.isFunction(second.then);
+            assert.isFunction(second.tap);
+
+            assert.equals(first.tap(), "tap resolved");
+            assert.equals(second.tap(), "tap resolved again");
+        });
+    });
+
     if (typeof window !== "undefined") {
         describe("#1456", function () {
             var sandbox;


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
> Fix issue #1474 by copying stub promiseLibrary to its new behaviors.

#### Background (Problem in detail)  - optional
The problem was that stub behaviors created with onCall, did not preserve the promise library defined when calling usingPromise on the original stub.

#### Solution  - optional
> Extending the new behavior with the promiseLibrary from the stub.defaultBehavior solves the issue.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
