### PR TITLE
Prefer node 8 for single run tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,11 @@ before_install:
 before_script:
   # these build targets only need to run once per build, so let's conserve a few resources
   # ESLint only supports Node >=4
-  - if [ "x$TRAVIS_NODE_VERSION" = "x6" ]; then npm run lint; fi
-  # run these on node 6 to have npm 3 with flat dependencies
-  - if [ "x$TRAVIS_NODE_VERSION" = "x6" ]; then npm run lint-markdown; fi
-  - if [ "x$TRAVIS_NODE_VERSION" = "x6" ]; then npm run test-headless; fi
-  - if [ "x$TRAVIS_NODE_VERSION" = "x6" ]; then npm run test-webworker; fi
-  - if [ "x$TRAVIS_NODE_VERSION" = "x6" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test-cloud; fi
+  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run lint; fi
+  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run lint-markdown; fi
+  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run test-headless; fi
+  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run test-webworker; fi
+  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test-cloud; fi
 
 script:
   - npm run test-node

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test-cloud": "npm run test-headless -- --wd",
     "test-webworker": "browserify --no-commondir --full-paths -p [ mocaccino -R spec --color ] test/webworker/webworker-support-assessment.js | phantomic --web-security false",
     "test": "run-s test-node test-headless test-webworker",
-    "check-dependencies": "dependency-check package.json --unused --no-dev",
+    "check-dependencies": "dependency-check package.json --unused --no-dev --ignore-module coveralls",
     "build": "node ./build.js",
     "lint": "eslint .",
     "lint-markdown": "find docs -type f -name '*.md' ! -name 'changelog.md' | xargs markdownlint",


### PR DESCRIPTION
`node@8` will be faster than `node@6` at running all these tests, and will offer better compatibility as our dependencies update and stop supporting older LTS versions