### PR TITLE
Assertion error messages handle symbolic method names

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -376,7 +376,7 @@ var spyApi = {
             formatter = spyApi.formatters[specifyer];
 
             if (typeof formatter === "function") {
-                return formatter.call(null, spyInstance, args);
+                return String(formatter.call(null, spyInstance, args));
             } else if (!isNaN(parseInt(specifyer, 10))) {
                 return sinonFormat(args[specifyer - 1]);
             }

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1649,4 +1649,42 @@ describe("assert", function () {
                           "    actual = { foo: 1 }");
         });
     });
+
+    if (typeof Symbol === "function") {
+        describe("with symbol method names", function () {
+            var obj = {};
+
+            function setupSymbol(symbol) {
+                obj[symbol] = function () {};
+                sinonSpy(obj, symbol);
+            }
+
+            function createExceptionMessage(method, arg) {
+                try { // eslint-disable-line no-restricted-syntax
+                    sinonAssert[method](arg);
+                } catch (e) {
+                    return e.message;
+                }
+            }
+
+            it("should use the symbol's description in exception messages", function () {
+                var symbol = Symbol("Something Symbolic");
+                setupSymbol(symbol);
+
+                assert.equals(createExceptionMessage("called", obj[symbol]),
+                    "expected Symbol(Something Symbolic) to have been " +
+                    "called at least once but was never called");
+            });
+
+            it("should indicate that an assertion failure with a symbol method name " +
+               "occured in exception messages, even if the symbol has no description", function () {
+                var symbol = Symbol();
+                setupSymbol(symbol);
+
+                assert.equals(createExceptionMessage("called", obj[symbol]),
+                    "expected Symbol() to have been " +
+                    "called at least once but was never called");
+            });
+        });
+    }
 });


### PR DESCRIPTION
Resolves https://github.com/sinonjs/sinon/issues/1640 (assertion failure errors with "Cannot convert a Symbol value to a string")

#### Background (Problem in detail) 
Assertion error messages may reference a method's name (which may now be a symbol, not a string). However, symbols cannot be implicitly converted to strings.

#### Solution
Explicitly cast symbols to strings with `String`. The value returned should match http://www.ecma-international.org/ecma-262/6.0/#sec-symboldescriptivestring.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Run the following in node:

```
const sinon = require('./lib/sinon');
const sym = Symbol('my symbol');
const obj = { [sym]: (a, b) => a + b };
const spy = sinon.spy(obj, sym)
sinon.assert.calledWith(spy, 1, 2);
```

The error message should say something about expecting `Symbol(my symbol)` to be called, not an error about converting the symbol to a string.


#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
