### PR TITLE
Document the stub.reset breaking change

### DIFF
--- a/docs/guides/migrating-to-2.0.md
+++ b/docs/guides/migrating-to-2.0.md
@@ -39,7 +39,7 @@ sinon.stub(obj, 'meth').callsFake(fn);
 ```
 
 ## stub.resetHistory replaces stub.reset
-`sinon.reset()` now resets the history and the behaviour of the stub. Previously `stub.reset()` only reset the history of the stub. Stubs now have separate methods for resetting the history and the behaviour. To mimic the old behaviour replace all `stub.reset()` calls with `stub.resetHistory()`.
+`stub.reset()` now resets the history and the behaviour of the stub. Previously `stub.reset()` only reset the history of the stub. Stubs now have separate methods for resetting the history and the behaviour. To mimic the old behaviour replace all `stub.reset()` calls with `stub.resetHistory()`.
 
 ```js
 // Old

--- a/docs/guides/migrating-to-2.0.md
+++ b/docs/guides/migrating-to-2.0.md
@@ -43,9 +43,9 @@ sinon.stub(obj, 'meth').callsFake(fn);
 
 ```js
 // Old
-sinon.reset();
+stub.reset();
 // New
-sinon.resetHistory();
+stub.resetHistory();
 ```
 
 ## Deprecation of internal helpers

--- a/docs/guides/migrating-to-2.0.md
+++ b/docs/guides/migrating-to-2.0.md
@@ -38,6 +38,16 @@ sinon.stub(obj, 'meth', fn);
 sinon.stub(obj, 'meth').callsFake(fn);
 ```
 
+## stub.resetHistory replaces stub.reset
+`sinon.reset()` now resets the history and the behaviour of the stub. Previously `stub.reset()` only reset the history of the stub. Stubs now have separate methods for resetting the history and the behaviour. To mimic the old behaviour replace all `stub.reset()` calls with `stub.resetHistory()`.
+
+```js
+// Old
+sinon.reset();
+// New
+sinon.resetHistory();
+```
+
 ## Deprecation of internal helpers
 The following utility functions are being marked as deprecated and are planned for removal in Sinon v3.0; please check your codebase for usage to ease future migrations:
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Document the breaking change of `stub.reset` between version 1 and version 2 of Sinon.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
