### PR TITLE
Alias spy.reset to spy.resetHistory

### DIFF
--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -395,11 +395,6 @@ If the call did not explicitly return a value, the value at the call's location 
 Resets the state of a spy.
 
 
-#### `spy.reset()`
-
-Alias for `spy.reset();`
-
-
 #### `spy.restore()`
 
 Replaces the spy with the original method. Only available if the spy replaced an existing method.

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -390,9 +390,14 @@ Array of return values, `spy.returnValues[0]` is the return value of the first c
 If the call did not explicitly return a value, the value at the call's location in `.returnValues` will be `undefined`.
 
 
-#### `spy.reset()`
+#### `spy.resetHistory()`
 
 Resets the state of a spy.
+
+
+#### `spy.reset()`
+
+Alias for `spy.reset();`
 
 
 #### `spy.restore()`

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -2,6 +2,7 @@
 
 var createBehavior = require("./behavior").create;
 var extend = require("./util/core/extend");
+var deprecated = require("./util/core/deprecated");
 var functionName = require("./util/core/function-name");
 var functionToString = require("./util/core/function-to-string");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
@@ -32,7 +33,7 @@ function spy(object, property, types) {
         return spy.create(function () { });
     }
 
-    if (!types) {
+    if (!types) {        
         return wrapMethod(object, property, spy.create(object[property]));
     }
 
@@ -156,7 +157,7 @@ var spyApi = {
         delete proxy.create;
         extend(proxy, func);
 
-        proxy.reset();
+        proxy.resetHistory();
         proxy.prototype = func.prototype;
         proxy.displayName = name || "spy";
         proxy.toString = functionToString;
@@ -413,7 +414,7 @@ function delegateToCalls(method, matchAny, actual, notCalled) {
     };
 }
 
-spyApi.reset = spyApi.resetHistory;
+spyApi.reset = deprecated.wrap(spyApi.resetHistory, deprecated.defaultMsg('reset'));
 
 delegateToCalls("calledOn", true);
 delegateToCalls("alwaysCalledOn", false, "calledOn");

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -33,7 +33,7 @@ function spy(object, property, types) {
         return spy.create(function () { });
     }
 
-    if (!types) {        
+    if (!types) {
         return wrapMethod(object, property, spy.create(object[property]));
     }
 
@@ -414,7 +414,7 @@ function delegateToCalls(method, matchAny, actual, notCalled) {
     };
 }
 
-spyApi.reset = deprecated.wrap(spyApi.resetHistory, deprecated.defaultMsg('reset'));
+spyApi.reset = deprecated.wrap(spyApi.resetHistory, deprecated.defaultMsg("reset"));
 
 delegateToCalls("calledOn", true);
 delegateToCalls("alwaysCalledOn", false, "calledOn");

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -100,7 +100,7 @@ var uuid = 0;
 var spyApi = {
     formatters: require("./spy-formatters"),
 
-    reset: function () {
+    resetHistory: function () {
         if (this.invoking) {
             var err = new Error("Cannot reset Sinon function while invoking it. " +
                                 "Move the call to .reset outside of the callback.");
@@ -412,6 +412,8 @@ function delegateToCalls(method, matchAny, actual, notCalled) {
         return matches === this.callCount;
     };
 }
+
+spyApi.reset = spyApi.resetHistory;
 
 delegateToCalls("calledOn", true);
 delegateToCalls("alwaysCalledOn", false, "calledOn");

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -132,7 +132,7 @@ var proto = {
         });
     },
 
-    resetHistory: spy.reset,
+    resetHistory: spy.resetHistory,
 
     reset: function () {
         this.resetHistory();

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -971,7 +971,7 @@ describe("sinonSpy.call", function () {
             var spy = sinonSpy();
             spy();
 
-            spy.reset();
+            spy.resetHistory();
 
             assertReset(spy);
         });
@@ -981,7 +981,7 @@ describe("sinonSpy.call", function () {
             spies[0]();
             spies[1]();
 
-            spies[0].reset();
+            spies[0].resetHistory();
 
             assert(!spies[0].calledBefore(spies[1]));
         });
@@ -995,7 +995,7 @@ describe("sinonSpy.call", function () {
             spy("c");
             var fakeC = spy.withArgs("c");
 
-            spy.reset();
+            spy.resetHistory();
 
             assertReset(fakeA);
             assertReset(fakeB);
@@ -1288,7 +1288,7 @@ describe("sinonSpy.call", function () {
                     "\n\n    spy(" + str + ")" +
                     "\n\n    spy(" + str + ")");
 
-                spy.reset();
+                spy.resetHistory();
 
                 spy("test");
                 spy("spy\ntest");
@@ -1306,7 +1306,7 @@ describe("sinonSpy.call", function () {
             spy();
             assert.equals(spy.printf("%t"), "undefined");
 
-            spy.reset();
+            spy.resetHistory();
             spy.call(true);
             assert.equals(spy.printf("%t"), "true");
         });

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2539,16 +2539,24 @@ describe("spy", function () {
     });
 
     describe(".reset", function () {
+        it("is alias for resetHistory", function () {
+            var spy = createSpy();
+
+            assert.same(spy.reset, spy.resetHistory);
+        });
+    });
+
+    describe(".resetHistory", function () {
         it("return same object", function () {
             var spy = createSpy();
-            var reset = spy.reset();
+            var reset = spy.resetHistory();
 
             assert(reset === spy);
         });
 
         it("throws if called during spy invocation", function () {
             var spy = createSpy(function () {
-                spy.reset();
+                spy.resetHistory();
             });
 
             assert.exception(spy, "InvalidResetException");

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2538,14 +2538,6 @@ describe("spy", function () {
         });
     });
 
-    describe(".reset", function () {
-        it("is alias for resetHistory", function () {
-            var spy = createSpy();
-
-            assert.same(spy.reset, spy.resetHistory);
-        });
-    });
-
     describe(".resetHistory", function () {
         it("return same object", function () {
             var spy = createSpy();

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -607,7 +607,7 @@ describe("stub", function () {
                 this.originalError = global.Error;
                 errorSpy = createSpy(global, "Error");
                 // errorSpy starts with a call already made, not sure why
-                errorSpy.reset();
+                errorSpy.resetHistory();
             });
 
             afterEach(function () {

--- a/test/util/core/every-test.js
+++ b/test/util/core/every-test.js
@@ -34,7 +34,7 @@ describe("util/core/every", function () {
         every(iterableOne, callback);
         assert.equals(callback.callCount, 4);
 
-        callback.reset();
+        callback.resetHistory();
 
         every(iterableTwo, callback);
         assert.equals(callback.callCount, 3);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
As per #1446 - deprecates and aliases `spy.reset` in favour of `spy.resetHistory`

#### Background (Problem in detail)  - optional
See ticket. 

#### Solution  - optional
* Change existing `spy.reset` test to instead use `spy.resetHistory`
* Introduce `spy.reset` test to make sure alias works
* Implement changes (just a function name change and an alias)
* Updated docs to reflect changes

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
