### PR TITLE
Move yieldsAsync* documentation to the first yieldsAsync*

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -473,13 +473,13 @@ Same as their corresponding non-Async counterparts, but with callback being defe
 
 #### `stub.yieldsAsync([arg1, arg2, ...]);`
 
+Same as their corresponding non-Async counterparts, but with callback being deferred (executed not immediately but after short timeout and in another "thread")
+
 #### `stub.yieldsOnAsync(context, [arg1, arg2, ...]);`
 
 #### `stub.yieldsToAsync(property, [arg1, arg2, ...]);`
 
 #### `stub.yieldsToOnAsync(property, context, [arg1, arg2, ...])`
-
-Same as their corresponding non-Async counterparts, but with callback being deferred (executed not immediately but after short timeout and in another "thread")
 
 #### `sinon.addBehavior(name, fn);`
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

> Move the description for `yieldsAsync*` methods to the first `yieldsAsync*` because it makes more sense to be there.

#### Background (Problem in detail)  - optional

> If you visit  http://sinonjs.org/releases/v4.1.2/stubs/, at first glance it looks like the `yieldsAsync*` methods lack on documentation.
> The generic explanation for all the `yieldsAsync*` is under `yieldsToOnAsync` which is the last method on the list
> Makes more sense to have the generic documentation under the first `yieldsAsync*` of the list.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
