### PR TITLE
`stub.callsArgAsync(index);` is already listed in line #466

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -463,8 +463,6 @@ Like `callArg`, but with arguments.
 
 Same as their corresponding non-Async counterparts, but with callback being deferred (executed not immediately but after short timeout and in another "thread")
 
-#### `stub.callsArgAsync(index);`
-
 #### `stub.callsArgOnAsync(index, context);`
 
 #### `stub.callsArgWithAsync(index, arg1, arg2, ...);`


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
> Remove a duplicated line from the documentation

#### Background (Problem in detail)  - optional
> If you visit the [http://sinonjs.org/releases/v4.1.2/stubs/](stubs documentation) you can see that `stub.callsArgAsync(index);` is duplicated.

#### How to verify - mandatory
1. Open docs/release-source/release/stubs.md and verify that `stub.callsArgAsync(index);` appears only once.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
