### PR TITLE
Issue 1598 (Feature Request): sandbox.createStubInstance

### DIFF
--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -131,6 +131,9 @@ A convenience reference for [`sinon.assert`](./assertions)
 
 Works exactly like `sinon.spy`, only also adds the returned spy to the internal collection of fakes for easy restoring through `sandbox.restore()`
 
+#### `sandbox.createStubInstance();`
+
+Works almost exactly like `sinon.createStubInstance`, only also adds the returned stubs to the internal collection of fakes for easy restoring through `sandbox.restore()`.
 
 #### `sandbox.stub();`
 

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -86,6 +86,13 @@ var collection = {
         return this.add(sinonSpy.apply(sinonSpy, arguments));
     },
 
+    createStubInstance: function createStubInstance(constructor) {
+        if (typeof constructor !== "function") {
+            throw new TypeError("The constructor should be a function.");
+        }
+        return this.stub.call(this, Object.create(constructor.prototype));
+    },
+
     stub: function stub(object, property) {
         if (object && typeof property !== "undefined"
             && !(property in object)) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test-webworker": "browserify --no-commondir --full-paths -p [ mocaccino -R spec --color ] test/webworker/webworker-support-assessment.js | phantomic --web-security false",
     "test": "run-s test-node test-headless test-webworker",
     "check-dependencies": "dependency-check package.json --unused --no-dev",
-    "build": "./build.js",
+    "build": "node ./build.js",
     "lint": "eslint .",
     "precommit": "lint-staged",
     "pretest-webworker": "npm run build",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix issue #1598 by implementing sandbox.createStubInstance(), tests, and documentation.

#### Background (Problem in detail)  - optional
The addition of sandbox.createStubInstance() increases orthogonality with the Sinon stub interface.

#### Solution  - optional
Implemented sandbox.createStubInstance() as a convenience wrapper around sandbox.stub(), for the case of stubbing an entire object.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author
- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
- [ ] Verify that documentation is sufficient for new functionality
- [ ] Verify that unit test coverage is sufficient for new functionality.
