### PR TITLE
Update Lolex to include fix for #872

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3432,9 +3432,9 @@
       }
     },
     "lolex": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.3.tgz",
-      "integrity": "sha512-BdHq78SeI+6PAUtl4atDuCt7L6E4fab3mSRtqxm4ywaXe4uP7jZ0TTcFNuU20syUjxZc2l7jFqKVMJ+AX0LnpQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.2.0.tgz",
+      "integrity": "sha512-zYUlrvbts2Gc553FGu/Ovmjf8acQD/9/bWCbw/D8jdg+W0GbHY08mZpwcp7mPMpjSvTX0O035W8GLG4maGAU4Q=="
     },
     "longest": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "diff": "^3.1.0",
     "formatio": "1.2.0",
     "lodash.get": "^4.4.2",
-    "lolex": "^2.1.3",
+    "lolex": "^2.2.0",
     "nise": "^1.2.0",
     "supports-color": "^4.4.0",
     "type-detect": "^4.0.0"


### PR DESCRIPTION
Update Lolex to include fix for #872
Got `Error: Cannot clear timer: timer created with setTimeout() but cleared with clearInterval()`

Run this test using `mocha test.js` before and after applying this commit
<details>
<summary>test.js</summary>

```javascript
'use strict';

const sinon = require('./');

describe('Test', function() {
  let clock;
  beforeEach(() => {
    clock = sinon.useFakeTimers(24 * 60 * 60 * 1000);
  });
  afterEach(() => clock.restore());
  it('should work', function() {
    const id = setInterval(() => null);
    clearInterval(id);
  });
});
```
</details>


- [x] `npm run lint` passes