### PR TITLE
Add factory functions for sandbox and fake server

### DIFF
--- a/docs/release-source/release/fake-xhr-and-server.md
+++ b/docs/release-source/release/fake-xhr-and-server.md
@@ -201,7 +201,7 @@ High-level API to manipulate `FakeXMLHttpRequest` instances.
 ```javascript
 {
     setUp: function () {
-        this.server = sinon.fakeServer.create();
+        this.server = sinon.createFakeServer();
     },
 
     tearDown: function () {
@@ -225,16 +225,16 @@ High-level API to manipulate `FakeXMLHttpRequest` instances.
 ```
 
 
-#### `var server = sinon.fakeServer.create([config]);``
+#### `var server = sinon.createFakeServer([config]);``
 
 Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
 
 
-#### `var server = sinon.fakeServerWithClock.create();`
+#### `var server = sinon.createFakeServerWithClock();`
 
 Creates a server that also manages fake timers.
 
@@ -360,7 +360,7 @@ These options are properties on the server object and can be set directly
 server.autoRespond = true
 ```
 
-You can also pass options with an object literal to `fakeServer.create` and `.configure`.
+You can also pass options with an object literal to `createFakeServer` and `.configure`.
 
 #### `Boolean autoRespond`
 

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -10,7 +10,7 @@ Sandboxes removes the need to keep track of every fake created, which greatly si
 var sinon = require('sinon');
 
 var myAPI = { hello: function () {} };
-var sandbox = sinon.sandbox.create();
+var sandbox = sinon.createSandbox();
 
 describe('myAPI.hello method', function () {
 
@@ -39,25 +39,25 @@ describe('myAPI.hello method', function () {
 
 ## Sandbox API
 
-#### `var sandbox = sinon.sandbox.create();`
+#### `var sandbox = sinon.createSandbox();`
 
 Creates a sandbox object with spies, stubs, and mocks.
 
 
-#### `var sandbox = sinon.sandbox.create(config);`
+#### `var sandbox = sinon.createSandbox(config);`
 
-The `sinon.sandbox.create(config)` method is often an integration feature, and can be used for scenarios including a global object to coordinate all fakes through.
+The `sinon.createSandbox(config)` method is often an integration feature, and can be used for scenarios including a global object to coordinate all fakes through.
 
 Sandboxes are partially configured by default such that calling:
 
 ```javascript
-var sandbox = sinon.sandbox.create({});
+var sandbox = sinon.createSandbox({});
 ```
 
 will merge in extra defaults analogous to:
 
 ```javascript
-var sandbox = sinon.sandbox.create({
+var sandbox = sinon.createSandbox({
     // ...
     injectInto: null,
     properties: ["spy", "stub", "mock"],
@@ -82,10 +82,10 @@ To get a full sandbox with stubs, spies, etc. **and** fake timers and servers, y
 
 ```javascript
 // Inject the sinon defaults explicitly.
-var sandbox = sinon.sandbox.create(sinon.defaultConfig);
+var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
-var sandbox = sinon.sandbox.create({
+var sandbox = sinon.createSandbox({
     useFakeTimers: true
     useFakeServer: true
 });

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -7,7 +7,9 @@ exports.spy = require("./sinon/spy");
 exports.spyCall = require("./sinon/call");
 exports.stub = require("./sinon/stub");
 exports.mock = require("./sinon/mock");
-exports.sandbox = require("./sinon/sandbox");
+
+var sandbox = require("./sinon/sandbox");
+exports.sandbox = sandbox;
 exports.expectation = require("./sinon/mock-expectation");
 exports.createStubInstance = require("./sinon/stub").createStubInstance;
 
@@ -25,6 +27,10 @@ exports.useFakeXMLHttpRequest = nise.fakeXhr.useFakeXMLHttpRequest;
 
 exports.fakeServer = nise.fakeServer;
 exports.fakeServerWithClock = nise.fakeServerWithClock;
+
+exports.createSandbox = sandbox.create;
+exports.createFakeServer = nise.fakeServer.create;
+exports.createFakeServerWithClock = nise.fakeServerWithClock.create;
 
 var behavior = require("./sinon/behavior");
 

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -10,34 +10,61 @@ if (!hasPromise) {
 
 describe("sinon module", function () {
     var sinon,
+        fakeSandbox,
         fakeNise;
 
     beforeEach(function () {
 
         fakeNise = {
-            fakeServer: "47c86a4c-6b48-4748-bb8c-d853f999720c",
-            fakeServerWithClock: "e69974f8-4568-48d1-a5e9-2b511a59c14b",
+            fakeServer: {
+                create: "47c86a4c-6b48-4748-bb8c-d853f999720c"
+            },
+            fakeServerWithClock: {
+                create: "e69974f8-4568-48d1-a5e9-2b511a59c14b"
+            },
             fakeXhr: {
                 xhr: "958e8996-0cc3-4136-8a0e-6a120f5311bc",
                 FakeXMLHttpRequest: "6adbf569-f6d7-4b86-be22-38340ae0f8c8",
                 useFakeXMLHttpRequest: "ba8bd609-c921-4a62-a1b9-49336bd426a4"
             }
         };
+        fakeSandbox = {
+            create: "dc61d622-407f-46eb-af24-7a83bb30b8bf"
+        };
         sinon = proxyquire("../lib/sinon", {
-            nise: fakeNise
+            nise: fakeNise,
+            "./sinon/sandbox": fakeSandbox
         });
     });
 
     describe("exports", function () {
+        describe("createSandbox", function () {
+            it("should be sandbox.create", function () {
+                assert.equals(sinon.createSandbox, fakeSandbox.create);
+            });
+        });
+
         describe("fakeServer", function () {
             it("should be the fakeServer export from nise", function () {
-                assert.equals(sinon.fakeServer, fakeNise.fakeServer);
+                assert.same(sinon.fakeServer, fakeNise.fakeServer);
+            });
+        });
+
+        describe("createFakeServer", function () {
+            it("should be fakeServer.create from nise", function () {
+                assert.equals(sinon.createFakeServer, fakeNise.fakeServer.create);
             });
         });
 
         describe("fakeServerWithClock", function () {
             it("should be the fakeServerWithClock export from nise", function () {
-                assert.equals(sinon.fakeServerWithClock, fakeNise.fakeServerWithClock);
+                assert.same(sinon.fakeServerWithClock, fakeNise.fakeServerWithClock);
+            });
+        });
+
+        describe("createFakeServerWithClock", function () {
+            it("should be fakeServerWithClock.create from nise", function () {
+                assert.equals(sinon.createFakeServerWithClock, fakeNise.fakeServerWithClock.create);
             });
         });
 


### PR DESCRIPTION
As discussed in #1514, this adds the following methods as aliases:

- `createSandbox` = `sandbox.create`
- `createFakeServer` = `fakeServer.create`
- `createFakeServerWithClock` = `fakeServerWithClock.create`

Also adjusted the docs to show the new functions. Is it okay to suggest the new functions only? Or do we want to keep API docs for the "old" functions?

Did I miss anything else?