### PR TITLE
Fix headless chrome in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,22 +27,14 @@ jobs:
               else
                 npm install
               fi
-
-              # install latest chrome unstable version
-              if node --version | grep -q '^v6'; then
-                wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-                echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
-                apt-get update
-                apt-get install -y --no-install-recommends google-chrome-unstable
-              fi
       - run:
           name: Pre-Test
           # ESLint only supports Node >=4
           command: |
               if node --version | grep -q '^v6'; then
                 npm run lint;
-                npm run test-headless -- --chrome $(which google-chrome-unstable) --allow-chrome-as-root;
-                npm run test-webworker -- --chrome $(which google-chrome-unstable) --allow-chrome-as-root;
+                npm run test-headless -- --allow-chrome-as-root;
+                npm run test-webworker -- --allow-chrome-as-root;
               fi
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: |
               if node --version | grep -q '^v6'; then
                 npm run lint;
-                npm run test-headless;
+                npm run test-headless -- --chrome $(which google-chrome-unstable);
                 npm run test-webworker;
               fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
   node-6:
     <<: *common-build
     docker:
-      - image: node:6-alpine
+      - image: node:6
 
   node-8:
     <<: *common-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-npm-{{ .Branch }}-{{ checksum "package.json" }}
-            - v1-npm-master-{{ checksum "package.json" }}
+            - v2-npm-{{ .Branch }}-{{ checksum "package.json" }}
+            - v2-npm-master-{{ checksum "package.json" }}
       - run:
           name: Install dependencies
           command: |
@@ -40,7 +40,7 @@ jobs:
           name: Test
           command: npm run test-node
       - save_cache:
-          key: v1-npm-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v2-npm-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             - node_modules
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,17 +18,20 @@ jobs:
           name: Install dependencies
           command: |
               npm config set strict-ssl false
-              # Avoid downloading chromium unnecessarily
-              npm config set ignore-scripts true
+              if ! node --version | grep -q '^v6'; then
+                # Avoid downloading chromium unnecessarily
+                npm config set ignore-scripts true
+              fi
               npm install
               npm config set ignore-scripts false
       - run:
           name: Pre-Test
           # ESLint only supports Node >=4
           command: |
-              NODE_VERSION=$(node --version)
-              if [[ ${NODE_VERSION:0:3} == "v6." ]]; then
+              if node --version | grep -q '^v6'; then
                 npm run lint;
+                npm run test-headless;
+                npm run test-webworker;
               fi
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,8 @@ jobs:
           command: |
               if node --version | grep -q '^v6'; then
                 npm run lint;
-                # HACK: modify mochify to pass args to chrome to allow it to run as root
-                #   --no-sandbox --disable-setuid-sandbox
-                # See https://github.com/mantoni/mochify.js/issues/162
-                sed -i "s#'--allow-insecure-localhost'#'--allow-insecure-localhost', '--no-sandbox', '--disable-setuid-sandbox'#" node_modules/mochify/lib/chromium.js && echo "modified mochify/lib/chromium.js";
-                npm run test-headless -- --chrome $(which google-chrome-unstable);
-                npm run test-webworker -- --chrome $(which google-chrome-unstable);
+                npm run test-headless -- --chrome $(which google-chrome-unstable) --allow-chrome-as-root;
+                npm run test-webworker -- --chrome $(which google-chrome-unstable) --allow-chrome-as-root;
               fi
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,15 @@ jobs:
           name: Install dependencies
           command: |
               npm config set strict-ssl false
-              npm install
+              # puppeteer install script throws syntax errors for Node v4
+              # https://github.com/GoogleChrome/puppeteer/blob/f19e2ade0d4859435422131905e932abe3db199c/install.js#L66
+              if node --version | grep -q '^v4'; then
+                npm config set ignore-scripts true
+                npm install
+                npm config set ignore-scripts false
+              else
+                npm install
+              fi
 
               if node --version | grep -q '^v6'; then
                 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,14 @@ jobs:
           name: Install dependencies
           command: |
               npm config set strict-ssl false
-              if ! node --version | grep -q '^v6'; then
-                # Avoid downloading chromium unnecessarily
-                npm config set ignore-scripts true
-              fi
               npm install
-              npm config set ignore-scripts false
+
+              if node --version | grep -q '^v6'; then
+                wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+                echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+                apt-get update
+                apt-get install -y --no-install-recommends google-chrome-unstable
+              fi
       - run:
           name: Pre-Test
           # ESLint only supports Node >=4
@@ -45,6 +47,8 @@ jobs:
     <<: *common-build
     docker:
       - image: node:4
+    environment:
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 
   node-6:
     <<: *common-build
@@ -55,6 +59,8 @@ jobs:
     <<: *common-build
     docker:
       - image: node:8
+    environment:
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-npm-{{ .Branch }}-{{ checksum "package.json" }}
-            - v2-npm-master-{{ checksum "package.json" }}
+            - v3-npm-{{ .Branch }}-{{ checksum "package.json" }}
+            - v3-npm-master-{{ checksum "package.json" }}
       - run:
           name: Install dependencies
           command: |
@@ -27,27 +27,35 @@ jobs:
               else
                 npm install
               fi
+
+              # install latest chrome unstable version
+              if node --version | grep -q '^v6'; then
+                wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+                echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+                apt-get update
+                apt-get install -y --no-install-recommends google-chrome-unstable
+              fi
       - run:
           name: Pre-Test
           # ESLint only supports Node >=4
           command: |
               if node --version | grep -q '^v6'; then
                 npm run lint;
-                npm run test-headless -- --allow-chrome-as-root;
-                npm run test-webworker -- --allow-chrome-as-root;
+                npm run test-headless -- --chrome $(which google-chrome-unstable) --allow-chrome-as-root;
+                npm run test-webworker -- --chrome $(which google-chrome-unstable) --allow-chrome-as-root;
               fi
       - run:
           name: Test
           command: npm run test-node
       - save_cache:
-          key: v2-npm-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v3-npm-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             - node_modules
 
   node-4:
     <<: *common-build
     docker:
-      - image: node:4
+      - image: node:4-alpine
 
   node-6:
     <<: *common-build
@@ -57,7 +65,7 @@ jobs:
   node-8:
     <<: *common-build
     docker:
-      - image: node:8
+      - image: node:8-alpine
     environment:
         PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ jobs:
           command: |
               if node --version | grep -q '^v6'; then
                 npm run lint;
+                # modify mochify to pass additional params to chrome
+                sed -i "s#'--allow-insecure-localhost'#'--allow-insecure-localhost', '--no-sandbox', '--disable-setuid-sandbox'#" node_modules/mochify/lib/chromium.js && echo "modified mochify/lib/chromium.js";
                 npm run test-headless -- --chrome $(which google-chrome-unstable);
                 npm run test-webworker;
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
                 # modify mochify to pass additional params to chrome
                 sed -i "s#'--allow-insecure-localhost'#'--allow-insecure-localhost', '--no-sandbox', '--disable-setuid-sandbox'#" node_modules/mochify/lib/chromium.js && echo "modified mochify/lib/chromium.js";
                 npm run test-headless -- --chrome $(which google-chrome-unstable);
-                npm run test-webworker;
+                npm run test-webworker -- --chrome $(which google-chrome-unstable);
               fi
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
                 npm install
               fi
 
+              # install latest chrome unstable version
               if node --version | grep -q '^v6'; then
                 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
                 echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
@@ -40,7 +41,9 @@ jobs:
           command: |
               if node --version | grep -q '^v6'; then
                 npm run lint;
-                # modify mochify to pass additional params to chrome
+                # HACK: modify mochify to pass args to chrome to allow it to run as root
+                #   --no-sandbox --disable-setuid-sandbox
+                # See https://github.com/mantoni/mochify.js/issues/162
                 sed -i "s#'--allow-insecure-localhost'#'--allow-insecure-localhost', '--no-sandbox', '--disable-setuid-sandbox'#" node_modules/mochify/lib/chromium.js && echo "modified mochify/lib/chromium.js";
                 npm run test-headless -- --chrome $(which google-chrome-unstable);
                 npm run test-webworker -- --chrome $(which google-chrome-unstable);
@@ -57,8 +60,6 @@ jobs:
     <<: *common-build
     docker:
       - image: node:4
-    environment:
-        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 
   node-6:
     <<: *common-build

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lint-staged": "^4.0.0",
     "markdownlint-cli": "^0.4.0",
     "mocha": "^4.0.0",
-    "mochify": "^5.0.0",
+    "mochify": "mantoni/mochify.js#2cdbc02a4db887bfe3604f8d18f593c980f7897e",
     "mochify-istanbul": "^2.4.1",
     "native-promise-only": "^0.8.1",
     "npm-run-all": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lint-staged": "^4.0.0",
     "markdownlint-cli": "^0.4.0",
     "mocha": "^4.0.0",
-    "mochify": "mantoni/mochify.js#2cdbc02a4db887bfe3604f8d18f593c980f7897e",
+    "mochify": "^5.1.0",
     "mochify-istanbul": "^2.4.1",
     "native-promise-only": "^0.8.1",
     "npm-run-all": "^4.0.2",


### PR DESCRIPTION
This re-enables headless chrome testing in CircleCI. It has one [huge hack](https://github.com/sinonjs/sinon/pull/1636/files#diff-1d37e48f9ceff6d8030570cd36286a61R44) in it right now (manually editing a dependency). I think perhaps we should wait on merging this for a cleaner solution. I filed an issue with mochify (mantoni/mochify.js#162) (cc @mantoni).

This reverts small amounts of #1629.