### PR TITLE
Use 'npm ci' on Travis for speedier builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ before_install:
   # Prevent mochify -> puppeteer install script to run unnecessarily
   - if [ "x$TRAVIS_NODE_VERSION" != "x8" ]; then npm config set ignore-scripts true; fi
 
+install:
+  - npm i -g npm@5.7.1 # this should be deleted once 5.7.X is out of "pre-release"
+  - npm ci
+
 before_script:
   # Make npm run work for the script phase:
   - if [ "x$TRAVIS_NODE_VERSION" != "x8" ]; then npm config set ignore-scripts false; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ node_js:
 
 sudo: false
 
-cache:
-  directories:
-  - node_modules
-
 env:
   global:
     - SAUCE_USERNAME=sinonjs


### PR DESCRIPTION
This PR might speed up builds on Travis.

https://medium.com/@tomastrajan/how-to-speed-up-continuous-integration-build-with-new-npm-ci-and-package-lock-json-7647f91751a

#### Results

Nope.

Using the cache is still ~20s faster than `npm ci`, which throws away `node_modules` folder