### PR TITLE
fix #1442

### DIFF
--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -71,6 +71,7 @@ extend(mock, {
         }
 
         var expectation = mockExpectation.create(method);
+        extend(expectation, this.object[method]);
         push.call(this.expectations[method], expectation);
 
         return expectation;

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -375,4 +375,19 @@ describe("issues", function () {
             });
         });
     });
+
+    describe("#1442 - callThrough with a mock expectation", function () {
+        it("should call original method", function () {
+            var foo = {
+                bar: function () { }
+            };
+
+            var mock = this.sandbox.mock(foo);
+            mock.expects("bar").callThrough();
+
+            foo.bar();
+
+            mock.verify();
+        });
+    });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix issue #1442 by extending expectation with wrapped method props

#### Background (Problem in detail)  - optional
See issue #1442

#### Solution
Extend expectation with wrapped method's props

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
