### PR TITLE
Fix more markdown

### DIFF
--- a/docs/_releases/v1.17.6/spies.md
+++ b/docs/_releases/v1.17.6/spies.md
@@ -414,7 +414,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v1.17.7/spies.md
+++ b/docs/_releases/v1.17.7/spies.md
@@ -414,7 +414,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.0.0/spies.md
+++ b/docs/_releases/v2.0.0/spies.md
@@ -412,7 +412,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.1.0/spies.md
+++ b/docs/_releases/v2.1.0/spies.md
@@ -412,7 +412,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n);`

--- a/docs/_releases/v2.2.0/spies.md
+++ b/docs/_releases/v2.2.0/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.3.0/spies.md
+++ b/docs/_releases/v2.3.0/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.3.1/spies.md
+++ b/docs/_releases/v2.3.1/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.3.2/spies.md
+++ b/docs/_releases/v2.3.2/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.3.3/spies.md
+++ b/docs/_releases/v2.3.3/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.3.5/spies.md
+++ b/docs/_releases/v2.3.5/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.3.6/spies.md
+++ b/docs/_releases/v2.3.6/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.3.7/spies.md
+++ b/docs/_releases/v2.3.7/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.3.8/spies.md
+++ b/docs/_releases/v2.3.8/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.4.0/spies.md
+++ b/docs/_releases/v2.4.0/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v2.4.1/spies.md
+++ b/docs/_releases/v2.4.1/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v3.0.0/spies.md
+++ b/docs/_releases/v3.0.0/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v3.1.0/spies.md
+++ b/docs/_releases/v3.1.0/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v3.2.0/spies.md
+++ b/docs/_releases/v3.2.0/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v3.2.1/spies.md
+++ b/docs/_releases/v3.2.1/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v3.3.0/spies.md
+++ b/docs/_releases/v3.3.0/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v4.0.0/spies.md
+++ b/docs/_releases/v4.0.0/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v4.0.1/spies.md
+++ b/docs/_releases/v4.0.1/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/_releases/v4.0.2/spies.md
+++ b/docs/_releases/v4.0.2/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/api/v1.17.3/spies/index.md
+++ b/docs/api/v1.17.3/spies/index.md
@@ -434,7 +434,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -424,7 +424,7 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 
-### Individual spy calls"
+### Individual spy calls
 
 
 ##### `var spyCall = spy.getCall(n)`

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "lint-staged": {
     "*.js": "eslint",
-    "docs/!(changelog)*.md": "markdownlint"
+    "docs/**/*.md": "markdownlint"
   },
   "dependencies": {
     "diff": "^3.1.0",

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -19,4 +19,4 @@ cp "./pkg/sinon.js" "./docs/releases/sinon-$PACKAGE_VERSION.js"
 git add "docs/releases/sinon-$PACKAGE_VERSION.js"
 git add docs/changelog.md
 git add docs/_config.yml
-git commit -m "Update docs/changelog.md and set new release id in docs/_config.yml"
+git commit -n -m "Update docs/changelog.md and set new release id in docs/_config.yml"


### PR DESCRIPTION
Immediately after merging #1600 I discovered a trailing quote in one of the headings. During fixing that, I also discovered that the pre commit hook didn't run any validations for the changed markdown files.

This PR fixes both those issues.

#### To verify

1. Check out this branch
1. Add a Markdown violation to one of the files in `docs/`. `<a href="asdf">asdf</a>` works well for me.
1. `git add docs/`
1. `git commit`
1. Observe that `markdownlint` aborts the commit and spits out an error message