### PR TITLE
Replace referee dependency with @sinonjs/referee

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,29 @@
         }
       }
     },
+    "@sinonjs/referee": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-2.0.0.tgz",
+      "integrity": "sha512-inOh34xub2/0diAWHrAZuakWe1NhtR2DkOXoS/3N7ooddxRZCxTH3TWyI4q7GatFGh+vmPCdWhws/1fziVdPhA==",
+      "dev": true,
+      "requires": {
+        "array.from": "1.0.3",
+        "bane": "1.1.2",
+        "es6-promise": "4.2.4",
+        "lodash.includes": "4.3.0",
+        "lodash.isarguments": "3.1.0",
+        "object-assign": "4.1.1",
+        "samsam": "1.2.1"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+          "dev": true
+        }
+      }
+    },
     "JSONStream": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
@@ -258,6 +281,16 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
+    },
+    "array.from": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array.from/-/array.from-1.0.3.tgz",
+      "integrity": "sha1-y1hqrZIGfzQSKfQeDtZDKB26Vrc=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.2"
+      }
     },
     "arrify": {
       "version": "1.0.1",
@@ -4080,6 +4113,18 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
@@ -5611,25 +5656,6 @@
         "minimatch": "3.0.4",
         "readable-stream": "2.3.3",
         "set-immediate-shim": "1.0.1"
-      }
-    },
-    "referee": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/referee/-/referee-1.2.0.tgz",
-      "integrity": "sha1-eneb7llVx4r/fYjAFhxaH0VFjJA=",
-      "dev": true,
-      "requires": {
-        "bane": "1.1.2",
-        "lodash": "3.10.1",
-        "samsam": "1.2.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
       }
     },
     "regex-cache": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "type-detect": "^4.0.5"
   },
   "devDependencies": {
+    "@sinonjs/referee": "^2.0.0",
     "browserify": "^15.1.0",
     "dependency-check": "^2.9.1",
     "eslint": "^4.6.1",
@@ -63,7 +64,6 @@
     "proxyquire": "^1.8.0",
     "proxyquire-universal": "^1.0.8",
     "proxyquireify": "^3.2.1",
-    "referee": "^1.2.0",
     "rimraf": "^2.5.3",
     "samsam": "^1.1.3"
   },

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var color = require("../lib/sinon/color");
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var sinonStub = require("../lib/sinon/stub");
 var sinonSpy = require("../lib/sinon/spy");
 var sinonAssert = require("../lib/sinon/assert");

--- a/test/behavior-test.js
+++ b/test/behavior-test.js
@@ -2,7 +2,7 @@
 
 var createStub = require("../lib/sinon/stub");
 var addBehavior = require("../lib/sinon").addBehavior;
-var assert = require("referee").assert;
+var assert = require("@sinonjs/referee").assert;
 
 describe("behaviors", function () {
     it("adds and uses a custom behavior", function () {

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var sinonSpyCall = require("../lib/sinon/call");
 var sinonSpy = require("../lib/sinon/spy");
 var sinonStub = require("../lib/sinon/stub");

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var sinonCollection = require("../lib/sinon/collection");
 var sinonSpy = require("../lib/sinon/spy");
 var sinonStub = require("../lib/sinon/stub");

--- a/test/extend-test.js
+++ b/test/extend-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var extend = require("../lib/sinon/util/core/extend");
 var assert = referee.assert;
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var sinon = require("../../lib/sinon");
 var createStub = require("../../lib/sinon/stub");
 var assert = referee.assert;

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var assert = referee.assert;
 var refute = referee.refute;
 var sinonMatch = require("../lib/sinon/match");

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var sinonMock = require("../lib/sinon/mock");
 var sinonExpectation = require("../lib/sinon/mock-expectation");
 var sinonMatch = require("../lib/sinon/match");

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var samsam = require("samsam");
 var assert = referee.assert;
 var refute = referee.refute;

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var assert = require("referee").assert;
+var assert = require("@sinonjs/referee").assert;
 var hasPromise = typeof Promise === "function";
 
 if (!hasPromise) {

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var createSpy = require("../lib/sinon/spy");
 var sinonMatch = require("../lib/sinon/match");
 var assert = referee.assert;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var createStub = require("../lib/sinon/stub");
 var createStubInstance = require("../lib/sinon/stub").createStubInstance;
 var createSpy = require("../lib/sinon/spy");

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 
 referee.add("spy", {
     assert: function (obj) {

--- a/test/util/core/called-in-order-test.js
+++ b/test/util/core/called-in-order-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var calledInOrder = require("../../../lib/sinon/util/core/called-in-order");
 var sinonStub = require("../../../lib/sinon/stub");
 var assert = referee.assert;

--- a/test/util/core/color-test.js
+++ b/test/util/core/color-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var assert = require("referee").assert;
+var assert = require("@sinonjs/referee").assert;
 var proxyquire = require("proxyquire");
 
 function getColorMethods() {

--- a/test/util/core/deep-equal-test.js
+++ b/test/util/core/deep-equal-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var deepEqual = require("../../../lib/sinon/util/core/deep-equal");
 var match = require("../../../lib/sinon/match");
 var createSpy = require("../../../lib/sinon/spy").create;

--- a/test/util/core/every-test.js
+++ b/test/util/core/every-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var createSpy = require("../../../lib/sinon/spy");
 var every = require("../../../lib/sinon/util/core/every");
 var assert = referee.assert;

--- a/test/util/core/format-test.js
+++ b/test/util/core/format-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var sinon = require("../../../lib/sinon");
 var format = require("../../../lib/sinon/util/core/format");
 var assert = referee.assert;

--- a/test/util/core/function-to-string-test.js
+++ b/test/util/core/function-to-string-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var createSpy = require("../../../lib/sinon/spy");
 var functionToString = require("../../../lib/sinon/util/core/function-to-string");
 var assert = referee.assert;

--- a/test/util/core/get-config-test.js
+++ b/test/util/core/get-config-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var getConfig = require("../../../lib/sinon/util/core/get-config");
 var defaultConfig = require("../../../lib/sinon/util/core/default-config");
 var assert = referee.assert;

--- a/test/util/core/iterable-to-string-test.js
+++ b/test/util/core/iterable-to-string-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var iterableToString = require("../../../lib/sinon/util/core/iterable-to-string");
 var assert = referee.assert;
 

--- a/test/util/core/restore-test.js
+++ b/test/util/core/restore-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var restore = require("../../../lib/sinon/util/core/restore");
 var createStub = require("../../../lib/sinon/stub");
 var assert = referee.assert;

--- a/test/util/core/times-in-words-test.js
+++ b/test/util/core/times-in-words-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var timesInWords = require("../../../lib/sinon/util/core/times-in-words");
 var assert = referee.assert;
 

--- a/test/util/core/typeOf-test.js
+++ b/test/util/core/typeOf-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var sinonTypeOf = require("../../../lib/sinon/util/core/typeOf");
 var assert = referee.assert;
 

--- a/test/util/core/value-to-string-test.js
+++ b/test/util/core/value-to-string-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var valueToString = require("../../../lib/sinon/util/core/value-to-string");
 var assert = referee.assert;
 

--- a/test/util/core/walk-test.js
+++ b/test/util/core/walk-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var walk = require("../../../lib/sinon/util/core/walk");
 var createSpy = require("../../../lib/sinon/spy");
 var assert = referee.assert;

--- a/test/util/core/wrap-method-test.js
+++ b/test/util/core/wrap-method-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var wrapMethod = require("../../../lib/sinon/util/core/wrap-method");
 var createSpy = require("../../../lib/sinon/spy");
 var createStub = require("../../../lib/sinon/stub");

--- a/test/util/fake-timers-test.js
+++ b/test/util/fake-timers-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var fakeTimers = require("../../lib/sinon/util/fake_timers");
 var sinonStub = require("../../lib/sinon/stub");
 var sinonSpy = require("../../lib/sinon/spy");

--- a/test/webworker/webworker-support-assessment.js
+++ b/test/webworker/webworker-support-assessment.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var assert = referee.assert;
 
 


### PR DESCRIPTION
This PR replaces the `referee` dependency with `@sinonjs/referee`.

#### How to verify - mandatory

1. Observe that all tests pass on Travis
2. ?
3. Win!