### PR TITLE
Add calledOnceWithExactly assertion

### DIFF
--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -255,6 +255,10 @@ Returns `true` if spy was called at least once with the provided arguments.
 
 Can be used for partial matching, Sinon only checks the provided arguments against actual arguments, so a call that received the provided arguments (in the same spots) and possibly others as well will return `true`.
 
+#### `spy.calledOnceWith(arg1, arg2, ...);`
+
+Returns `true` if spy was called at exactly once with the provided arguments.
+
 
 #### `spy.alwaysCalledWith(arg1, arg2, ...);`
 
@@ -264,6 +268,10 @@ Returns `true` if spy was always called with the provided arguments (and possibl
 #### `spy.calledWithExactly(arg1, arg2, ...);`
 
 Returns `true` if spy was called at least once with the provided arguments and no others.
+
+#### `spy.calledOnceWithExactly(arg1, arg2, ...);`
+
+Returns `true` if spy was called exactly once with the provided arguments and no others.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -423,6 +423,7 @@ spyApi.reset = deprecated.wrap(spyApi.resetHistory, deprecated.defaultMsg("reset
 delegateToCalls("calledOn", true);
 delegateToCalls("alwaysCalledOn", false, "calledOn");
 delegateToCalls("calledWith", true);
+delegateToCalls("calledOnceWith", true, "calledWith", undefined, 1);
 delegateToCalls("calledWithMatch", true);
 delegateToCalls("alwaysCalledWith", false, "calledWith");
 delegateToCalls("alwaysCalledWithMatch", false, "calledWithMatch");

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -386,13 +386,19 @@ var spyApi = {
     }
 };
 
-function delegateToCalls(method, matchAny, actual, notCalled) {
+function delegateToCalls(method, matchAny, actual, notCalled, totalCallCount) {
     spyApi[method] = function () {
         if (!this.called) {
             if (notCalled) {
                 return notCalled.apply(this, arguments);
             }
             return false;
+        }
+
+        if (totalCallCount !== undefined) {
+            if (this.callCount !== totalCallCount) {
+                return false;
+            }
         }
 
         var currentCall;
@@ -423,6 +429,7 @@ delegateToCalls("calledWithMatch", true);
 delegateToCalls("alwaysCalledWith", false, "calledWith");
 delegateToCalls("alwaysCalledWithMatch", false, "calledWithMatch");
 delegateToCalls("calledWithExactly", true);
+delegateToCalls("calledOnceWithExactly", true, "calledWithExactly", undefined, 1);
 delegateToCalls("alwaysCalledWithExactly", false, "calledWithExactly");
 delegateToCalls("neverCalledWith", false, "notCalledWith", function () {
     return true;

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -395,10 +395,8 @@ function delegateToCalls(method, matchAny, actual, notCalled, totalCallCount) {
             return false;
         }
 
-        if (totalCallCount !== undefined) {
-            if (this.callCount !== totalCallCount) {
-                return false;
-            }
+        if (totalCallCount !== undefined && this.callCount !== totalCallCount) {
+            return false;
         }
 
         var currentCall;

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -1181,6 +1181,38 @@ describe("spy", function () {
         });
     });
 
+    describe(".calledOnceWith", function () {
+        beforeEach(function () {
+            this.spy = createSpy.create();
+        });
+
+        it("returns true for not exact match", function () {
+            this.spy(1, 2, 3, 4);
+
+            assert.isTrue(this.spy.calledOnceWith(1, 2, 3));
+        });
+
+        it("returns false for matching calls but called more then once", function () {
+            this.spy(1, 2, 3, 4);
+            this.spy(1, 2, 3, 6);
+
+            assert.isFalse(this.spy.calledOnceWith(1, 2, 3));
+        });
+
+        it("return false for one mismatched call", function () {
+            this.spy(1, 2);
+
+            assert.isFalse(this.spy.calledOnceWith(1, 2, 3));
+        });
+
+        it("return false for one mismatched call with some other ", function () {
+            this.spy(1, 2, 3);
+            this.spy(1, 2);
+
+            assert.isFalse(this.spy.calledOnceWith(1, 2, 3));
+        });
+    });
+
     describe(".calledOnceWithExactly", function () {
         beforeEach(function () {
             this.spy = createSpy.create();

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -1181,6 +1181,38 @@ describe("spy", function () {
         });
     });
 
+    describe(".calledOnceWithExactly", function () {
+        beforeEach(function () {
+            this.spy = createSpy.create();
+        });
+
+        it("returns true for exact match", function () {
+            this.spy(1, 2, 3);
+
+            assert.isTrue(this.spy.calledOnceWithExactly(1, 2, 3));
+        });
+
+        it("returns false for exact parameters but called more then once", function () {
+            this.spy(1, 2, 3);
+            this.spy(1, 2, 3);
+
+            assert.isFalse(this.spy.calledOnceWithExactly(1, 2, 3));
+        });
+
+        it("return false for one mismatched call", function () {
+            this.spy(1, 2);
+
+            assert.isFalse(this.spy.calledOnceWithExactly(1, 2, 3));
+        });
+
+        it("return false for one mismatched call with some other ", function () {
+            this.spy(1, 2, 3);
+            this.spy(1, 2);
+
+            assert.isFalse(this.spy.calledOnceWithExactly(1, 2, 3));
+        });
+    });
+
     describe(".alwaysCalledWithExactly", function () {
         beforeEach(function () {
             this.spy = createSpy.create();


### PR DESCRIPTION
#### Purpose
Adds `calledOnceWithExactly` due to popular request. https://github.com/sinonjs/sinon/issues/1247
Adds `calledOnceWith` for consistency.

#### How to verify - mandatory
Just run new tests.

#### Checklist for author

- [x] `npm run lint` passes (it passes for my code but it was failing before :( )
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
