### PR TITLE
stub#withArgs:  set promiseLibrary correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage/
 .idea
 .sass_cache
 _site
+.vscode
+npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ coverage/
 .idea
 .sass_cache
 _site
-.vscode
-npm-debug.log*

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var createBehavior = require("./behavior").create;
 var extend = require("./util/core/extend");
 var functionName = require("./util/core/function-name");
 var functionToString = require("./util/core/function-to-string");
@@ -307,6 +308,11 @@ var spyApi = {
         fake.matchingArguments = args;
         fake.parent = this;
         push.call(this.fakes, fake);
+
+        if (original.defaultBehavior && original.defaultBehavior.promiseLibrary) {
+            fake.defaultBehavior = fake.defaultBehavior || createBehavior(fake);
+            fake.defaultBehavior.promiseLibrary = original.defaultBehavior.promiseLibrary;
+        }
 
         fake.withArgs = function () {
             return original.withArgs.apply(original, arguments);

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -250,8 +250,17 @@ describe("issues", function () {
         });
     });
 
-    describe("#1474 - stub.onCall", function () {
-        it("should preserve promise library", function () {
+    describe("#1474 - promise library should be propagated through fakes and behaviors", function () {
+        var stub;
+
+        function makeAssertions(fake, expected) {
+            assert.isFunction(fake.then);
+            assert.isFunction(fake.tap);
+
+            assert.equals(fake.tap(), expected);
+        }
+
+        beforeEach(function () {
             var promiseLib = {
                 resolve: function (value) {
                     var promise = Promise.resolve(value);
@@ -262,22 +271,26 @@ describe("issues", function () {
                     return promise;
                 }
             };
-            var stub = sinon.stub().usingPromise(promiseLib);
+
+            stub = sinon.stub().usingPromise(promiseLib);
 
             stub.resolves("resolved");
+        });
+
+        it("stub.onCall", function () {
             stub.onSecondCall().resolves("resolved again");
 
-            var first = stub();
-            var second = stub();
+            makeAssertions(stub(), "tap resolved");
+            makeAssertions(stub(), "tap resolved again");
+        });
 
-            assert.isFunction(first.then);
-            assert.isFunction(first.tap);
+        it("stub.withArgs", function () {
+            stub.withArgs(42).resolves("resolved again");
+            stub.withArgs(true).resolves("okay");
 
-            assert.isFunction(second.then);
-            assert.isFunction(second.tap);
-
-            assert.equals(first.tap(), "tap resolved");
-            assert.equals(second.tap(), "tap resolved again");
+            makeAssertions(stub(), "tap resolved");
+            makeAssertions(stub(42), "tap resolved again");
+            makeAssertions(stub(true), "tap okay");
         });
     });
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
> Fix issue #1474 (again) by copying stub promiseLibrary to its new fakes when calling stub#withArgs.

#### Background (Problem in detail)  - optional
> The problem was similar to the one identified with stub#onCall: stub fakes created with withArgs did not preserve the promise library defined when calling usingPromise on the original stub.
> There "defaultBehavior"s were missing the property promiseLibrary.

#### Solution  - optional
> The same patch was applied here.
> Extending the new fake with the promiseLibrary from the stub.defaultBehavior solves the issue.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`
