### PR TITLE
Fixes #1389: add .usePromise for global promise library usage

### DIFF
--- a/docs/release-source/release/utils.md
+++ b/docs/release-source/release/utils.md
@@ -36,13 +36,13 @@ Creates a new object with the given function as the protoype and stubs all imple
     class Container {
         contains(item) { /* ... */ }
     }
-    
+
     var stubContainer = sinon.createStubInstance(Container);
     stubContainer.contains.returns(false);
     stubContainer.contains.withArgs("item").returns(true);
 ```
 
-The given constructor function is not invoked. See also the [stub API](../stubs).
+The given constructor function is not invoked. See also the [stub API](./stubs.md).
 
 #### `sinon.format(object);`
 
@@ -60,3 +60,22 @@ sinon.log = function (message) {
     jstestdriver.console.log(message);
 };
 ```
+
+#### `sinon.usePromise(promiseLibrary);`
+
+Ensures all future stubs will use the provided promise library instead of native
+promises. For per-stub promise overriding, see the [stub API.](./stubs.md#stubusingpromisepromiselibrary)
+
+```javascript
+sinon.usePromise(bluebird.Promise);
+var myObj = {
+    saveSomething: sinon.stub().resolves("baz")
+};
+
+myObj.saveSomething()
+    .tap(function(actual) {
+        console.log(actual); // baz
+    });
+```
+
+*Since `sinon@3.0.0`*

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -13,7 +13,8 @@ exports.sandbox = sandbox;
 exports.expectation = require("./sinon/mock-expectation");
 exports.createStubInstance = require("./sinon/stub").createStubInstance;
 
-exports.defaultConfig = require("./sinon/util/core/default-config");
+var defaultConfig = require("./sinon/util/core/default-config");
+exports.defaultConfig = defaultConfig;
 
 var fakeTimers = require("./sinon/util/fake_timers");
 exports.useFakeTimers = fakeTimers.useFakeTimers;
@@ -36,6 +37,10 @@ var behavior = require("./sinon/behavior");
 
 exports.addBehavior = function (name, fn) {
     behavior.addBehavior(exports.stub, name, fn);
+};
+
+exports.usePromise = function (promiseLibrary) {
+    defaultConfig.promiseLibrary = promiseLibrary;
 };
 
 var format = require("./sinon/util/core/format");

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -3,6 +3,7 @@
 var extend = require("./util/core/extend");
 var functionName = require("./util/core/function-name");
 var valueToString = require("./util/core/value-to-string");
+var getConfig = require("./util/core/get-config");
 
 var slice = Array.prototype.slice;
 var join = Array.prototype.join;
@@ -104,8 +105,12 @@ var proto = {
         delete behavior.addBehavior;
         delete behavior.createBehavior;
         behavior.stub = stub;
+        behavior.promiseLibrary = getConfig().promiseLibrary;
 
-        if (stub.defaultBehavior && stub.defaultBehavior.promiseLibrary) {
+        if (!behavior.promiseLibrary &&
+            stub.defaultBehavior &&
+            stub.defaultBehavior.promiseLibrary) {
+
             behavior.promiseLibrary = stub.defaultBehavior.promiseLibrary;
         }
 
@@ -218,6 +223,11 @@ function addBehavior(stub, name, fn) {
     stub[name] = createBehavior(name);
 }
 
+function usePromise(promiseLibrary) {
+    proto.promiseLibrary = promiseLibrary;
+}
+
 proto.addBehavior = addBehavior;
 proto.createBehavior = createBehavior;
+proto.usePromise = usePromise;
 module.exports = proto;

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -11,6 +11,8 @@ var sinonSandbox = require("../lib/sinon/sandbox");
 var sinonCollection = require("../lib/sinon/collection");
 var sinonSpy = require("../lib/sinon/spy");
 var sinonStub = require("../lib/sinon/stub");
+var usePromise = require("../lib/sinon").usePromise;
+var defaultConfig = require("../lib/sinon/util/core/default-config");
 var sinonConfig = require("../lib/sinon/util/core/get-config");
 var sinonMatch = require("../lib/sinon/match");
 var sinonAssert = require("../lib/sinon/assert");
@@ -123,6 +125,61 @@ describe("sinonSandbox", function () {
             this.sandbox.restore();
 
             assert.same(setTimeout, originalSetTimeout, "fakeTimers restored");
+        });
+    });
+
+    // sinon.usePromise
+    describe(".usePromise (global)", function () {
+        beforeEach(function () {
+            this.sandbox = Object.create(sinonSandbox);
+        });
+
+        afterEach(function () {
+            delete defaultConfig.promiseLibrary;
+        });
+
+        it("must set all stubs created from sandbox with mockPromise", function () {
+            if (!supportPromise) { return this.skip(); }
+
+            var resolveValue = {};
+            var mockPromise = {
+                resolve: sinonStub.create().resolves(resolveValue)
+            };
+
+            usePromise(mockPromise);
+            var stub = this.sandbox.stub().resolves();
+
+            return stub()
+                .then(function (action) {
+
+                    assert.same(resolveValue, action);
+                    assert(mockPromise.resolve.calledOnce);
+                });
+        });
+
+        it("must set all stubs created from sandbox with mockPromise (object)", function () {
+            if (!supportPromise) { return this.skip(); }
+
+            var resolveValue = {};
+            var mockPromise = {
+                resolve: sinonStub.create().resolves(resolveValue)
+            };
+            var stubbedObject = {
+                stubbedMethod: function () {
+                    return;
+                }
+            };
+
+            usePromise(mockPromise);
+            this.sandbox.stub(stubbedObject);
+            stubbedObject.stubbedMethod.resolves({});
+
+            return stubbedObject.stubbedMethod()
+                .then(function (action) {
+
+                    assert.same(resolveValue, action);
+                    assert(mockPromise.resolve.calledOnce);
+                });
         });
     });
 


### PR DESCRIPTION
#### Purpose (TL;DR)
Provide a way to specify a promise library (e.g. Bluebird) to be used for all future stub creation.

#### Background (Problem in detail)
See issue #1389, but specifying the promise library every time a stub is created is rather cumbersome. For codebases that use a non-native promise library, this is a much needed feature.

#### How to verify
See unit tests. Feel free to test with your repo (checkout, install, and npm link this branch). I've already pointed a rather large codebase/test suite at this branch and it has been working well for me so far. 

#### Open questions/comments
I'm not familiar with the history of this codebase, so feel free to suggest alternative approaches - this is the simple approach that worked for me when taking a first stab at getting a working solution. 

1) For this approach, I used default-config and used get-config. It seems like these files aren't heavily used throughout the codebase and haven't been touched since 2015. If these are going away and shouldn't be used, let me know and I'll make the necessary changes.

2) Not sure about the release number in the docs. I just put @3.0.0 for now, but that'll likely need to be updated.