### PR TITLE
Rename argument to index to match thrown error and documentation

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -35,48 +35,48 @@ module.exports = {
         fake.fakeFn = fn;
     },
 
-    callsArg: function callsArg(fake, pos) {
-        if (typeof pos !== "number") {
+    callsArg: function callsArg(fake, index) {
+        if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
 
-        fake.callArgAt = pos;
+        fake.callArgAt = index;
         fake.callbackArguments = [];
         fake.callbackContext = undefined;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
     },
 
-    callsArgOn: function callsArgOn(fake, pos, context) {
-        if (typeof pos !== "number") {
+    callsArgOn: function callsArgOn(fake, index, context) {
+        if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
 
-        fake.callArgAt = pos;
+        fake.callArgAt = index;
         fake.callbackArguments = [];
         fake.callbackContext = context;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
     },
 
-    callsArgWith: function callsArgWith(fake, pos) {
-        if (typeof pos !== "number") {
+    callsArgWith: function callsArgWith(fake, index) {
+        if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
 
-        fake.callArgAt = pos;
+        fake.callArgAt = index;
         fake.callbackArguments = slice.call(arguments, 2);
         fake.callbackContext = undefined;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
     },
 
-    callsArgOnWith: function callsArgWith(fake, pos, context) {
-        if (typeof pos !== "number") {
+    callsArgOnWith: function callsArgWith(fake, index, context) {
+        if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
 
-        fake.callArgAt = pos;
+        fake.callArgAt = index;
         fake.callbackArguments = slice.call(arguments, 3);
         fake.callbackContext = context;
         fake.callArgProp = undefined;
@@ -140,20 +140,20 @@ module.exports = {
         fake.fakeFn = undefined;
     },
 
-    returnsArg: function returnsArg(fake, pos) {
-        if (typeof pos !== "number") {
+    returnsArg: function returnsArg(fake, index) {
+        if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
 
-        fake.returnArgAt = pos;
+        fake.returnArgAt = index;
     },
 
-    throwsArg: function throwsArg(fake, pos) {
-        if (typeof pos !== "number") {
+    throwsArg: function throwsArg(fake, index) {
+        if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
 
-        fake.throwArgAt = pos;
+        fake.throwArgAt = index;
     },
 
     returnsThis: function returnsThis(fake) {


### PR DESCRIPTION
This PR renames the `pos` argument in `default-behaviors.js` to match the name used in the thrown errors and in the documentation for the methods.

It's a minor inconsistency that might confuse users.