### PR TITLE
Fix for 1512: sandbox.stub() fails on prototype props

### DIFF
--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -86,7 +86,8 @@ var collection = {
     },
 
     stub: function stub(object, property) {
-        if (object && typeof property !== "undefined" && !Object.prototype.hasOwnProperty.call(object, property)) {
+        if (object && typeof property !== "undefined"
+            && !(property in object)) {
             throw new TypeError("Cannot stub non-existent own property " + valueToString(property));
         }
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -320,4 +320,25 @@ describe("issues", function () {
             assert.equals(this.stub.withArgs("arg").lastCall.returnValue, "return value");
         });
     });
+
+    describe("#1512", function () {
+        var sandbox;
+
+        beforeEach(function () {
+            sandbox = sinon.sandbox.create();
+        });
+
+        afterEach(function () {
+            sandbox.restore();
+        });
+
+        it("can stub methods on the prototype", function () {
+            var proto = { someFunction: function () {} };
+            var instance = Object.create(proto);
+
+            var stub = sandbox.stub(instance, "someFunction");
+            instance.someFunction();
+            assert(stub.called);
+        });
+    });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
This PR restores the functionality in sandboxes that made it possible to stub methods that were higher on the prototype chain. 

#### Background 
The bug introduced in 74263dd happened as the check for a property only checked on the instance, not on the properties further up the prototype chain. That meant it was no longer possible to stub out methods on instances of a "class". See issue #1512 for background info.

#### Solution 
Simply checks for existence of the (enumerable) property.

#### How to verify - mandatory
1. Check out this branch 
2. `npm install`
3. `npm test` (will run the testcase) 
4. `git checkout HEAD~1 && npm test` should fail