### PR TITLE
Fix doc typo: scenarious -> scenarios

### DIFF
--- a/docs/how-to/index.html
+++ b/docs/how-to/index.html
@@ -7,7 +7,7 @@ permalink: /how-to/
   <h1>How To articles</h1>
 </div>
 <p>
-    This is a collection of how to articles for common scenarious using Sinon.JS.
+    This is a collection of how to articles for common scenarios using Sinon.JS.
 </p>
 
 <ul>


### PR DESCRIPTION
Just a typo fix!

#### How to verify - mandatory
1. Check out this branch
2. cd docs && bundle exec jekyll serve
3. http://localhost:4000/how-to/

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
