### PR TITLE
Fix #176 by ensuring the most specific fake is used in .withArgs if several of them match

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -10,6 +10,7 @@ var wrapMethod = require("./util/core/wrap-method");
 var stubEntireObject = require("./stub-entire-object");
 var throwOnFalsyObject = require("./throw-on-falsy-object");
 var valueToString = require("./util/core/value-to-string");
+var sinonMatch = require("./match");
 
 var slice = Array.prototype.slice;
 
@@ -82,6 +83,10 @@ function getCurrentBehavior(stubInstance) {
     var currentBehavior = stubInstance.behaviors[stubInstance.callCount - 1];
     return currentBehavior && currentBehavior.isPresent() ? currentBehavior : getDefaultBehavior(stubInstance);
 }
+
+function fakeUsesSinonAnyMatcher(fake) {
+    return fake.matchingArguments.length === 1 && fake.matchingArguments[0] === sinonMatch.any;
+}
 /*eslint-enable no-use-before-define*/
 
 var uuid = 0;
@@ -93,6 +98,9 @@ var proto = {
             var matchings = functionStub.matchingFakes(args);
 
             var fnStub = matchings.sort(function (a, b) {
+                if (fakeUsesSinonAnyMatcher(b)) {
+                    return 1;
+                }
                 return a.matchingArguments.length - b.matchingArguments.length;
             }).pop() || functionStub;
             return getCurrentBehavior(fnStub).invoke(this, arguments);

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1766,6 +1766,22 @@ describe("stub", function () {
             assert.equals(stub(), unmatchedValue);
             assert.equals(stub(expectedArgument), secondMatchedValue);
         });
+
+        it("ensure stub doesn't use sinonMatch.any argument if there are more matches", function () {
+            var unmatchedValue = "d3ada6a0-8dac-4136-956d-033b5f23eadf";
+            var matchedValue = "68128619-a639-4b32-a4a0-6519165bf301";
+            var anyMatcherValue = "555a8c4a-fae0-11e7-8c3f-9a214cf093ae";
+            var expectedArgument = "3e1ed1ec-c377-4432-a33e-3c937f1406d1";
+
+            var stub = createStub().returns(unmatchedValue);
+
+            stub.withArgs(expectedArgument).returns(matchedValue);
+            stub.withArgs(sinonMatch.any).returns(anyMatcherValue);
+
+            assert.equals(stub(), unmatchedValue);
+            assert.equals(stub(expectedArgument), matchedValue);
+            assert.equals(stub("any-value"), anyMatcherValue);
+        });
     });
 
     describe(".callsArgAsync", function () {


### PR DESCRIPTION
As discussed in  #176, `.withArgs` is implemented so that it picks the last matching fake. However, if the last time `.withArgs` was called passing `sinonMatch.any`, it will always pick that fake, even if there's any other more accurate match. For example:

```javascript
const s = sinon.stub();
s.withArgs(1).returns(1)
 .withArgs(2).returns(2)
 .withArgs(sinon.match.any).returns('my-default-value')

s(1) // my-default-value
s(2) // my-default-value
s(5) // my-default-value
```

This commit avoids this and returns the appropriate fake.
