### PR TITLE
[feature] Spy passes through calling with `new`

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -196,7 +196,7 @@ var spyApi = {
                 // Call through with `new`
                 // eslint-disable-next-line new-parens
                 returnValue = new (Function.prototype.bind.apply(this.func || func, [thisValue].concat(args)));
-                
+
                 if (typeof returnValue !== "object") {
                     returnValue = thisValue;
                 }

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -193,10 +193,11 @@ var spyApi = {
             var thisCall = this.getCall(this.callCount - 1);
 
             if (thisCall.calledWithNew()) {
-              // Call through with `new`
-              returnValue = new (Function.prototype.bind.apply(this.func || func, [thisValue].concat(args)));
+                // Call through with `new`
+                // eslint-disable-next-line new-parens
+                returnValue = new (Function.prototype.bind.apply(this.func || func, [thisValue].concat(args)));
             } else {
-              returnValue = (this.func || func).apply(thisValue, args);
+                returnValue = (this.func || func).apply(thisValue, args);
             }
 
             if (thisCall.calledWithNew() && typeof returnValue !== "object") {

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -196,12 +196,12 @@ var spyApi = {
                 // Call through with `new`
                 // eslint-disable-next-line new-parens
                 returnValue = new (Function.prototype.bind.apply(this.func || func, [thisValue].concat(args)));
+                
+                if (typeof returnValue !== "object") {
+                    returnValue = thisValue;
+                }
             } else {
                 returnValue = (this.func || func).apply(thisValue, args);
-            }
-
-            if (thisCall.calledWithNew() && typeof returnValue !== "object") {
-                returnValue = thisValue;
             }
         } catch (e) {
             exception = e;

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -17,6 +17,7 @@ var push = Array.prototype.push;
 var slice = Array.prototype.slice;
 var filter = Array.prototype.filter;
 var ErrorConstructor = Error.prototype.constructor;
+var bind = Function.prototype.bind;
 
 var callId = 0;
 
@@ -195,7 +196,7 @@ var spyApi = {
             if (thisCall.calledWithNew()) {
                 // Call through with `new`
                 // eslint-disable-next-line new-parens
-                returnValue = new (Function.prototype.bind.apply(this.func || func, [thisValue].concat(args)));
+                returnValue = new (bind.apply(this.func || func, [thisValue].concat(args)))();
 
                 if (typeof returnValue !== "object") {
                     returnValue = thisValue;

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -190,9 +190,15 @@ var spyApi = {
         try {
             this.invoking = true;
 
-            returnValue = (this.func || func).apply(thisValue, args);
-
             var thisCall = this.getCall(this.callCount - 1);
+
+            if (thisCall.calledWithNew()) {
+              // Call through with `new`
+              returnValue = new (Function.prototype.bind.apply(this.func || func, [thisValue].concat(args)));
+            } else {
+              returnValue = (this.func || func).apply(thisValue, args);
+            }
+
             if (thisCall.calledWithNew() && typeof returnValue !== "object") {
                 returnValue = thisValue;
             }

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -438,14 +438,13 @@ describe("spy", function () {
 
             assert(called);
         });
-        
-        it("passes 'new' to underlying function", function () {
-            var called = false;
-            var TestClass = function(){};
 
-            var spy = createSpy.create(TestClass);
-            
-            var instance = new spy();
+        it("passes 'new' to underlying function", function () {
+            var TestClass = function () {};
+
+            var SpyClass = createSpy.create(TestClass);
+
+            var instance = new SpyClass();
 
             assert(instance instanceof TestClass);
         });

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -438,6 +438,17 @@ describe("spy", function () {
 
             assert(called);
         });
+        
+        it("passes 'new' to underlying function", function () {
+            var called = false;
+            var TestClass = function(){};
+
+            var spy = createSpy.create(TestClass);
+            
+            var instance = new spy();
+
+            assert(instance instanceof TestClass);
+        });
 
         it("passs arguments to function", function () {
             var actualArgs;

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -440,7 +440,7 @@ describe("spy", function () {
         });
 
         it("passes 'new' to underlying function", function () {
-            var TestClass = function () {};
+            function TestClass() {}
 
             var SpyClass = createSpy.create(TestClass);
 


### PR DESCRIPTION
#### Purpose (TL;DR)
This changes the spy behavior so that if the spy is `calledWithNew()` then
the original function will also get called with `new`.

This was throwing an error if you tried spying on an ES6 class object.

Fixes #1265

#### How to verify
```
let x = {
  y: class {}
};

spy(x, 'y');

// This would normally throw during callThrough()
new x.y();

assert(x.y.calledWithNew());
```

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
