### PR TITLE
Fix #1638: resetHistory for props

### DIFF
--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -47,12 +47,29 @@ var collection = {
     },
 
     resetHistory: function resetHistory() {
-        getFakes(this).forEach(function (fake) {
-            var method = fake.resetHistory || fake.reset;
-
+        function privateResetHistory(f) {
+            var method = f.resetHistory || f.reset;
             if (method) {
-                method.call(fake);
+                method.call(f);
             }
+        }
+
+        getFakes(this).forEach(function (fake) {
+            if (typeof fake === "function") {
+                privateResetHistory(fake);
+                return;
+            }
+
+            var methods = [];
+            if (fake.get) {
+                methods.push(fake.get);
+            }
+
+            if (fake.set) {
+                methods.push(fake.set);
+            }
+
+            methods.forEach(privateResetHistory);
         });
     },
 

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -458,29 +458,40 @@ describe("collection", function () {
     describe(".resetHistory", function () {
         beforeEach(function () {
             this.collection = Object.create(sinonCollection);
-            this.collection.fakes = [{
-                // this fake has a resetHistory method
-                resetHistory: sinonSpy()
-            }, {
-                // this fake has a resetHistory method
-                resetHistory: sinonSpy()
-            }, {
-                // this fake pretends to be a spy, which does not have resetHistory method
-                // but has a reset method
-                reset: sinonSpy()
-            }];
+            var spy1 = sinonSpy();
+            spy1();
+
+            var spy2 = sinonSpy();
+            spy2();
+
+            this.collection.fakes = [
+                spy1,
+                spy2
+            ];
         });
 
         it("resets the history on all fakes", function () {
             var fake0 = this.collection.fakes[0];
             var fake1 = this.collection.fakes[1];
-            var fake2 = this.collection.fakes[2];
 
             this.collection.resetHistory();
 
-            assert(fake0.resetHistory.called);
-            assert(fake1.resetHistory.called);
-            assert(fake2.reset.called);
+            refute(fake0.called);
+            refute(fake1.called);
+        });
+
+        it("calls reset on fake that do not have a resetHistory", function () {
+            var noop = function noop() {};
+
+            noop.reset = function reset() {
+                noop.reset.called = true;
+            };
+
+            this.collection.fakes.push(noop);
+
+            this.collection.resetHistory();
+
+            assert.isTrue(noop.reset.called);
         });
     });
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -390,4 +390,34 @@ describe("issues", function () {
             mock.verify();
         });
     });
+
+    describe("#1648 - resetHistory ", function () {
+        it("should reset property spies", function () {
+            var obj = {
+                func: function () {},
+                get prop() {
+                    return 1;
+                }
+            };
+
+            var sandbox = sinon.createSandbox();
+            var spyFunc = sandbox.spy(obj, "func");
+            var spyProp = sandbox.spy(obj, "prop", ["get"]);
+
+            refute.isTrue(spyFunc.called);
+            refute.isTrue(spyProp.get.called);
+
+            obj.func();
+            //eslint-disable-next-line no-unused-expressions
+            obj.prop;
+
+            assert.isTrue(spyFunc.called);
+            assert.isTrue(spyProp.get.called);
+
+            sandbox.resetHistory();
+
+            refute.isTrue(spyFunc.called);
+            refute.isTrue(spyProp.get.called);
+        });
+    });
 });


### PR DESCRIPTION
This PR is a fix for #1638.

The first commit is a fix for a poorly constructed test. Reviewers: is the commit message adequate to describe what the issue was?

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`
4. Observe no test failures

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
