### PR TITLE
Add documentation for spyCall.returned

### DIFF
--- a/docs/_releases/v1.17.6/spies.md
+++ b/docs/_releases/v1.17.6/spies.md
@@ -370,7 +370,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v1.17.6/spies.md
+++ b/docs/_releases/v1.17.6/spies.md
@@ -461,6 +461,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v1.17.7/spies.md
+++ b/docs/_releases/v1.17.7/spies.md
@@ -370,7 +370,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v1.17.7/spies.md
+++ b/docs/_releases/v1.17.7/spies.md
@@ -461,6 +461,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.0.0/spies.md
+++ b/docs/_releases/v2.0.0/spies.md
@@ -459,6 +459,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.0.0/spies.md
+++ b/docs/_releases/v2.0.0/spies.md
@@ -368,7 +368,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.1.0/spies.md
+++ b/docs/_releases/v2.1.0/spies.md
@@ -459,6 +459,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.2.0/spies.md
+++ b/docs/_releases/v2.2.0/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.2.0/spies.md
+++ b/docs/_releases/v2.2.0/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.3.0/spies.md
+++ b/docs/_releases/v2.3.0/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.3.0/spies.md
+++ b/docs/_releases/v2.3.0/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.3.1/spies.md
+++ b/docs/_releases/v2.3.1/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.3.1/spies.md
+++ b/docs/_releases/v2.3.1/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.3.2/spies.md
+++ b/docs/_releases/v2.3.2/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.3.2/spies.md
+++ b/docs/_releases/v2.3.2/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.3.3/spies.md
+++ b/docs/_releases/v2.3.3/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.3.3/spies.md
+++ b/docs/_releases/v2.3.3/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.3.4/spies.md
+++ b/docs/_releases/v2.3.4/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.3.4/spies.md
+++ b/docs/_releases/v2.3.4/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.3.5/spies.md
+++ b/docs/_releases/v2.3.5/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.3.5/spies.md
+++ b/docs/_releases/v2.3.5/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.3.6/spies.md
+++ b/docs/_releases/v2.3.6/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.3.6/spies.md
+++ b/docs/_releases/v2.3.6/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.3.7/spies.md
+++ b/docs/_releases/v2.3.7/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.3.7/spies.md
+++ b/docs/_releases/v2.3.7/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.3.8/spies.md
+++ b/docs/_releases/v2.3.8/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.3.8/spies.md
+++ b/docs/_releases/v2.3.8/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.4.0/spies.md
+++ b/docs/_releases/v2.4.0/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.4.0/spies.md
+++ b/docs/_releases/v2.4.0/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v2.4.1/spies.md
+++ b/docs/_releases/v2.4.1/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v2.4.1/spies.md
+++ b/docs/_releases/v2.4.1/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v3.0.0/spies.md
+++ b/docs/_releases/v3.0.0/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v3.0.0/spies.md
+++ b/docs/_releases/v3.0.0/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v3.1.0/spies.md
+++ b/docs/_releases/v3.1.0/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v3.1.0/spies.md
+++ b/docs/_releases/v3.1.0/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v3.2.0/spies.md
+++ b/docs/_releases/v3.2.0/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v3.2.0/spies.md
+++ b/docs/_releases/v3.2.0/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v3.2.1/spies.md
+++ b/docs/_releases/v3.2.1/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v3.2.1/spies.md
+++ b/docs/_releases/v3.2.1/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v3.3.0/spies.md
+++ b/docs/_releases/v3.3.0/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v3.3.0/spies.md
+++ b/docs/_releases/v3.3.0/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v4.0.0/spies.md
+++ b/docs/_releases/v4.0.0/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v4.0.0/spies.md
+++ b/docs/_releases/v4.0.0/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v4.0.1/spies.md
+++ b/docs/_releases/v4.0.1/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v4.0.1/spies.md
+++ b/docs/_releases/v4.0.1/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/_releases/v4.0.2/spies.md
+++ b/docs/_releases/v4.0.2/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/_releases/v4.0.2/spies.md
+++ b/docs/_releases/v4.0.2/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/api/v1.17.3/spies/index.md
+++ b/docs/api/v1.17.3/spies/index.md
@@ -390,7 +390,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`

--- a/docs/api/v1.17.3/spies/index.md
+++ b/docs/api/v1.17.3/spies/index.md
@@ -481,6 +481,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -471,6 +471,11 @@ Returns `true` if call did not receive provided arguments.
 Returns `true` if call did not receive matching arguments.
 This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(arg2), ...)`.
 
+#### `spyCall.returned(value);`
+
+Returns `true` if spied function returned the provided `value` on this call.
+
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -380,7 +380,7 @@ Array of arguments received, `spy.args[0]` is an array of arguments received in 
 
 Array of exception objects thrown, `spy.exceptions[0]` is the exception thrown by the first call.
 
-If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined.
+If the call did not throw an error, the value at the call's location in `.exceptions` will be `undefined`.
 
 
 #### `spy.returnValues`


### PR DESCRIPTION
This PR adds missing documentation for `spyCall.returned`.

Bonus commit: fix a markdown syntax violation