### PR TITLE
Issue #1485: Update lolex version and update fakeTimers documentation

### DIFF
--- a/docs/release-source/release/fake-timers.md
+++ b/docs/release-source/release/fake-timers.md
@@ -37,40 +37,101 @@ set of features (Sinon uses it under the hood) and was previously extracted from
 }
 ```
 
-
 ## Fake timers API
 
 
 #### `var clock = sinon.useFakeTimers();`
 
-Causes Sinon to replace the global `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`, `setImmediate`, `clearImmediate` and `Date` with a custom implementation which is bound to the returned `clock` object.
+Causes Sinon to replace the global `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`, `setImmediate`, `clearImmediate`, `process.hrtime`, `performance.now`(when available) and `Date` with a custom implementation which is bound to the returned `clock` object.
 
-Starts the clock at the UNIX epoch (timestamp of 0).
+Starts the clock at the UNIX epoch (timestamp of `0`).
 
 
 #### `var clock = sinon.useFakeTimers(now);`
 
-As above, but rather than starting the clock with a timestamp of 0, start at the provided timestamp.
+As above, but rather than starting the clock with a timestamp of 0, start at the provided timestamp `now`.
 
 *Since `sinon@2.0.0`*
 
 You can also pass in a Date object, and its `getTime()` will be used for the starting timestamp.
 
-#### `var clock = sinon.useFakeTimers([now, ]prop1, prop2, ...);`
+#### `var clock = sinon.useFakeTimers(config);`
 
-Sets the clock start timestamp and names functions to fake. If the first argument is not numeric, it sets the clock to 0 and treats all arguments as names of functions to fake.
+As above, but allows further configuration options, some of which are:
 
-Possible functions are `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`, `setImmediate`, `clearImmediate` and `Date`.  Any functions not listed continue to use the original version of the function, including the actual time for the timestamp. This can have surprising results and should be done with care.
+- `config.now` - *Number/Date* - installs lolex with the specified unix epoch (default: 0)
+- `config.toFake` - *String[ ]* - an array with explicit function names to fake. By default lolex will automatically fake all methods *except* `process.nextTick`. You could, however, still fake `nextTick` by providing it explicitly
+- `config.shouldAdvanceTime` - *Boolean* - tells lolex to increment mocked time automatically based on the real system time shift (default: false)
 
-Note that if no functions are listed, the default behavior is to replace all eligible functions.
+Please visit the `lolex.install` [documentation](https://github.com/sinonjs/lolex#var-clock--lolexinstallconfig) for the full feature set.
+
+**Important note:** when faking `nextTick`, normal calls to `process.nextTick()` would not execute automatically as they would during normal event-loop phases. You would have to call either `clock.next()`, `clock.tick()`, `clock.runAll()` or `clock.runToLast()` (see example below). Please refer to the [lolex](https://github.com/sinonjs/lolex) documentation for more information.
+
+#### Examples:
+
+Installs fake timers at January 1st 2017 and fakes `setTimeout` and `process.nextTick` only:
+
+```javascript
+var clock = sinon.useFakeTimers({
+                now: 1483228800000, 
+                toFake: ["setTimeout", "nextTick"] 
+            }); 
+
+var called = false;
+
+process.nextTick(function () {
+    called = true;
+});
+
+clock.runAll(); //forces nextTick calls to flush synchronously
+assert(called); //true
+```
+
+Install at the same date, advancing the fake time automatically (default is every `20ms`), causing timers to be fired automatically without the need to `tick()` the clock:
+
+```js
+var clock = sinon.useFakeTimers({
+                now: 1483228800000, 
+                shouldAdvanceTime: true 
+            });
+
+setImmediate(function () {
+    console.log('tick'); //will print after 20ms
+});
+
+setTimeout(function () {
+    console.log('tock'); //will print after 20ms
+}, 15);
+
+setTimeout(function () {
+    console.log('tack'); //will print after 40ms
+}, 35);
+```
+
+Please refer to the `lolex.install` [documentation](https://github.com/sinonjs/lolex#var-clock--lolexinstallconfig) for the full set of features available and more elaborate explanations.
+
+*Since `sinon@3.0.0`*
+
+`var clock = sinon.useFakeTimers([now, ]prop1, prop2, ...)` is deprecated. To define which methods to fake, please use `config.toFake`.
 
 
-#### `clock.tick(ms);`
+#### `clock.tick(time);`
 
-Tick the clock ahead `ms` milliseconds.
+Tick the clock ahead `time` milliseconds.
 
-Causes all timers scheduled within the affected time range to be called.
+Causes all timers scheduled within the affected time range to be called. `time` may be the number of milliseconds to advance the clock by or a human-readable string. Valid string formats are "08" for eight seconds, "01:00" for one minute and "02:34:10" for two hours, 34 minutes and ten seconds.
 
+time may be negative, which causes the clock to change but won't fire any callbacks.
+
+#### `clock.next();`
+
+Advances the clock to the the moment of the first scheduled timer, firing it.
+
+#### `clock.runAll();`
+
+This runs all pending timers until there are none remaining. If new timers are added while it is executing they will be run as well.
+
+This makes it easier to run asynchronous tests to completion without worrying about the number of timers they use, or the delays in those timers.
 
 #### `clock.restore();`
 

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -39,7 +39,7 @@ function prepareSandboxFromConfig(config) {
 
     if (config.useFakeTimers) {
         if (typeof config.useFakeTimers === "object") {
-            sandbox.useFakeTimers.apply(sandbox, config.useFakeTimers);
+            sandbox.useFakeTimers.call(sandbox, config.useFakeTimers);
         } else {
             sandbox.useFakeTimers();
         }
@@ -49,8 +49,8 @@ function prepareSandboxFromConfig(config) {
 }
 
 extend(sinonSandbox, {
-    useFakeTimers: function useFakeTimers() {
-        this.clock = sinonClock.useFakeTimers.apply(null, arguments);
+    useFakeTimers: function (args) {
+        this.clock = sinonClock.useFakeTimers.call(null, args);
 
         return this.add(this.clock);
     },

--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -2,17 +2,28 @@
 
 var llx = require("lolex");
 
-exports.useFakeTimers = function () {
-    var now;
-    var methods = Array.prototype.slice.call(arguments);
+/**
+ * @param config {number|Date|Object} the unix epoch value to install with (default 0) or
+ */
+exports.useFakeTimers = function (args) {
+    var config = {};
 
-    if (typeof methods[0] === "string") {
-        now = 0;
+    if (typeof args === "undefined" || args === null) {
+        config.now = 0;
+    } else if ((typeof args === "number" || args instanceof Date) && arguments.length === 1) {
+        config.now = args;
+    } else if (args !== null && typeof args === "object" && arguments.length === 1) {
+        var keys = Object.keys(args);
+        for (var i = 0; i < keys.length; i++) {
+            if (args.hasOwnProperty(keys[i])) {
+                config[keys[i]] = args[keys[i]];
+            }
+        }
     } else {
-        now = methods.shift();
+        throw new TypeError("useFakeTimers expected epoch or config object. See https://github.com/sinonjs/sinon");
     }
 
-    var clock = llx.install(now || 0, methods);
+    var clock = llx.install(config);
     clock.restore = clock.uninstall;
     return clock;
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "diff": "^3.1.0",
     "formatio": "1.2.0",
-    "lolex": "^1.6.0",
+    "lolex": "^2.1.2",
     "native-promise-only": "^0.8.1",
     "path-to-regexp": "^1.7.0",
     "samsam": "^1.1.3",

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -104,11 +104,11 @@ describe("sinonSandbox", function () {
         it("passes arguments to sinon.useFakeTimers", function () {
             var useFakeTimersStub = sinonStub(sinonClock, "useFakeTimers").returns({});
 
-            this.sandbox.useFakeTimers("Date", "setTimeout");
-            this.sandbox.useFakeTimers("setTimeout", "clearTimeout", "setInterval");
+            this.sandbox.useFakeTimers({toFake: ["Date", "setTimeout"]});
+            this.sandbox.useFakeTimers({toFake: ["setTimeout", "clearTimeout", "setInterval"]});
 
-            assert(useFakeTimersStub.calledWith("Date", "setTimeout"));
-            assert(useFakeTimersStub.calledWith("setTimeout", "clearTimeout", "setInterval"));
+            assert(useFakeTimersStub.calledWith({toFake: ["Date", "setTimeout"]}));
+            assert(useFakeTimersStub.calledWith({toFake: ["setTimeout", "clearTimeout", "setInterval"]}));
 
             useFakeTimersStub.restore();
         });
@@ -529,10 +529,10 @@ describe("sinonSandbox", function () {
             var sandbox = sinonSandbox.create(sinonConfig({
                 injectIntoThis: false,
                 properties: ["clock"],
-                useFakeTimers: ["Date", "setTimeout"]
+                useFakeTimers: {toFake: ["Date", "setTimeout"]}
             }));
 
-            assert(this.useFakeTimersSpy.calledWith("Date", "setTimeout"));
+            assert(this.useFakeTimersSpy.calledWith({toFake: ["Date", "setTimeout"]}));
 
             sandbox.restore();
         });


### PR DESCRIPTION
This PR is to take care of updating to the latest lolex version, updating the fakeTimers method signatures and related tests.
I've also started updating the documentation but wanted to consult beforehand.

The question that arises is how to expose the lolex configuration (if at all).
Right now the implementation is straightforward - just sends a copy of the `config` object that was sent to `useFakeTimers()`. the copy was made because otherwise lolex alters the config object with the default values, resulting in tests breaking due to altered values showing up in the spies used in the tests.

However I believe that we should just allow users to send a lolex config object down the pipe and not just whitelist certain features. 

This is up to you however, just let me know what's your take on this - if we should whitelist certain features of lolex or we should just forward the object to the install method.

In the case of useFakeTimers I think that we should still support the possibility to `useFakeTimers(<Date|Epoch>)` and just break the tests that use other features from lolex e.g., `config.toFake` with a proper exception.

I will also edit the documentation accordingly.

fixes #1485 
fixes expressjs/express#2447
