### PR TITLE
Allow replacing non-own object properties

### DIFF
--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -463,6 +463,22 @@ describe("Sandbox", function () {
             assert.equals(object.property, existing);
         });
 
+        it("should replace an inherited property", function () {
+            var replacement = "replacement";
+            var existing = "existing";
+            var object = Object.create({
+                property: existing
+            });
+
+            this.sandbox.replace(object, "property", replacement);
+
+            assert.equals(object.property, replacement);
+
+            this.sandbox.restore();
+
+            assert.equals(object.property, existing);
+        });
+
         it("should refuse to replace a non-function with a function", function () {
             var sandbox = this.sandbox;
             var replacement = function () { return "replacement"; };


### PR DESCRIPTION
As discussed in #1695, the new `sandbox.replace` function requires the replaced property to be an own property of the object. Inherited properties can not be replaced.

For now, this PR adds a failing test case to demonstrate the issue.