### PR TITLE
Fix double backticks in inline code examples

### DIFF
--- a/docs/release-source/release/fake-xhr-and-server.md
+++ b/docs/release-source/release/fake-xhr-and-server.md
@@ -154,13 +154,13 @@ The filter will be called when `xhr.open` is called, with the exact same argumen
 
 ### Simulating server responses
 
-#### `request.setStatus(status);``
+#### `request.setStatus(status);`
 
 Sets response status (`status` and `statusText` properties).
 
 Status should be a number, the status text is looked up from `sinon.FakeXMLHttpRequest.statusCodes`.
 
-#### `request.setResponseHeaders(object);``
+#### `request.setResponseHeaders(object);`
 
 Sets response headers (e.g. `{ "Content-Type": "text/html", /* ... */ }`, updates the `readyState` property and fires `onreadystatechange`.
 
@@ -172,7 +172,7 @@ Sets the respond body, updates the `readyState` property and fires `onreadystate
 Additionally, populates `responseXML` with a parsed document if [response headers indicate as much](http://www.w3.org/TR/XMLHttpRequest/).
 
 
-#### `request.respond(status, headers, body);``
+#### `request.respond(status, headers, body);`
 
 Calls the above three methods.
 
@@ -225,7 +225,7 @@ High-level API to manipulate `FakeXMLHttpRequest` instances.
 ```
 
 
-#### `var server = sinon.createFakeServer([config]);``
+#### `var server = sinon.createFakeServer([config]);`
 
 Creates a new server.
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

In some places in the file the inline code examples are terminated with double backtics, which makes the second backtick visible in rendered output

#### How to verify - mandatory
1. Compile the markdown
2. See that the additional backtics are not visible