### PR TITLE
Update fake-xhr-and-server.md

### DIFF
--- a/docs/_releases/v2.3.8/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.8/fake-xhr-and-server.md
@@ -219,7 +219,7 @@ High-level API to manipulate `FakeXMLHttpRequest` instances.
 
         sinon.assert.calledWith(callback, [{ id: 12, comment: "Hey there" }]);
 
-        assert(server.requests.length > 0)
+        assert(this.server.requests.length > 0)
     }
 }
 ```


### PR DESCRIPTION
__before__:  
`assert(server.requests.length > 0)` 
__now__:  
`assert(this.server.requests.length > 0)`

#### Purpose (TL;DR) - mandatory
Fix documentary to be consistent. 
I'm still not too familiar with sinon but looking at the code above this line I think it should be `this.server` as well. Sorry if I'm wrong here.