### PR TITLE
Issue 431

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -485,6 +485,32 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
             this.onSend(this);
         }
 
+        // Only listen if setInterval is a stubbed clock.
+        if (typeof setInterval.clock === "object" && typeof Date.clock === "object") {
+            var initiatedTime = Date.now();
+            var self = this;
+
+            // Listen to any possible tick by fake timers and check to see if timeout has
+            // been exceeded. It's important to note that timeout can be changed while a request
+            // is in flight, so we must check anytime the end user forces a clock tick to make
+            // sure timeout hasn't changed.
+            // https://xhr.spec.whatwg.org/#dfnReturnLink-2
+            var clearIntervalId = setInterval(function () {
+                // Check if the readyState has been reset or is done. If this is the case, there
+                // should be no timeout. This will also prevent aborted requests and
+                // fakeServerWithClock from triggering unnecessary responses.
+                if (self.readyState === FakeXMLHttpRequest.UNSENT
+                  || self.readyState === FakeXMLHttpRequest.DONE) {
+                    clearInterval(clearIntervalId);
+                } else if (typeof self.timeout === "number" && self.timeout > 0) {
+                    if (Date.now() >= (initiatedTime + self.timeout)) {
+                        self.triggerTimeout();
+                        clearInterval(clearIntervalId);
+                    }
+                }
+            }, 1);
+        }
+
         this.dispatchEvent(new sinonEvent.Event("loadstart", false, false, this));
     },
 

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -87,6 +87,7 @@ function FakeXMLHttpRequest(config) {
     this.readyState = FakeXMLHttpRequest.UNSENT;
     this.requestHeaders = {};
     this.requestBody = null;
+    this.timeout = 0;
     this.status = 0;
     this.statusText = "";
     this.upload = new EventTargetHandler();
@@ -270,6 +271,23 @@ function clearResponse(xhr) {
     xhr.responseXML = null;
 }
 
+/**
+ * Steps to follow when there is an error, according to:
+ * https://xhr.spec.whatwg.org/#request-error-steps
+ */
+function requestErrorSteps(xhr) {
+    clearResponse(xhr);
+    xhr.errorFlag = true;
+    xhr.requestHeaders = {};
+    xhr.responseHeaders = {};
+
+    if (xhr.readyState !== FakeXMLHttpRequest.UNSENT && xhr.sendFlag
+        && xhr.readyState !== FakeXMLHttpRequest.DONE) {
+        xhr.readyStateChange(FakeXMLHttpRequest.DONE);
+        xhr.sendFlag = false;
+    }
+}
+
 FakeXMLHttpRequest.parseXML = function parseXML(text) {
     // Treat empty string as parsing failure
     if (text !== "") {
@@ -376,9 +394,9 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         }
 
         if (this.readyState === FakeXMLHttpRequest.DONE) {
-            if (this.aborted || this.status === 0) {
+            if (this.timedout || this.aborted || this.status === 0) {
                 progress = {loaded: 0, total: 0};
-                event = this.aborted ? "abort" : "error";
+                event = (this.timedOut && "timeout") || (this.aborted && "abort") || "error";
             } else {
                 progress = {loaded: 100, total: 100};
                 event = "load";
@@ -472,17 +490,7 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
 
     abort: function abort() {
         this.aborted = true;
-        clearResponse(this);
-        this.errorFlag = true;
-        this.requestHeaders = {};
-        this.responseHeaders = {};
-
-        if (this.readyState !== FakeXMLHttpRequest.UNSENT && this.sendFlag
-            && this.readyState !== FakeXMLHttpRequest.DONE) {
-            this.readyStateChange(FakeXMLHttpRequest.DONE);
-            this.sendFlag = false;
-        }
-
+        requestErrorSteps(this);
         this.readyState = FakeXMLHttpRequest.UNSENT;
     },
 
@@ -493,6 +501,11 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         this.responseHeaders = {};
 
         this.readyStateChange(FakeXMLHttpRequest.DONE);
+    },
+
+    triggerTimeout: function triggerTimeout() {
+        this.timedOut = true;
+        requestErrorSteps(this);
     },
 
     getResponseHeader: function getResponseHeader(header) {

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -34,6 +34,8 @@ sinonXhr.GlobalActiveXObject = global.ActiveXObject;
 sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject !== "undefined";
 sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest !== "undefined";
 sinonXhr.workingXHR = getWorkingXHR(global);
+sinonXhr.supportsTimeout =
+    (sinonXhr.supportsXHR && "timeout" in (new sinonXhr.GlobalXMLHttpRequest()));
 sinonXhr.supportsCORS = isReactNative ||
     (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
@@ -87,13 +89,17 @@ function FakeXMLHttpRequest(config) {
     this.readyState = FakeXMLHttpRequest.UNSENT;
     this.requestHeaders = {};
     this.requestBody = null;
-    this.timeout = 0;
     this.status = 0;
     this.statusText = "";
     this.upload = new EventTargetHandler();
     this.responseType = "";
     this.response = "";
     this.logError = configureLogError(config);
+
+    if (sinonXhr.supportsTimeout) {
+        this.timeout = 0;
+    }
+
     if (sinonXhr.supportsCORS) {
         this.withCredentials = false;
     }
@@ -486,7 +492,7 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         }
 
         // Only listen if setInterval is a stubbed clock.
-        if (typeof setInterval.clock === "object" && typeof Date.clock === "object") {
+        if (sinonXhr.supportsTimeout && typeof setInterval.clock === "object" && typeof Date.clock === "object") {
             var initiatedTime = Date.now();
             var self = this;
 
@@ -530,8 +536,10 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
     },
 
     triggerTimeout: function triggerTimeout() {
-        this.timedOut = true;
-        requestErrorSteps(this);
+        if (sinonXhr.supportsTimeout) {
+            this.timedOut = true;
+            requestErrorSteps(this);
+        }
     },
 
     getResponseHeader: function getResponseHeader(header) {

--- a/test/util/fake-server-with-clock-test.js
+++ b/test/util/fake-server-with-clock-test.js
@@ -185,6 +185,18 @@ if (typeof window !== "undefined") {
                 assert(respond.calledWith("GET", "/", ""));
                 assert(respond.calledOn(this.server));
             });
+
+            it("does not trigger a timeout event", function () {
+                var xhr = new FakeXMLHttpRequest();
+                xhr.open("GET", "/");
+                xhr.timeout = 1;
+                xhr.triggerTimeout = sinonSpy();
+                xhr.send();
+
+                this.server.respond();
+
+                assert.isFalse(xhr.triggerTimeout.called);
+            });
         });
 
         describe("jQuery compat mode", function () {


### PR DESCRIPTION
Attempt to resolve issue #431. This issue was closed, but has a `help-wanted` label on it. I have a bunch of uncommented tests in a few codebases that try to check that timeout is working as expected, but I can't simulate them passing because there is no implementation here. It seems that despite the issue being inactive, it's still unresolved. I'd like to submit this PR as a possible resolution.

I added a method to XMLHttpRequest called `triggerTimeout`. This can be used to simulate a timeout event. 

At the moment, I've changed `send` to call `setInterval` *ONLY* if there is a fake timer available. I've added some comments to the code, but any tick caused by the user should trigger the `setInterval` callback. According to the spec, timeout can be changed while the request is being fetched. So, we can't use `setTimeout` unless we add a `getter` and `setter` method for `timeout` and create more variables that are intended to be private.

I made sure that the request was not complete before triggering the callback. This should prevent fakeServerWithClocks odd (jQuery legacy) behavior from causing unnecessary triggering after calling `respond`.

I've added a number of tests and even refactored a few things. None of the existing tests break and I think I've covered a lot of the possible edge cases for timeout.

Some outstanding thoughts on my end:

1) I chose to only call `setInterval` with a fake timer because it would seem bad if the library actually ran timeouts in a test environment with the `FakeXMLHttpRequest`. It seems like you don't want your requests to actually timeout in a test environment. I did not consult anyone in the issues thread, though. Perhaps I should do this?

2) I haven't written any tests for when `supportsTimeout` is false. It wouldn't be too difficult to do, though. I'm also not sure if I should mock the test so it runs as though supportsTimeout is true and supportsTimeout is false. I noticed a lot of conditional tests, so I followed the pattern. Let me know if you want more.

3) PhantomJS does not seem to support timeouts in their XMLHttpRequest implementation. Since a lot of people run tests in that browser, I almost wonder if it makes sense to assume that `supportsTimeout` works as expected (or allow a way to override it). Relevant issue: https://github.com/ariya/phantomjs/issues/12837.

4) Let me know if you want me to annotate the PR with github comments.

5) Let me know if you want me to squash commits.