### PR TITLE
Remove deprecated methods from documentation

### DIFF
--- a/docs/release-source/release/utils.md
+++ b/docs/release-source/release/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.
@@ -43,20 +23,3 @@ Creates a new object with the given function as the protoype and stubs all imple
 ```
 
 The given constructor function is not invoked. See also the [stub API](../stubs).
-
-#### `sinon.format(object);`
-
-Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
-override this method with your own implementation if you prefer different
-visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```


### PR DESCRIPTION
#### Purpose
Remove from docs `sinon.restore()`, `sinon.format()` and `sinon.log()`
These methods were long time deprecated and removed from code, but were still available in the utilities docs

related issue #1610 
