### PR TITLE
Remove extra backtick from fake-xhr-and-server docs

### DIFF
--- a/docs/_releases/v1.17.6/fake-xhr-and-server.md
+++ b/docs/_releases/v1.17.6/fake-xhr-and-server.md
@@ -302,7 +302,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v1.17.7/fake-xhr-and-server.md
+++ b/docs/_releases/v1.17.7/fake-xhr-and-server.md
@@ -302,7 +302,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.0.0/fake-xhr-and-server.md
+++ b/docs/_releases/v2.0.0/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.2.0/fake-xhr-and-server.md
+++ b/docs/_releases/v2.2.0/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.3.0/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.0/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.3.1/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.1/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.3.2/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.2/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.3.3/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.3/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.3.4/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.4/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.3.5/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.5/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.3.6/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.6/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.3.7/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.7/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.3.8/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.8/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.4.0/fake-xhr-and-server.md
+++ b/docs/_releases/v2.4.0/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v2.4.1/fake-xhr-and-server.md
+++ b/docs/_releases/v2.4.1/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v3.0.0/fake-xhr-and-server.md
+++ b/docs/_releases/v3.0.0/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v3.1.0/fake-xhr-and-server.md
+++ b/docs/_releases/v3.1.0/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v3.2.0/fake-xhr-and-server.md
+++ b/docs/_releases/v3.2.0/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v3.2.1/fake-xhr-and-server.md
+++ b/docs/_releases/v3.2.1/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v3.3.0/fake-xhr-and-server.md
+++ b/docs/_releases/v3.3.0/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/_releases/v4.0.0/fake-xhr-and-server.md
+++ b/docs/_releases/v4.0.0/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.

--- a/docs/release-source/release/fake-xhr-and-server.md
+++ b/docs/release-source/release/fake-xhr-and-server.md
@@ -305,7 +305,7 @@ If called with arguments, `respondWith` will be called with those arguments befo
 
 
 #### `server.autoRespond = true;`
-`
+
 If set, will automatically respond to every request after a timeout.
 
 The default timeout is 10ms but you can control it through the `autoRespondAfter` property.


### PR DESCRIPTION
Fix extra backtick in doc page:

before:

<img width="750" alt="screen shot 2017-10-02 at 3 57 54 pm" src="https://user-images.githubusercontent.com/5827130/31096644-a7665144-a78a-11e7-999b-d73ed26c6ae6.png">

after:

<img width="908" alt="screen shot 2017-10-02 at 3 57 44 pm" src="https://user-images.githubusercontent.com/5827130/31096647-ad01e154-a78a-11e7-8ce7-e2f5dec0efdc.png">

#### How to verify
1. Check out this branch
2. `npm install`
3. `cd docs && bundle exec jekyll serve`
4. `http://localhost:4000/releases/v4.0.0/fake-xhr-and-server/`