### PR TITLE
Patch docs

### DIFF
--- a/docs/_releases/v3.1.0/migrating-to-3.0.md
+++ b/docs/_releases/v3.1.0/migrating-to-3.0.md
@@ -28,6 +28,10 @@ Calling `sinon.stub` with three arguments will throw an Error. This was deprecat
 The [changes in configuration](../fake-timers) for fake timers implicitly affect sandbox creation. If your config used to look like `{ useFaketimers: ["setTimeout", "setInterval"]}`, you
 will now need to change it to `{ useFaketimers: { toFake: ["setTimeout", "setInterval"] }}`.
 
+## `sandbox.stub(obj, 'nonExistingProperty')` - Throws
+Trying to stub a non-existing property will now fail to ensure you are creating
+[less error-prone tests](https://github.com/sinonjs/sinon/issues/1537#issuecomment-323948482).
+
 ## Removal of internal helpers
 The following internal functions were deprecated as of `sinon@1.x` and have been removed in `sinon@3`:
 

--- a/docs/_releases/v3.2.0/migrating-to-3.0.md
+++ b/docs/_releases/v3.2.0/migrating-to-3.0.md
@@ -28,6 +28,10 @@ Calling `sinon.stub` with three arguments will throw an Error. This was deprecat
 The [changes in configuration](../fake-timers) for fake timers implicitly affect sandbox creation. If your config used to look like `{ useFaketimers: ["setTimeout", "setInterval"]}`, you
 will now need to change it to `{ useFaketimers: { toFake: ["setTimeout", "setInterval"] }}`.
 
+## `sandbox.stub(obj, 'nonExistingProperty')` - Throws
+Trying to stub a non-existing property will now fail to ensure you are creating
+[less error-prone tests](https://github.com/sinonjs/sinon/issues/1537#issuecomment-323948482).
+
 ## Removal of internal helpers
 The following internal functions were deprecated as of `sinon@1.x` and have been removed in `sinon@3`:
 

--- a/docs/_releases/v3.2.1/migrating-to-3.0.md
+++ b/docs/_releases/v3.2.1/migrating-to-3.0.md
@@ -28,6 +28,10 @@ Calling `sinon.stub` with three arguments will throw an Error. This was deprecat
 The [changes in configuration](../fake-timers) for fake timers implicitly affect sandbox creation. If your config used to look like `{ useFaketimers: ["setTimeout", "setInterval"]}`, you
 will now need to change it to `{ useFaketimers: { toFake: ["setTimeout", "setInterval"] }}`.
 
+## `sandbox.stub(obj, 'nonExistingProperty')` - Throws
+Trying to stub a non-existing property will now fail to ensure you are creating
+[less error-prone tests](https://github.com/sinonjs/sinon/issues/1537#issuecomment-323948482).
+
 ## Removal of internal helpers
 The following internal functions were deprecated as of `sinon@1.x` and have been removed in `sinon@3`:
 

--- a/docs/_releases/v3.3.0/migrating-to-3.0.md
+++ b/docs/_releases/v3.3.0/migrating-to-3.0.md
@@ -28,6 +28,10 @@ Calling `sinon.stub` with three arguments will throw an Error. This was deprecat
 The [changes in configuration](../fake-timers) for fake timers implicitly affect sandbox creation. If your config used to look like `{ useFaketimers: ["setTimeout", "setInterval"]}`, you
 will now need to change it to `{ useFaketimers: { toFake: ["setTimeout", "setInterval"] }}`.
 
+## `sandbox.stub(obj, 'nonExistingProperty')` - Throws
+Trying to stub a non-existing property will now fail to ensure you are creating
+[less error-prone tests](https://github.com/sinonjs/sinon/issues/1537#issuecomment-323948482).
+
 ## Removal of internal helpers
 The following internal functions were deprecated as of `sinon@1.x` and have been removed in `sinon@3`:
 

--- a/docs/release-source/release.md
+++ b/docs/release-source/release.md
@@ -22,6 +22,7 @@ This page contains the entire Sinon.JS API documentation along with brief    int
 ### Migration guides
 * Migrating from [v1.x to v2.0](./migrating-to-2.0)
 * Migrating from [v2.x to v3.0](./migrating-to-3.0)
+* Migrating from [v3.x to v4.0](./migrating-to-4.0)
 
 ### Compatibility
 

--- a/docs/release-source/release/migrating-to-3.0.md
+++ b/docs/release-source/release/migrating-to-3.0.md
@@ -28,6 +28,10 @@ Calling `sinon.stub` with three arguments will throw an Error. This was deprecat
 The [changes in configuration](../fake-timers) for fake timers implicitly affect sandbox creation. If your config used to look like `{ useFaketimers: ["setTimeout", "setInterval"]}`, you
 will now need to change it to `{ useFaketimers: { toFake: ["setTimeout", "setInterval"] }}`.
 
+## `sandbox.stub(obj, 'nonExistingProperty')` - Throws
+Trying to stub a non-existing property will now fail to ensure you are creating
+[less error-prone tests](https://github.com/sinonjs/sinon/issues/1537#issuecomment-323948482).
+
 ## Removal of internal helpers
 The following internal functions were deprecated as of `sinon@1.x` and have been removed in `sinon@3`:
 

--- a/docs/release-source/release/migrating-to-4.0.md
+++ b/docs/release-source/release/migrating-to-4.0.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Migrating to v4.0 - Sinon.JS
+breadcrumb: migrating to 4.0
+---
+
+As with all `MAJOR` releases in [`semver`](http://semver.org/), there are breaking changes in `sinon@4`.
+This guide will walk you through those changes.
+
+## `sinon.stub(obj, 'nonExistingProperty')` - Throws
+
+Trying to stub a non-existing property will now fail to ensure you are creating
+[less error-prone tests](https://github.com/sinonjs/sinon/pull/1557).
+


### PR DESCRIPTION
This patches the docs for the 3.x releases to include info on the breaking change in sandboxes (see #1537), and also adds a migration guide for 4.0