### PR TITLE
Alias spy.reset to spy.resetHistory

### DIFF
--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -390,10 +390,13 @@ Array of return values, `spy.returnValues[0]` is the return value of the first c
 If the call did not explicitly return a value, the value at the call's location in `.returnValues` will be `undefined`.
 
 
-#### `spy.reset()`
+#### `spy.resetHistory()`
 
 Resets the state of a spy.
 
+#### `spy.reset();`
+
+Alias for `spy.resetHistory();`
 
 #### `spy.restore()`
 

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -100,7 +100,7 @@ var uuid = 0;
 var spyApi = {
     formatters: require("./spy-formatters"),
 
-    reset: function () {
+    resetHistory: function () {
         if (this.invoking) {
             var err = new Error("Cannot reset Sinon function while invoking it. " +
                                 "Move the call to .reset outside of the callback.");
@@ -412,6 +412,8 @@ function delegateToCalls(method, matchAny, actual, notCalled) {
         return matches === this.callCount;
     };
 }
+
+spyApi.reset = spyApi.resetHistory;
 
 delegateToCalls("calledOn", true);
 delegateToCalls("alwaysCalledOn", false, "calledOn");

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2539,16 +2539,24 @@ describe("spy", function () {
     });
 
     describe(".reset", function () {
+        it("is alias for resetHistory", function () {
+            var spy = createSpy();
+
+            assert.same(spy.reset, spy.resetHistory);
+        });
+    });
+
+    describe(".resetHistory", function () {
         it("return same object", function () {
             var spy = createSpy();
-            var reset = spy.reset();
+            var reset = spy.resetHistory();
 
             assert(reset === spy);
         });
 
         it("throws if called during spy invocation", function () {
             var spy = createSpy(function () {
-                spy.reset();
+                spy.resetHistory();
             });
 
             assert.exception(spy, "InvalidResetException");


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
As per #1446 - `spy.reset` aliased to `spy.resetHistory`.

#### Background (Problem in detail)  - optional
N/A, original ticket explains it all. 

#### Solution  - optional
* Changed name of `reset` to `resetHistory` in code and tests
* Added new test to ensure alias works
* Updated docs to reflect changes

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
