### PR TITLE
Update documentation to emphasize Stack Overflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ There are several ways of contributing to Sinon.JS
   at [the Sinon.JS website](http://sinonjs.org). [Documentation issues](https://github.com/sinonjs/sinon/issues?q=is%3Aopen+is%3Aissue+label%3ADocumentation).
 * Help someone understand and use Sinon.JS on [Stack Overflow](https://stackoverflow.com/questions/tagged/sinon)
 * Report an issue, please read instructions below
-* Help with triaging the [issues](http://github.com/cjohansen/Sinon.JS/issues). The clearer they are, the more likely they are to be fixed soon.
+* Help with triaging the [issues](https://github.com/sinonjs/sinon/issues). The clearer they are, the more likely they are to be fixed soon.
 * Contribute to the code base.
 
 ## Reporting an issue
@@ -28,9 +28,9 @@ See [our issue template](https://github.com/sinonjs/sinon/blob/master/.github/) 
 
 ## Contributing to the code base
 
-Pick [an issue](http://github.com/cjohansen/Sinon.JS/issues) to fix, or pitch
+Pick [an issue](https://github.com/sinonjs/sinon/issues) to fix, or pitch
 new features. To avoid wasting your time, please ask for feedback on feature
-suggestions with [an issue](http://github.com/cjohansen/Sinon.JS/issues/new).
+suggestions with [an issue](https://github.com/sinonjs/sinon/issues/new).
 
 ### Making a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ There are several ways of contributing to Sinon.JS
 * Look into [issues tagged `help-wanted`](https://github.com/sinonjs/sinon/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22)
 * Help [improve the documentation](https://github.com/sinonjs/sinon/tree/master/docs) published
   at [the Sinon.JS website](http://sinonjs.org). [Documentation issues](https://github.com/sinonjs/sinon/issues?q=is%3Aopen+is%3Aissue+label%3ADocumentation).
-* Help someone understand and use Sinon.JS on [the mailing list](http://groups.google.com/group/sinonjs) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/sinon)
+* Help someone understand and use Sinon.JS on [Stack Overflow](https://stackoverflow.com/questions/tagged/sinon)
 * Report an issue, please read instructions below
 * Help with triaging the [issues](http://github.com/cjohansen/Sinon.JS/issues). The clearer they are, the more likely they are to be fixed soon.
 * Contribute to the code base.
@@ -30,8 +30,7 @@ See [our issue template](https://github.com/sinonjs/sinon/blob/master/.github/) 
 
 Pick [an issue](http://github.com/cjohansen/Sinon.JS/issues) to fix, or pitch
 new features. To avoid wasting your time, please ask for feedback on feature
-suggestions either with [an issue](http://github.com/cjohansen/Sinon.JS/issues/new)
-or on [the mailing list](http://groups.google.com/group/sinonjs).
+suggestions with [an issue](http://github.com/cjohansen/Sinon.JS/issues/new).
 
 ### Making a pull request
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ or via sinon's browser builds available for download on the [homepage](http://si
 
 See the [sinon project homepage](http://sinonjs.org/) for documentation on usage.
 
-If you have questions that are not covered by the documentation, please post them to the [Sinon.JS mailing list](http://groups.google.com/group/sinonjs) or drop by <a href="irc://irc.freenode.net:6667/sinon.js">#sinon.js on irc.freenode.net:6667</a> or the [Gitter channel](https://gitter.im/sinonjs/sinon).
+If you have questions that are not covered by the documentation, you can [check out the `sinon` tag on Stack Overflow](https://stackoverflow.com/questions/tagged/sinon) or drop by <a href="irc://irc.freenode.net:6667/sinon.js">#sinon.js on irc.freenode.net:6667</a>.
+
+You can also search through the [Sinon.JS mailing list archives](http://groups.google.com/group/sinonjs).
 
 ## Goals
 

--- a/docs/_includes/docs/contribute.md
+++ b/docs/_includes/docs/contribute.md
@@ -1,6 +1,6 @@
 ### Stuck?
 
-Please ask questions on [the mailing list](http://groups.google.com/group/sinonjs) if you're stuck.
+Please ask questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/sinon) if you're stuck.
 
 ### Contribute
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -244,7 +244,7 @@ You've seen the most common tasks people tackle with Sinon.JS, yet we've only sc
 
 ### Get help
 
-* [Sinon.JS mailing list][sinon-group]
+* [Stack Overflow](https://stackoverflow.com/questions/tagged/sinon)
 * IRC: #sinon.js on freenode
 
 ### Sinon.JS elsewhere


### PR DESCRIPTION
And retire the mailinglist

Fixes #1639 

[gist to close usage question](https://gist.github.com/mroderick/37e60c4d08e9411ec36e) has been updated, and can be copied to your saved reply under your personal GitHub settings.