### PR TITLE
Add support to instanceOf for [Symbol.hasInstance]

### DIFF
--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -185,7 +185,7 @@ match.typeOf = function (type) {
 };
 
 match.instanceOf = function (type) {
-    if (typeof Symbol === "undefined") {
+    if (typeof Symbol === "undefined" || typeof Symbol.hasInstance === "undefined") {
         assertType(type, "function", "type");
     } else {
         assertMethodExists(type, Symbol.hasInstance, "type", "[Symbol.hasInstance]");

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -17,6 +17,12 @@ function assertType(value, type, name) {
     }
 }
 
+function assertMethodExists(value, method, name, methodPath) {
+    if (value[method] == null) {
+        throw new TypeError("Expected " + name + " to have method " + methodPath);
+    }
+}
+
 var matcher = {
     toString: function () {
         return this.message;
@@ -179,10 +185,14 @@ match.typeOf = function (type) {
 };
 
 match.instanceOf = function (type) {
-    assertType(type, "function", "type");
+    if (typeof Symbol === "undefined") {
+        assertType(type, "function", "type");
+    } else {
+        assertMethodExists(type, Symbol.hasInstance, "type", "[Symbol.hasInstance]");
+    }
     return match(function (actual) {
         return actual instanceof type;
-    }, "instanceOf(" + functionName(type) + ")");
+    }, "instanceOf(" + (functionName(type) || Object.prototype.toString.call(type)) + ")");
 };
 
 function createPropertyMatcher(propertyTest, messagePrefix) {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -493,6 +493,14 @@ describe("sinonMatch", function () {
             }, "TypeError");
         });
 
+        if (typeof Symbol !== "undefined") {
+            it("does not throw if given argument defines Symbol.hasInstance", function () {
+                var objectWithCustomTypeChecks = {};
+                objectWithCustomTypeChecks[Symbol.hasInstance] = function () {};
+                sinonMatch.instanceOf(objectWithCustomTypeChecks);
+            });
+        }
+
         it("returns matcher", function () {
             var instanceOf = sinonMatch.instanceOf(function () {});
 

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -493,7 +493,7 @@ describe("sinonMatch", function () {
             }, "TypeError");
         });
 
-        if (typeof Symbol !== "undefined") {
+        if (typeof Symbol !== "undefined" && typeof Symbol.hasInstance !== "undefined") {
             it("does not throw if given argument defines Symbol.hasInstance", function () {
                 var objectWithCustomTypeChecks = {};
                 objectWithCustomTypeChecks[Symbol.hasInstance] = function () {};


### PR DESCRIPTION
#### Background
Though it is easy to replicate this functionality (eg: ```sinon.match(x => s instanceof foo)```), the fact that this is not supported out-of-the-box can produce confusion, as the behaviour of instanceOf matchers and the instanceof operator differs regarding [Symbol.hasInstance].

#### Solution
This PR addresses this issue by lifting the limitation to allow not only functions, but any object with [Symbol.hasInstance] method, as defined [by the standard](https://tc39.github.io/ecma262/#sec-instanceofoperator), if supported by the interpreter.

#### How to verify
1. Check out this branch
2. `npm install`
3. `node` (make sure your node version supports ES6 symbols)
4. `var sinon = require("./")`
5. `var matcher = sinon.match.instanceOf({ [Symbol.hasInstance]: () => true })`
6. `matcher.test("foo")` // returns true

#### Checklist for author
- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
