### PR TITLE
Fix broken test-coverage task

### DIFF
--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var proxyquire = require("proxyquire");
 var assert = require("referee").assert;
 var hasPromise = typeof Promise === "function";
 
@@ -8,13 +7,14 @@ if (!hasPromise) {
     return;
 }
 
+var proxyquire = require("proxyquire");
+
 describe("sinon module", function () {
     var sinon,
         fakeSandbox,
         fakeNise;
 
     beforeEach(function () {
-
         fakeNise = {
             fakeServer: {
                 create: function () {


### PR DESCRIPTION
PhantomJS doesn't support promises, so proxyquire will break when running `npm run test-coverage`.

This was broken in a712acbf0f7aaaa3bf193231140ff51087347ddc, which I found out using the `git bisect run` script below

```shell
#!/bin/bash
# Template for using with `git bisect run`. Place it outside (over) the folder the git repo resides in.
# For an example of a fully expanded file, see sinon-1526.sh
# Example run 
# ../my-test-script.sh # Test FAIL
# git bisect bad master 
# git checkout v2.0.0
# ../my-test-script.sh # Test OK
# git bisect good 
# git bisect run ../my-test-script.sh


artefact="some-resulting-file.js"

# You do not need to customize this function: just customize the clean, build and do_test sections
main(){
    clean

    build

    # Ignore the results of this test if the build step failed
    if (( $? != 0 ));then
        echo "Build step erred! Skipping current commit to avoid false negatives ..."

        # Returning 125 in a script is equivalent to doing a `git bisect skip` on the CLI
        # See `git help bisect` for more info
        exit 125
    fi

    do_test

    STATUS=$?

    if (( $STATUS == 0 )); then
        echo "Test OK"
    else
        echo "Test FAIL"
    fi

    exit $STATUS
}

build(){
    # run compile step, Makefile, grunt, gulp, whatever, that results in a file
    echo "we are producing files" > $artefact
    npm install
    
    # check for existence of the produced file - totally optional
    (( $? == 0 )) && [[ -e $artefact ]]
}

clean(){
    rm $artefact 
    git reset --hard

    # Maybe also add `git clean -fd`? Remember that this file then needs to be outside the repo ...
    
    rm -r node_modules
}


# the actual test: this can be whatever you like, as long as it exits with a non-zero exit code on error
#Examples: see the sample `max-size` for a test that simply checks if a file exceeds some size threshold
do_test(){
    #node my-test-that-exits-with-non-zero-when-failing.js
    npm run test-coverage
}

main
```