### PR TITLE
Documentation update for assert.calledWithNew

### DIFF
--- a/docs/release-source/release/assertions.md
+++ b/docs/release-source/release/assertions.md
@@ -127,6 +127,11 @@ Passes if `spy` was always called with matching arguments.
 This behaves the same way as `sinon.assert.alwaysCalledWith(spy, sinon.match(arg1), sinon.match(arg2), ...)`.
 
 
+#### `sinon.assert.calledWithNew(spy)`
+
+Passes if `spy` was called with the `new` operator.
+
+
 #### `sinon.assert.neverCalledWithMatch(spy, arg1, arg2, ...)`
 
 Passes if `spy` was never called with matching arguments.


### PR DESCRIPTION
#### Purpose (TL;DR)

Documentation update for #1535 that adds missing assert.calledWithNew.

#### Background (Problem in detail) 

It was reported that there was no assert.calledWithNew, while Assert did feature most other assertions that Spy had.

#### Solution 

Upon investigation, it turned out that Assert did in fact have this method, but it had been left out in the API documentation.

#### How to verify
1. Check out this branch
2. `npm install`
3. `node`
4. `var sinonAssert = require("./lib/sinon/assert")`
5. `var sinonSpy = require("./lib/sinon/spy")`
6. `var testSpy = sinonSpy()`
7. `new testSpy()`
7. `sinonAssert.calledWithNew(testSpy)` // this should not throw an exception

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
