### PR TITLE
Fix missed switch from referee to @sinonjs/referee

### DIFF
--- a/test/es2015/module-support-assessment-test.mjs
+++ b/test/es2015/module-support-assessment-test.mjs
@@ -1,5 +1,4 @@
-
-import referee from "referee";
+import referee from "@sinonjs/referee";
 import sinon from "../../lib/sinon";
 import * as aModule from "./a-module";
 import aModuleWithDefaultExport from "./a-module-with-default";


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
It appears one of the instances of switching from `referee` to `@sinonjs/referee` was missed due to a clash between these pull requests:
- https://github.com/sinonjs/sinon/pull/1719
- https://github.com/sinonjs/sinon/pull/1715

Running `npm test` after updating my fork from upstream while I was working on another ticket, I started getting this error message:
```
> sinon@4.4.2 test-es-module /home/REDACTED/code/sinon
> mocha -r @std/esm test/es2015/module-support-assessment-test.mjs

file:///home/REDACTED/code/sinon/test/es2015/module-support-assessment-test.mjs:1
Error: Cannot find module 'referee'
    at module.exports.t.a (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at module.exports.t.a (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at w (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at Object.watch (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at /home/REDACTED/code/sinon/test/es2015/module-support-assessment-test.mjs:1
    at O (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at Object.run (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at Object.<anonymous> (file:///home/REDACTED/code/sinon/test/es2015/module-support-assessment-test.mjs:1)
    at Module.e (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at q (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at /home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1
    at module.exports.r.a (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at Module.y (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at Object.f (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at Object.p (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at Object.<anonymous> (file:///home/REDACTED/code/sinon/node_modules/@std/esm/esm.js:1)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
    at /home/REDACTED/code/sinon/node_modules/mocha/lib/mocha.js:231:27
    at Array.forEach (<anonymous>)
    at Mocha.loadFiles (file:///home/REDACTED/code/sinon/node_modules/mocha/lib/mocha.js:228:14)
    at Mocha.run (file:///home/REDACTED/code/sinon/node_modules/mocha/lib/mocha.js:514:10)
    at Object.<anonymous> (file:///home/REDACTED/code/sinon/node_modules/mocha/bin/_mocha:484:18)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
    at Function.Module.runMain (module.js:684:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! sinon@4.4.2 test-es-module: `mocha -r @std/esm test/es2015/module-support-assessment-test.mjs`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the sinon@4.4.2 test-es-module script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/REDACTED/.npm/_logs/2018-03-06T04_39_28_138Z-debug.log
ERROR: "test-es-module" exited with 1.
npm ERR! Test failed.  See above for more details.
```

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
