### PR TITLE
Add support for passing a function to stub.throws(...)

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -271,6 +271,11 @@ Causes the stub to throw an exception of the provided type.
 Causes the stub to throw the provided exception object.
 
 
+#### `stub.throws(function() { return new Error(); });`
+
+Causes the stub to throw the exception returned by the function.
+
+
 #### `stub.rejects();`
 
 Causes the stub to return a Promise which rejects with an exception (`Error`).

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -127,6 +127,10 @@ var proto = {
 
         if (this.exception) {
             throw this.exception;
+        } else if (this.exceptionCreator) {
+            this.exception = this.exceptionCreator();
+            this.exceptionCreator = undefined;
+            throw this.exception;
         } else if (typeof this.returnArgAt === "number") {
             return args[this.returnArgAt];
         } else if (this.returnThis) {

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -7,11 +7,18 @@ var useLeftMostCallback = -1;
 var useRightMostCallback = -2;
 
 function throwsException(fake, error, message) {
-    if (typeof error === "string") {
-        fake.exception = new Error(message || "");
-        fake.exception.name = error;
+    if (typeof error === "function") {
+        fake.exceptionCreator = error;
+    } else if (typeof error === "string") {
+        fake.exceptionCreator = function () {
+            var newException = new Error(message || "");
+            newException.name = error;
+            return newException;
+        };
     } else if (!error) {
-        fake.exception = new Error("Error");
+        fake.exceptionCreator = function () {
+            return new Error("Error");
+        };
     } else {
         fake.exception = error;
     }
@@ -129,6 +136,7 @@ module.exports = {
         fake.reject = false;
         fake.returnValueDefined = true;
         fake.exception = undefined;
+        fake.exceptionCreator = undefined;
         fake.fakeFn = undefined;
     },
 
@@ -158,6 +166,7 @@ module.exports = {
         fake.reject = false;
         fake.returnValueDefined = true;
         fake.exception = undefined;
+        fake.exceptionCreator = undefined;
         fake.fakeFn = undefined;
     },
 
@@ -176,6 +185,7 @@ module.exports = {
         fake.reject = true;
         fake.returnValueDefined = true;
         fake.exception = undefined;
+        fake.exceptionCreator = undefined;
         fake.fakeFn = undefined;
 
         return fake;


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fixes #1507 
This PR adds functionality to allow `stub.throws(...)` to accept a function as an argument. This function is invoked at the point that the exception is thrown which allows the end user to have a more descriptive stack trace for the error. This also delays instantiating the `Error` until it is thrown (except when the user has already instantiated it) to create a more detailed stack trace.

#### Background (Problem in detail)  - optional
At least in node, the stack trace for an `Error` is created when the object is instantiated rather than when it's thrown ([from here](https://nodejs.org/api/errors.html#errors_class_error)). The stack trace is sometimes useful in figuring out what pieces of code are involved with an error. Currently errors used in `throws(...)` are instantiated by the caller or soon after in the setup of the stub which results in a stack trace showing where the setup occurred rather than where the problem occurred.

#### Solution  - optional
In cases where the exception is not passed into `throws(...)`, a function which will instantiate the exception is used internally instead and assigned to a new field `exceptionCreator`. When the exception is thrown `exceptionCreator` is instantiated and the result is assigned to `exception` to allow inspection via `toString` or other means.

#### How to verify - mandatory
To see the difference in stack trace see the test I included in the linked issue.