### PR TITLE
Cache references to Array.prototype.filter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,11 +13,16 @@
 #### Solution  - optional
 > When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
 >
-> Example: 
+> Example:
 > "This solution works by adding a `paintBlue()` method"
 > Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
 
 #### How to verify - mandatory
-1. Check out this branch (see github instructions below)
+1. Check out this branch
 2. `npm install`
 3. <your-steps-here>
+
+#### Checklist for author
+
+- [ ] `npm run lint` passes
+- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -6,6 +6,7 @@ var functionName = require("./util/core/function-name");
 var sinonFormat = require("./util/core/format");
 var valueToString = require("./util/core/value-to-string");
 var slice = Array.prototype.slice;
+var filter = Array.prototype.filter;
 
 function throwYieldError(proxy, text, args) {
     var msg = functionName(proxy) + text;
@@ -131,7 +132,7 @@ var callProto = {
 
     yieldOn: function (thisValue) {
         var args = slice.call(this.args);
-        var yieldFn = args.filter(function (arg) {
+        var yieldFn = filter.call(args, function (arg) {
             return typeof arg === "function";
         })[0];
 
@@ -148,7 +149,7 @@ var callProto = {
 
     yieldToOn: function (prop, thisValue) {
         var args = slice.call(this.args);
-        var yieldArg = args.filter(function (arg) {
+        var yieldArg = filter.call(args, function (arg) {
             return arg && typeof arg[prop] === "function";
         })[0];
         var yieldFn = yieldArg && yieldArg[prop];

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -6,7 +6,8 @@ var sinonMock = require("./mock");
 var collectOwnMethods = require("./collect-own-methods");
 var valueToString = require("./util/core/value-to-string");
 
-var push = [].push;
+var push = Array.prototype.push;
+var filter = Array.prototype.filter;
 
 function getFakes(fakeCollection) {
     if (!fakeCollection.fakes) {
@@ -18,7 +19,7 @@ function getFakes(fakeCollection) {
 
 function each(fakeCollection, method) {
     var fakes = getFakes(fakeCollection);
-    var matchingFakes = fakes.filter(function (fake) {
+    var matchingFakes = filter.call(fakes, function (fake) {
         return typeof fake[method] === "function";
     });
 

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -8,6 +8,7 @@ var deepEqual = require("./util/core/deep-equal").use(match);
 var wrapMethod = require("./util/core/wrap-method");
 
 var push = Array.prototype.push;
+var filter = Array.prototype.filter;
 
 function mock(object) {
     if (!object || typeof object === "string") {
@@ -118,13 +119,13 @@ extend(mock, {
         var currentArgs = args || [];
         var available;
 
-        var expectationsWithMatchingArgs = expectations.filter(function (expectation) {
+        var expectationsWithMatchingArgs = filter.call(expectations, function (expectation) {
             var expectedArgs = expectation.expectedArguments || [];
 
             return arrayEquals(expectedArgs, currentArgs, expectation.expectsExactArgCount);
         });
 
-        var expectationsToApply = expectationsWithMatchingArgs.filter(function (expectation) {
+        var expectationsToApply = filter.call(expectationsWithMatchingArgs, function (expectation) {
             return !expectation.met() && expectation.allowsCall(thisValue, args);
         });
 

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -12,10 +12,13 @@ var wrapMethod = require("./util/core/wrap-method");
 var sinonFormat = require("./util/core/format");
 var valueToString = require("./util/core/value-to-string");
 
+/* cache references to library methods so that they also can be stubbed without problems */
 var push = Array.prototype.push;
 var slice = Array.prototype.slice;
-var callId = 0;
+var filter = Array.prototype.filter;
 var ErrorConstructor = Error.prototype.constructor;
+
+var callId = 0;
 
 function spy(object, property, types) {
     var descriptor, methodDesc;
@@ -340,7 +343,7 @@ var spyApi = {
     },
 
     matchingFakes: function (args, strict) {
-        return (this.fakes || []).filter(function (fake) {
+        return filter.call(this.fakes || [], function (fake) {
             return fake.matches(args, strict);
         });
     },

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -321,7 +321,7 @@ describe("issues", function () {
         });
     });
 
-    describe("#1512", function () {
+    describe("#1512 - sandbox.stub(obj,protoMethod)", function () {
         var sandbox;
 
         beforeEach(function () {
@@ -340,5 +340,25 @@ describe("issues", function () {
             instance.someFunction();
             assert(stub.called);
         });
+    });
+
+    describe("#1521 - stubbing Array.prototype.filter", function () {
+        var orgFilter;
+
+        before(function () {
+            orgFilter = Array.prototype.filter;
+        });
+
+        afterEach(function () {
+            /* eslint-disable no-extend-native */
+            Array.prototype.filter = orgFilter;
+        });
+
+        it("should be possible stub filter", function () {
+            var stub = sinon.stub(Array.prototype, "filter");
+            [1, 2, 3].filter(function () { return false; });
+            assert(stub.calledOnce);
+        });
+
     });
 });


### PR DESCRIPTION
#### Purpose
Fixes issue #1521 by caching references to the `filter` method so that it can be stubbed. Also adds a hint to the pull request template on things that should be in place.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`
