### PR TITLE
Fix #1487: incorrect withArgs().returnValue

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -219,6 +219,9 @@ var spyApi = {
 
         // Make return value and exception available in the calls:
         createCallProperties.call(this);
+        matchings.forEach(function (matching) {
+            createCallProperties.call(matching);
+        });
 
         if (exception !== undefined) {
             throw exception;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -127,7 +127,7 @@ describe("stub", function () {
     describe("should work firstCall and lastCall", function () {
         var testComponentA = function () { return { render: function () { return "test a"; } }; };
         var testComponentB = function () { return { render: function () { return "test b"; } }; };
-        var inject;
+        var stub;
 
         beforeEach(function () {
             var fakeComponent = function (variant) {
@@ -135,26 +135,26 @@ describe("stub", function () {
                     render: createStub().returns("fake component " + variant)
                 });
             };
-            inject = createStub().throws("Nothing set");
-            inject.withArgs(testComponentA).returns(fakeComponent("a"));
-            inject.withArgs(testComponentB).returns(fakeComponent("b"));
+            stub = createStub().throws("Nothing set");
+            stub.withArgs(testComponentA).returns(fakeComponent("a"));
+            stub.withArgs(testComponentB).returns(fakeComponent("b"));
         });
 
         it("returnValues", function () {
             var config = { option: "a" };
-            var component = inject(testComponentA)(config);
+            var component = stub(testComponentA)(config);
 
-            assert.isTrue(inject.calledWith(testComponentA));
-            assert.isFalse(inject.calledWith(testComponentB));
+            assert.isTrue(stub.calledWith(testComponentA));
+            assert.isFalse(stub.calledWith(testComponentB));
 
             assert.isFunction(component.render);
             assert.equals(component.render(), "fake component a");
 
-            assert.isTrue(inject.withArgs(testComponentA).returnValues[0].calledWith(config));
-            assert.isTrue(inject.withArgs(testComponentA).getCall(0).returnValue.calledWith(config));
+            assert.isTrue(stub.withArgs(testComponentA).returnValues[0].calledWith(config));
+            assert.isTrue(stub.withArgs(testComponentA).getCall(0).returnValue.calledWith(config));
 
-            assert.isTrue(inject.withArgs(testComponentA).firstCall.returnValue.calledWith(config));
-            assert.isTrue(inject.withArgs(testComponentA).lastCall.returnValue.calledWith(config));
+            assert.isTrue(stub.withArgs(testComponentA).firstCall.returnValue.calledWith(config));
+            assert.isTrue(stub.withArgs(testComponentA).lastCall.returnValue.calledWith(config));
         });
     });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -127,7 +127,6 @@ describe("stub", function () {
     describe("should work firstCall and lastCall", function () {
         var testComponentA = function () { return { render: function () { return "test a"; } }; };
         var testComponentB = function () { return { render: function () { return "test b"; } }; };
-        var stub;
 
         beforeEach(function () {
             var fakeComponent = function (variant) {
@@ -135,26 +134,26 @@ describe("stub", function () {
                     render: createStub().returns("fake component " + variant)
                 });
             };
-            stub = createStub().throws("Nothing set");
-            stub.withArgs(testComponentA).returns(fakeComponent("a"));
-            stub.withArgs(testComponentB).returns(fakeComponent("b"));
+            this.stub = createStub().throws("Nothing set");
+            this.stub.withArgs(testComponentA).returns(fakeComponent("a"));
+            this.stub.withArgs(testComponentB).returns(fakeComponent("b"));
         });
 
         it("returnValues", function () {
             var config = { option: "a" };
-            var component = stub(testComponentA)(config);
+            var component = this.stub(testComponentA)(config);
 
-            assert.isTrue(stub.calledWith(testComponentA));
-            assert.isFalse(stub.calledWith(testComponentB));
+            assert.isTrue(this.stub.calledWith(testComponentA));
+            assert.isFalse(this.stub.calledWith(testComponentB));
 
             assert.isFunction(component.render);
             assert.equals(component.render(), "fake component a");
 
-            assert.isTrue(stub.withArgs(testComponentA).returnValues[0].calledWith(config));
-            assert.isTrue(stub.withArgs(testComponentA).getCall(0).returnValue.calledWith(config));
+            assert.isTrue(this.stub.withArgs(testComponentA).returnValues[0].calledWith(config));
+            assert.isTrue(this.stub.withArgs(testComponentA).getCall(0).returnValue.calledWith(config));
 
-            assert.isTrue(stub.withArgs(testComponentA).firstCall.returnValue.calledWith(config));
-            assert.isTrue(stub.withArgs(testComponentA).lastCall.returnValue.calledWith(config));
+            assert.isTrue(this.stub.withArgs(testComponentA).firstCall.returnValue.calledWith(config));
+            assert.isTrue(this.stub.withArgs(testComponentA).lastCall.returnValue.calledWith(config));
         });
     });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -124,6 +124,40 @@ describe("stub", function () {
         refute.isNull(stub.withArgs(1).firstCall);
     });
 
+    describe("should work firstCall and lastCall", function () {
+        var testComponentA = function () { return { render: function () { return "test a"; } }; };
+        var testComponentB = function () { return { render: function () { return "test b"; } }; };
+        var inject;
+
+        beforeEach(function () {
+            var fakeComponent = function (variant) {
+                return createStub().returns({
+                    render: createStub().returns("fake component " + variant)
+                });
+            };
+            inject = createStub().throws("Nothing set");
+            inject.withArgs(testComponentA).returns(fakeComponent("a"));
+            inject.withArgs(testComponentB).returns(fakeComponent("b"));
+        });
+
+        it("returnValues", function () {
+            var config = { option: "a" };
+            var component = inject(testComponentA)(config);
+
+            assert.isTrue(inject.calledWith(testComponentA));
+            assert.isFalse(inject.calledWith(testComponentB));
+
+            assert.isFunction(component.render);
+            assert.equals(component.render(), "fake component a");
+
+            assert.isTrue(inject.withArgs(testComponentA).returnValues[0].calledWith(config));
+            assert.isTrue(inject.withArgs(testComponentA).getCall(0).returnValue.calledWith(config));
+
+            assert.isTrue(inject.withArgs(testComponentA).firstCall.returnValue.calledWith(config));
+            assert.isTrue(inject.withArgs(testComponentA).lastCall.returnValue.calledWith(config));
+        });
+    });
+
     describe(".returns", function () {
         it("returns specified value", function () {
             var stub = createStub.create();


### PR DESCRIPTION
Fix issue #1487
The cause of this bug is that createCallProperties(matching) is never called to make returnValue and exception.