### PR TITLE
Slim down npm package

### DIFF
--- a/build.js
+++ b/build.js
@@ -30,7 +30,6 @@ function makeBundle(name, config) {
 
             var script = preamble + buffer.toString();
             fs.writeFile("pkg/" + name + ".js", script);
-            fs.writeFile("pkg/" + name + "-" + pkg.version + ".js", script);
         });
 }
 

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -14,7 +14,7 @@ echo 'build new package'
 node ./build.js
 
 echo 'copy new version'
-cp "./pkg/sinon-$PACKAGE_VERSION.js" ./docs/releases
+cp "./pkg/sinon.js" "./docs/releases/sinon-$PACKAGE_VERSION.js"
 
 git add "docs/releases/sinon-$PACKAGE_VERSION.js"
 git add docs/changelog.md


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Slim down NPM package in size

#### Background (Problem in detail)  - optional

Sinon is downloaded from NPM around 3.8 millions times per month.

This change will save around `3.1 MB` of uncompressed files and `0.9 MB` of NPM package tarball (`3.42 TB` of NPM traffic per month).

#### Solution  - optional

The build step should only create one set of packaged files.

The NPM CDN URL is still functional, since it supports package versioning: https://cdn.jsdelivr.net/npm/sinon@4.0.1/pkg/sinon.js

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run build`
5. `npm pack`
4. `npm run postversion`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
