### PR TITLE
resolvesThis should override previous throws

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -200,6 +200,7 @@ module.exports = {
         fake.reject = false;
         fake.returnValueDefined = false;
         fake.exception = undefined;
+        fake.exceptionCreator = undefined;
         fake.fakeFn = undefined;
     },
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -324,6 +324,24 @@ describe("stub", function () {
 
             assert.same(stub.resolvesThis(), stub);
         });
+
+        it("overrides throws behavior for error objects", function () {
+            var instance = {};
+            instance.stub = createStub.create().throws(new Error()).resolvesThis();
+
+            return instance.stub().then(function (actual) {
+                assert.same(actual, instance);
+            });
+        });
+
+        it("overrides throws behavior for dynamically created errors", function () {
+            var instance = {};
+            instance.stub = createStub.create().throws().resolvesThis();
+
+            return instance.stub().then(function (actual) {
+                assert.same(actual, instance);
+            });
+        });
     });
 
     describe(".returnsArg", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fixed missing reset of `exceptionCreator` for `resolvesThis` which exists in other similar functions. Where `exception` is set to `undefined` `exceptionCreator` should also be set to `undefined.

#### How to verify - mandatory
In the branch, remove the change to `default-behaviors.js` and run the tests. One of the two new tests should fail, showing that the previous behavior is inconsistent regarding how `throws` affects `resolveThis`.

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
