### PR TITLE
Fix the link to #fake-server-options

### DIFF
--- a/docs/_releases/v1.17.6/fake-xhr-and-server.md
+++ b/docs/_releases/v1.17.6/fake-xhr-and-server.md
@@ -228,7 +228,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -242,7 +242,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v1.17.7/fake-xhr-and-server.md
+++ b/docs/_releases/v1.17.7/fake-xhr-and-server.md
@@ -228,7 +228,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -242,7 +242,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.0.0/fake-xhr-and-server.md
+++ b/docs/_releases/v2.0.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.1.0/fake-xhr-and-server.md
+++ b/docs/_releases/v2.1.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.2.0/fake-xhr-and-server.md
+++ b/docs/_releases/v2.2.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.3.0/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.3.1/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.1/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.3.2/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.2/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.3.3/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.3/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.3.4/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.4/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.3.5/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.5/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.3.6/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.6/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.3.7/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.7/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.3.8/fake-xhr-and-server.md
+++ b/docs/_releases/v2.3.8/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.4.0/fake-xhr-and-server.md
+++ b/docs/_releases/v2.4.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v2.4.1/fake-xhr-and-server.md
+++ b/docs/_releases/v2.4.1/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v3.0.0/fake-xhr-and-server.md
+++ b/docs/_releases/v3.0.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`create` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`create` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.fakeServerWithClock.create();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v3.1.0/fake-xhr-and-server.md
+++ b/docs/_releases/v3.1.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v3.2.0/fake-xhr-and-server.md
+++ b/docs/_releases/v3.2.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v3.2.1/fake-xhr-and-server.md
+++ b/docs/_releases/v3.2.1/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v3.3.0/fake-xhr-and-server.md
+++ b/docs/_releases/v3.3.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.0.0/fake-xhr-and-server.md
+++ b/docs/_releases/v4.0.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.0.1/fake-xhr-and-server.md
+++ b/docs/_releases/v4.0.1/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.0.2/fake-xhr-and-server.md
+++ b/docs/_releases/v4.0.2/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.1.0/fake-xhr-and-server.md
+++ b/docs/_releases/v4.1.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.1.1/fake-xhr-and-server.md
+++ b/docs/_releases/v4.1.1/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.1.2/fake-xhr-and-server.md
+++ b/docs/_releases/v4.1.2/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.1.3/fake-xhr-and-server.md
+++ b/docs/_releases/v4.1.3/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.1.4/fake-xhr-and-server.md
+++ b/docs/_releases/v4.1.4/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.1.5/fake-xhr-and-server.md
+++ b/docs/_releases/v4.1.5/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.1.6/fake-xhr-and-server.md
+++ b/docs/_releases/v4.1.6/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.2.0/fake-xhr-and-server.md
+++ b/docs/_releases/v4.2.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.2.1/fake-xhr-and-server.md
+++ b/docs/_releases/v4.2.1/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.2.2/fake-xhr-and-server.md
+++ b/docs/_releases/v4.2.2/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.2.3/fake-xhr-and-server.md
+++ b/docs/_releases/v4.2.3/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.3.0/fake-xhr-and-server.md
+++ b/docs/_releases/v4.3.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.4.0/fake-xhr-and-server.md
+++ b/docs/_releases/v4.4.0/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.4.1/fake-xhr-and-server.md
+++ b/docs/_releases/v4.4.1/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See[options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See[options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/_releases/v4.4.2/fake-xhr-and-server.md
+++ b/docs/_releases/v4.4.2/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 

--- a/docs/release-source/release/fake-xhr-and-server.md
+++ b/docs/release-source/release/fake-xhr-and-server.md
@@ -231,7 +231,7 @@ Creates a new server.
 
 This function also calls `sinon.useFakeXMLHttpRequest()`.
 
-`createFakeServer` accepts optional properties to configure the fake server. See [options](#options) below for configuration parameters.
+`createFakeServer` accepts optional properties to configure the fake server. See [options](#fake-server-options) below for configuration parameters.
 
 
 #### `var server = sinon.createFakeServerWithClock();`
@@ -245,7 +245,7 @@ This is useful when testing `XHR` objects created with e.g. jQuery 1.3.x, which 
 
 Configures the fake server.
 
-See [options](#options) below for configuration parameters.
+See [options](#fake-server-options) below for configuration parameters.
 
 #### `server.respondWith(response);`
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fixes the link to `#fake-server-options` in documentation
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->


<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. <your-steps-here>

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
