### PR TITLE
Patch fake server without clock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_script:
   # ESLint only supports Node >=4
   - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run lint; fi
   - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run lint-markdown; fi
-  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run test-headless; fi
-  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run test-webworker; fi
+  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run test-headless -- --allow-chrome-as-root; fi
+  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run test-webworker -- --allow-chrome-as-root; fi
   - if [ "x$TRAVIS_NODE_VERSION" = "x8" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test-cloud; fi
 
 script:

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -7,7 +7,6 @@ var sinonAssert = require("./assert");
 var sinonClock = require("./util/fake_timers");
 var fakeServer = require("nise").fakeServer;
 var fakeXhr = require("nise").fakeXhr;
-var fakeServerWithClock = require("nise").fakeServerWithClock;
 
 var push = [].push;
 
@@ -55,7 +54,7 @@ extend(sinonSandbox, {
         return this.add(this.clock);
     },
 
-    serverPrototype: fakeServerWithClock,
+    serverPrototype: fakeServer,
 
     useFakeServer: function useFakeServer() {
         var proto = this.serverPrototype || fakeServer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4271,64 +4271,18 @@
         }
       }
     },
-    "mocha": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.0.tgz",
-      "integrity": "sha512-83e2QQWKbcBiPb1TuS80i4DxkpqQoOC9Y0TxOuML8NkzZWUkJJqWHAslhUS7x5nQcYMqnMwZDp5v3ABzV+ivCA==",
-      "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.11.0",
-        "debug": "3.1.0",
-        "diff": "3.3.1",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.2",
-        "he": "1.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
-      }
-    },
-    "mochify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/mochify/-/mochify-5.0.0.tgz",
-      "integrity": "sha512-fTvi6GpPe8M/xP7z8KkQ9LCE64UUw+OYFnOwEVBicBdrhMvphmXfXAZVO6GE8OOOqCVeEiupuEeRewew0JIKPA==",
+    "mocaccino": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mocaccino/-/mocaccino-3.0.0.tgz",
+      "integrity": "sha512-mc0xkHFGxnW4B49la2LG8qaHBIiLArqG9zkgP+byp/kmWby1/Bi8CIpwBKANu91SkZ/c4Qk+0JnYM5u1PXEQYw==",
       "dev": true,
       "requires": {
         "brout": "1.2.0",
-        "browserify": "14.4.0",
-        "consolify": "2.2.0",
-        "coverify": "1.4.1",
-        "glob": "7.1.2",
-        "min-wd": "2.9.3",
-        "mocaccino": "3.0.0",
-        "mocha": "4.0.1",
-        "puppeteer": "0.13.0",
+        "listen": "1.0.1",
+        "mocha": "4.1.0",
         "resolve": "1.4.0",
-        "source-mapper": "2.0.0",
-        "subarg": "1.0.0",
-        "through2": "2.0.3",
-        "watchify": "3.9.0"
+        "supports-color": "3.2.3",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "debug": {
@@ -4346,24 +4300,10 @@
           "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
           "dev": true
         },
-        "mocaccino": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mocaccino/-/mocaccino-3.0.0.tgz",
-          "integrity": "sha512-mc0xkHFGxnW4B49la2LG8qaHBIiLArqG9zkgP+byp/kmWby1/Bi8CIpwBKANu91SkZ/c4Qk+0JnYM5u1PXEQYw==",
-          "dev": true,
-          "requires": {
-            "brout": "1.2.0",
-            "listen": "1.0.1",
-            "mocha": "4.0.1",
-            "resolve": "1.4.0",
-            "supports-color": "3.2.3",
-            "through2": "2.0.3"
-          }
-        },
         "mocha": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-          "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+          "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
           "dev": true,
           "requires": {
             "browser-stdout": "1.3.0",
@@ -4404,6 +4344,101 @@
               "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
               "dev": true
             }
+          }
+        }
+      }
+    },
+    "mocha": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.0.tgz",
+      "integrity": "sha512-83e2QQWKbcBiPb1TuS80i4DxkpqQoOC9Y0TxOuML8NkzZWUkJJqWHAslhUS7x5nQcYMqnMwZDp5v3ABzV+ivCA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.2",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "mochify": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/mochify/-/mochify-5.1.0.tgz",
+      "integrity": "sha512-cbBlm/9z1Ks371c/5Y7CTqo3dG2Zd4gHoyqqN8uND0bUsh/g4vDvo8Mnal9MZgV63JO9ufS8gYx4U9XzuC3maQ==",
+      "dev": true,
+      "requires": {
+        "brout": "1.2.0",
+        "browserify": "14.4.0",
+        "consolify": "2.2.0",
+        "coverify": "1.4.1",
+        "glob": "7.1.2",
+        "min-wd": "2.9.3",
+        "mocaccino": "3.0.0",
+        "mocha": "4.1.0",
+        "puppeteer": "0.13.0",
+        "resolve": "1.4.0",
+        "source-mapper": "2.0.0",
+        "subarg": "1.0.0",
+        "through2": "2.0.3",
+        "watchify": "3.9.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "growl": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+          "dev": true
+        },
+        "mocha": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+          "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+          "dev": true,
+          "requires": {
+            "browser-stdout": "1.3.0",
+            "commander": "2.11.0",
+            "debug": "3.1.0",
+            "diff": "3.3.1",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.3",
+            "he": "1.1.1",
+            "mkdirp": "0.5.1",
+            "supports-color": "4.4.0"
           }
         }
       }

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -257,7 +257,13 @@ describe("sinonSandbox", function () {
                     assert(fakeServer.isPrototypeOf(server));
                 });
 
-                it("creates server with cock", function () {
+                it("creates server without clock by default", function () {
+                    var server = this.sandbox.useFakeServer();
+
+                    refute(fakeServerWithClock.isPrototypeOf(server));
+                });
+
+                it("creates server with clock", function () {
                     this.sandbox.serverPrototype = fakeServerWithClock;
                     var server = this.sandbox.useFakeServer();
 
@@ -470,6 +476,20 @@ describe("sinonSandbox", function () {
                     assert.fakeServerWithClock(sandbox.args[0], this.fakeServer);
 
                     sandbox.restore();
+                });
+
+                it("uses fakeServer as the serverPrototype by default", function () {
+                    var sandbox = sinonSandbox.create();
+
+                    assert.same(sandbox.serverPrototype, fakeServer);
+                });
+
+                it("uses configured implementation as the serverPrototype", function () {
+                    var sandbox = sinonSandbox.create({
+                        useFakeServer: fakeServerWithClock
+                    });
+
+                    assert.same(sandbox.serverPrototype, fakeServerWithClock);
                 });
 
                 it("yields clock when faking timers", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Use `nise.fakeServer` as the default sandbox `serverPrototype` to fix #1534.

Apparently the Chrome installation has changed and it is now necessary to pass the `--allow-chrome-as-root` flag on Travis like we already do on CircleCI.

#### Background (Problem in detail)  - optional

Creating a sandbox with fake server installed fake timers on the first XHR request. Both ways to install fake servers are affected:

```js
sandbox = sinon.createSandbox({
  useFakeServer: true
});
```

and

```js
sandbox = sinon.createSandbox();
sandbox.useFakeServer();
```

#### Solution  - optional

Setting `nise.fakeServer` as the default `serverPrototype` on the sandbox fixes the issue.

#### How to verify - mandatory

The new tests ensure the correct `serverPrototype` is used and the fake server returned by `useFakeServer()` is not an instance of `fakeServerWithClock` anymore.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).