### PR TITLE
Add clearFields function to put logic clearing common fields in one place

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -6,7 +6,24 @@ var slice = [].slice;
 var useLeftMostCallback = -1;
 var useRightMostCallback = -2;
 
+function clearFields(fake) {
+    fake.returnValue = undefined;
+    fake.resolve = false;
+    fake.resolveThis = false;
+    fake.reject = false;
+    fake.returnValueDefined = false;
+    fake.exception = undefined;
+    fake.exceptionCreator = undefined;
+    fake.fakeFn = undefined;
+    fake.callArgAt = undefined;
+    fake.callbackArguments = [];
+    fake.callbackContext = undefined;
+    fake.callArgProp = undefined;
+    fake.callbackAsync = false;
+}
+
 function throwsException(fake, error, message) {
+    clearFields(fake);
     if (typeof error === "function") {
         fake.exceptionCreator = error;
     } else if (typeof error === "string") {
@@ -32,6 +49,7 @@ function isPropertyConfigurable(obj, propName) {
 
 module.exports = {
     callsFake: function callsFake(fake, fn) {
+        clearFields(fake);
         fake.fakeFn = fn;
     },
 
@@ -40,11 +58,9 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
+        clearFields(fake);
         fake.callArgAt = pos;
         fake.callbackArguments = [];
-        fake.callbackContext = undefined;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
     },
 
     callsArgOn: function callsArgOn(fake, pos, context) {
@@ -52,11 +68,9 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
+        clearFields(fake);
         fake.callArgAt = pos;
-        fake.callbackArguments = [];
         fake.callbackContext = context;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
     },
 
     callsArgWith: function callsArgWith(fake, pos) {
@@ -64,11 +78,9 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
+        clearFields(fake);
         fake.callArgAt = pos;
         fake.callbackArguments = slice.call(arguments, 2);
-        fake.callbackContext = undefined;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
     },
 
     callsArgOnWith: function callsArgWith(fake, pos, context) {
@@ -76,11 +88,10 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
+        clearFields(fake);
         fake.callArgAt = pos;
         fake.callbackArguments = slice.call(arguments, 3);
         fake.callbackContext = context;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
     },
 
     usingPromise: function usingPromise(fake, promiseLibrary) {
@@ -124,20 +135,15 @@ module.exports = {
         fake.callbackArguments = slice.call(arguments, 3);
         fake.callbackContext = context;
         fake.callArgProp = prop;
-        fake.callbackAsync = false;
     },
 
     throws: throwsException,
     throwsException: throwsException,
 
     returns: function returns(fake, value) {
+        clearFields(fake);
         fake.returnValue = value;
-        fake.resolve = false;
-        fake.reject = false;
         fake.returnValueDefined = true;
-        fake.exception = undefined;
-        fake.exceptionCreator = undefined;
-        fake.fakeFn = undefined;
     },
 
     returnsArg: function returnsArg(fake, pos) {
@@ -145,6 +151,7 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
+        clearFields(fake);
         fake.returnArgAt = pos;
     },
 
@@ -153,22 +160,20 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
+        clearFields(fake);
         fake.throwArgAt = pos;
     },
 
     returnsThis: function returnsThis(fake) {
+        clearFields(fake);
         fake.returnThis = true;
     },
 
     resolves: function resolves(fake, value) {
+        clearFields(fake);
         fake.returnValue = value;
         fake.resolve = true;
-        fake.resolveThis = false;
-        fake.reject = false;
         fake.returnValueDefined = true;
-        fake.exception = undefined;
-        fake.exceptionCreator = undefined;
-        fake.fakeFn = undefined;
     },
 
     rejects: function rejects(fake, error, message) {
@@ -181,29 +186,22 @@ module.exports = {
         } else {
             reason = error;
         }
+
+        clearFields(fake);
         fake.returnValue = reason;
-        fake.resolve = false;
-        fake.resolveThis = false;
         fake.reject = true;
         fake.returnValueDefined = true;
-        fake.exception = undefined;
-        fake.exceptionCreator = undefined;
-        fake.fakeFn = undefined;
 
         return fake;
     },
 
     resolvesThis: function resolvesThis(fake) {
-        fake.returnValue = undefined;
-        fake.resolve = false;
+        clearFields(fake);
         fake.resolveThis = true;
-        fake.reject = false;
-        fake.returnValueDefined = false;
-        fake.exception = undefined;
-        fake.fakeFn = undefined;
     },
 
     callThrough: function callThrough(fake) {
+        clearFields(fake);
         fake.callsThrough = true;
     },
 


### PR DESCRIPTION
Note: Please let me know if this solution is desirable behavior. I haven't yet added unit tests but I'm happy to add them if this PR implementation fits with the goals of the project.

#### Purpose (TL;DR) - mandatory
This PR adds a function `clearFields` to centralize the functionality resetting stub behavior if multiple behavior functions are called. This PR also uses `clearFields` on other behavior functions like `callsFake`.

#### Background (Problem in detail)  - optional
The problem deals with the behavior of this situation:

    stub.throws("TypeError");
    stub.returns(3);
    assert(stub() === 3);

`returns` resets certain fields including `exception` and `exceptionCreator`, effectively overriding the previous behavior.

I originally created https://github.com/sinonjs/sinon/pull/1511 which added the field `exceptionCreator`, and I noticed today that in https://github.com/sinonjs/sinon/pull/1517 it doesn't reset `exceptionCreator`. Also, my coworker told me that `callsFake` doesn't have the same behavior resetting behavior that `returns` does. 

#### Solution  - optional
I added the `clearFields` function which clears every field I could find referenced for `default-behaviors.js`, except for `usingPromise` since I wasn't sure if that should be reset or not.

There are a few extra behavior functions which clear fields which didn't clear fields before. The `yield`* functions were left alone because there were tests asserting that they didn't override `returns`, for example [this one](https://github.com/sinonjs/sinon/blob/master/test/stub-test.js#L1241).

#### How to verify - mandatory
Run `npm test`

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
