### PR TITLE
Adds sinon.match.hasNested

### DIFF
--- a/docs/release-source/release/matchers.md
+++ b/docs/release-source/release/matchers.md
@@ -220,6 +220,22 @@ The property might be inherited via the prototype chain. If the optional expecta
 Same as `sinon.match.has` but the property must be defined by the value itself. Inherited properties are ignored.
 
 
+#### `sinon.match.hasNested(propertyPath[, expectation])`
+
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+
+The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
+
+
+```javascript
+sinon.match.hasNested("a[0].b.c");
+sinon.match.hasNested("a.b.c");
+
+// Where actual is something like
+var actual = { "a": [{ "b": { "c": 3 } }] };
+```
+
+
 ## Combining matchers
 
 All matchers implement `and` and `or`. This allows to logically combine mutliple matchers. The result is a new matchers that requires both (and) or one of the matchers (or) to return `true`.

--- a/docs/release-source/release/matchers.md
+++ b/docs/release-source/release/matchers.md
@@ -229,10 +229,14 @@ The propertyPath might be inherited via the prototype chain. If the optional exp
 
 ```javascript
 sinon.match.hasNested("a[0].b.c");
-sinon.match.hasNested("a.b.c");
 
 // Where actual is something like
 var actual = { "a": [{ "b": { "c": 3 } }] };
+
+sinon.match.hasNested("a.b.c");
+
+// Where actual is something like
+var actual = { "a": { "b": { "c": 3 } } };
 ```
 
 

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -3,6 +3,7 @@
 var deepEqual = require("./util/core/deep-equal").use(match); // eslint-disable-line no-use-before-define
 var every = require("./util/core/every");
 var functionName = require("./util/core/function-name");
+var get = require("lodash.get");
 var iterableToString = require("./util/core/iterable-to-string");
 var typeOf = require("./util/core/typeOf");
 var valueToString = require("./util/core/value-to-string");
@@ -224,6 +225,23 @@ match.has = createPropertyMatcher(function (actual, property) {
 match.hasOwn = createPropertyMatcher(function (actual, property) {
     return actual.hasOwnProperty(property);
 }, "hasOwn");
+
+match.hasNested = function (property, value) {
+    assertType(property, "string", "property");
+    var onlyProperty = arguments.length === 1;
+    var message = "hasNested(\"" + property + "\"";
+    if (!onlyProperty) {
+        message += ", " + valueToString(value);
+    }
+    message += ")";
+    return match(function (actual) {
+        if (actual === undefined || actual === null ||
+                get(actual, property) === undefined) {
+            return false;
+        }
+        return onlyProperty || deepEqual(value, get(actual, property));
+    }, message);
+};
 
 match.array = match.typeOf("array");
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "diff": "^3.1.0",
     "formatio": "1.2.0",
+    "lodash.get": "^4.4.2",
     "lolex": "^2.1.2",
     "native-promise-only": "^0.8.1",
     "nise": "^1.0.1",

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -3,7 +3,7 @@
 var assert = require("referee").assert;
 var sinonMatch = require("../lib/sinon/match");
 
-function propertyMatcherTests(matcher) {
+function propertyMatcherTests(matcher, additionalTests) {
     return function () {
         it("returns matcher", function () {
             var has = matcher("foo");
@@ -69,6 +69,10 @@ function propertyMatcherTests(matcher) {
 
             assert(has.test({ callback: function () {} }));
         });
+
+        if (typeof additionalTests === "function") {
+            additionalTests();
+        }
     };
 }
 
@@ -522,6 +526,22 @@ describe("sinonMatch", function () {
 
     describe(".has", propertyMatcherTests(sinonMatch.has));
     describe(".hasOwn", propertyMatcherTests(sinonMatch.hasOwn));
+
+    describe(".hasNested", propertyMatcherTests(sinonMatch.hasNested, function () {
+
+        it("compares nested value", function () {
+            var hasNested = sinonMatch.hasNested("foo.bar", "doo");
+
+            assert(hasNested.test({ foo: { bar: "doo" } }));
+        });
+
+        it("compares nested array value", function () {
+            var hasNested = sinonMatch.hasNested("foo[0].bar", "doo");
+
+            assert(hasNested.test({ foo: [{ bar: "doo" }] }));
+        });
+
+    }));
 
     describe(".hasSpecial", function () {
         it("returns true if object has inherited property", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
PR for #1556, adds `sinon.match.hasNested` so `sinon.match.has` chains can be avoided.

    sinon.match.has('outer', sinon.match.has('middle', sinon.match.has('inner', sinon.match.string)));
    sinon.match.hasNested('outer.middle.inner', sinon.match.string);

Nested array's are supported too.

    sinon.match.hasNested('outer[0].inner', sinon.match.string);

- Adds dependency `lodash.get@^4.4.2`.
- Adds tests for `hasNested`
- Adds documentation for `hasNested`

#### Solution  - optional
I was unable to use the existing `createPropertyMatcher` in the marcher code because it expects the property to not be nested when comparing the expectation.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
  - What?