### PR TITLE
Add method to set custom formatter

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -54,3 +54,6 @@ var behavior = require("./sinon/behavior");
 exports.addBehavior = function (name, fn) {
     behavior.addBehavior(exports.stub, name, fn);
 };
+
+var format = require("./sinon/util/core/format");
+exports.setFormatter = format.setFormatter;

--- a/lib/sinon/util/core/format.js
+++ b/lib/sinon/util/core/format.js
@@ -7,6 +7,22 @@ var formatter = formatio.configure({
     limitChildrenCount: 250
 });
 
-module.exports = function format() {
+var customFormatter;
+
+function format() {
+    if (customFormatter) {
+        return customFormatter.apply(null, arguments);
+    }
+
     return formatter.ascii.apply(formatter, arguments);
+}
+
+format.setFormatter = function (aCustomFormatter) {
+    if (typeof aCustomFormatter !== "function") {
+        throw new Error("format.setFormatter must be called with a function");
+    }
+
+    customFormatter = aCustomFormatter;
 };
+
+module.exports = format;

--- a/test/util/core/format-test.js
+++ b/test/util/core/format-test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var referee = require("referee");
+var sinon = require("../../../lib/sinon");
 var format = require("../../../lib/sinon/util/core/format");
 var assert = referee.assert;
 
@@ -19,5 +20,24 @@ describe("util/core/format", function () {
 
     it("formats strings without quotes", function () {
         assert.equals(format("Hey"), "Hey");
+    });
+
+    describe("format.setFormatter", function () {
+        it("sets custom formatter", function () {
+            format.setFormatter(function () { return "formatted"; });
+            assert.equals(format("Hey"), "formatted");
+        });
+
+        it("throws if custom formatter is not a function", function () {
+            assert.exception(function () {
+                format.setFormatter("foo");
+            }, {
+                message: "format.setFormatter must be called with a function"
+            });
+        });
+
+        it("exposes method on sinon", function () {
+            assert.equals(sinon.setFormatter, format.setFormatter);
+        });
     });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Allows overriding the default formatter (`formatio`) with a custom one.

#### Background (Problem in detail)  - optional
In [Cypress](https://www.cypress.io/), we prefer to use our own formatting for printing out values instead of what `formatio` provides. With sinon 1.x, we overrode `sinon.format` to achieve this. 

Although `sinon.format` is still exposed in 2.x, overriding it doesn't work anymore because the modules within sinon use `util/core/format` directly. 

Overriding `sinon.format` was always a bit of hack anyway. This provides a better way to achieve setting a custom formatter.

#### Solution  - optional

This solution adds `sinon.setFormatter`, which is a method that takes a formatter function. The formatter function's signature is the same as `formatio.ascii`. It's called with a value and should return a formatted version of that value.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`
