### PR TITLE
Fix #1432: add details around expectations.withArgs behavior to docs

### DIFF
--- a/docs/release-source/release/mocks.md
+++ b/docs/release-source/release/mocks.md
@@ -146,10 +146,14 @@ Expect the method to be called exactly `number` times.
 
 Expect the method to be called with the provided arguments and possibly others.
 
+An `expectation` instance only holds onto a single set of arguments specified with `withArgs`. Subsequent calls will overwrite the previously-specified set of arguments (even if they are different), so it is generally not intended that this method be invoked more than once per test case.
+
 
 #### `expectation.withExactArgs(arg1, arg2, ...);`
 
 Expect the method to be called with the provided arguments and no others.
+
+An `expectation` instance only holds onto a single set of arguments specified with `withExactArgs`. Subsequent calls will overwrite the previously-specified set of arguments (even if they are different), so it is generally not intended that this method be invoked more than once per test case.
 
 
 #### `expectation.on(obj);`


### PR DESCRIPTION
#### Purpose
Fix issue #1432 - adds details to documentation of `expectations` methods `withArgs` and `withExactArgs` to prevent confusion, such as #992

#### How to verify
Probably not necessary to run the docs application - please review the copy and confirm whether it is clear, informative, etc, and whether I've touched the correct / necessary files.
