### PR TITLE
Removes dependency to "build"

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "*.js": "eslint"
   },
   "dependencies": {
-    "build": "^0.1.4",
     "diff": "^3.1.0",
     "formatio": "1.2.0",
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
#### Purpose (TL;DR)
I noticed that `npm install` started complaining about some outdated sub-dependencies after switching to Sinon version 3.3.

#### Background (Problem in detail)
[`build`](https://www.npmjs.com/package/build) was added as a dependency in 85f30b5e2b73676acb0100e2d39727abf83b995c. I think that was a mistake (maybe a typo on the command line)?

#### How to verify
1. Check out this branch
2. `npm install`
3. Look for the following deprecation message (it should no longer appear):

> npm WARN deprecated wrench@1.3.9: wrench.js is deprecated! You should check out fs-extra (https://github.com/jprichardson/node-fs-extra) for any operations you were using wrench for. Thanks for all the usage over the years.

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
