### PR TITLE
Update docs for sandbox config

### DIFF
--- a/docs/_releases/v3.0.0/migrating-to-3.0.md
+++ b/docs/_releases/v3.0.0/migrating-to-3.0.md
@@ -22,7 +22,7 @@ Codemod available at https://github.com/hurrymaplelad/sinon-codemod
 Calling `sinon.stub` with three arguments will throw an Error. This was deprecated with `sinon@2` and has been removed with `sinon@3`
 
 ## `sinon.useFakeTimers([now, ]prop1, prop2, ...)` - Removed
-`sinon.useFakeTimers()` signature has [changed](./fake-timers). To define which methods to fake, please use `config.toFake`. Other options are now available when configuring `useFakeTimers`. Please consult the [documentation](./fake-timers) for more information.
+`sinon.useFakeTimers()` signature has [changed](../fake-timers). To define which methods to fake, please use `config.toFake`. Other options are now available when configuring `useFakeTimers`. Please consult the [documentation](../fake-timers) for more information.
 
 ## Removal of internal helpers
 The following internal functions were deprecated as of `sinon@1.x` and have been removed in `sinon@3`:

--- a/docs/_releases/v3.0.0/migrating-to-3.0.md
+++ b/docs/_releases/v3.0.0/migrating-to-3.0.md
@@ -24,6 +24,10 @@ Calling `sinon.stub` with three arguments will throw an Error. This was deprecat
 ## `sinon.useFakeTimers([now, ]prop1, prop2, ...)` - Removed
 `sinon.useFakeTimers()` signature has [changed](../fake-timers). To define which methods to fake, please use `config.toFake`. Other options are now available when configuring `useFakeTimers`. Please consult the [documentation](../fake-timers) for more information.
 
+## `sinon.sandbox.create(config)` - Config changes
+The [changes in configuration](../fake-timers) for fake timers implicitly affect sandbox creation. If your config used to look like `{ useFaketimers: ["setTimeout", "setInterval"]}`, you
+will now need to change it to `{ useFaketimers: { toFake: ["setTimeout", "setInterval"] }}`.
+
 ## Removal of internal helpers
 The following internal functions were deprecated as of `sinon@1.x` and have been removed in `sinon@3`:
 

--- a/docs/_releases/v3.0.0/sandbox.md
+++ b/docs/_releases/v3.0.0/sandbox.md
@@ -104,8 +104,9 @@ have to set `useFakeServer` to `true`.
 
 ##### useFakeTimers
 
-If `true`, the sandbox will have a `clock` property. Can also be an `Array` of
-timer properties to fake.
+If set to `true`, the sandbox will have a `clock` property. You can optionally pass
+in a configuration object that follows the [specification for fake timers](../fake-timers),
+such as `{ toFake: ["setTimeout", "setInterval"] }`.
 
 ##### useFakeServer
 

--- a/docs/release-source/release/migrating-to-3.0.md
+++ b/docs/release-source/release/migrating-to-3.0.md
@@ -22,7 +22,7 @@ Codemod available at https://github.com/hurrymaplelad/sinon-codemod
 Calling `sinon.stub` with three arguments will throw an Error. This was deprecated with `sinon@2` and has been removed with `sinon@3`
 
 ## `sinon.useFakeTimers([now, ]prop1, prop2, ...)` - Removed
-`sinon.useFakeTimers()` signature has [changed](./fake-timers). To define which methods to fake, please use `config.toFake`. Other options are now available when configuring `useFakeTimers`. Please consult the [documentation](./fake-timers) for more information.
+`sinon.useFakeTimers()` signature has [changed](../fake-timers). To define which methods to fake, please use `config.toFake`. Other options are now available when configuring `useFakeTimers`. Please consult the [documentation](../fake-timers) for more information.
 
 ## Removal of internal helpers
 The following internal functions were deprecated as of `sinon@1.x` and have been removed in `sinon@3`:

--- a/docs/release-source/release/migrating-to-3.0.md
+++ b/docs/release-source/release/migrating-to-3.0.md
@@ -24,6 +24,10 @@ Calling `sinon.stub` with three arguments will throw an Error. This was deprecat
 ## `sinon.useFakeTimers([now, ]prop1, prop2, ...)` - Removed
 `sinon.useFakeTimers()` signature has [changed](../fake-timers). To define which methods to fake, please use `config.toFake`. Other options are now available when configuring `useFakeTimers`. Please consult the [documentation](../fake-timers) for more information.
 
+## `sinon.sandbox.create(config)` - Config changes
+The [changes in configuration](../fake-timers) for fake timers implicitly affect sandbox creation. If your config used to look like `{ useFaketimers: ["setTimeout", "setInterval"]}`, you
+will now need to change it to `{ useFaketimers: { toFake: ["setTimeout", "setInterval"] }}`.
+
 ## Removal of internal helpers
 The following internal functions were deprecated as of `sinon@1.x` and have been removed in `sinon@3`:
 

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -10,7 +10,7 @@ Sandboxes removes the need to keep track of every fake created, which greatly si
 var sinon = require('sinon');
 
 var myAPI = { hello: function () {} };
-var sandbox = sinon.createSandbox();
+var sandbox = sinon.sandbox.create();
 
 describe('myAPI.hello method', function () {
 
@@ -39,25 +39,25 @@ describe('myAPI.hello method', function () {
 
 ## Sandbox API
 
-#### `var sandbox = sinon.createSandbox();`
+#### `var sandbox = sinon.sandbox.create();`
 
 Creates a sandbox object with spies, stubs, and mocks.
 
 
-#### `var sandbox = sinon.createSandbox(config);`
+#### `var sandbox = sinon.sandbox.create(config);`
 
-The `sinon.createSandbox(config)` method is often an integration feature, and can be used for scenarios including a global object to coordinate all fakes through.
+The `sinon.sandbox.create(config)` method is often an integration feature, and can be used for scenarios including a global object to coordinate all fakes through.
 
 Sandboxes are partially configured by default such that calling:
 
 ```javascript
-var sandbox = sinon.createSandbox({});
+var sandbox = sinon.sandbox.create({});
 ```
 
 will merge in extra defaults analogous to:
 
 ```javascript
-var sandbox = sinon.createSandbox({
+var sandbox = sinon.sandbox.create({
     // ...
     injectInto: null,
     properties: ["spy", "stub", "mock"],
@@ -82,10 +82,10 @@ To get a full sandbox with stubs, spies, etc. **and** fake timers and servers, y
 
 ```javascript
 // Inject the sinon defaults explicitly.
-var sandbox = sinon.createSandbox(sinon.defaultConfig);
+var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
-var sandbox = sinon.createSandbox({
+var sandbox = sinon.sandbox.create({
     useFakeTimers: true
     useFakeServer: true
 });
@@ -104,8 +104,9 @@ have to set `useFakeServer` to `true`.
 
 ##### useFakeTimers
 
-If `true`, the sandbox will have a `clock` property. Can also be an `Array` of
-timer properties to fake.
+If set to `true`, the sandbox will have a `clock` property. You can optionally pass
+in a configuration object that follows the [specification for fake timers](../fake-timers),
+such as `{ toFake: ["setTimeout", "setInterval"] }`.
 
 ##### useFakeServer
 


### PR DESCRIPTION
#### Purpose (TL;DR)
The [migration docs for 3.0](http://sinonjs.org/releases/v3.0.0/migrating-to-3.0/) mentions that the format for the config object to `sinon.useFakeTimers()` has changed, but this is also used by the sandboxes. This PR updates the migration docs with a new section, updates the sandbox docs with the omission, and also fixes a couple of relative links that pointed to 404s.

I needed to change both the source and the released docs, as it can be regarded as a bug that this fix is not already present.

#### How to verify - mandatory
1. Build the docs per the instructions in `docs/CONTRIBUTING.MD`.
2. See the changes ([1](http://localhost:4000/releases/v3.0.0/sandbox) and [2](http://localhost:4000/releases/v3.0.0/migrating-to-3.0/))
3. Check the links
