### PR TITLE
Fix regression for issue #1526 regarding onFirstCall().throws()

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -115,6 +115,7 @@ var proto = {
     isPresent: function isPresent() {
         return (typeof this.callArgAt === "number" ||
                 this.exception ||
+                this.exceptionCreator ||
                 typeof this.returnArgAt === "number" ||
                 this.returnThis ||
                 this.resolveThis ||

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -137,6 +137,19 @@ describe("stub", function () {
                 stub();
             });
         });
+
+        it("throws only on the first call", function () {
+            var stub = createStub.create();
+            stub.returns("no exception");
+            stub.onFirstCall().throws();
+
+            assert.exception(function () {
+                stub();
+            });
+
+            // on the second call there is no exception
+            assert.same(stub(), "no exception");
+        });
     });
 
     describe(".resolves", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix #1526 by adding `exceptionCreator` to the list of fields checked in `isPresent`

#### Background (Problem in detail)  - optional
The PR #1511 broke this behavior because it added `exceptionCreator` as a field which stored a function which would create the exception.

#### Solution  - optional
The check was added in `isPresent` so that the behavior is detected as being set.

#### How to verify - mandatory
If you run the new test on master it should fail, and it should pass on this branch.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
