### PR TITLE
Add %D to spy.printf documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,8 +12,8 @@ indent_size = 4
 trim_trailing_whitespace = true
 
 # Matches the exact files either package.json or .travis.yml
-[{package.json, .travis.yml}]
-indent_style = space
+# and all Markdown files
+[{package.json,.travis.yml,*.md}]
 indent_size = 2
 
 ; Needed if doing `git add --patch` to edit patches

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -413,22 +413,26 @@ Replaces the spy with the original method. Only available if the spy replaced an
 Returns the passed format string with the following replacements performed:
 
 <dl>
-    <dt><code>%n</code></dt>
-    <dd>the name of the spy "spy" by default)</dd>
+  <dt><code>%n</code></dt>
+  <dd>the name of the spy "spy" by default)</dd>
 
-    <dt><code>%c</code></dt>
-    <dd>the number of times the spy was called, in words ("once", "twice", etc.)</dd>
-    <dt><code>%C</code></dt>
-    <dd>a list of string representations of the calls to the spy, with each call prefixed by a newline and four spaces</dd>
+  <dt><code>%c</code></dt>
+  <dd>the number of times the spy was called, in words ("once", "twice", etc.)</dd>
 
-    <dt><code>%t</code></dt>
-    <dd>a comma-delimited list of <code>this</code> values the spy was called on</dd>
+  <dt><code>%C</code></dt>
+  <dd>a list of string representations of the calls to the spy, with each call prefixed by a newline and four spaces</dd>
 
-    <dt><code>%<var>n</var></code></dt>
-    <dd>the formatted value of the <var>n</var>th argument passed to <code>printf</code></dd>
+  <dt><code>%t</code></dt>
+  <dd>a comma-delimited list of <code>this</code> values the spy was called on</dd>
 
-    <dt><code>%*</code></dt>
-    <dd>a comma-delimited list of the (non-format string) arguments passed to <code>printf</code></dd>
+  <dt><code>%<var>n</var></code></dt>
+  <dd>the formatted value of the <var>n</var>th argument passed to <code>printf</code></dd>
+
+  <dt><code>%*</code></dt>
+  <dd>a comma-delimited list of the (non-format string) arguments passed to <code>printf</code></dd>
+
+  <dt><code>%D</code></dt>
+  <dd>a multi-line list of the arguments received by all calls to the spy</dd>
 </dl>
 
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
- Add %D to `spy.printf` documentation
- Fix spy.printf layout for viewing outside the site

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. ???
4. Profit!

(This is just a documentation update.)