### PR TITLE
Allow anonymous mock functions to be named

### DIFF
--- a/docs/release-source/release/mocks.md
+++ b/docs/release-source/release/mocks.md
@@ -103,7 +103,7 @@ Creates an expectation without a mock object, basically an anonymous mock functi
 Method name is optional and is used in exception messages to make them more readable.
 
 
-#### `var expectation = sinon.mock();`
+#### `var expectation = sinon.mock([methodName]);`
 
 The same as the above.
 

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -10,8 +10,8 @@ var wrapMethod = require("./util/core/wrap-method");
 var push = Array.prototype.push;
 
 function mock(object) {
-    if (!object) {
-        return mockExpectation.create("Anonymous mock");
+    if (!object || typeof object === "string") {
+        return mockExpectation.create(object ? object : "Anonymous mock");
     }
 
     return mock.create(object);

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -10,6 +10,16 @@ var assert = referee.assert;
 var refute = referee.refute;
 
 describe("sinonMock", function () {
+    it("creates anonymous mock functions", function () {
+        var expectation = sinonMock();
+        assert.equals(expectation.method, "Anonymous mock");
+    });
+
+    it("creates named anonymous mock functions", function () {
+        var expectation = sinonMock("functionName");
+        assert.equals(expectation.method, "functionName");
+    });
+
     describe(".create", function () {
         it("returns function with expects method", function () {
             var mock = sinonMock.create({});


### PR DESCRIPTION
#### Purpose
Makes debugging anonymous mock functions a lot easier by allowing an optional method name to be specified. Since there's currently nothing in the `sandbox.verify()` error message/stacktrace that points to which mock is broken.

#### How to verify
1. Check out this branch.
2. Write a test with `sinon.mock().once().verify();`.
3. Write a test with `sinon.mock('functionName').once().verify();`.
