### PR TITLE
Add eslint-plugin-ie11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -641,6 +641,15 @@
         "parse-asn1": "5.1.0"
       }
     },
+    "browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "requires": {
+        "pako": "1.0.6"
+      }
+    },
     "buffer": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.7.tgz",
@@ -1524,6 +1533,15 @@
       "resolved": "https://registry.npmjs.org/eslint-config-sinon/-/eslint-config-sinon-1.0.3.tgz",
       "integrity": "sha1-6vcFIqGL8yUKuQMcfEPw2LD0Daw=",
       "dev": true
+    },
+    "eslint-plugin-ie11": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ie11/-/eslint-plugin-ie11-1.0.0.tgz",
+      "integrity": "sha512-PPv2Cbq5roUmoIZJfPWbEEILHvi2Yfp/cRVzaVKL/YJiYGGLJ0/Qrq1HKd2OZKb3RQQOXweCd/hh261bljEe8A==",
+      "dev": true,
+      "requires": {
+        "requireindex": "1.1.0"
+      }
     },
     "eslint-plugin-mocha": {
       "version": "4.11.0",
@@ -4512,6 +4530,7 @@
       "dev": true,
       "requires": {
         "brout": "1.2.0",
+        "browserify": "14.5.0",
         "consolify": "2.2.0",
         "coverify": "1.4.1",
         "glob": "7.1.2",
@@ -4526,6 +4545,61 @@
         "watchify": "3.9.0"
       },
       "dependencies": {
+        "browserify": {
+          "version": "14.5.0",
+          "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.5.0.tgz",
+          "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
+          "dev": true,
+          "requires": {
+            "JSONStream": "1.3.1",
+            "assert": "1.4.1",
+            "browser-pack": "6.0.2",
+            "browser-resolve": "1.11.2",
+            "browserify-zlib": "0.2.0",
+            "buffer": "5.0.7",
+            "cached-path-relative": "1.0.1",
+            "concat-stream": "1.5.2",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "1.0.0",
+            "crypto-browserify": "3.11.1",
+            "defined": "1.0.0",
+            "deps-sort": "2.0.0",
+            "domain-browser": "1.1.7",
+            "duplexer2": "0.1.4",
+            "events": "1.1.1",
+            "glob": "7.1.2",
+            "has": "1.0.1",
+            "htmlescape": "1.1.1",
+            "https-browserify": "1.0.0",
+            "inherits": "2.0.3",
+            "insert-module-globals": "7.0.1",
+            "labeled-stream-splicer": "2.0.0",
+            "module-deps": "4.1.1",
+            "os-browserify": "0.3.0",
+            "parents": "1.0.1",
+            "path-browserify": "0.0.0",
+            "process": "0.11.10",
+            "punycode": "1.4.1",
+            "querystring-es3": "0.2.1",
+            "read-only-stream": "2.0.0",
+            "readable-stream": "2.3.3",
+            "resolve": "1.4.0",
+            "shasum": "1.0.2",
+            "shell-quote": "1.6.1",
+            "stream-browserify": "2.0.1",
+            "stream-http": "2.7.2",
+            "string_decoder": "1.0.3",
+            "subarg": "1.0.0",
+            "syntax-error": "1.3.0",
+            "through2": "2.0.3",
+            "timers-browserify": "1.4.2",
+            "tty-browserify": "0.0.0",
+            "url": "0.11.0",
+            "util": "0.10.3",
+            "vm-browserify": "0.0.4",
+            "xtend": "4.0.1"
+          }
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -4555,7 +4629,17 @@
             "glob": "7.1.2",
             "growl": "1.10.3",
             "he": "1.1.1",
-            "mkdirp": "0.5.1"
+            "mkdirp": "0.5.1",
+            "supports-color": "4.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -4590,6 +4674,29 @@
             "through2": "2.0.3"
           }
         }
+      }
+    },
+    "module-deps": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+      "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
+      "dev": true,
+      "requires": {
+        "JSONStream": "1.3.1",
+        "browser-resolve": "1.11.2",
+        "cached-path-relative": "1.0.1",
+        "concat-stream": "1.5.2",
+        "defined": "1.0.0",
+        "detective": "4.5.0",
+        "duplexer2": "0.1.4",
+        "inherits": "2.0.3",
+        "parents": "1.0.1",
+        "readable-stream": "2.3.3",
+        "resolve": "1.4.0",
+        "stream-combiner2": "1.1.1",
+        "subarg": "1.0.0",
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "module-not-found-error": {
@@ -4890,6 +4997,12 @@
         }
       }
     },
+    "os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+      "dev": true
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -4915,6 +5028,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "pako": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
       "dev": true
     },
     "parents": {
@@ -5564,6 +5683,12 @@
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
       }
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "dev": true
     },
     "resolve": {
       "version": "1.4.0",
@@ -6299,11 +6424,69 @@
       "dev": true,
       "requires": {
         "anymatch": "1.3.2",
+        "browserify": "14.5.0",
         "chokidar": "1.7.0",
         "defined": "1.0.0",
         "outpipe": "1.1.1",
         "through2": "2.0.3",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "browserify": {
+          "version": "14.5.0",
+          "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.5.0.tgz",
+          "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
+          "dev": true,
+          "requires": {
+            "JSONStream": "1.3.1",
+            "assert": "1.4.1",
+            "browser-pack": "6.0.2",
+            "browser-resolve": "1.11.2",
+            "browserify-zlib": "0.2.0",
+            "buffer": "5.0.7",
+            "cached-path-relative": "1.0.1",
+            "concat-stream": "1.5.2",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "1.0.0",
+            "crypto-browserify": "3.11.1",
+            "defined": "1.0.0",
+            "deps-sort": "2.0.0",
+            "domain-browser": "1.1.7",
+            "duplexer2": "0.1.4",
+            "events": "1.1.1",
+            "glob": "7.1.2",
+            "has": "1.0.1",
+            "htmlescape": "1.1.1",
+            "https-browserify": "1.0.0",
+            "inherits": "2.0.3",
+            "insert-module-globals": "7.0.1",
+            "labeled-stream-splicer": "2.0.0",
+            "module-deps": "4.1.1",
+            "os-browserify": "0.3.0",
+            "parents": "1.0.1",
+            "path-browserify": "0.0.0",
+            "process": "0.11.10",
+            "punycode": "1.4.1",
+            "querystring-es3": "0.2.1",
+            "read-only-stream": "2.0.0",
+            "readable-stream": "2.3.3",
+            "resolve": "1.4.0",
+            "shasum": "1.0.2",
+            "shell-quote": "1.6.1",
+            "stream-browserify": "2.0.1",
+            "stream-http": "2.7.2",
+            "string_decoder": "1.0.3",
+            "subarg": "1.0.0",
+            "syntax-error": "1.3.0",
+            "through2": "2.0.3",
+            "timers-browserify": "1.4.2",
+            "tty-browserify": "0.0.0",
+            "url": "0.11.0",
+            "util": "0.10.3",
+            "vm-browserify": "0.0.4",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "dependency-check": "^2.9.1",
     "eslint": "^4.6.1",
     "eslint-config-sinon": "^1.0.0",
+    "eslint-plugin-ie11": "^1.0.0",
     "eslint-plugin-mocha": "^4.2.0",
     "husky": "^0.14.2",
     "lint-staged": "^6.0.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -2,6 +2,7 @@ env:
   mocha: true
 
 plugins:
+  - ie11
   - mocha
 
 rules:
@@ -20,3 +21,8 @@ rules:
   mocha/no-sibling-hooks: error
   mocha/no-skipped-tests: warn
   mocha/no-top-level-hooks: error
+
+  ie11/no-collection-args: error
+  ie11/no-for-in-const: error
+  ie11/no-loop-func: warn
+  ie11/no-weak-collections: error

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -102,7 +102,8 @@ describe("collection", function () {
 
             for (var i = 0; i < types.length; i++) {
                 // yes, it's silly to create functions in a loop, it's also a test
-                assert.exception(function () { // eslint-disable-line no-loop-func
+                // eslint-disable-next-line no-loop-func ie11/no-loop-func
+                assert.exception(function () {
                     this.collection.createStubInstance(types[i]);
                 });
             }

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2451,7 +2451,8 @@ describe("stub", function () {
 
             for (var i = 0; i < types.length; i++) {
                 // yes, it's silly to create functions in a loop, it's also a test
-                assert.exception(function () { // eslint-disable-line no-loop-func
+                // eslint-disable-next-line no-loop-func ie11/no-loop-func
+                assert.exception(function () {
                     createStubInstance(types[i]);
                 });
             }


### PR DESCRIPTION
This PR adds `eslint-plugin-ie11`, which would have prevented me from merging #1661, which caused a failing build (and more work for me). Instead, the author would have seen the error and fixed it.

#### Background
In IE11 `Map` and `Set` constructors do not accept arguments, but instead of throwing an error, they fail silently, and just produce the empty state.

```js
// works in modern browsers, not in IE11
new Set([1, 2]);
```

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Add the code above to any linted JS file, save it
4. `npm run lint`
5. Observe the failure