### PR TITLE
Return returned value of invokant when using yields* and callsArg*

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -92,9 +92,11 @@ function callCallback(behavior, args) {
                 func.apply(behavior.callbackContext, behavior.callbackArguments);
             });
         } else {
-            func.apply(behavior.callbackContext, behavior.callbackArguments);
+            return func.apply(behavior.callbackContext, behavior.callbackArguments);
         }
     }
+
+    return undefined;
 }
 
 var proto = {
@@ -125,7 +127,7 @@ var proto = {
     },
 
     invoke: function invoke(context, args) {
-        callCallback(this, args);
+        var returnValue = callCallback(this, args);
 
         if (this.exception) {
             throw this.exception;
@@ -156,7 +158,12 @@ var proto = {
             return (this.promiseLibrary || Promise).reject(this.returnValue);
         } else if (this.callsThrough) {
             return this.stub.wrappedMethod.apply(context, args);
+        } else if (this.returnValueDefined) {
+            return this.returnValue;
+        } else if (this.yields) {
+            return returnValue;
         }
+
         return this.returnValue;
     },
 

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -158,7 +158,7 @@ var proto = {
             return (this.promiseLibrary || Promise).reject(this.returnValue);
         } else if (this.callsThrough) {
             return this.stub.wrappedMethod.apply(context, args);
-        } else if (this.returnValueDefined) {
+        } else if (typeof this.returnValue !== "undefined") {
             return this.returnValue;
         } else if (typeof this.callArgAt === "number") {
             return returnValue;

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -160,7 +160,7 @@ var proto = {
             return this.stub.wrappedMethod.apply(context, args);
         } else if (this.returnValueDefined) {
             return this.returnValue;
-        } else if (this.yields) {
+        } else if (typeof this.callArgAt === "number") {
             return returnValue;
         }
 

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -40,6 +40,7 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
+        fake.yields = true;
         fake.callArgAt = index;
         fake.callbackArguments = [];
         fake.callbackContext = undefined;
@@ -52,6 +53,7 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
+        fake.yields = true;
         fake.callArgAt = index;
         fake.callbackArguments = [];
         fake.callbackContext = context;
@@ -64,6 +66,7 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
+        fake.yields = true;
         fake.callArgAt = index;
         fake.callbackArguments = slice.call(arguments, 2);
         fake.callbackContext = undefined;
@@ -76,6 +79,7 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
+        fake.yields = true;
         fake.callArgAt = index;
         fake.callbackArguments = slice.call(arguments, 3);
         fake.callbackContext = context;
@@ -88,6 +92,7 @@ module.exports = {
     },
 
     yields: function (fake) {
+        fake.yields = true;
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice.call(arguments, 1);
         fake.callbackContext = undefined;
@@ -96,6 +101,7 @@ module.exports = {
     },
 
     yieldsRight: function (fake) {
+        fake.yields = true;
         fake.callArgAt = useRightMostCallback;
         fake.callbackArguments = slice.call(arguments, 1);
         fake.callbackContext = undefined;
@@ -104,6 +110,7 @@ module.exports = {
     },
 
     yieldsOn: function (fake, context) {
+        fake.yields = true;
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice.call(arguments, 2);
         fake.callbackContext = context;
@@ -112,6 +119,7 @@ module.exports = {
     },
 
     yieldsTo: function (fake, prop) {
+        fake.yields = true;
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice.call(arguments, 2);
         fake.callbackContext = undefined;
@@ -120,6 +128,7 @@ module.exports = {
     },
 
     yieldsToOn: function (fake, prop, context) {
+        fake.yields = true;
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice.call(arguments, 3);
         fake.callbackContext = context;

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -40,7 +40,6 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
-        fake.yields = true;
         fake.callArgAt = index;
         fake.callbackArguments = [];
         fake.callbackContext = undefined;
@@ -53,7 +52,6 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
-        fake.yields = true;
         fake.callArgAt = index;
         fake.callbackArguments = [];
         fake.callbackContext = context;
@@ -66,7 +64,6 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
-        fake.yields = true;
         fake.callArgAt = index;
         fake.callbackArguments = slice.call(arguments, 2);
         fake.callbackContext = undefined;
@@ -79,7 +76,6 @@ module.exports = {
             throw new TypeError("argument index is not number");
         }
 
-        fake.yields = true;
         fake.callArgAt = index;
         fake.callbackArguments = slice.call(arguments, 3);
         fake.callbackContext = context;
@@ -92,7 +88,6 @@ module.exports = {
     },
 
     yields: function (fake) {
-        fake.yields = true;
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice.call(arguments, 1);
         fake.callbackContext = undefined;
@@ -101,7 +96,6 @@ module.exports = {
     },
 
     yieldsRight: function (fake) {
-        fake.yields = true;
         fake.callArgAt = useRightMostCallback;
         fake.callbackArguments = slice.call(arguments, 1);
         fake.callbackContext = undefined;
@@ -110,7 +104,6 @@ module.exports = {
     },
 
     yieldsOn: function (fake, context) {
-        fake.yields = true;
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice.call(arguments, 2);
         fake.callbackContext = context;
@@ -119,7 +112,6 @@ module.exports = {
     },
 
     yieldsTo: function (fake, prop) {
-        fake.yields = true;
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice.call(arguments, 2);
         fake.callbackContext = undefined;
@@ -128,7 +120,6 @@ module.exports = {
     },
 
     yieldsToOn: function (fake, prop, context) {
-        fake.yields = true;
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice.call(arguments, 3);
         fake.callbackContext = context;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1307,6 +1307,7 @@ describe("stub", function () {
         it("plays nice with throws", function () {
             var stub = createStub().throws().yields();
             var callback = createStub().returns("return value");
+
             assert.exception(function () {
                 stub(callback);
             });
@@ -1317,6 +1318,7 @@ describe("stub", function () {
             var obj = {};
             var stub = createStub().returns(obj).yields();
             var callback = createStub().returns("return value");
+
             assert.same(stub(callback), obj);
             assert(callback.calledOnce);
         });
@@ -1324,6 +1326,7 @@ describe("stub", function () {
         it("plays nice with returnsArg", function () {
             var stub = createStub().returnsArg(0).yields();
             var callback = createStub().returns("return value");
+
             assert.same(stub(callback), callback);
             assert(callback.calledOnce);
         });
@@ -1332,6 +1335,7 @@ describe("stub", function () {
             var obj = {};
             var stub = createStub().returnsThis().yields();
             var callback = createStub().returns("return value");
+
             assert.same(stub.call(obj, callback), obj);
             assert(callback.calledOnce);
         });
@@ -1339,6 +1343,7 @@ describe("stub", function () {
         it("returns the result of the yielded callback", function () {
             var stub = createStub().yields();
             var callback = createStub().returns("return value");
+
             assert.same(stub(callback), "return value");
             assert(callback.calledOnce);
         });
@@ -1418,6 +1423,7 @@ describe("stub", function () {
         it("plays nice with throws", function () {
             var stub = createStub().yieldsRight().throws();
             var callback = createStub().returns("return value");
+
             assert.exception(function () {
                 stub(callback);
             });
@@ -1428,6 +1434,7 @@ describe("stub", function () {
             var obj = {};
             var stub = createStub().returns(obj).yieldsRight();
             var callback = createStub().returns("return value");
+
             assert.same(stub(callback), obj);
             assert(callback.calledOnce);
         });
@@ -1435,6 +1442,7 @@ describe("stub", function () {
         it("plays nice with returnsArg", function () {
             var stub = createStub().returnsArg(0).yieldsRight();
             var callback = createStub().returns("return value");
+
             assert.same(stub(callback), callback);
             assert(callback.calledOnce);
         });
@@ -1443,6 +1451,7 @@ describe("stub", function () {
             var obj = {};
             var stub = createStub().returnsThis().yieldsRight();
             var callback = createStub().returns("return value");
+
             assert.same(stub.call(obj, callback), obj);
             assert(callback.calledOnce);
         });
@@ -1450,6 +1459,7 @@ describe("stub", function () {
         it("returns the result of the yielded callback", function () {
             var stub = createStub().yields();
             var callback = createStub().returns("return value");
+
             assert.same(stub(callback), "return value");
             assert(callback.calledOnce);
         });
@@ -1549,6 +1559,7 @@ describe("stub", function () {
         it("plays nice with throws", function () {
             var stub = this.stub.throws().yieldsOn(this.fakeContext);
             var callback = createStub().returns("return value");
+
             assert.exception(function () {
                 stub(callback);
             });
@@ -1559,6 +1570,7 @@ describe("stub", function () {
             var obj = {};
             var stub = this.stub.returns(obj).yieldsOn(this.fakeContext);
             var callback = createStub().returns("return value");
+
             assert.same(stub(callback), obj);
             assert(callback.calledOnce);
         });
@@ -1566,6 +1578,7 @@ describe("stub", function () {
         it("plays nice with returnsArg", function () {
             var stub = this.stub.returnsArg(0).yieldsOn();
             var callback = createStub().returns("return value");
+
             assert.same(stub(callback), callback);
             assert(callback.calledOnce);
         });
@@ -1574,6 +1587,7 @@ describe("stub", function () {
             var obj = {};
             var stub = this.stub.returnsThis().yieldsOn(this.fakeContext);
             var callback = createStub().returns("return value");
+
             assert.same(stub.call(obj, callback), obj);
             assert(callback.calledOnce);
         });
@@ -1581,6 +1595,7 @@ describe("stub", function () {
         it("returns the result of the yielded callback", function () {
             var stub = this.stub.yieldsOn(this.fakeContext);
             var callback = createStub().returns("return value");
+
             assert.same(stub(callback), "return value");
             assert(callback.calledOnce);
         });
@@ -1676,6 +1691,7 @@ describe("stub", function () {
         it("plays nice with throws", function () {
             var stub = createStub().throws().yieldsTo("success");
             var callback = createStub().returns("return value");
+
             assert.exception(function () {
                 stub({success: callback});
             });
@@ -1686,6 +1702,7 @@ describe("stub", function () {
             var obj = {};
             var stub = createStub().returns(obj).yieldsTo("success");
             var callback = createStub().returns("return value");
+
             assert.same(stub({success: callback}), obj);
             assert(callback.calledOnce);
         });
@@ -1693,6 +1710,7 @@ describe("stub", function () {
         it("plays nice with returnsArg", function () {
             var stub = createStub().returnsArg(0).yieldsTo("success");
             var callback = createStub().returns("return value");
+
             assert.equals(stub({success: callback}), {success: callback});
             assert(callback.calledOnce);
         });
@@ -1701,6 +1719,7 @@ describe("stub", function () {
             var obj = {};
             var stub = createStub().returnsThis().yieldsTo("success");
             var callback = createStub().returns("return value");
+
             assert.same(stub.call(obj, {success: callback}), obj);
             assert(callback.calledOnce);
         });
@@ -1708,6 +1727,7 @@ describe("stub", function () {
         it("returns the result of the yielded callback", function () {
             var stub = createStub().yieldsTo("success");
             var callback = createStub().returns("return value");
+
             assert.same(stub({success: callback}), "return value");
             assert(callback.calledOnce);
         });
@@ -1825,6 +1845,7 @@ describe("stub", function () {
         it("plays nice with throws", function () {
             var stub = this.stub.throws().yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
+
             assert.exception(function () {
                 stub({success: callback});
             });
@@ -1835,6 +1856,7 @@ describe("stub", function () {
             var obj = {};
             var stub = this.stub.returns(obj).yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
+
             assert.same(stub({success: callback}), obj);
             assert(callback.calledOnce);
         });
@@ -1842,6 +1864,7 @@ describe("stub", function () {
         it("plays nice with returnsArg", function () {
             var stub = this.stub.returnsArg(0).yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
+
             assert.equals(stub({success: callback}), {success: callback});
             assert(callback.calledOnce);
         });
@@ -1850,6 +1873,7 @@ describe("stub", function () {
             var obj = {};
             var stub = this.stub.returnsThis().yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
+
             assert.same(stub.call(obj, {success: callback}), obj);
             assert(callback.calledOnce);
         });
@@ -1857,6 +1881,7 @@ describe("stub", function () {
         it("returns the result of the yielded callback", function () {
             var stub = this.stub.yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
+
             assert.same(stub({success: callback}), "return value");
             assert(callback.calledOnce);
         });

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -712,6 +712,14 @@ describe("stub", function () {
                 stub.callsArg({});
             }, "TypeError");
         });
+
+        it("returns result of invocant", function () {
+            var stub = this.stub.callsArg(0);
+            var callback = createStub().returns("return value");
+
+            assert.same(stub(callback), "return value");
+            assert(callback.calledOnce);
+        });
     });
 
     describe(".callsArgWith", function () {
@@ -769,6 +777,14 @@ describe("stub", function () {
             assert.exception(function () {
                 stub.callsArgWith({});
             }, "TypeError");
+        });
+
+        it("returns result of invocant", function () {
+            var stub = this.stub.callsArgWith(0, "test");
+            var callback = createStub().returns("return value");
+
+            assert.same(stub(callback), "return value");
+            assert(callback.calledOnce);
         });
     });
 
@@ -838,6 +854,15 @@ describe("stub", function () {
             assert.exception(function () {
                 stub.callsArgOn(this.fakeContext, 2);
             }, "TypeError");
+        });
+
+        it("returns result of invocant", function () {
+            var stub = this.stub.callsArgOn(0, this.fakeContext);
+            var callback = createStub().returns("return value");
+
+            assert.same(stub(callback), "return value");
+            assert(callback.calledOnce);
+            assert(callback.calledOn(this.fakeContext));
         });
     });
 
@@ -944,6 +969,16 @@ describe("stub", function () {
             assert.exception(function () {
                 stub.callsArgOnWith({});
             }, "TypeError");
+        });
+
+        it("returns result of invocant", function () {
+            var object = {};
+            var stub = this.stub.callsArgOnWith(0, this.fakeContext, object);
+            var callback = createStub().returns("return value");
+
+            assert.same(stub(callback), "return value");
+            assert(callback.calledOnce);
+            assert(callback.calledWith(object));
         });
     });
 
@@ -1271,34 +1306,41 @@ describe("stub", function () {
 
         it("plays nice with throws", function () {
             var stub = createStub().throws().yields();
-            var spy = createSpy();
+            var callback = createStub().returns("return value");
             assert.exception(function () {
-                stub(spy);
+                stub(callback);
             });
-            assert(spy.calledOnce);
+            assert(callback.calledOnce);
         });
 
         it("plays nice with returns", function () {
             var obj = {};
             var stub = createStub().returns(obj).yields();
-            var spy = createSpy();
-            assert.same(stub(spy), obj);
-            assert(spy.calledOnce);
+            var callback = createStub().returns("return value");
+            assert.same(stub(callback), obj);
+            assert(callback.calledOnce);
         });
 
         it("plays nice with returnsArg", function () {
             var stub = createStub().returnsArg(0).yields();
-            var spy = createSpy();
-            assert.same(stub(spy), spy);
-            assert(spy.calledOnce);
+            var callback = createStub().returns("return value");
+            assert.same(stub(callback), callback);
+            assert(callback.calledOnce);
         });
 
         it("plays nice with returnsThis", function () {
             var obj = {};
             var stub = createStub().returnsThis().yields();
-            var spy = createSpy();
-            assert.same(stub.call(obj, spy), obj);
-            assert(spy.calledOnce);
+            var callback = createStub().returns("return value");
+            assert.same(stub.call(obj, callback), obj);
+            assert(callback.calledOnce);
+        });
+
+        it("returns the result of the yielded callback", function () {
+            var stub = createStub().yields();
+            var callback = createStub().returns("return value");
+            assert.same(stub(callback), "return value");
+            assert(callback.calledOnce);
         });
     });
 
@@ -1374,35 +1416,42 @@ describe("stub", function () {
         });
 
         it("plays nice with throws", function () {
-            var stub = createStub().throws().yieldsRight();
-            var spy = createSpy();
+            var stub = createStub().yieldsRight().throws();
+            var callback = createStub().returns("return value");
             assert.exception(function () {
-                stub(spy);
+                stub(callback);
             });
-            assert(spy.calledOnce);
+            assert(callback.calledOnce);
         });
 
         it("plays nice with returns", function () {
             var obj = {};
             var stub = createStub().returns(obj).yieldsRight();
-            var spy = createSpy();
-            assert.same(stub(spy), obj);
-            assert(spy.calledOnce);
+            var callback = createStub().returns("return value");
+            assert.same(stub(callback), obj);
+            assert(callback.calledOnce);
         });
 
         it("plays nice with returnsArg", function () {
             var stub = createStub().returnsArg(0).yieldsRight();
-            var spy = createSpy();
-            assert.same(stub(spy), spy);
-            assert(spy.calledOnce);
+            var callback = createStub().returns("return value");
+            assert.same(stub(callback), callback);
+            assert(callback.calledOnce);
         });
 
         it("plays nice with returnsThis", function () {
             var obj = {};
             var stub = createStub().returnsThis().yieldsRight();
-            var spy = createSpy();
-            assert.same(stub.call(obj, spy), obj);
-            assert(spy.calledOnce);
+            var callback = createStub().returns("return value");
+            assert.same(stub.call(obj, callback), obj);
+            assert(callback.calledOnce);
+        });
+
+        it("returns the result of the yielded callback", function () {
+            var stub = createStub().yields();
+            var callback = createStub().returns("return value");
+            assert.same(stub(callback), "return value");
+            assert(callback.calledOnce);
         });
     });
 
@@ -1496,6 +1545,45 @@ describe("stub", function () {
                 this.stub(callback);
             });
         });
+
+        it("plays nice with throws", function () {
+            var stub = this.stub.throws().yieldsOn(this.fakeContext);
+            var callback = createStub().returns("return value");
+            assert.exception(function () {
+                stub(callback);
+            });
+            assert(callback.calledOnce);
+        });
+
+        it("plays nice with returns", function () {
+            var obj = {};
+            var stub = this.stub.returns(obj).yieldsOn(this.fakeContext);
+            var callback = createStub().returns("return value");
+            assert.same(stub(callback), obj);
+            assert(callback.calledOnce);
+        });
+
+        it("plays nice with returnsArg", function () {
+            var stub = this.stub.returnsArg(0).yieldsOn();
+            var callback = createStub().returns("return value");
+            assert.same(stub(callback), callback);
+            assert(callback.calledOnce);
+        });
+
+        it("plays nice with returnsThis", function () {
+            var obj = {};
+            var stub = this.stub.returnsThis().yieldsOn(this.fakeContext);
+            var callback = createStub().returns("return value");
+            assert.same(stub.call(obj, callback), obj);
+            assert(callback.calledOnce);
+        });
+
+        it("returns the result of the yielded callback", function () {
+            var stub = this.stub.yieldsOn(this.fakeContext);
+            var callback = createStub().returns("return value");
+            assert.same(stub(callback), "return value");
+            assert(callback.calledOnce);
+        });
     });
 
     describe(".yieldsTo", function () {
@@ -1583,6 +1671,45 @@ describe("stub", function () {
             assert.exception(function () {
                 stub({ error: callback });
             });
+        });
+
+        it("plays nice with throws", function () {
+            var stub = createStub().throws().yieldsTo("success");
+            var callback = createStub().returns("return value");
+            assert.exception(function () {
+                stub({success: callback});
+            });
+            assert(callback.calledOnce);
+        });
+
+        it("plays nice with returns", function () {
+            var obj = {};
+            var stub = createStub().returns(obj).yieldsTo("success");
+            var callback = createStub().returns("return value");
+            assert.same(stub({success: callback}), obj);
+            assert(callback.calledOnce);
+        });
+
+        it("plays nice with returnsArg", function () {
+            var stub = createStub().returnsArg(0).yieldsTo("success");
+            var callback = createStub().returns("return value");
+            assert.equals(stub({success: callback}), {success: callback});
+            assert(callback.calledOnce);
+        });
+
+        it("plays nice with returnsThis", function () {
+            var obj = {};
+            var stub = createStub().returnsThis().yieldsTo("success");
+            var callback = createStub().returns("return value");
+            assert.same(stub.call(obj, {success: callback}), obj);
+            assert(callback.calledOnce);
+        });
+
+        it("returns the result of the yielded callback", function () {
+            var stub = createStub().yieldsTo("success");
+            var callback = createStub().returns("return value");
+            assert.same(stub({success: callback}), "return value");
+            assert(callback.calledOnce);
         });
     });
 
@@ -1693,6 +1820,45 @@ describe("stub", function () {
             assert.exception(function () {
                 this.stub({ error: callback });
             });
+        });
+
+        it("plays nice with throws", function () {
+            var stub = this.stub.throws().yieldsToOn("success", this.fakeContext);
+            var callback = createStub().returns("return value");
+            assert.exception(function () {
+                stub({success: callback});
+            });
+            assert(callback.calledOnce);
+        });
+
+        it("plays nice with returns", function () {
+            var obj = {};
+            var stub = this.stub.returns(obj).yieldsToOn("success", this.fakeContext);
+            var callback = createStub().returns("return value");
+            assert.same(stub({success: callback}), obj);
+            assert(callback.calledOnce);
+        });
+
+        it("plays nice with returnsArg", function () {
+            var stub = this.stub.returnsArg(0).yieldsToOn("success", this.fakeContext);
+            var callback = createStub().returns("return value");
+            assert.equals(stub({success: callback}), {success: callback});
+            assert(callback.calledOnce);
+        });
+
+        it("plays nice with returnsThis", function () {
+            var obj = {};
+            var stub = this.stub.returnsThis().yieldsToOn("success", this.fakeContext);
+            var callback = createStub().returns("return value");
+            assert.same(stub.call(obj, {success: callback}), obj);
+            assert(callback.calledOnce);
+        });
+
+        it("returns the result of the yielded callback", function () {
+            var stub = this.stub.yieldsToOn("success", this.fakeContext);
+            var callback = createStub().returns("return value");
+            assert.same(stub({success: callback}), "return value");
+            assert(callback.calledOnce);
         });
     });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1304,7 +1304,7 @@ describe("stub", function () {
             });
         });
 
-        it("plays nice with throws", function () {
+        it("throws takes precident over yielded return value", function () {
             var stub = createStub().throws().yields();
             var callback = createStub().returns("return value");
 
@@ -1314,7 +1314,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returns", function () {
+        it("returns takes precident over yielded return value", function () {
             var obj = {};
             var stub = createStub().returns(obj).yields();
             var callback = createStub().returns("return value");
@@ -1323,7 +1323,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returnsArg", function () {
+        it("returnsArg takes precident over yielded return value", function () {
             var stub = createStub().returnsArg(0).yields();
             var callback = createStub().returns("return value");
 
@@ -1331,7 +1331,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returnsThis", function () {
+        it("returnsThis takes precident over yielded return value", function () {
             var obj = {};
             var stub = createStub().returnsThis().yields();
             var callback = createStub().returns("return value");
@@ -1420,7 +1420,7 @@ describe("stub", function () {
             });
         });
 
-        it("plays nice with throws", function () {
+        it("throws takes precident over yielded return value", function () {
             var stub = createStub().yieldsRight().throws();
             var callback = createStub().returns("return value");
 
@@ -1430,7 +1430,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returns", function () {
+        it("returns takes precident over yielded return value", function () {
             var obj = {};
             var stub = createStub().returns(obj).yieldsRight();
             var callback = createStub().returns("return value");
@@ -1439,7 +1439,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returnsArg", function () {
+        it("returnsArg takes precident over yielded return value", function () {
             var stub = createStub().returnsArg(0).yieldsRight();
             var callback = createStub().returns("return value");
 
@@ -1447,7 +1447,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returnsThis", function () {
+        it("returnsThis takes precident over yielded return value", function () {
             var obj = {};
             var stub = createStub().returnsThis().yieldsRight();
             var callback = createStub().returns("return value");
@@ -1556,7 +1556,7 @@ describe("stub", function () {
             });
         });
 
-        it("plays nice with throws", function () {
+        it("throws takes precident over yielded return value", function () {
             var stub = this.stub.throws().yieldsOn(this.fakeContext);
             var callback = createStub().returns("return value");
 
@@ -1566,7 +1566,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returns", function () {
+        it("returns takes precident over yielded return value", function () {
             var obj = {};
             var stub = this.stub.returns(obj).yieldsOn(this.fakeContext);
             var callback = createStub().returns("return value");
@@ -1575,7 +1575,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returnsArg", function () {
+        it("returnsArg takes precident over yielded return value", function () {
             var stub = this.stub.returnsArg(0).yieldsOn();
             var callback = createStub().returns("return value");
 
@@ -1583,7 +1583,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returnsThis", function () {
+        it("returnsThis takes precident over yielded return value", function () {
             var obj = {};
             var stub = this.stub.returnsThis().yieldsOn(this.fakeContext);
             var callback = createStub().returns("return value");
@@ -1688,7 +1688,7 @@ describe("stub", function () {
             });
         });
 
-        it("plays nice with throws", function () {
+        it("throws takes precident over yielded return value", function () {
             var stub = createStub().throws().yieldsTo("success");
             var callback = createStub().returns("return value");
 
@@ -1698,7 +1698,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returns", function () {
+        it("returns takes precident over yielded return value", function () {
             var obj = {};
             var stub = createStub().returns(obj).yieldsTo("success");
             var callback = createStub().returns("return value");
@@ -1707,7 +1707,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returnsArg", function () {
+        it("returnsArg takes precident over yielded return value", function () {
             var stub = createStub().returnsArg(0).yieldsTo("success");
             var callback = createStub().returns("return value");
 
@@ -1715,7 +1715,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returnsThis", function () {
+        it("returnsThis takes precident over yielded return value", function () {
             var obj = {};
             var stub = createStub().returnsThis().yieldsTo("success");
             var callback = createStub().returns("return value");
@@ -1842,7 +1842,7 @@ describe("stub", function () {
             });
         });
 
-        it("plays nice with throws", function () {
+        it("throws takes precident over yielded return value", function () {
             var stub = this.stub.throws().yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
 
@@ -1852,7 +1852,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returns", function () {
+        it("returns takes precident over yielded return value", function () {
             var obj = {};
             var stub = this.stub.returns(obj).yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
@@ -1861,7 +1861,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returnsArg", function () {
+        it("returnsArg takes precident over yielded return value", function () {
             var stub = this.stub.returnsArg(0).yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
 
@@ -1869,7 +1869,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("plays nice with returnsThis", function () {
+        it("returnsThis takes precident over yielded return value", function () {
             var obj = {};
             var stub = this.stub.returnsThis().yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1304,7 +1304,7 @@ describe("stub", function () {
             });
         });
 
-        it("throws takes precident over yielded return value", function () {
+        it("throws takes precedent over yielded return value", function () {
             var stub = createStub().throws().yields();
             var callback = createStub().returns("return value");
 
@@ -1314,7 +1314,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returns takes precident over yielded return value", function () {
+        it("returns takes precedent over yielded return value", function () {
             var obj = {};
             var stub = createStub().returns(obj).yields();
             var callback = createStub().returns("return value");
@@ -1323,7 +1323,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returnsArg takes precident over yielded return value", function () {
+        it("returnsArg takes precedent over yielded return value", function () {
             var stub = createStub().returnsArg(0).yields();
             var callback = createStub().returns("return value");
 
@@ -1331,7 +1331,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returnsThis takes precident over yielded return value", function () {
+        it("returnsThis takes precedent over yielded return value", function () {
             var obj = {};
             var stub = createStub().returnsThis().yields();
             var callback = createStub().returns("return value");
@@ -1420,7 +1420,7 @@ describe("stub", function () {
             });
         });
 
-        it("throws takes precident over yielded return value", function () {
+        it("throws takes precedent over yielded return value", function () {
             var stub = createStub().yieldsRight().throws();
             var callback = createStub().returns("return value");
 
@@ -1430,7 +1430,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returns takes precident over yielded return value", function () {
+        it("returns takes precedent over yielded return value", function () {
             var obj = {};
             var stub = createStub().returns(obj).yieldsRight();
             var callback = createStub().returns("return value");
@@ -1439,7 +1439,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returnsArg takes precident over yielded return value", function () {
+        it("returnsArg takes precedent over yielded return value", function () {
             var stub = createStub().returnsArg(0).yieldsRight();
             var callback = createStub().returns("return value");
 
@@ -1447,7 +1447,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returnsThis takes precident over yielded return value", function () {
+        it("returnsThis takes precedent over yielded return value", function () {
             var obj = {};
             var stub = createStub().returnsThis().yieldsRight();
             var callback = createStub().returns("return value");
@@ -1556,7 +1556,7 @@ describe("stub", function () {
             });
         });
 
-        it("throws takes precident over yielded return value", function () {
+        it("throws takes precedent over yielded return value", function () {
             var stub = this.stub.throws().yieldsOn(this.fakeContext);
             var callback = createStub().returns("return value");
 
@@ -1566,7 +1566,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returns takes precident over yielded return value", function () {
+        it("returns takes precedent over yielded return value", function () {
             var obj = {};
             var stub = this.stub.returns(obj).yieldsOn(this.fakeContext);
             var callback = createStub().returns("return value");
@@ -1575,7 +1575,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returnsArg takes precident over yielded return value", function () {
+        it("returnsArg takes precedent over yielded return value", function () {
             var stub = this.stub.returnsArg(0).yieldsOn();
             var callback = createStub().returns("return value");
 
@@ -1583,7 +1583,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returnsThis takes precident over yielded return value", function () {
+        it("returnsThis takes precedent over yielded return value", function () {
             var obj = {};
             var stub = this.stub.returnsThis().yieldsOn(this.fakeContext);
             var callback = createStub().returns("return value");
@@ -1688,7 +1688,7 @@ describe("stub", function () {
             });
         });
 
-        it("throws takes precident over yielded return value", function () {
+        it("throws takes precedent over yielded return value", function () {
             var stub = createStub().throws().yieldsTo("success");
             var callback = createStub().returns("return value");
 
@@ -1698,7 +1698,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returns takes precident over yielded return value", function () {
+        it("returns takes precedent over yielded return value", function () {
             var obj = {};
             var stub = createStub().returns(obj).yieldsTo("success");
             var callback = createStub().returns("return value");
@@ -1707,7 +1707,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returnsArg takes precident over yielded return value", function () {
+        it("returnsArg takes precedent over yielded return value", function () {
             var stub = createStub().returnsArg(0).yieldsTo("success");
             var callback = createStub().returns("return value");
 
@@ -1715,7 +1715,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returnsThis takes precident over yielded return value", function () {
+        it("returnsThis takes precedent over yielded return value", function () {
             var obj = {};
             var stub = createStub().returnsThis().yieldsTo("success");
             var callback = createStub().returns("return value");
@@ -1842,7 +1842,7 @@ describe("stub", function () {
             });
         });
 
-        it("throws takes precident over yielded return value", function () {
+        it("throws takes precedent over yielded return value", function () {
             var stub = this.stub.throws().yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
 
@@ -1852,7 +1852,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returns takes precident over yielded return value", function () {
+        it("returns takes precedent over yielded return value", function () {
             var obj = {};
             var stub = this.stub.returns(obj).yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
@@ -1861,7 +1861,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returnsArg takes precident over yielded return value", function () {
+        it("returnsArg takes precedent over yielded return value", function () {
             var stub = this.stub.returnsArg(0).yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");
 
@@ -1869,7 +1869,7 @@ describe("stub", function () {
             assert(callback.calledOnce);
         });
 
-        it("returnsThis takes precident over yielded return value", function () {
+        it("returnsThis takes precedent over yielded return value", function () {
             var obj = {};
             var stub = this.stub.returnsThis().yieldsToOn("success", this.fakeContext);
             var callback = createStub().returns("return value");


### PR DESCRIPTION
#### Purpose
Ensure that the yields* and callsArg* methods of the stub cause the stub to return the returned value of the invoked callback. Will defer to all other return value handlers (returns, returnsThis, resolves, rejects ect)

#### Background
#1689 allows the yield* and callArg* methods to return the value returned by the invoked callback. It is preferable that the stub methods of yields* and callsArg* provide the same functionality to allow testing of functions that are invoked as a callback on the stub that return a promise.

This prevents the need for the test to wait for `Process.nextTick()` to check if the promise has resolved but can instead us `await` or `.then` to do so instead. Thus guaranteeing that the promise is resolved

#### Solution
Adds a new property to the behaviour of yields that is set to true for all yields* and callsArg* methods in `default-behaviour.js`.

Ensure that if the yields property is true, and no other return setting is enabled (such as returns, returnsThis ect) then the returned value of the invoked callback is returned. by the `invoke` function in `behaviour.js`

#### How to verify
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

-  [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
