### PR TITLE
Added comma in v4 migration guide, for clarity

### DIFF
--- a/docs/guides/migrating-to-4.0.md
+++ b/docs/guides/migrating-to-4.0.md
@@ -9,6 +9,6 @@ This guide will walk you through those changes.
 
 ## `sinon.stub(obj, 'nonExistingProperty')` - Throws
 
-Trying to stub a non-existing property will now fail to ensure you are creating
+Trying to stub a non-existing property will now fail, to ensure you are creating
 [less error-prone tests](https://github.com/sinonjs/sinon/pull/1557).
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Added comma to docs for increased clarity. Wouldn't want anyone thinking sinon will in any way "fail to ensure you are creating less error prone tests" :)

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. No further steps required - documentation change

#### Checklist for author
- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
