### PR TITLE
Fix eslint peerDependencies error

### DIFF
--- a/lib/sinon/sandbox-stub.js
+++ b/lib/sinon/sandbox-stub.js
@@ -20,8 +20,8 @@ function sandboxStub(object, property) {
                                     && (typeof actualDescriptor === "undefined"
                                     || typeof actualDescriptor.value !== "function");
     var stubbed = isStubbingNonFuncProperty ?
-                    stubNonFunctionProperty.apply(null, arguments) :
-                    sinonStub.apply(null, arguments);
+        stubNonFunctionProperty.apply(null, arguments) :
+        sinonStub.apply(null, arguments);
 
     if (isStubbingEntireObject) {
         var ownMethods = collectOwnMethods(stubbed);

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -245,8 +245,8 @@ var spyApi = {
         }
 
         return spyCall(this, this.thisValues[i], this.args[i],
-                                this.returnValues[i], this.exceptions[i],
-                                this.callIds[i], this.errorsWithCallStack[i]);
+            this.returnValues[i], this.exceptions[i],
+            this.callIds[i], this.errorsWithCallStack[i]);
     },
 
     getCalls: function () {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "browserify": "^14.0.0",
-    "eslint": "^3.1.1",
+    "eslint": "^4.6.1",
     "eslint-config-sinon": "^1.0.0",
     "eslint-plugin-mocha": "^4.2.0",
     "husky": "^0.14.2",

--- a/scripts/set-release-id-in-config-yml.js
+++ b/scripts/set-release-id-in-config-yml.js
@@ -7,6 +7,6 @@ var yaml = require("js-yaml");
 var releaseId = "v" + require("../package.json").version;
 var config = yaml.safeLoad(fs.readFileSync(configYmlPath, UTF8));
 
-config.sinon.current_release = releaseId;  // eslint-disable-line camelcase
+config.sinon.current_release = releaseId; // eslint-disable-line camelcase
 
 fs.writeFileSync(configYmlPath, yaml.safeDump(config), UTF8);

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1165,7 +1165,7 @@ describe("assert", function () {
 
         it("assert.called exception message", function () {
             assert.equals(this.message("called", this.obj.doSomething),
-                          "expected doSomething to have been called at " +
+                "expected doSomething to have been called at " +
                           "least once but was never called");
         });
 
@@ -1173,7 +1173,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("notCalled", this.obj.doSomething).replace(/ at.*/g, ""),
-                          "expected doSomething to not have been called " +
+                "expected doSomething to not have been called " +
                           "but was called once\n    doSomething()");
         });
 
@@ -1184,7 +1184,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("notCalled", this.obj.doSomething).replace(/ at.*/g, ""),
-                          "expected doSomething to not have been called " +
+                "expected doSomething to not have been called " +
                           "but was called 4 times\n    doSomething()\n    " +
                           "doSomething()\n    doSomething()\n    doSomething()");
         });
@@ -1196,7 +1196,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("notCalled", this.obj.doSomething).replace(/ at.*/g, ""),
-                          "expected doSomething to not have been called " +
+                "expected doSomething to not have been called " +
                           "but was called 4 times\n    doSomething()\n    " +
                           "doSomething(3)\n    doSomething(42, 1)\n    doSomething()");
         });
@@ -1213,7 +1213,7 @@ describe("assert", function () {
             var message = this.message("callOrder", this.obj.doSomething, obj.doop, obj.foo);
 
             assert.equals(message,
-                          "expected doSomething, doop, foo to be called in " +
+                "expected doSomething, doop, foo to be called in " +
                           "order but were called as doop, doSomething, foo");
         });
 
@@ -1227,7 +1227,7 @@ describe("assert", function () {
             var message = this.message("callOrder", obj.doop, obj.foo);
 
             assert.equals(message,
-                          "expected doop, foo to be called in " +
+                "expected doop, foo to be called in " +
                           "order but were called as foo");
         });
 
@@ -1241,7 +1241,7 @@ describe("assert", function () {
             var message = this.message("callOrder", obj.doop, obj.foo);
 
             assert.equals(message,
-                          "expected doop, foo to be called in " +
+                "expected doop, foo to be called in " +
                           "order but were called as doop");
         });
 
@@ -1249,7 +1249,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("callCount", this.obj.doSomething, 3).replace(/ at.*/g, ""),
-                          "expected doSomething to be called thrice but was called " +
+                "expected doSomething to be called thrice but was called " +
                           "once\n    doSomething()");
         });
 
@@ -1258,13 +1258,13 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("calledOnce", this.obj.doSomething).replace(/ at.*/g, ""),
-                          "expected doSomething to be called once but was called " +
+                "expected doSomething to be called once but was called " +
                           "twice\n    doSomething()\n    doSomething()");
 
             this.obj.doSomething();
 
             assert.equals(this.message("calledOnce", this.obj.doSomething).replace(/ at.*/g, ""),
-                          "expected doSomething to be called once but was called " +
+                "expected doSomething to be called once but was called " +
                           "thrice\n    doSomething()\n    doSomething()\n    doSomething()");
         });
 
@@ -1272,7 +1272,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("calledTwice", this.obj.doSomething).replace(/ at.*/g, ""),
-                          "expected doSomething to be called twice but was called " +
+                "expected doSomething to be called twice but was called " +
                           "once\n    doSomething()");
         });
 
@@ -1345,7 +1345,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("calledWithNew", this.obj.doSomething),
-                          "expected doSomething to be called with new");
+                "expected doSomething to be called with new");
         });
 
         it("assert.alwaysCalledWithNew exception message", function () {
@@ -1353,14 +1353,14 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("alwaysCalledWithNew", this.obj.doSomething),
-                          "expected doSomething to always be called with new");
+                "expected doSomething to always be called with new");
         });
 
         it("assert.calledWith exception message", function () {
             this.obj.doSomething(4, 3, "hey");
 
             assert.equals(this.message("calledWith", this.obj.doSomething, 1, 3, "hey").replace(/ at.*/g, ""),
-                        "expected doSomething to be called with arguments \n" +
+                "expected doSomething to be called with arguments \n" +
                         color.red("4") + " " + color.green("1") + " \n" +
                         "3\n" +
                         "hey");
@@ -1371,7 +1371,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 3, "not");
 
             assert.equals(this.message("calledWith", this.obj.doSomething, 1, 3, "hey").replace(/ at.*/g, ""),
-                        "expected doSomething to be called with arguments " +
+                "expected doSomething to be called with arguments " +
                         "Call 1:\n" +
                         color.red("4") + " " + color.green("1") + " \n" +
                         "3\n" +
@@ -1408,7 +1408,7 @@ describe("assert", function () {
                 "fifth"
             ];
             assert.equals(this.message("calledWith", this.obj.doSomething, expectedArg).replace(/ at.*/g, ""),
-                        "expected doSomething to be called with arguments \n" +
+                "expected doSomething to be called with arguments \n" +
                         "[{\n" +
                         "  first: \"a\",\n" +
                         color.red("  mismatchKey: true,\n") +
@@ -1423,7 +1423,7 @@ describe("assert", function () {
             this.obj.doSomething(4);
 
             assert.equals(this.message("calledWith", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
-                        "expected doSomething to be called with arguments \n" +
+                "expected doSomething to be called with arguments \n" +
                         color.red("4") + " " + color.green("1") + " \n" +
                         color.green("3"));
         });
@@ -1432,7 +1432,7 @@ describe("assert", function () {
             this.obj.doSomething(4, 3);
 
             assert.equals(this.message("calledWith", this.obj.doSomething, 1).replace(/ at.*/g, ""),
-                        "expected doSomething to be called with arguments \n" +
+                "expected doSomething to be called with arguments \n" +
                         color.red("4") + " " + color.green("1") + " \n" +
                         color.red("3"));
         });
@@ -1467,7 +1467,7 @@ describe("assert", function () {
             this.obj.doSomething(true);
 
             assert.equals(this.message("calledWith", this.obj.doSomething, sinonMatch.falsy).replace(/ at.*/g, ""),
-                          "expected doSomething to be called with arguments \n" +
+                "expected doSomething to be called with arguments \n" +
                           color.green("true") + " " + color.red("falsy"));
         });
 
@@ -1510,14 +1510,14 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("calledWith", this.obj.doSomething, sinonMatch(true)).replace(/ at.*/g, ""),
-                          "expected doSomething to be called with arguments \n " + color.red("match(true)"));
+                "expected doSomething to be called with arguments \n " + color.red("match(true)"));
         });
 
         it("assert.calledWith match number exception message", function () {
             this.obj.doSomething();
 
             assert.equals(this.message("calledWith", this.obj.doSomething, sinonMatch(123)).replace(/ at.*/g, ""),
-                          "expected doSomething to be called with arguments \n " + color.red("match(123)"));
+                "expected doSomething to be called with arguments \n " + color.red("match(123)"));
         });
 
         it("assert.calledWith match string exception message", function () {
@@ -1525,7 +1525,7 @@ describe("assert", function () {
             var matcher = sinonMatch("Sinon");
 
             assert.equals(this.message("calledWith", this.obj.doSomething, matcher).replace(/ at.*/g, ""),
-                          "expected doSomething to be called with arguments \n " + color.red("match(\"Sinon\")"));
+                "expected doSomething to be called with arguments \n " + color.red("match(\"Sinon\")"));
         });
 
         it("assert.calledWith match regexp exception message", function () {
@@ -1549,7 +1549,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 3, "hey");
 
             assert.equals(this.message("calledWithMatch", this.obj.doSomething, 4, 3, "hey").replace(/ at.*/g, ""),
-                          "expected doSomething to be called with match \n" +
+                "expected doSomething to be called with match \n" +
                           color.red("1") + " " + color.green("4") + " \n" +
                           "3\n" +
                           "hey");
@@ -1560,7 +1560,7 @@ describe("assert", function () {
             this.obj.doSomething(1, "hey");
 
             assert.equals(this.message("alwaysCalledWith", this.obj.doSomething, 1, "hey").replace(/ at.*/g, ""),
-                         "expected doSomething to always be called with arguments Call 1:\n" +
+                "expected doSomething to always be called with arguments Call 1:\n" +
                           "1\n" +
                           color.red("3") + " " + color.green("hey") + " \n" +
                           color.red("hey") + "\n" +
@@ -1588,7 +1588,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 3, "hey");
 
             assert.equals(this.message("calledWithExactly", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
-                          "expected doSomething to be called with exact arguments \n" +
+                "expected doSomething to be called with exact arguments \n" +
                           "1\n" +
                           "3\n" +
                           color.red("hey"));
@@ -1599,7 +1599,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 3);
 
             assert.equals(this.message("alwaysCalledWithExactly", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
-                          "expected doSomething to always be called with exact arguments Call 1:\n" +
+                "expected doSomething to always be called with exact arguments Call 1:\n" +
                           "1\n" +
                           "3\n" +
                           color.red("hey") + "\n" +
@@ -1612,7 +1612,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 2, 3);
 
             assert.equals(this.message("neverCalledWith", this.obj.doSomething, 1, 2).replace(/ at.*/g, ""),
-                          "expected doSomething to never be called with " +
+                "expected doSomething to never be called with " +
                           "arguments 1, 2\n    doSomething(1, 2, 3)");
         });
 
@@ -1620,7 +1620,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 2, 3);
 
             assert.equals(this.message("neverCalledWithMatch", this.obj.doSomething, 1, 2).replace(/ at.*/g, ""),
-                          "expected doSomething to never be called with match " +
+                "expected doSomething to never be called with match " +
                           "1, 2\n    doSomething(1, 2, 3)");
         });
 
@@ -1629,7 +1629,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 3);
 
             assert.equals(this.message("threw", this.obj.doSomething).replace(/ at.*/g, ""),
-                          "doSomething did not throw exception\n" +
+                "doSomething did not throw exception\n" +
                           "    doSomething(1, 3, hey)\n    doSomething(1, 3)");
         });
 
@@ -1638,13 +1638,13 @@ describe("assert", function () {
             this.obj.doSomething(1, 3);
 
             assert.equals(this.message("alwaysThrew", this.obj.doSomething).replace(/ at.*/g, ""),
-                          "doSomething did not always throw exception\n" +
+                "doSomething did not always throw exception\n" +
                           "    doSomething(1, 3, hey)\n    doSomething(1, 3)");
         });
 
         it("assert.match exception message", function () {
             assert.equals(this.message("match", { foo: 1 }, [1, 3]),
-                          "expected value to match\n" +
+                "expected value to match\n" +
                           "    expected = [1, 3]\n" +
                           "    actual = { foo: 1 }");
         });

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -864,11 +864,11 @@ describe("sinonSpy.call", function () {
             }
 
             run()
-            .then(function () {
-                assert.equals(stub2.getCall(0).toString().replace(/ at.*/g, ""), "stub(1) => 1");
-                done();
-            })
-            .catch( done );
+                .then(function () {
+                    assert.equals(stub2.getCall(0).toString().replace(/ at.*/g, ""), "stub(1) => 1");
+                    done();
+                })
+                .catch( done );
         });
         /* eslint-enable consistent-return */
     });

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -130,7 +130,7 @@ describe("issues", function () {
             // makes sure that Object.prototype.watch is set back to its old value
             function restore(oldWatch) {
                 if (oldWatch) {
-                    Object.prototype.watch = oldWatch;  // eslint-disable-line no-extend-native
+                    Object.prototype.watch = oldWatch; // eslint-disable-line no-extend-native
                 } else {
                     delete Object.prototype.watch;
                 }
@@ -203,7 +203,7 @@ describe("issues", function () {
             this.sandbox.resetHistory();
 
             spy();
-            assert.equals(spy.callCount, 1);  // should not fail but fails
+            assert.equals(spy.callCount, 1); // should not fail but fails
         });
     });
 

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -1001,7 +1001,7 @@ describe("sinonMatch", function () {
 
             assert(sinonMatch.isMatcher(numberOrString));
             assert.equals(numberOrString.toString(),
-                          "typeOf(\"number\").or(typeOf(\"string\"))");
+                "typeOf(\"number\").or(typeOf(\"string\"))");
         });
 
         it("requires matcher argument", function () {
@@ -1015,7 +1015,7 @@ describe("sinonMatch", function () {
 
             assert(sinonMatch.isMatcher(abcOrDef));
             assert.equals(abcOrDef.toString(),
-                          "match(\"abc\").or(match(\"def\"))");
+                "match(\"abc\").or(match(\"def\"))");
         });
 
         it("returns true if either matcher matches", function () {
@@ -1060,7 +1060,7 @@ describe("sinonMatch", function () {
 
             assert(sinonMatch.isMatcher(abcOrObj));
             assert.equals(abcOrObj.toString(),
-                          "match(\"abc\").or(match(a: 1))");
+                "match(\"abc\").or(match(a: 1))");
         });
 
         it("returns true if both matchers match", function () {

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -346,8 +346,8 @@ describe("sinonSandbox", function () {
                     this.sandbox.clock.tick(10);
 
                     var xhr = window.XMLHttpRequest ?
-                                new XMLHttpRequest() :
-                                new ActiveXObject("Microsoft.XMLHTTP"); //eslint-disable-line no-undef
+                        new XMLHttpRequest() :
+                        new ActiveXObject("Microsoft.XMLHTTP"); //eslint-disable-line no-undef
 
                     assert.isFunction(this.obj.spy);
                     assert.isFunction(this.obj.stub);

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -346,17 +346,17 @@ describe("spy", function () {
             refute.defined(spy.getCall(3).args[2]);
             ["args", "callCount", "callId"].forEach(function (propName) {
                 assert.equals(spy.withArgs(1).getCall(0)[propName],
-                              spy.getCall(1)[propName]);
+                    spy.getCall(1)[propName]);
                 assert.equals(spy.withArgs(1).getCall(1)[propName],
-                              spy.getCall(2)[propName]);
+                    spy.getCall(2)[propName]);
                 assert.equals(spy.withArgs(1).getCall(2)[propName],
-                              spy.getCall(3)[propName]);
+                    spy.getCall(3)[propName]);
                 assert.isNull(spy.withArgs(1).getCall(3));
                 assert.equals(spy.withArgs(1, 1).getCall(0)[propName],
-                              spy.getCall(2)[propName]);
+                    spy.getCall(2)[propName]);
                 assert.isNull(spy.withArgs(1, 1).getCall(1));
                 assert.equals(spy.withArgs(1, 2).getCall(0)[propName],
-                              spy.getCall(3)[propName]);
+                    spy.getCall(3)[propName]);
                 assert.isNull(spy.withArgs(1, 2).getCall(1));
             });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1959,9 +1959,9 @@ describe("stub", function () {
 
         it("supports chained declaration of behavior", function () {
             var stub = createStub()
-                    .onCall(0).returns(1)
-                    .onCall(1).returns(2)
-                    .onCall(2).returns(3);
+                .onCall(0).returns(1)
+                .onCall(1).returns(2)
+                .onCall(2).returns(3);
 
             assert.same(stub(), 1);
             assert.same(stub(), 2);


### PR DESCRIPTION

#### Purpose 
Fix the error 
```
npm ERR! peerinvalid The package eslint@3.19.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer eslint-config-sinon@1.0.3 wants eslint@^4.2.0
npm ERR! peerinvalid Peer eslint-plugin-mocha@4.11.0 wants eslint@^2.0.0 || ^3.0.0 || ^4.0.0
```

#### Background 
See https://travis-ci.org/sinonjs/sinon/jobs/274700350
