### PR TITLE
Remove unneeded characters

### DIFF
--- a/docs/_releases/v1.17.6/spies.md
+++ b/docs/_releases/v1.17.6/spies.md
@@ -494,4 +494,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v1.17.7/spies.md
+++ b/docs/_releases/v1.17.7/spies.md
@@ -494,4 +494,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.0.0/spies.md
+++ b/docs/_releases/v2.0.0/spies.md
@@ -492,4 +492,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.2.0/spies.md
+++ b/docs/_releases/v2.2.0/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.3.0/spies.md
+++ b/docs/_releases/v2.3.0/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.3.1/spies.md
+++ b/docs/_releases/v2.3.1/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.3.2/spies.md
+++ b/docs/_releases/v2.3.2/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.3.3/spies.md
+++ b/docs/_releases/v2.3.3/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.3.5/spies.md
+++ b/docs/_releases/v2.3.5/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.3.6/spies.md
+++ b/docs/_releases/v2.3.6/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.3.7/spies.md
+++ b/docs/_releases/v2.3.7/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.3.8/spies.md
+++ b/docs/_releases/v2.3.8/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.4.0/spies.md
+++ b/docs/_releases/v2.4.0/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v2.4.1/spies.md
+++ b/docs/_releases/v2.4.1/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v3.0.0/spies.md
+++ b/docs/_releases/v3.0.0/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v3.1.0/spies.md
+++ b/docs/_releases/v3.1.0/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v3.2.0/spies.md
+++ b/docs/_releases/v3.2.0/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v3.2.1/spies.md
+++ b/docs/_releases/v3.2.1/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v3.3.0/spies.md
+++ b/docs/_releases/v3.3.0/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v4.0.0/spies.md
+++ b/docs/_releases/v4.0.0/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/_releases/v4.0.1/spies.md
+++ b/docs/_releases/v4.0.1/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -504,4 +504,4 @@ Exception thrown, if any.
 
 #### `spyCall.returnValue`
 
-Return value.]}]}
+Return value.


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Clean up Spies documentation to remove unnecessary characters (`]}]}`) within the `spyCall.returnValue` description.

#### Background (Problem in detail)  - optional
Extra characters are included within the `spyCall.returnValue` description text.

#### Solution  - optional
Removed the extra characters.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Follow the [Running the documentation site locally](https://github.com/DevLab2425/sinon/blob/master/docs/CONTRIBUTING.md#running-the-documentation-site-locally) steps within the CONTRIBUTING.md file
4. Navigate to the Spies documentation
5. Scroll to the `spyCall.returnValue` description (last one on the page)
6. Confirm the description simply says "Return value" and NOT "Return value.]}]}"

#### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
