### PR TITLE
Update documentatation for older releases

### DIFF
--- a/docs/_releases/v2.0.0/utils.md
+++ b/docs/_releases/v2.0.0/utils.md
@@ -39,14 +39,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.1.0/utils.md
+++ b/docs/_releases/v2.1.0/utils.md
@@ -39,14 +39,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.2.0/utils.md
+++ b/docs/_releases/v2.2.0/utils.md
@@ -39,14 +39,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.3.0/utils.md
+++ b/docs/_releases/v2.3.0/utils.md
@@ -39,14 +39,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.3.1/utils.md
+++ b/docs/_releases/v2.3.1/utils.md
@@ -39,14 +39,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.3.2/utils.md
+++ b/docs/_releases/v2.3.2/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.3.3/utils.md
+++ b/docs/_releases/v2.3.3/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.3.4/utils.md
+++ b/docs/_releases/v2.3.4/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.3.5/utils.md
+++ b/docs/_releases/v2.3.5/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.3.6/utils.md
+++ b/docs/_releases/v2.3.6/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.3.7/utils.md
+++ b/docs/_releases/v2.3.7/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.3.8/utils.md
+++ b/docs/_releases/v2.3.8/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.4.0/utils.md
+++ b/docs/_releases/v2.4.0/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v2.4.1/utils.md
+++ b/docs/_releases/v2.4.1/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v3.0.0/utils.md
+++ b/docs/_releases/v3.0.0/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v3.0.0/utils.md
+++ b/docs/_releases/v3.0.0/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v3.1.0/utils.md
+++ b/docs/_releases/v3.1.0/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v3.1.0/utils.md
+++ b/docs/_releases/v3.1.0/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v3.2.0/utils.md
+++ b/docs/_releases/v3.2.0/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v3.2.0/utils.md
+++ b/docs/_releases/v3.2.0/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v3.2.1/utils.md
+++ b/docs/_releases/v3.2.1/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v3.2.1/utils.md
+++ b/docs/_releases/v3.2.1/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v3.3.0/utils.md
+++ b/docs/_releases/v3.3.0/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v3.3.0/utils.md
+++ b/docs/_releases/v3.3.0/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v4.0.0/utils.md
+++ b/docs/_releases/v4.0.0/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v4.0.0/utils.md
+++ b/docs/_releases/v4.0.0/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v4.0.1/utils.md
+++ b/docs/_releases/v4.0.1/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v4.0.1/utils.md
+++ b/docs/_releases/v4.0.1/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v4.0.2/utils.md
+++ b/docs/_releases/v4.0.2/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v4.0.2/utils.md
+++ b/docs/_releases/v4.0.2/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v4.1.0/utils.md
+++ b/docs/_releases/v4.1.0/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v4.1.0/utils.md
+++ b/docs/_releases/v4.1.0/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```

--- a/docs/_releases/v4.1.1/utils.md
+++ b/docs/_releases/v4.1.1/utils.md
@@ -8,26 +8,6 @@ Sinon.JS has a few utilities used internally in `lib/sinon.js`. Unless the metho
 
 ## Utils API
 
-#### `sinon.restore(object);`
-
-Restores all fake methods of supplied object
-
-```javascript
-    sinon.stub(obj);
-
-    // run tests...
-
-    sinon.restore(obj);
-```
-
-#### `sinon.restore(method);`
-
-Restores supplied method
-
-```javascript
-    sinon.restore(obj.someMethod);
-```
-
 #### `sinon.createStubInstance(constructor);`
 
 Creates a new object with the given function as the protoype and stubs all implemented functions.

--- a/docs/_releases/v4.1.1/utils.md
+++ b/docs/_releases/v4.1.1/utils.md
@@ -49,14 +49,3 @@ The given constructor function is not invoked. See also the [stub API](../stubs)
 Formats an object for pretty printing in error messages using [formatio](https://github.com/busterjs/formatio). Feel free to
 override this method with your own implementation if you prefer different
 visualization of e.g. objects. The method should return a string.
-
-#### `sinon.log(string);`
-
-Logs internal errors, helpful for debugging. By default this property is a noop function, set it to something that prints warnings in your
-environment for more help, e.g. (if you are using JsTestDriver):
-
-```javascript
-sinon.log = function (message) {
-    jstestdriver.console.log(message);
-};
-```


### PR DESCRIPTION
This PR is a followup to #1610, #1613, where we removed deprecated methods from documentation ... but only for `docs/release-source`.

This PR removes the documentation from the documentation from all the releases.

As alway, read commits separately to keep a firm grasp on sanity.