### PR TITLE
Fix inconsistent naming

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -454,9 +454,9 @@ Useful if a function is called with more than one callback, and simply calling t
 }
 ```
 
-#### `stub.callArgWith(argNum, [arg1, arg2, ...])`
+#### `stub.callsArgWith(argNum, [arg1, arg2, ...])`
 
-Like `callArg`, but with arguments.
+Like `callsArg`, but with arguments.
 
 #### Asynchronous calls
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -435,7 +435,7 @@ Like `yield`, `yieldTo` grabs the first matching argument, finds the callback an
 ```
 
 
-#### `stub.callArg(argNum)`
+#### `stub.callsArg(argNum)`
 
 Like `yield`, but with an explicit argument number specifying which callback to call.
 
@@ -450,7 +450,7 @@ Useful if a function is called with more than one callback, and simply calling t
         console.log("Oh noes!");
     });
 
-    callback.callArg(1); // Logs "Oh noes!"
+    callback.callsArg(1); // Logs "Oh noes!"
 }
 ```
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -306,7 +306,7 @@ Causes the stub to return a Promise which rejects with the provided exception ob
 Causes the stub to call the argument at the provided index as a callback function. `stub.callsArg(0);` causes the stub to call the first argument as a callback.
 
 
-#### `stub.callThrough();`
+#### `stub.callsThrough();`
 
 Causes the original method wrapped into the stub to be called when none of the conditional stubs are matched.
 
@@ -325,7 +325,7 @@ obj.sum.withArgs(2, 2).callsFake(function foo() {
     return 'bar';
 });
 
-obj.sum.callThrough();
+obj.sum.callsThrough();
 
 obj.sum(2, 2); // 'bar'
 obj.sum(1, 2); // 3

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -154,7 +154,7 @@ var proto = {
             return (this.promiseLibrary || Promise).resolve(this.returnValue);
         } else if (this.reject) {
             return (this.promiseLibrary || Promise).reject(this.returnValue);
-        } else if (this.callsThrough) {
+        } else if (this.callsWrappedMethod) {
             return this.stub.wrappedMethod.apply(context, args);
         }
         return this.returnValue;

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -2,6 +2,7 @@
 
 var sinonMatch = require("./match");
 var deepEqual = require("./util/core/deep-equal").use(sinonMatch);
+var deprecated = require("./util/core/deprecated");
 var functionName = require("./util/core/function-name");
 var sinonFormat = require("./util/core/format");
 var valueToString = require("./util/core/value-to-string");
@@ -97,7 +98,12 @@ var callProto = {
         return this.callId === other.callId + 1;
     },
 
-    callArg: function (pos) {
+    callArg: deprecated.wrap(function () {
+        this.callsArg.apply(this, arguments);
+        // eslint-disable-next-line max-len
+    }, ".callArg has been renamed to .callsArg. You should fix your call sites to use the new name, the old method will be removed in a future release"),
+
+    callsArg: function callsArg(pos) {
         this.args[pos]();
     },
 

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -111,7 +111,12 @@ var callProto = {
         this.args[pos].apply(thisValue);
     },
 
-    callArgWith: function (pos) {
+    callArgWith: deprecated.wrap(function () {
+        this.callsArgWith.apply(this, arguments);
+        // eslint-disable-next-line max-len
+    }, ".callArgWith has been renamed to .callsArgWith. You should fix your call sites to use the new name, the old method will be removed in a future release"),
+
+    callsArgWith: function (pos) {
         this.callArgOnWith.apply(this, [pos, null].concat(slice.call(arguments, 1)));
     },
 

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -120,7 +120,12 @@ var callProto = {
         this.callArgOnWith.apply(this, [pos, null].concat(slice.call(arguments, 1)));
     },
 
-    callArgOnWith: function (pos, thisValue) {
+    callArgOnWith: deprecated.wrap(function () {
+        this.callsArgOnWith.apply(this, arguments);
+        // eslint-disable-next-line max-len
+    }, ".callArgOnWith has been renamed to .callsArgOnWith. You should fix your call sites to use the new name, the old method will be removed in a future release"),
+
+    callsArgOnWith: function (pos, thisValue) {
         var args = slice.call(arguments, 2);
         this.args[pos].apply(thisValue, args);
     },

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var deprecated = require("./util/core/deprecated");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 
 var slice = [].slice;
@@ -204,8 +205,13 @@ module.exports = {
         fake.fakeFn = undefined;
     },
 
-    callThrough: function callThrough(fake) {
-        fake.callsThrough = true;
+    callThrough: deprecated.wrap(function callThrough(fake) {
+        fake.callsWrappedMethod = true;
+        // eslint-disable-next-line max-len
+    }, ".callThrough has been renamed to .callsThrough. You should fix your call sites to use the new name, the old method will be removed in a future release"),
+
+    callsThrough: function callsThrough(fake) {
+        fake.callsWrappedMethod = true;
     },
 
     get: function get(fake, getterFunction) {

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -364,6 +364,55 @@ describe("sinonSpy.call", function () {
             }, "TypeError");
         });
     });
+    describe("call.callsArgWith", function () {
+        beforeEach(spyCallCallSetup);
+
+        it("calls argument at specified index with provided args", function () {
+            var object = {};
+            var callback = sinonSpy();
+            this.args.push(1, callback);
+
+            this.call.callsArgWith(1, object);
+
+            assert(callback.calledWith(object));
+        });
+
+        it("calls callback without args", function () {
+            var callback = sinonSpy();
+            this.args.push(1, callback);
+
+            this.call.callsArgWith(1);
+
+            assert(callback.calledWith());
+        });
+
+        it("calls callback wit multiple args", function () {
+            var object = {};
+            var array = [];
+            var callback = sinonSpy();
+            this.args.push(1, 2, callback);
+
+            this.call.callsArgWith(2, object, array);
+
+            assert(callback.calledWith(object, array));
+        });
+
+        it("throws if no index is specified", function () {
+            var call = this.call;
+
+            assert.exception(function () {
+                call.callsArgWith();
+            }, "TypeError");
+        });
+
+        it("throws if index is not number", function () {
+            var call = this.call;
+
+            assert.exception(function () {
+                call.callsArgWith({});
+            }, "TypeError");
+        });
+    });
 
     describe("call.callArgOnWith", function () {
         beforeEach(spyCallCallSetup);

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -243,6 +243,44 @@ describe("sinonSpy.call", function () {
         });
     });
 
+    describe("call.callsArg", function () {
+        beforeEach(spyCallCallSetup);
+
+        it("calls argument at specified index", function () {
+            var callback = sinonSpy();
+            this.args.push(1, 2, callback);
+
+            this.call.callsArg(2);
+
+            assert(callback.called);
+        });
+
+        it("throws if argument at specified index is not callable", function () {
+            this.args.push(1);
+            var call = this.call;
+
+            assert.exception(function () {
+                call.callsArg(0);
+            }, "TypeError");
+        });
+
+        it("throws if no index is specified", function () {
+            var call = this.call;
+
+            assert.exception(function () {
+                call.callsArg();
+            }, "TypeError");
+        });
+
+        it("throws if index is not number", function () {
+            var call = this.call;
+
+            assert.exception(function () {
+                call.callsArg({});
+            }, "TypeError");
+        });
+    });
+
     describe("call.callArgOn", function () {
         beforeEach(spyCallCallSetup);
 

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -463,6 +463,55 @@ describe("sinonSpy.call", function () {
         });
     });
 
+    describe("call.callsArgOnWith", function () {
+        beforeEach(spyCallCallSetup);
+
+        it("calls argument at specified index with provided args", function () {
+            var object = {};
+            var thisObj = { name1: "value1", name2: "value2" };
+            var callback = sinonSpy();
+            this.args.push(1, callback);
+
+            this.call.callsArgOnWith(1, thisObj, object);
+
+            assert(callback.calledWith(object));
+            assert(callback.calledOn(thisObj));
+        });
+
+        it("calls callback without args", function () {
+            var callback = sinonSpy();
+            var thisObj = { name1: "value1", name2: "value2" };
+            this.args.push(1, callback);
+
+            this.call.callsArgOnWith(1, thisObj);
+
+            assert(callback.calledWith());
+            assert(callback.calledOn(thisObj));
+        });
+
+        it("calls callback with multiple args", function () {
+            var object = {};
+            var array = [];
+            var thisObj = { name1: "value1", name2: "value2" };
+            var callback = sinonSpy();
+            this.args.push(1, 2, callback);
+
+            this.call.callsArgOnWith(2, thisObj, object, array);
+
+            assert(callback.calledWith(object, array));
+            assert(callback.calledOn(thisObj));
+        });
+
+        it("throws if index is not number", function () {
+            var thisObj = { name1: "value1", name2: "value2" };
+            var call = this.call;
+
+            assert.exception(function () {
+                call.callsArgOnWith({}, thisObj);
+            }, "TypeError");
+        });
+    });
+
     describe("call.yieldTest", function () {
         beforeEach(spyCallCallSetup);
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2458,7 +2458,7 @@ describe("stub", function () {
         });
     });
 
-    describe(".callThrough", function () {
+    describe(".callsThrough - deprecated", function () {
         it("does not call original function when arguments match conditional stub", function () {
             // We need a function here because we can't wrap properties that are already stubs
             var callCount = 0;
@@ -2540,6 +2540,95 @@ describe("stub", function () {
             var propStub = createStub(myObj, "prop");
             propStub.withArgs("foo").returns("bar");
             propStub.callThrough();
+
+            myObj.prop("not foo");
+
+            assert.equals(reference, myObj);
+        });
+    });
+
+    describe(".callsThrough", function () {
+        it("does not call original function when arguments match conditional stub", function () {
+            // We need a function here because we can't wrap properties that are already stubs
+            var callCount = 0;
+            var originalFunc = function increaseCallCount() {
+                callCount++;
+            };
+
+            var myObj = {
+                prop: originalFunc
+            };
+
+            var propStub = createStub(myObj, "prop");
+            propStub.withArgs("foo").returns("bar");
+            propStub.callsThrough();
+
+            var result = myObj.prop("foo");
+
+            assert.equals(result, "bar");
+            assert.equals(callCount, 0);
+        });
+
+        it("calls original function when arguments do not match conditional stub", function () {
+            // We need a function here because we can't wrap properties that are already stubs
+            var callCount = 0;
+
+            var originalFunc = function increaseCallCount() {
+                callCount++;
+                return 1337;
+            };
+
+            var myObj = {
+                prop: originalFunc
+            };
+
+            var propStub = createStub(myObj, "prop");
+            propStub.withArgs("foo").returns("bar");
+            propStub.callsThrough(propStub);
+
+            var result = myObj.prop("not foo");
+
+            assert.equals(result, 1337);
+            assert.equals(callCount, 1);
+        });
+
+        it("calls original function with same arguments when call does not match conditional stub", function () {
+            // We need a function here because we can't wrap properties that are already stubs
+            var callArgs = [];
+
+            var originalFunc = function increaseCallCount() {
+                callArgs = arguments;
+            };
+
+            var myObj = {
+                prop: originalFunc
+            };
+
+            var propStub = createStub(myObj, "prop");
+            propStub.withArgs("foo").returns("bar");
+            propStub.callsThrough();
+
+            myObj.prop("not foo");
+
+            assert.equals(callArgs.length, 1);
+            assert.equals(callArgs[0], "not foo");
+        });
+
+        it("calls original function with same `this` reference when call does not match conditional stub", function () {
+            // We need a function here because we can't wrap properties that are already stubs
+            var reference = {};
+
+            var originalFunc = function increaseCallCount() {
+                reference = this;
+            };
+
+            var myObj = {
+                prop: originalFunc
+            };
+
+            var propStub = createStub(myObj, "prop");
+            propStub.withArgs("foo").returns("bar");
+            propStub.callsThrough();
 
             myObj.prop("not foo");
 


### PR DESCRIPTION
This PR is a fix for #1509, it renames the following methods

* `stub.callArg ` => `stub.callsArg`
* `stub.callArgOnWith` => `stub.callsArgOnWith`
* `stub.callArgWith ` => `stub.callsArgWith`
* `stub.callThrough` => `stub.callsThrough`

AFAICT, this fixes the inconsistent naming of the `calls*` methods.

I've added deprecation warnings to all the old names. We can remove them in the next major version, or the one after that.

#### How to verify - mandatory

1. Carefully read the PR
1. Observe that tests pass
