### PR TITLE
fixes issue #1368 by adding stub#resolvesThis

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -117,6 +117,7 @@ var proto = {
                 this.exception ||
                 typeof this.returnArgAt === "number" ||
                 this.returnThis ||
+                this.resolveThis ||
                 typeof this.throwArgAt === "number" ||
                 this.fakeFn ||
                 this.returnValueDefined);
@@ -142,6 +143,8 @@ var proto = {
             throw args[this.throwArgAt];
         } else if (this.fakeFn) {
             return this.fakeFn.apply(context, args);
+        } else if (this.resolveThis) {
+            return (this.promiseLibrary || Promise).resolve(context);
         } else if (this.resolve) {
             return (this.promiseLibrary || Promise).resolve(this.returnValue);
         } else if (this.reject) {

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -155,6 +155,7 @@ module.exports = {
     resolves: function resolves(fake, value) {
         fake.returnValue = value;
         fake.resolve = true;
+        fake.resolveThis = false;
         fake.reject = false;
         fake.returnValueDefined = true;
         fake.exception = undefined;
@@ -173,12 +174,19 @@ module.exports = {
         }
         fake.returnValue = reason;
         fake.resolve = false;
+        fake.resolveThis = false;
         fake.reject = true;
         fake.returnValueDefined = true;
         fake.exception = undefined;
         fake.fakeFn = undefined;
 
         return fake;
+    },
+
+    resolvesThis: function resolvesThis(fake) {
+        fake.resolveThis = true;
+        fake.resolve = false;
+        fake.reject = false;
     },
 
     callThrough: function callThrough(fake) {

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -187,6 +187,9 @@ module.exports = {
         fake.resolveThis = true;
         fake.resolve = false;
         fake.reject = false;
+        fake.returnValueDefined = false;
+        fake.exception = undefined;
+        fake.fakeFn = undefined;
     },
 
     callThrough: function callThrough(fake) {

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -184,8 +184,9 @@ module.exports = {
     },
 
     resolvesThis: function resolvesThis(fake) {
-        fake.resolveThis = true;
+        fake.returnValue = undefined;
         fake.resolve = false;
+        fake.resolveThis = true;
         fake.reject = false;
         fake.returnValueDefined = false;
         fake.exception = undefined;

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -123,6 +123,7 @@ var proto = {
         delete this.throwArgAt;
         delete this.fakeFn;
         this.returnThis = false;
+        this.resolveThis = false;
 
         fakes.forEach(function (fake) {
             fake.resetBehavior();

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -292,7 +292,7 @@ describe("stub", function () {
             }
         });
 
-        it("returns a promise resolves with this", function () {
+        it("returns a promise resolved with this", function () {
             var instance = {};
             instance.stub = createStub.create();
             instance.stub.resolvesThis();
@@ -302,22 +302,7 @@ describe("stub", function () {
             });
         });
 
-        var strictMode = (function () {
-            return this;
-        }()) === undefined;
-        if (strictMode) {
-            it("returns a promise resolves with undefined when detached", function () {
-                var stub = createStub.create();
-                stub.resolvesThis();
-
-                // Due to strict mode, would be `global` otherwise
-                return stub().then(function (actual) {
-                    assert.same(actual, undefined);
-                });
-            });
-        }
-
-        it("stub respects call", function () {
+        it("returns a promise resolved with the context bound with stub#call", function () {
             var stub = createStub.create();
             stub.resolvesThis();
             var object = {};
@@ -327,7 +312,7 @@ describe("stub", function () {
             });
         });
 
-        it("stub respects apply", function () {
+        it("returns a promise resolved with the context bound with stub#apply", function () {
             var stub = createStub.create();
             stub.resolvesThis();
             var object = {};
@@ -337,7 +322,7 @@ describe("stub", function () {
             });
         });
 
-        it("returns stub", function () {
+        it("returns the stub itself, allowing to chain function calls", function () {
             var stub = createStub.create();
 
             assert.same(stub.resolvesThis(), stub);
@@ -2230,7 +2215,7 @@ describe("stub", function () {
             refute.defined(instance.stub());
         });
 
-        it("cleans 'resolvesThis' behavior", function () {
+        it("cleans 'resolvesThis' behavior, so the stub does not resolve nor returns anything", function () {
             var instance = {};
             instance.stub = createStub.create();
             instance.stub.resolvesThis();

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -285,6 +285,65 @@ describe("stub", function () {
         });
     });
 
+    describe(".resolvesThis", function () {
+        afterEach(function () {
+            if (Promise.resolve.restore) {
+                Promise.resolve.restore();
+            }
+        });
+
+        it("returns a promise resolves with this", function () {
+            var instance = {};
+            instance.stub = createStub.create();
+            instance.stub.resolvesThis();
+
+            return instance.stub().then(function (actual) {
+                assert.same(actual, instance);
+            });
+        });
+
+        var strictMode = (function () {
+            return this;
+        }()) === undefined;
+        if (strictMode) {
+            it("returns a promise resolves with undefined when detached", function () {
+                var stub = createStub.create();
+                stub.resolvesThis();
+
+                // Due to strict mode, would be `global` otherwise
+                return stub().then(function (actual) {
+                    assert.same(actual, undefined);
+                });
+            });
+        }
+
+        it("stub respects call", function () {
+            var stub = createStub.create();
+            stub.resolvesThis();
+            var object = {};
+
+            return stub.call(object).then(function (actual) {
+                assert.same(actual, object);
+            });
+        });
+
+        it("stub respects apply", function () {
+            var stub = createStub.create();
+            stub.resolvesThis();
+            var object = {};
+
+            return stub.apply(object).then(function (actual) {
+                assert.same(actual, object);
+            });
+        });
+
+        it("returns stub", function () {
+            var stub = createStub.create();
+
+            assert.same(stub.resolvesThis(), stub);
+        });
+    });
+
     describe(".returnsArg", function () {
         it("returns argument at specified index", function () {
             var stub = createStub.create();
@@ -2165,6 +2224,16 @@ describe("stub", function () {
             var instance = {};
             instance.stub = createStub.create();
             instance.stub.returnsThis();
+
+            instance.stub.resetBehavior();
+
+            refute.defined(instance.stub());
+        });
+
+        it("cleans 'resolvesThis' behavior", function () {
+            var instance = {};
+            instance.stub = createStub.create();
+            instance.stub.resolvesThis();
 
             instance.stub.resetBehavior();
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
> This PR fixes issue #1368. 

#### Background (Problem in detail)  - optional
> The feature request was to make stub able to resolve a promise with its own context, like stub#returnsThis would do synchronously.

#### Solution  - optional
> Simply add the method stub#resolvesThis, which is the async version of stub#returnsThis.

#### How to verify - mandatory
1. Check out this branch (see github instructions below)
2. `npm install`
3. `npm test`
