### PR TITLE
Add hints on using NPM based CDNs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ via [npm](https://github.com/npm/npm)
 
     $ npm install sinon
 
-or via sinon's browser builds available for download on the [homepage](http://sinonjs.org/releases/).
+or via sinon's browser builds available for download on the [homepage](http://sinonjs.org/releases/). There are also [NPM based CDNs]((http://sinonjs.org/releases#npm-cdns) one can use.
 
 ## Usage
 

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -11,6 +11,7 @@ redirect_from:
 
 <div class="head-page">
   <h1>Releases</h1>
+  In addition to our download page, you can also <a href="#npm-cdns">use a NPM based CDN</a> for your convenience.
 </div>
 
 <div class="in-content releases">
@@ -31,4 +32,23 @@ redirect_from:
         {% endif %}
   {% endfor %}
   </ul>
+</div>
+
+
+<div>
+    <h2 id="npm-cdns">Using NPM based CDNs</h2>
+    <p>
+    There are now several CDNs that are backed by NPM,
+    which means that you can have auto-updated scripts.
+    Examples of such free providers are
+    <a href="http://jsdelivr.com">jsDelivr</a>,
+    <a href="https://unpkg.com">UNPKG</a> and
+    <a href="https://cdnjs.com">cdnjs</a>.
+    </p>
+    <p>
+    Their adressing schemes vary, but an example
+    url such as <a href="https://cdn.jsdelivr.net/npm/sinon@3/pkg/sinon.js">https://cdn.jsdelivr.net/npm/sinon@3/pkg/sinon.js</a>
+    would download the latest browser bundle of Sinon 3.
+    </p>
+
 </div>

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "README.md"
   ],
   "main": "./lib/sinon.js",
+  "cdn": "./pkg/sinon.js",
+  "jsdelivr": "./pkg/sinon.js",
   "engines": {
     "node": ">=0.1.103"
   }


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Adds docs on how to use NPM based CDNs. Also supports default file for jsDelivr using a field in package.json

#### How to verify - mandatory
1. Build the docs
2. Check out localhost:4000/releases/
