### PR TITLE
Change yields semantics to match stub behaviour

### DIFF
--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -3,6 +3,8 @@
 var spy = require("./spy");
 var nextTick = require("./util/core/next-tick");
 
+var slice = Array.prototype.slice;
+
 function getError(value) {
     return value instanceof Error ? value : new Error(value);
 }
@@ -74,8 +76,12 @@ fake.rejects = function rejects(value) {
     return wrapFunc(f);
 };
 
-function yieldInternal(async, callback, values) {
+function yieldInternal(async, values) {
     function f() {
+        var callback = arguments[arguments.length - 1];
+        if (typeof callback !== "function") {
+            throw new TypeError("Expected last argument to be a function");
+        }
         if (async) {
             nextTick(function () {
                 callback.apply(null, values);
@@ -89,25 +95,11 @@ function yieldInternal(async, callback, values) {
 }
 
 fake.yields = function yields() {
-    var callback = Array.prototype.slice.call(arguments, 0, 1)[0];
-    var values = Array.prototype.slice.call(arguments, 1);
-
-    if (typeof callback !== "function") {
-        throw new TypeError("Expected callback to be a Function");
-    }
-
-    return yieldInternal(false, callback, values);
+    return yieldInternal(false, slice.call(arguments));
 };
 
 fake.yieldsAsync = function yieldsAsync() {
-    var callback = Array.prototype.slice.call(arguments, 0, 1)[0];
-    var values = Array.prototype.slice.call(arguments, 1);
-
-    if (typeof callback !== "function") {
-        throw new TypeError("Expected callback to be a Function");
-    }
-
-    return yieldInternal(true, callback, values);
+    return yieldInternal(true, slice.call(arguments));
 };
 
 module.exports = fake;

--- a/test/fake-test.js
+++ b/test/fake-test.js
@@ -160,14 +160,31 @@ describe("fake", function () {
     describe(".yields", function () {
         verifyProxy(fake.yields, noop, "42", "43");
 
-        it("should call the callback with the provided values", function () {
+        it("should call a callback with the provided values", function () {
             var callback = sinon.spy();
-            var myFake = fake.yields(callback, "one", "two", "three");
+            var myFake = fake.yields("one", "two", "three");
 
-            myFake();
+            myFake(callback);
 
             sinon.assert.calledOnce(callback);
             sinon.assert.calledWith(callback, "one", "two", "three");
+        });
+
+        it("should call the last function argument", function () {
+            var callback = sinon.spy();
+            var myFake = fake.yields();
+
+            myFake(function () {}, callback);
+
+            sinon.assert.calledOnce(callback);
+        });
+
+        it("should throw if the last argument is not a function", function () {
+            var myFake = fake.yields();
+
+            assert.exception(function () {
+                myFake(function () {}, "not a function");
+            }, /TypeError: Expected last argument to be a function/);
         });
     });
 
@@ -176,9 +193,9 @@ describe("fake", function () {
 
         it("should call the callback asynchronously with the provided values", function (done) {
             var callback = sinon.spy();
-            var myFake = fake.yieldsAsync(callback, "one", "two", "three");
+            var myFake = fake.yieldsAsync("one", "two", "three");
 
-            myFake();
+            myFake(callback);
 
             sinon.assert.notCalled(callback);
 
@@ -188,6 +205,29 @@ describe("fake", function () {
 
                 done();
             }, 0);
+        });
+
+        it("should call the last function argument", function (done) {
+            var callback = sinon.spy();
+            var myFake = fake.yieldsAsync();
+
+            myFake(function () {}, callback);
+
+            sinon.assert.notCalled(callback);
+
+            setTimeout(function () {
+                sinon.assert.calledOnce(callback);
+
+                done();
+            }, 0);
+        });
+
+        it("should throw if the last argument is not a function", function () {
+            var myFake = fake.yieldsAsync();
+
+            assert.exception(function () {
+                myFake(function () {}, "not a function");
+            }, /TypeError: Expected last argument to be a function/);
         });
     });
 });


### PR DESCRIPTION
As discussed in #1697 the `fake.yields` semantics should match the `stub.yields` semantics.

We also agreed that we wouldn't want to support `yieldsRight`. As a solution, the fake `yields` and `yieldsAsync` behaviour is more strict and requires the last argument to be a callback function. If it's not, an exception is thrown.

This should match most implementations and make a migration from stub to fake possible (with a caveat).