### PR TITLE
Replace formatio with @sinonjs/formatio

### DIFF
--- a/lib/sinon/util/core/format.js
+++ b/lib/sinon/util/core/format.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var formatio = require("formatio");
+var formatio = require("@sinonjs/formatio");
 
 var formatter = formatio.configure({
     quoteStrings: false,

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "docs/**/*.md": "markdownlint"
   },
   "dependencies": {
+    "@sinonjs/formatio": "^2.0.0",
     "diff": "^3.1.0",
-    "formatio": "1.2.0",
     "lodash.get": "^4.4.2",
     "lolex": "^2.2.0",
     "nise": "^1.2.0",


### PR DESCRIPTION
#### Purpose (TL;DR)

As agreed in #1650, this pull request replaces the use of `formatio@1.2.0` with `@sinonjs/formatio@2.0.0`, which is now on npm.


#### How to verify - mandatory

This PR should preferably be verified using a project that consumes `sinon`.

1. Check out this branch
2. `npm install`
3. `npm link`
4. Switch to your consuming project
5. `npm link sinon`
6. Run your tests
