### PR TITLE
Fix to #1627

### DIFF
--- a/lib/sinon/util/core/wrap-method.js
+++ b/lib/sinon/util/core/wrap-method.js
@@ -43,8 +43,8 @@ module.exports = function wrapMethod(object, property, method) {
         }
 
         if (error) {
-            if (wrappedMethod && wrappedMethod.stackTrace) {
-                error.stack += "\n--------------\n" + wrappedMethod.stackTrace;
+            if (wrappedMethod && wrappedMethod.stackTraceError) {
+                error.stack += "\n--------------\n" + wrappedMethod.stackTraceError.stack;
             }
             throw error;
         }
@@ -73,8 +73,8 @@ module.exports = function wrapMethod(object, property, method) {
             error = new TypeError("Attempted to wrap " + property + " which is already wrapped");
         }
         if (error) {
-            if (wrappedMethodDesc && wrappedMethodDesc.stackTrace) {
-                error.stack += "\n--------------\n" + wrappedMethodDesc.stackTrace;
+            if (wrappedMethodDesc && wrappedMethodDesc.stackTraceError) {
+                error.stack += "\n--------------\n" + wrappedMethodDesc.stackTraceError.stack;
             }
             throw error;
         }
@@ -105,9 +105,9 @@ module.exports = function wrapMethod(object, property, method) {
 
     method.displayName = property;
 
-    // Set up a stack trace which can be used later to find what line of
+    // Set up an Error object for a stack trace which can be used later to find what line of
     // code the original method was created on.
-    method.stackTrace = (new Error("Stack Trace for original")).stack;
+    method.stackTraceError = (new Error("Stack Trace for original"));
 
     method.restore = function () {
         // For prototype properties try to reset by delete first.


### PR DESCRIPTION
Fix issue #1627 by creating an error object and use the property 'stack' only when needed, instead of read stack property in the creation time of the error object.

#### Background (Problem in detail) 
The slowness seems to come from accessing the .stack property on the error, as v8 seems to go through considerable trouble in order to convert it from its internal representation to the string version it uses to report errors.

#### Solution  
the fix for this is to change the line to method.stackTraceError = new Error("Stack Trace for original"), and only access the .stack property if an error needs to be reported.

####Test
passed: 'npm run test' and 'npm run lint'
