### PR TITLE
Change return value of yield and callArg

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -409,6 +409,8 @@ Invoke callbacks passed to the `stub` with the given arguments.
 
 If the stub was never called with a function argument, `yield` throws an error.
 
+Returns an Array with all callbacks return values in the order they were called, if no error is thrown.
+
 Also aliased as `invokeCallback`.
 
 

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -98,20 +98,20 @@ var callProto = {
     },
 
     callArg: function (pos) {
-        this.args[pos]();
+        return this.args[pos]();
     },
 
     callArgOn: function (pos, thisValue) {
-        this.args[pos].apply(thisValue);
+        return this.args[pos].apply(thisValue);
     },
 
     callArgWith: function (pos) {
-        this.callArgOnWith.apply(this, [pos, null].concat(slice.call(arguments, 1)));
+        return this.callArgOnWith.apply(this, [pos, null].concat(slice.call(arguments, 1)));
     },
 
     callArgOnWith: function (pos, thisValue) {
         var args = slice.call(arguments, 2);
-        this.args[pos].apply(thisValue, args);
+        return this.args[pos].apply(thisValue, args);
     },
 
     throwArg: function (pos) {
@@ -127,7 +127,7 @@ var callProto = {
     },
 
     "yield": function () {
-        this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
+        return this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
     yieldOn: function (thisValue) {
@@ -140,11 +140,11 @@ var callProto = {
             throwYieldError(this.proxy, " cannot yield since no callback was passed.", args);
         }
 
-        yieldFn.apply(thisValue, slice.call(arguments, 1));
+        return yieldFn.apply(thisValue, slice.call(arguments, 1));
     },
 
     yieldTo: function (prop) {
-        this.yieldToOn.apply(this, [prop, null].concat(slice.call(arguments, 1)));
+        return this.yieldToOn.apply(this, [prop, null].concat(slice.call(arguments, 1)));
     },
 
     yieldToOn: function (prop, thisValue) {
@@ -159,7 +159,7 @@ var callProto = {
                 "' since no callback was passed.", args);
         }
 
-        yieldFn.apply(thisValue, slice.call(arguments, 2));
+        return yieldFn.apply(thisValue, slice.call(arguments, 2));
     },
 
     toString: function () {

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -386,7 +386,7 @@ var spyApi = {
     }
 };
 
-function delegateToCalls(method, matchAny, actual, notCalled, totalCallCount) {
+function delegateToCalls(method, matchAny, actual, returnsValues, notCalled, totalCallCount) {
     spyApi[method] = function () {
         if (!this.called) {
             if (notCalled) {
@@ -401,11 +401,13 @@ function delegateToCalls(method, matchAny, actual, notCalled, totalCallCount) {
 
         var currentCall;
         var matches = 0;
+        var returnValues = [];
 
         for (var i = 0, l = this.callCount; i < l; i += 1) {
             currentCall = this.getCall(i);
-
-            if (currentCall[actual || method].apply(currentCall, arguments)) {
+            var returnValue = currentCall[actual || method].apply(currentCall, arguments);
+            returnValues.push(returnValue);
+            if (returnValue) {
                 matches += 1;
 
                 if (matchAny) {
@@ -414,6 +416,9 @@ function delegateToCalls(method, matchAny, actual, notCalled, totalCallCount) {
             }
         }
 
+        if (returnsValues) {
+            return returnValues;
+        }
         return matches === this.callCount;
     };
 }
@@ -423,17 +428,17 @@ spyApi.reset = deprecated.wrap(spyApi.resetHistory, deprecated.defaultMsg("reset
 delegateToCalls("calledOn", true);
 delegateToCalls("alwaysCalledOn", false, "calledOn");
 delegateToCalls("calledWith", true);
-delegateToCalls("calledOnceWith", true, "calledWith", undefined, 1);
+delegateToCalls("calledOnceWith", true, "calledWith", false, undefined, 1);
 delegateToCalls("calledWithMatch", true);
 delegateToCalls("alwaysCalledWith", false, "calledWith");
 delegateToCalls("alwaysCalledWithMatch", false, "calledWithMatch");
 delegateToCalls("calledWithExactly", true);
-delegateToCalls("calledOnceWithExactly", true, "calledWithExactly", undefined, 1);
+delegateToCalls("calledOnceWithExactly", true, "calledWithExactly", false, undefined, 1);
 delegateToCalls("alwaysCalledWithExactly", false, "calledWithExactly");
-delegateToCalls("neverCalledWith", false, "notCalledWith", function () {
+delegateToCalls("neverCalledWith", false, "notCalledWith", false, function () {
     return true;
 });
-delegateToCalls("neverCalledWithMatch", false, "notCalledWithMatch", function () {
+delegateToCalls("neverCalledWithMatch", false, "notCalledWithMatch", false, function () {
     return true;
 });
 delegateToCalls("threw", true);
@@ -442,30 +447,30 @@ delegateToCalls("returned", true);
 delegateToCalls("alwaysReturned", false, "returned");
 delegateToCalls("calledWithNew", true);
 delegateToCalls("alwaysCalledWithNew", false, "calledWithNew");
-delegateToCalls("callArg", false, "callArgWith", function () {
+delegateToCalls("callArg", false, "callArgWith", true, function () {
     throw new Error(this.toString() + " cannot call arg since it was not yet invoked.");
 });
 spyApi.callArgWith = spyApi.callArg;
-delegateToCalls("callArgOn", false, "callArgOnWith", function () {
+delegateToCalls("callArgOn", false, "callArgOnWith", true, function () {
     throw new Error(this.toString() + " cannot call arg since it was not yet invoked.");
 });
 spyApi.callArgOnWith = spyApi.callArgOn;
-delegateToCalls("throwArg", false, "throwArg", function () {
+delegateToCalls("throwArg", false, "throwArg", false, function () {
     throw new Error(this.toString() + " cannot throw arg since it was not yet invoked.");
 });
-delegateToCalls("yield", false, "yield", function () {
+delegateToCalls("yield", false, "yield", true, function () {
     throw new Error(this.toString() + " cannot yield since it was not yet invoked.");
 });
 // "invokeCallback" is an alias for "yield" since "yield" is invalid in strict mode.
 spyApi.invokeCallback = spyApi.yield;
-delegateToCalls("yieldOn", false, "yieldOn", function () {
+delegateToCalls("yieldOn", false, "yieldOn", true, function () {
     throw new Error(this.toString() + " cannot yield since it was not yet invoked.");
 });
-delegateToCalls("yieldTo", false, "yieldTo", function (property) {
+delegateToCalls("yieldTo", false, "yieldTo", true, function (property) {
     throw new Error(this.toString() + " cannot yield to '" + valueToString(property) +
         "' since it was not yet invoked.");
 });
-delegateToCalls("yieldToOn", false, "yieldToOn", function (property) {
+delegateToCalls("yieldToOn", false, "yieldToOn", true, function (property) {
     throw new Error(this.toString() + " cannot yield to '" + valueToString(property) +
         "' since it was not yet invoked.");
 });

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -234,6 +234,17 @@ describe("sinonSpy.call", function () {
             }, "TypeError");
         });
 
+        it("returns callbacks return value", function () {
+            var callback = sinonSpy(function () {
+                return "useful value";
+            });
+            this.args.push(1, 2, callback);
+
+            var returnValue = this.call.callArg(2);
+
+            assert.equals(returnValue, "useful value");
+        });
+
         it("throws if index is not number", function () {
             var call = this.call;
 
@@ -265,6 +276,18 @@ describe("sinonSpy.call", function () {
             assert.exception(function () {
                 call.callArgOn(0, thisObj);
             }, "TypeError");
+        });
+
+        it("returns callbacks return value", function () {
+            var callback = sinonSpy(function () {
+                return "useful value";
+            });
+            var thisObj = { name1: "value1", name2: "value2" };
+            this.args.push(1, 2, callback);
+
+            var returnValue = this.call.callArgOn(2, thisObj);
+
+            assert.equals(returnValue, "useful value");
         });
 
         it("throws if index is not number", function () {
@@ -308,6 +331,18 @@ describe("sinonSpy.call", function () {
             this.call.callArgWith(2, object, array);
 
             assert(callback.calledWith(object, array));
+        });
+
+        it("returns callbacks return value", function () {
+            var object = {};
+            var callback = sinonSpy(function () {
+                return "useful value";
+            });
+            this.args.push(1, callback);
+
+            var returnValue = this.call.callArgWith(1, object);
+
+            assert.equals(returnValue, "useful value");
         });
 
         it("throws if no index is specified", function () {
@@ -364,6 +399,19 @@ describe("sinonSpy.call", function () {
 
             assert(callback.calledWith(object, array));
             assert(callback.calledOn(thisObj));
+        });
+
+        it("returns callbacks return value", function () {
+            var object = {};
+            var thisObj = { name1: "value1", name2: "value2" };
+            var callback = sinonSpy(function () {
+                return "useful value";
+            });
+            this.args.push(1, callback);
+
+            var returnValue = this.call.callArgOnWith(1, thisObj, object);
+
+            assert.equals(returnValue, "useful value");
         });
 
         it("throws if index is not number", function () {
@@ -447,6 +495,17 @@ describe("sinonSpy.call", function () {
             this.call.yield(obj, "Crazy");
 
             assert(spy.calledWith(obj, "Crazy"));
+        });
+
+        it("returns callbacks return value", function () {
+            var spy = sinonSpy(function () {
+                return "useful value";
+            });
+            this.args.push(24, {}, spy);
+
+            var returnValue = this.call.yield();
+
+            assert.equals(returnValue, "useful value");
         });
 
         it("throws if callback throws", function () {
@@ -554,6 +613,18 @@ describe("sinonSpy.call", function () {
             assert(spy.calledOn(thisObj));
         });
 
+        it("returns callbacks return value", function () {
+            var spy = sinonSpy(function () {
+                return "useful value";
+            });
+            var thisObj = { name1: "value1", name2: "value2" };
+            this.args.push(24, {}, spy);
+
+            var returnValue = this.call.yieldOn(thisObj);
+
+            assert.equals(returnValue, "useful value");
+        });
+
         it("throws if callback throws", function () {
             this.args.push(function () {
                 throw new Error("d'oh!");
@@ -640,6 +711,17 @@ describe("sinonSpy.call", function () {
             this.call.yieldTo("success", obj, "Crazy");
 
             assert(spy.calledWith(obj, "Crazy"));
+        });
+
+        it("returns callbacks return value", function () {
+            var spy = sinonSpy(function () {
+                return "useful value";
+            });
+            this.args.push(24, {}, { success: spy });
+
+            var returnValue = this.call.yieldTo("success");
+
+            assert.equals(returnValue, "useful value");
         });
 
         it("throws if callback throws", function () {
@@ -755,6 +837,18 @@ describe("sinonSpy.call", function () {
 
             assert(spy.calledWith(obj, "Crazy"));
             assert(spy.calledOn(thisObj));
+        });
+
+        it("returns callbacks return value", function () {
+            var spy = sinonSpy(function () {
+                return "useful value";
+            });
+            var thisObj = { name1: "value1", name2: "value2" };
+            this.args.push(24, {}, { success: spy });
+
+            var returnValue = this.call.yieldToOn("success", thisObj);
+
+            assert.equals(returnValue, "useful value");
         });
 
         it("throws if callback throws", function () {

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2159,6 +2159,24 @@ describe("spy", function () {
 
             assert(callback.calledWith("abc", 123, array, object));
         });
+
+        it("returns callbacks return values for all calls", function () {
+            var spy = createSpy();
+            var i = 0;
+            var callback = createSpy(function () {
+                i++;
+                return "useful value " + i;
+            });
+            spy(1, 2, callback);
+            spy(3, 4, callback);
+
+            var returnValues = spy.callArg(2);
+
+            assert.equals(returnValues, [
+                "useful value 1",
+                "useful value 2"
+            ]);
+        });
     });
 
     describe(".callArgOn", function () {
@@ -2244,6 +2262,25 @@ describe("spy", function () {
             assert(callback.calledWith("abc", 123, array, object));
             assert(callback.calledOn(thisObj));
         });
+
+        it("returns callbacks return values for all calls", function () {
+            var spy = createSpy();
+            var i = 0;
+            var callback = createSpy(function () {
+                i++;
+                return "useful value " + i;
+            });
+            var thisObj = { name1: "value1", name2: "value2" };
+            spy(1, 2, callback);
+            spy(3, 4, callback);
+
+            var returnValues = spy.callArgOn(2, thisObj);
+
+            assert.equals(returnValues, [
+                "useful value 1",
+                "useful value 2"
+            ]);
+        });
     });
 
     describe(".callArgWith", function () {
@@ -2319,6 +2356,24 @@ describe("spy", function () {
 
             assert(callback.calledWith("abc", 123, array, object));
         });
+
+        it("returns callbacks return values for all calls", function () {
+            var spy = createSpy();
+            var i = 0;
+            var callback = createSpy(function () {
+                i++;
+                return "useful value " + i;
+            });
+            spy(1, 2, callback);
+            spy(3, 4, callback);
+
+            var returnValues = spy.yield();
+
+            assert.equals(returnValues, [
+                "useful value 1",
+                "useful value 2"
+            ]);
+        });
     });
 
     describe(".invokeCallback", function () {
@@ -2391,6 +2446,25 @@ describe("spy", function () {
 
             assert(callback.calledWith("abc", 123, array, object));
             assert(callback.calledOn(thisObj));
+        });
+
+        it("returns callbacks return values for all calls", function () {
+            var spy = createSpy();
+            var i = 0;
+            var callback = createSpy(function () {
+                i++;
+                return "useful value " + i;
+            });
+            var thisObj = { name1: "value1", name2: "value2" };
+            spy(1, 2, callback);
+            spy(3, 4, callback);
+
+            var returnValues = spy.yieldOn(thisObj);
+
+            assert.equals(returnValues, [
+                "useful value 1",
+                "useful value 2"
+            ]);
         });
     });
 
@@ -2465,6 +2539,24 @@ describe("spy", function () {
             spy.yieldTo("test", "abc", 123, array, object);
 
             assert(callback.calledWith("abc", 123, array, object));
+        });
+
+        it("returns callbacks return values for all calls", function () {
+            var spy = createSpy();
+            var i = 0;
+            var callback = createSpy(function () {
+                i++;
+                return "useful value " + i;
+            });
+            spy(1, 2, { success: callback });
+            spy(3, 4, { success: callback });
+
+            var returnValues = spy.yieldTo("success");
+
+            assert.equals(returnValues, [
+                "useful value 1",
+                "useful value 2"
+            ]);
         });
     });
 
@@ -2546,6 +2638,25 @@ describe("spy", function () {
 
             assert(callback.calledWith("abc", 123, array, object));
             assert(callback.calledOn(thisObj));
+        });
+
+        it("returns callbacks return values for all calls", function () {
+            var spy = createSpy();
+            var i = 0;
+            var callback = createSpy(function () {
+                i++;
+                return "useful value " + i;
+            });
+            var thisObj = { name1: "value1", name2: "value2" };
+            spy(1, 2, { success: callback });
+            spy(3, 4, { success: callback });
+
+            var returnValues = spy.yieldToOn("success", thisObj);
+
+            assert.equals(returnValues, [
+                "useful value 1",
+                "useful value 2"
+            ]);
         });
     });
 


### PR DESCRIPTION
Hi, thanks for the work on sinon!

#### Purpose
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Instead of returning false this change makes `yield`, `yieldOn`, `yieldTo`, `yieldToOn`, `callArg`, and `callArgOn` return the callbacks return values. This was also requested in #903.


#### Background
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->
When doing blackbox feature tests, where a codebase itself is not exposed to the tests, but instead adds listeners to global sinon stubs (imitating the WebExtensions API in this case), then it's necessary to trigger behavior in the codebase by yielding those listeners. Currently we have to rely on `process.nextTick` to wait for resolving promises and we have no way of getting the return value, e.g.

https://github.com/mozilla/multi-account-containers/blob/61da6b5e99e3265ed8fcfb40cc46e3ae01d0c2fa/test/issues/940.test.js#L32-L38

With this change we could await the actual returned promise and also verify return values.


#### Solution
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
Thanks to the tidy sinon codebase this was only a matter of adding some return statements and a slight change to `delegateToCalls`, which now accepts an additional parameter that triggers to return callback values instead of true or false. The parameter is only set to true for the yield and callArg functions. Also added tests and a sentence to the docs.

#### How to verify
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

#### Note

Like suggested in #903 did I test this against #1586 and it's working fine.