### PR TITLE
Upgrade dependencies

### DIFF
--- a/lib/sinon/color.js
+++ b/lib/sinon/color.js
@@ -3,7 +3,7 @@
 var supportsColor = require("supports-color");
 
 function colorize(str, color) {
-    if (!supportsColor) {
+    if (supportsColor.stdout === false) {
         return str;
     }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash.get": "^4.4.2",
     "lolex": "^2.2.0",
     "nise": "^1.2.0",
-    "supports-color": "^4.4.0",
+    "supports-color": "^5.1.0",
     "type-detect": "^4.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "type-detect": "^4.0.5"
   },
   "devDependencies": {
-    "browserify": "^14.0.0",
+    "browserify": "^15.1.0",
     "dependency-check": "^2.9.1",
     "eslint": "^4.6.1",
     "eslint-config-sinon": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-mocha": "^4.2.0",
     "husky": "^0.14.2",
     "lint-staged": "^6.0.0",
-    "markdownlint-cli": "^0.4.0",
+    "markdownlint-cli": "^0.6.0",
     "mocha": "^4.0.0",
     "mochify": "^5.1.0",
     "mochify-istanbul": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-config-sinon": "^1.0.0",
     "eslint-plugin-mocha": "^4.2.0",
     "husky": "^0.14.2",
-    "lint-staged": "^4.0.0",
+    "lint-staged": "^6.0.0",
     "markdownlint-cli": "^0.4.0",
     "mocha": "^4.0.0",
     "mochify": "^5.1.0",

--- a/test/util/core/color-test.js
+++ b/test/util/core/color-test.js
@@ -19,7 +19,9 @@ describe("color", function () {
 
         beforeEach(function () {
             color = proxyquire("../../../lib/sinon/color", {
-                "supports-color": {}
+                "supports-color": {
+                    stdout: true
+                }
             });
         });
 
@@ -40,13 +42,15 @@ describe("color", function () {
 
         beforeEach(function () {
             color = proxyquire("../../../lib/sinon/color", {
-                "supports-color": false
+                "supports-color": {
+                    stdout: false
+                }
             });
         });
 
         getColorMethods().forEach(function (method) {
             describe(method.name, function () {
-                it("should return a colored string", function () {
+                it("should return a regular string", function () {
                     var string = "lorem ipsum";
                     var actual = color[method.name](string);
 


### PR DESCRIPTION
This PR upgrades outdated dependencies.

I've looked at the changelogs and made necessary changes, I don't think this is a risky upgrade as only `supports-color` is used by end users, and is covered with updated tests.