### PR TITLE
Clarify behavior of useFakeTimers

### DIFF
--- a/docs/release-source/release/fake-timers.md
+++ b/docs/release-source/release/fake-timers.md
@@ -58,9 +58,11 @@ You can also pass in a Date object, and its `getTime()` will be used for the sta
 
 #### `var clock = sinon.useFakeTimers([now, ]prop1, prop2, ...);`
 
-Sets the clock start timestamp and names functions to fake.
+Sets the clock start timestamp and names functions to fake. If the first argument is not numeric, it sets the clock to 0 and treats all arguments as names of functions to fake.
 
-Possible functions are `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`, `setImmediate`, `clearImmediate` and `Date`. Can also be called without the timestamp.
+Possible functions are `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`, `setImmediate`, `clearImmediate` and `Date`.  Any functions not listed continue to use the original version of the function, including the actual time for the timestamp. This can have surprising results and should be done with care.
+
+Note that if no functions are listed, the default behavior is to replace all eligible functions.
 
 
 #### `clock.tick(ms);`


### PR DESCRIPTION
I no longer use sinon, so I don't know if it still has the apparent bugs that cause me to look for this documentation, but here's the clarification I wanted at the time.

#### Purpose (TL;DR) - mandatory
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`

address #1485 

#### Background (Problem in detail)  - optional
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution

useFakeTimers() documentation is still unclear bout why one would ever want to fake some but not all functions, but now at least it's clear that you don't have to list every function to fake them all. 

#### Solution  - optional
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example: 
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. <your-steps-here>

Read documentation. See if it is now clear and correct. 