### PR TITLE
Fix for `sinon.createFakeServer()` exception

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -29,8 +29,8 @@ exports.fakeServer = nise.fakeServer;
 exports.fakeServerWithClock = nise.fakeServerWithClock;
 
 exports.createSandbox = sandbox.create;
-exports.createFakeServer = nise.fakeServer.create;
-exports.createFakeServerWithClock = nise.fakeServerWithClock.create;
+exports.createFakeServer = nise.fakeServer.create.bind(nise.fakeServer);
+exports.createFakeServerWithClock = nise.fakeServerWithClock.create.bind(nise.fakeServerWithClock);
 
 var behavior = require("./sinon/behavior");
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -361,4 +361,18 @@ describe("issues", function () {
         });
 
     });
+
+    describe("#1531 - some copied functions on root sinon module throw", function () {
+        it("should create a fake server without throwing", function () {
+            refute.exception(function () {
+                sinon.createFakeServer();
+            });
+        });
+
+        it("should create a fake server with clock without throwing", function () {
+            refute.exception(function () {
+                sinon.createFakeServerWithClock();
+            });
+        });
+    });
 });

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -17,10 +17,14 @@ describe("sinon module", function () {
 
         fakeNise = {
             fakeServer: {
-                create: "47c86a4c-6b48-4748-bb8c-d853f999720c"
+                create: function () {
+                    return "47c86a4c-6b48-4748-bb8c-d853f999720c";
+                }
             },
             fakeServerWithClock: {
-                create: "e69974f8-4568-48d1-a5e9-2b511a59c14b"
+                create: function () {
+                    "e69974f8-4568-48d1-a5e9-2b511a59c14b";
+                }
             },
             fakeXhr: {
                 xhr: "958e8996-0cc3-4136-8a0e-6a120f5311bc",
@@ -52,7 +56,7 @@ describe("sinon module", function () {
 
         describe("createFakeServer", function () {
             it("should be fakeServer.create from nise", function () {
-                assert.equals(sinon.createFakeServer, fakeNise.fakeServer.create);
+                assert.equals(sinon.createFakeServer(), fakeNise.fakeServer.create());
             });
         });
 
@@ -64,7 +68,7 @@ describe("sinon module", function () {
 
         describe("createFakeServerWithClock", function () {
             it("should be fakeServerWithClock.create from nise", function () {
-                assert.equals(sinon.createFakeServerWithClock, fakeNise.fakeServerWithClock.create);
+                assert.equals(sinon.createFakeServerWithClock(), fakeNise.fakeServerWithClock.create());
             });
         });
 

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -23,7 +23,7 @@ describe("sinon module", function () {
             },
             fakeServerWithClock: {
                 create: function () {
-                    "e69974f8-4568-48d1-a5e9-2b511a59c14b";
+                    return "e69974f8-4568-48d1-a5e9-2b511a59c14b";
                 }
             },
             fakeXhr: {


### PR DESCRIPTION
Fixes #1531 by preserving the context of `nise.fakeServer.create` and `nise.fakeServerWithClock.create` 