### PR TITLE
Remove "engines" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,5 @@
   ],
   "main": "./lib/sinon.js",
   "cdn": "./pkg/sinon.js",
-  "jsdelivr": "./pkg/sinon.js",
-  "engines": {
-    "node": ">=0.1.103"
-  }
+  "jsdelivr": "./pkg/sinon.js"
 }


### PR DESCRIPTION
As discussed in #1607, this is outdated and should be removed