### PR TITLE
Ensure that argument is a function befor attempting to call it

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -98,10 +98,12 @@ var callProto = {
     },
 
     callArg: function (pos) {
+        this.ensureArgIsAFunction(pos);
         return this.args[pos]();
     },
 
     callArgOn: function (pos, thisValue) {
+        this.ensureArgIsAFunction(pos);
         return this.args[pos].apply(thisValue);
     },
 
@@ -110,6 +112,7 @@ var callProto = {
     },
 
     callArgOnWith: function (pos, thisValue) {
+        this.ensureArgIsAFunction(pos);
         var args = slice.call(arguments, 2);
         return this.args[pos].apply(thisValue, args);
     },
@@ -193,6 +196,16 @@ var callProto = {
         }
 
         return callStr;
+    },
+
+    ensureArgIsAFunction: function (pos) {
+        if (typeof this.args[pos] !== "function") {
+            throw new TypeError(
+                "Expected argument at position " + pos
+                + " to be a Function, but was "
+                + typeof this.args[pos]
+            );
+        }
     }
 };
 Object.defineProperty(callProto, "stack", {

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -223,7 +223,7 @@ describe("sinonSpy.call", function () {
 
             assert.exception(function () {
                 call.callArg(0);
-            }, "TypeError");
+            }, {message: "Expected argument at position 0 to be a Function, but was number"});
         });
 
         it("throws if no index is specified", function () {
@@ -275,7 +275,7 @@ describe("sinonSpy.call", function () {
 
             assert.exception(function () {
                 call.callArgOn(0, thisObj);
-            }, "TypeError");
+            }, {message: "Expected argument at position 0 to be a Function, but was number"});
         });
 
         it("returns callbacks return value", function () {
@@ -412,6 +412,16 @@ describe("sinonSpy.call", function () {
             var returnValue = this.call.callArgOnWith(1, thisObj, object);
 
             assert.equals(returnValue, "useful value");
+        });
+
+        it("throws if argument at specified index is not callable", function () {
+            var thisObj = { name1: "value1", name2: "value2" };
+            this.args.push(1, 2, 1);
+            var call = this.call;
+
+            assert.exception(function () {
+                call.callArgOnWith(2, thisObj);
+            }, {message: "Expected argument at position 2 to be a Function, but was number"});
         });
 
         it("throws if index is not number", function () {


### PR DESCRIPTION
Resolves issue https://github.com/sinonjs/sinon/issues/1694

BTW it looks like constructions like
```js
assert.exception(function () {
    call.callArgOnWith({}, thisObj);
}, "TypeError");
```
doesn't check that error is actually `TypeError` - you can change `TypeError` to any other string, even to empty, and the test will remain green. There are a lot of them in the tests