### PR TITLE
remove unnecessary properties quoting

### DIFF
--- a/docs/releases/sinon-1.1.0.js
+++ b/docs/releases/sinon-1.1.0.js
@@ -753,7 +753,7 @@ if (typeof module == "object" && typeof require == "function") {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.1.1.js
+++ b/docs/releases/sinon-1.1.1.js
@@ -754,7 +754,7 @@ if (typeof module == "object" && typeof require == "function") {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.10.0.js
+++ b/docs/releases/sinon-1.10.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -421,7 +421,7 @@ define.amd = {};
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true
@@ -1361,7 +1361,7 @@ var sinon = (function (formatio) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -2141,7 +2141,7 @@ var sinon = (function (formatio) {
         },
 
 
-        "throws": throwsException,
+        throws: throwsException,
         throwsException: throwsException,
 
         returns: function returns(value) {
@@ -3555,10 +3555,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -3919,7 +3919,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-1.10.1.js
+++ b/docs/releases/sinon-1.10.1.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -421,7 +421,7 @@ define.amd = {};
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true
@@ -1361,7 +1361,7 @@ var sinon = (function (formatio) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -2141,7 +2141,7 @@ var sinon = (function (formatio) {
         },
 
 
-        "throws": throwsException,
+        throws: throwsException,
         throwsException: throwsException,
 
         returns: function returns(value) {
@@ -3555,10 +3555,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -3919,7 +3919,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-1.10.2.js
+++ b/docs/releases/sinon-1.10.2.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -421,7 +421,7 @@ define.amd = {};
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true
@@ -1361,7 +1361,7 @@ var sinon = (function (formatio) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -2145,7 +2145,7 @@ var sinon = (function (formatio) {
         },
 
 
-        "throws": throwsException,
+        throws: throwsException,
         throwsException: throwsException,
 
         returns: function returns(value) {
@@ -3559,10 +3559,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -3923,7 +3923,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-1.10.3.js
+++ b/docs/releases/sinon-1.10.3.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -421,7 +421,7 @@ define.amd = {};
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true
@@ -1361,7 +1361,7 @@ var sinon = (function (formatio) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -2145,7 +2145,7 @@ var sinon = (function (formatio) {
         },
 
 
-        "throws": throwsException,
+        throws: throwsException,
         throwsException: throwsException,
 
         returns: function returns(value) {
@@ -3563,10 +3563,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -3927,7 +3927,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-1.16.0.js
+++ b/docs/releases/sinon-1.16.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -463,7 +463,7 @@
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true,
@@ -566,7 +566,7 @@
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -586,7 +586,7 @@
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -680,7 +680,7 @@
  */
 
 (function (global) {
-    
+
     // Make properties writable in IE, as per
     // http://www.adequatelygood.com/Replacing-setTimeout-Globally.html
     // JSLint being anal
@@ -1169,7 +1169,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -1218,7 +1218,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -1611,7 +1611,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -1722,7 +1722,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         function timesInWords(count) {
@@ -1779,7 +1779,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function typeOf(value) {
             if (value === null) {
@@ -1835,7 +1835,7 @@ var sinon = (function () {
  * Copyright (c) 2012 Maximilian Antoni
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function assertType(value, type, name) {
             var actual = sinon.typeOf(value);
@@ -2093,7 +2093,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -2191,7 +2191,7 @@ var sinon = (function () {
   * Copyright (c) 2013 Maximilian Antoni
   */
 (function (sinonGlobal) {
-    
+
     var slice = Array.prototype.slice;
 
     function makeApi(sinon) {
@@ -2294,7 +2294,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -2426,7 +2426,7 @@ var sinon = (function () {
   * Copyright (c) 2010-2013 Christian Johansen
   */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = Array.prototype.push;
         var slice = Array.prototype.slice;
@@ -2887,7 +2887,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var slice = Array.prototype.slice;
     var join = Array.prototype.join;
     var useLeftMostCallback = -1;
@@ -3259,7 +3259,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function stub(object, property, func) {
             if (!!func && typeof func !== "function" && typeof func !== "object") {
@@ -3457,7 +3457,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = [].push;
         var match = sinon.match;
@@ -3944,7 +3944,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var push = [].push;
     var hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -4120,7 +4120,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -4192,7 +4192,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -4298,7 +4298,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -4375,7 +4375,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -4598,7 +4598,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -5257,7 +5257,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -5327,10 +5327,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -5505,7 +5505,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;
@@ -5604,7 +5604,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = [].push;
 
@@ -5770,7 +5770,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var slice = Array.prototype.slice;
 
@@ -5871,7 +5871,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function createTest(property, setUp, tearDown) {
         return function () {
             if (setUp) {
@@ -5979,7 +5979,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     var slice = Array.prototype.slice;
 
     function makeApi(sinon) {

--- a/docs/releases/sinon-1.16.1.js
+++ b/docs/releases/sinon-1.16.1.js
@@ -2294,7 +2294,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -5327,10 +5327,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 

--- a/docs/releases/sinon-1.17.0.js
+++ b/docs/releases/sinon-1.17.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -463,7 +463,7 @@
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true,
@@ -566,7 +566,7 @@
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -586,7 +586,7 @@
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -1109,7 +1109,7 @@ exports.install = function install(target, now, toFake) {
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -1159,7 +1159,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -1552,7 +1552,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -1663,7 +1663,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         function timesInWords(count) {
@@ -1720,7 +1720,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function typeOf(value) {
             if (value === null) {
@@ -1776,7 +1776,7 @@ var sinon = (function () {
  * Copyright (c) 2012 Maximilian Antoni
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function assertType(value, type, name) {
             var actual = sinon.typeOf(value);
@@ -2034,7 +2034,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -2132,7 +2132,7 @@ var sinon = (function () {
   * Copyright (c) 2013 Maximilian Antoni
   */
 (function (sinonGlobal) {
-    
+
     var slice = Array.prototype.slice;
 
     function makeApi(sinon) {
@@ -2235,7 +2235,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -2367,7 +2367,7 @@ var sinon = (function () {
   * Copyright (c) 2010-2013 Christian Johansen
   */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = Array.prototype.push;
         var slice = Array.prototype.slice;
@@ -2828,7 +2828,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var slice = Array.prototype.slice;
     var join = Array.prototype.join;
     var useLeftMostCallback = -1;
@@ -3189,7 +3189,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         /* Public: walks the prototype chain of an object and iterates over every own property
          * name encountered. The iterator is called in the same fashion that Array.prototype.forEach
@@ -3271,7 +3271,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function stub(object, property, func) {
             if (!!func && typeof func !== "function" && typeof func !== "object") {
@@ -3473,7 +3473,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = [].push;
         var match = sinon.match;
@@ -3960,7 +3960,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var push = [].push;
     var hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -4136,7 +4136,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -4208,7 +4208,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -4314,7 +4314,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -4401,7 +4401,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -4624,7 +4624,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -5343,7 +5343,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -5413,10 +5413,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -5591,7 +5591,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;
@@ -5690,7 +5690,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = [].push;
 
@@ -5856,7 +5856,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var slice = Array.prototype.slice;
 
@@ -5956,7 +5956,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function createTest(property, setUp, tearDown) {
         return function () {
             if (setUp) {
@@ -6064,7 +6064,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     var slice = Array.prototype.slice;
 
     function makeApi(sinon) {

--- a/docs/releases/sinon-1.17.1.js
+++ b/docs/releases/sinon-1.17.1.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -463,7 +463,7 @@
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true,
@@ -566,7 +566,7 @@
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -586,7 +586,7 @@
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -680,7 +680,7 @@
  */
 
 (function (global) {
-    
+
     // Make properties writable in IE, as per
     // http://www.adequatelygood.com/Replacing-setTimeout-Globally.html
     // JSLint being anal
@@ -1206,7 +1206,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -1256,7 +1256,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -1649,7 +1649,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -1760,7 +1760,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         function timesInWords(count) {
@@ -1817,7 +1817,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function typeOf(value) {
             if (value === null) {
@@ -1873,7 +1873,7 @@ var sinon = (function () {
  * Copyright (c) 2012 Maximilian Antoni
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function assertType(value, type, name) {
             var actual = sinon.typeOf(value);
@@ -2131,7 +2131,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -2229,7 +2229,7 @@ var sinon = (function () {
   * Copyright (c) 2013 Maximilian Antoni
   */
 (function (sinonGlobal) {
-    
+
     var slice = Array.prototype.slice;
 
     function makeApi(sinon) {
@@ -2332,7 +2332,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -2464,7 +2464,7 @@ var sinon = (function () {
   * Copyright (c) 2010-2013 Christian Johansen
   */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = Array.prototype.push;
         var slice = Array.prototype.slice;
@@ -2925,7 +2925,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var slice = Array.prototype.slice;
     var join = Array.prototype.join;
     var useLeftMostCallback = -1;
@@ -3286,7 +3286,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function walkInternal(obj, iterator, context, originalObj) {
             var proto, prop;
@@ -3374,7 +3374,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function stub(object, property, func) {
             if (!!func && typeof func !== "function" && typeof func !== "object") {
@@ -3577,7 +3577,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = [].push;
         var match = sinon.match;
@@ -4064,7 +4064,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var push = [].push;
     var hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -4240,7 +4240,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -4312,7 +4312,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -4418,7 +4418,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -4505,7 +4505,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -4728,7 +4728,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -5447,7 +5447,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -5517,10 +5517,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -5695,7 +5695,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;
@@ -5794,7 +5794,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = [].push;
 
@@ -5960,7 +5960,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var slice = Array.prototype.slice;
 
@@ -6060,7 +6060,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function createTest(property, setUp, tearDown) {
         return function () {
             if (setUp) {
@@ -6168,7 +6168,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     var slice = Array.prototype.slice;
 
     function makeApi(sinon) {

--- a/docs/releases/sinon-1.17.2.js
+++ b/docs/releases/sinon-1.17.2.js
@@ -2332,7 +2332,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -5520,10 +5520,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 

--- a/docs/releases/sinon-1.17.3.js
+++ b/docs/releases/sinon-1.17.3.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -463,7 +463,7 @@
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true,
@@ -566,7 +566,7 @@
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -586,7 +586,7 @@
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -680,7 +680,7 @@
  */
 
 (function (global) {
-    
+
     // Make properties writable in IE, as per
     // http://www.adequatelygood.com/Replacing-setTimeout-Globally.html
     // JSLint being anal
@@ -1238,7 +1238,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -1288,7 +1288,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -1681,7 +1681,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -1792,7 +1792,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         function timesInWords(count) {
@@ -1849,7 +1849,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function typeOf(value) {
             if (value === null) {
@@ -1905,7 +1905,7 @@ var sinon = (function () {
  * Copyright (c) 2012 Maximilian Antoni
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function assertType(value, type, name) {
             var actual = sinon.typeOf(value);
@@ -2163,7 +2163,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -2261,7 +2261,7 @@ var sinon = (function () {
   * Copyright (c) 2013 Maximilian Antoni
   */
 (function (sinonGlobal) {
-    
+
     var slice = Array.prototype.slice;
 
     function makeApi(sinon) {
@@ -2364,7 +2364,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -2500,7 +2500,7 @@ var sinon = (function () {
   * Copyright (c) 2010-2013 Christian Johansen
   */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = Array.prototype.push;
         var slice = Array.prototype.slice;
@@ -2961,7 +2961,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var slice = Array.prototype.slice;
     var join = Array.prototype.join;
     var useLeftMostCallback = -1;
@@ -3322,7 +3322,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function walkInternal(obj, iterator, context, originalObj, seen) {
             var proto, prop;
@@ -3413,7 +3413,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function stub(object, property, func) {
             if (!!func && typeof func !== "function" && typeof func !== "object") {
@@ -3616,7 +3616,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = [].push;
         var match = sinon.match;
@@ -4103,7 +4103,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var push = [].push;
     var hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -4279,7 +4279,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -4351,7 +4351,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -4457,7 +4457,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -4545,7 +4545,7 @@ if (typeof sinon === "undefined") {
  * @private
  */
 function getGlobal() {
-    
+
     return typeof window !== "undefined" ? window : global;
 }
 
@@ -4559,7 +4559,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -4782,7 +4782,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -5501,7 +5501,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -5571,10 +5571,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -5749,7 +5749,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;
@@ -5848,7 +5848,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = [].push;
 
@@ -6014,7 +6014,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var slice = Array.prototype.slice;
 
@@ -6114,7 +6114,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function createTest(property, setUp, tearDown) {
         return function () {
             if (setUp) {
@@ -6222,7 +6222,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     var slice = Array.prototype.slice;
 
     function makeApi(sinon) {

--- a/docs/releases/sinon-1.17.4.js
+++ b/docs/releases/sinon-1.17.4.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -463,7 +463,7 @@
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true,
@@ -566,7 +566,7 @@
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -586,7 +586,7 @@
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -680,7 +680,7 @@
  */
 
 (function (global) {
-    
+
     // Make properties writable in IE, as per
     // http://www.adequatelygood.com/Replacing-setTimeout-Globally.html
     // JSLint being anal
@@ -1206,7 +1206,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -1256,7 +1256,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -1649,7 +1649,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -1760,7 +1760,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         function timesInWords(count) {
@@ -1817,7 +1817,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function typeOf(value) {
             if (value === null) {
@@ -1873,7 +1873,7 @@ var sinon = (function () {
  * Copyright (c) 2012 Maximilian Antoni
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function assertType(value, type, name) {
             var actual = sinon.typeOf(value);
@@ -2131,7 +2131,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -2229,7 +2229,7 @@ var sinon = (function () {
   * Copyright (c) 2013 Maximilian Antoni
   */
 (function (sinonGlobal) {
-    
+
     var slice = Array.prototype.slice;
 
     function makeApi(sinon) {
@@ -2332,7 +2332,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -2468,7 +2468,7 @@ var sinon = (function () {
   * Copyright (c) 2010-2013 Christian Johansen
   */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = Array.prototype.push;
         var slice = Array.prototype.slice;
@@ -2929,7 +2929,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var slice = Array.prototype.slice;
     var join = Array.prototype.join;
     var useLeftMostCallback = -1;
@@ -3290,7 +3290,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function walkInternal(obj, iterator, context, originalObj, seen) {
             var proto, prop;
@@ -3381,7 +3381,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         function stub(object, property, func) {
             if (!!func && typeof func !== "function" && typeof func !== "object") {
@@ -3584,7 +3584,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = [].push;
         var match = sinon.match;
@@ -4071,7 +4071,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var push = [].push;
     var hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -4247,7 +4247,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -4319,7 +4319,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -4425,7 +4425,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -4513,7 +4513,7 @@ if (typeof sinon === "undefined") {
  * @private
  */
 function getGlobal() {
-    
+
     return typeof window !== "undefined" ? window : global;
 }
 
@@ -4527,7 +4527,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -4750,7 +4750,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -5478,7 +5478,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -5548,10 +5548,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -5726,7 +5726,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;
@@ -5825,7 +5825,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var push = [].push;
 
@@ -5991,7 +5991,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
         var slice = Array.prototype.slice;
 
@@ -6089,7 +6089,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     function createTest(property, setUp, tearDown) {
         return function () {
             if (setUp) {
@@ -6197,7 +6197,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     var slice = Array.prototype.slice;
 
     function makeApi(sinon) {

--- a/docs/releases/sinon-1.17.5.js
+++ b/docs/releases/sinon-1.17.5.js
@@ -2332,7 +2332,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -5562,10 +5562,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 

--- a/docs/releases/sinon-1.17.6.js
+++ b/docs/releases/sinon-1.17.6.js
@@ -2345,7 +2345,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -5575,10 +5575,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 

--- a/docs/releases/sinon-1.17.7.js
+++ b/docs/releases/sinon-1.17.7.js
@@ -2525,7 +2525,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -5759,10 +5759,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 

--- a/docs/releases/sinon-1.2.0.js
+++ b/docs/releases/sinon-1.2.0.js
@@ -843,7 +843,7 @@ if (typeof module == "object" && typeof require == "function") {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.3.0.js
+++ b/docs/releases/sinon-1.3.0.js
@@ -4,13 +4,13 @@
  * @author Christian Johansen (christian@cjohansen.no)
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2011, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -19,7 +19,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -1009,7 +1009,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(null, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 var args = this.args;
                 for (var i = 0, l = args.length; i < l; ++i) {
                     if (typeof args[i] === "function") {
@@ -1197,7 +1197,7 @@ var sinon = (function (buster) {
             } else {
                 this.exception = error;
             }
-            
+
             return this;
         }
 
@@ -1238,13 +1238,13 @@ var sinon = (function (buster) {
                 if (typeof pos != "number") {
                     throw new TypeError("argument index is not number");
                 }
-                
+
                 this.returnArgAt = pos;
 
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {
@@ -2278,7 +2278,7 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
     xhr.GlobalActiveXObject = global.ActiveXObject;
     xhr.supportsActiveX = typeof xhr.GlobalActiveXObject != "undefined";
     xhr.supportsXHR = typeof xhr.GlobalXMLHttpRequest != "undefined";
-    xhr.workingXHR = xhr.supportsXHR ? xhr.GlobalXMLHttpRequest : xhr.supportsActiveX 
+    xhr.workingXHR = xhr.supportsXHR ? xhr.GlobalXMLHttpRequest : xhr.supportsActiveX
                                      ? function() { return new xhr.GlobalActiveXObject("MSXML2.XMLHTTP.3.0") } : false;
 
     /*jsl:ignore*/
@@ -2325,7 +2325,7 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
             throw new Error("INVALID_STATE_ERR");
         }
     }
-    
+
     // filtering to enable a white-list version of Sinon FakeXhr,
     // where whitelisted requests are passed through to real XHR
     function each(collection, callback) {
@@ -2362,12 +2362,12 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
         each(["open","setRequestHeader","send","abort","getResponseHeader",
               "getAllResponseHeaders","addEventListener","overrideMimeType","removeEventListener"],
              function(method) {
-                 fakeXhr[method] = function() { 
+                 fakeXhr[method] = function() {
                    return apply(xhr,method,arguments);
                  };
              });
-        
-        var copyAttrs = function(args) { 
+
+        var copyAttrs = function(args) {
             each(args, function(attr) {
               try {
                 fakeXhr[attr] = xhr[attr]
@@ -2680,7 +2680,7 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
         504: "Gateway Timeout",
         505: "HTTP Version Not Supported"
     };
-    
+
     sinon.useFakeXMLHttpRequest = function () {
         sinon.FakeXMLHttpRequest.restore = function restore(keepOnCreate) {
             if (xhr.supportsXHR) {
@@ -2714,7 +2714,7 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
 
         return sinon.FakeXMLHttpRequest;
     };
-    
+
     sinon.FakeXMLHttpRequest = FakeXMLHttpRequest;
 })(this);
 

--- a/docs/releases/sinon-1.3.1.js
+++ b/docs/releases/sinon-1.3.1.js
@@ -4,13 +4,13 @@
  * @author Christian Johansen (christian@cjohansen.no)
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2011, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -19,7 +19,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -1009,7 +1009,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(null, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 var args = this.args;
                 for (var i = 0, l = args.length; i < l; ++i) {
                     if (typeof args[i] === "function") {
@@ -1197,7 +1197,7 @@ var sinon = (function (buster) {
             } else {
                 this.exception = error;
             }
-            
+
             return this;
         }
 
@@ -1238,13 +1238,13 @@ var sinon = (function (buster) {
                 if (typeof pos != "number") {
                     throw new TypeError("argument index is not number");
                 }
-                
+
                 this.returnArgAt = pos;
 
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.3.2.js
+++ b/docs/releases/sinon-1.3.2.js
@@ -1033,7 +1033,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(null, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 var args = this.args;
                 for (var i = 0, l = args.length; i < l; ++i) {
                     if (typeof args[i] === "function") {
@@ -1268,7 +1268,7 @@ var sinon = (function (buster) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.3.3.js
+++ b/docs/releases/sinon-1.3.3.js
@@ -1037,7 +1037,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(null, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 var args = this.args;
                 for (var i = 0, l = args.length; i < l; ++i) {
                     if (typeof args[i] === "function") {
@@ -1272,7 +1272,7 @@ var sinon = (function (buster) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.3.4.js
+++ b/docs/releases/sinon-1.3.4.js
@@ -4,13 +4,13 @@
  * @author Christian Johansen (christian@cjohansen.no)
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2011, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -19,7 +19,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -132,7 +132,7 @@ buster.format.excludeConstructors = ["Object", /^.$/];
 buster.format.quoteStrings = true;
 
 buster.format.ascii = (function () {
-    
+
     function keys(object) {
         var k = Object.keys && Object.keys(object) || [];
 
@@ -1037,7 +1037,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(null, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 var args = this.args;
                 for (var i = 0, l = args.length; i < l; ++i) {
                     if (typeof args[i] === "function") {
@@ -1225,7 +1225,7 @@ var sinon = (function (buster) {
             } else {
                 this.exception = error;
             }
-            
+
             return this;
         }
 
@@ -1266,13 +1266,13 @@ var sinon = (function (buster) {
                 if (typeof pos != "number") {
                     throw new TypeError("argument index is not number");
                 }
-                
+
                 this.returnArgAt = pos;
 
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.4.0.js
+++ b/docs/releases/sinon-1.4.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2012, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -268,7 +268,7 @@ buster.format.excludeConstructors = ["Object", /^.$/];
 buster.format.quoteStrings = true;
 
 buster.format.ascii = (function () {
-    
+
     var hasOwn = Object.prototype.hasOwnProperty;
 
     var specialObjects = [];
@@ -1477,7 +1477,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(null, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 var args = this.args;
                 for (var i = 0, l = args.length; i < l; ++i) {
                     if (typeof args[i] === "function") {
@@ -1740,7 +1740,7 @@ var sinon = (function (buster) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {
@@ -1835,7 +1835,7 @@ var sinon = (function (buster) {
                 return this;
             }
         };
-        
+
         // create asynchronous versions of callsArg* and yields* methods
         for (var method in proto) {
             if (proto.hasOwnProperty(method) && method.match(/^(callsArg|yields)/)) {
@@ -1847,9 +1847,9 @@ var sinon = (function (buster) {
                 })(method);
             }
         }
-        
+
         return proto;
-        
+
     }()));
 
     if (commonJSModule) {

--- a/docs/releases/sinon-1.4.1.js
+++ b/docs/releases/sinon-1.4.1.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2012, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -269,7 +269,7 @@ buster.format.excludeConstructors = ["Object", /^.$/];
 buster.format.quoteStrings = true;
 
 buster.format.ascii = (function () {
-    
+
     var hasOwn = Object.prototype.hasOwnProperty;
 
     var specialObjects = [];
@@ -1478,7 +1478,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(null, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 var args = this.args;
                 for (var i = 0, l = args.length; i < l; ++i) {
                     if (typeof args[i] === "function") {
@@ -1741,7 +1741,7 @@ var sinon = (function (buster) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {
@@ -1836,7 +1836,7 @@ var sinon = (function (buster) {
                 return this;
             }
         };
-        
+
         // create asynchronous versions of callsArg* and yields* methods
         for (var method in proto) {
             if (proto.hasOwnProperty(method) && method.match(/^(callsArg|yields)/)) {
@@ -1848,9 +1848,9 @@ var sinon = (function (buster) {
                 })(method);
             }
         }
-        
+
         return proto;
-        
+
     }()));
 
     if (commonJSModule) {

--- a/docs/releases/sinon-1.4.2.js
+++ b/docs/releases/sinon-1.4.2.js
@@ -1478,7 +1478,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(null, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 var args = this.args;
                 for (var i = 0, l = args.length; i < l; ++i) {
                     if (typeof args[i] === "function") {
@@ -1741,7 +1741,7 @@ var sinon = (function (buster) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.5.0.js
+++ b/docs/releases/sinon-1.5.0.js
@@ -1492,7 +1492,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(null, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 var args = this.args;
                 for (var i = 0, l = args.length; i < l; ++i) {
                     if (typeof args[i] === "function") {
@@ -1779,7 +1779,7 @@ var sinon = (function (buster) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.5.2.js
+++ b/docs/releases/sinon-1.5.2.js
@@ -1503,7 +1503,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(null, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 var args = this.args;
                 for (var i = 0, l = args.length; i < l; ++i) {
                     if (typeof args[i] === "function") {
@@ -1790,7 +1790,7 @@ var sinon = (function (buster) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.6.0.js
+++ b/docs/releases/sinon-1.6.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2013, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -270,7 +270,7 @@ buster.format.excludeConstructors = ["Object", /^.$/];
 buster.format.quoteStrings = true;
 
 buster.format.ascii = (function () {
-    
+
     var hasOwn = Object.prototype.hasOwnProperty;
 
     var specialObjects = [];
@@ -1533,7 +1533,7 @@ var sinon = (function (buster) {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -1844,7 +1844,7 @@ var sinon = (function (buster) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.7.0.js
+++ b/docs/releases/sinon-1.7.0.js
@@ -1169,7 +1169,7 @@ var sinon = (function (buster) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -1882,7 +1882,7 @@ var sinon = (function (buster) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.7.1.js
+++ b/docs/releases/sinon-1.7.1.js
@@ -1169,7 +1169,7 @@ var sinon = (function (buster) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -1882,7 +1882,7 @@ var sinon = (function (buster) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.7.3.js
+++ b/docs/releases/sinon-1.7.3.js
@@ -1169,7 +1169,7 @@ if (!this.sinon && commonJSModule) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -1868,7 +1868,7 @@ if (!this.sinon && commonJSModule) {
                 return this;
             },
 
-            "throws": throwsException,
+            throws: throwsException,
             throwsException: throwsException,
 
             callsArg: function callsArg(pos) {

--- a/docs/releases/sinon-1.8.0.js
+++ b/docs/releases/sinon-1.8.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2013, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -421,7 +421,7 @@ define.amd = true;
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true
@@ -1340,7 +1340,7 @@ var sinon = (function (formatio) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -2112,7 +2112,7 @@ var sinon = (function (formatio) {
         },
 
 
-        "throws": throwsException,
+        throws: throwsException,
         throwsException: throwsException,
 
         returns: function returns(value) {
@@ -3477,10 +3477,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -3829,7 +3829,7 @@ if (typeof sinon == "undefined") {
         },
 
         uploadError: function uploadError(error) {
-            this.upload.dispatchEvent(new CustomEvent("error", {"detail": error}));
+            this.upload.dispatchEvent(new CustomEvent("error", {detail: error}));
         }
     });
 

--- a/docs/releases/sinon-1.8.1.js
+++ b/docs/releases/sinon-1.8.1.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2013, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -421,7 +421,7 @@ define.amd = true;
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true
@@ -1340,7 +1340,7 @@ var sinon = (function (formatio) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -2112,7 +2112,7 @@ var sinon = (function (formatio) {
         },
 
 
-        "throws": throwsException,
+        throws: throwsException,
         throwsException: throwsException,
 
         returns: function returns(value) {
@@ -3477,10 +3477,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -3829,7 +3829,7 @@ if (typeof sinon == "undefined") {
         },
 
         uploadError: function uploadError(error) {
-            this.upload.dispatchEvent(new CustomEvent("error", {"detail": error}));
+            this.upload.dispatchEvent(new CustomEvent("error", {detail: error}));
         }
     });
 

--- a/docs/releases/sinon-1.8.2.js
+++ b/docs/releases/sinon-1.8.2.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -421,7 +421,7 @@ define.amd = true;
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true
@@ -1340,7 +1340,7 @@ var sinon = (function (formatio) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -2112,7 +2112,7 @@ var sinon = (function (formatio) {
         },
 
 
-        "throws": throwsException,
+        throws: throwsException,
         throwsException: throwsException,
 
         returns: function returns(value) {
@@ -3478,10 +3478,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -3835,7 +3835,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-1.9.0.js
+++ b/docs/releases/sinon-1.9.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -421,7 +421,7 @@ define.amd = true;
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true
@@ -773,7 +773,7 @@ var sinon = (function (formatio) {
             }
 
             if (a instanceof RegExp && b instanceof RegExp) {
-              return (a.source === b.source) && (a.global === b.global) && 
+              return (a.source === b.source) && (a.global === b.global) &&
                 (a.ignoreCase === b.ignoreCase) && (a.multiline === b.multiline);
             }
 
@@ -1349,7 +1349,7 @@ var sinon = (function (formatio) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -2121,7 +2121,7 @@ var sinon = (function (formatio) {
         },
 
 
-        "throws": throwsException,
+        throws: throwsException,
         throwsException: throwsException,
 
         returns: function returns(value) {
@@ -3506,10 +3506,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -3870,7 +3870,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-1.9.1.js
+++ b/docs/releases/sinon-1.9.1.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -421,7 +421,7 @@ define.amd = true;
     module.exports = m(require("samsam"));
 }) || function (m) { this.formatio = m(this.samsam); }
 )(function (samsam) {
-    
+
     var formatio = {
         excludeConstructors: ["Object", /^.$/],
         quoteStrings: true
@@ -1358,7 +1358,7 @@ var sinon = (function (formatio) {
             this.args[pos].apply(thisValue, args);
         },
 
-        "yield": function () {
+        yield: function () {
             this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
         },
 
@@ -2130,7 +2130,7 @@ var sinon = (function (formatio) {
         },
 
 
-        "throws": throwsException,
+        throws: throwsException,
         throwsException: throwsException,
 
         returns: function returns(value) {
@@ -3531,10 +3531,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -3895,7 +3895,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-2.0.0-pre.4.js
+++ b/docs/releases/sinon-2.0.0-pre.4.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -787,7 +787,7 @@ var callProto = {
         this.args[pos].apply(thisValue, args);
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1176,7 +1176,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -2857,7 +2857,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":39}],20:[function(require,module,exports){
+},{formatio:39}],20:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3439,7 +3439,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
+var wloc = typeof window !== "undefined" ? window.location : { host: "localhost", protocol: "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {
@@ -3511,12 +3511,12 @@ var fakeServer = {
 
     configure: function (config) {
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
         var setting;
 
@@ -4851,7 +4851,7 @@ module.exports = {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -4871,7 +4871,7 @@ module.exports = {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -4956,7 +4956,7 @@ module.exports = {
 });
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"samsam":40}],40:[function(require,module,exports){
+},{samsam:40}],40:[function(require,module,exports){
 ((typeof define === "function" && define.amd && function (m) { define("samsam", m); }) ||
  (typeof module === "object" &&
       function (m) { module.exports = m(); }) || // Node

--- a/docs/releases/sinon-2.0.0-pre.5.js
+++ b/docs/releases/sinon-2.0.0-pre.5.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -843,7 +843,7 @@ var callProto = {
         this.args[pos].apply(thisValue, args);
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1155,7 +1155,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3150,7 +3150,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":73}],25:[function(require,module,exports){
+},{formatio:73}],25:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3796,7 +3796,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
+var wloc = typeof window !== "undefined" ? window.location : { host: "localhost", protocol: "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {
@@ -3868,12 +3868,12 @@ var fakeServer = {
 
     configure: function (config) {
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
         var setting;
 
@@ -5109,7 +5109,7 @@ module.exports = {
 
 The MIT License (MIT)
 
-Original Library 
+Original Library
   - Copyright (c) Marak Squires
 
 Additional functionality
@@ -5395,7 +5395,7 @@ module['exports'] = function zalgo(text, options) {
     });
     return bool;
   }
-  
+
 
   function heComes(text, options) {
     var result = '', counts, l;
@@ -7120,7 +7120,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -7140,7 +7140,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -7225,7 +7225,7 @@ function generateOptions(options, defaults) {
 });
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"samsam":74}],74:[function(require,module,exports){
+},{samsam:74}],74:[function(require,module,exports){
 ((typeof define === "function" && define.amd && function (m) { define("samsam", m); }) ||
  (typeof module === "object" &&
       function (m) { module.exports = m(); }) || // Node
@@ -8715,7 +8715,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":75}],78:[function(require,module,exports){
+},{isarray:75}],78:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.0.0-pre.6.js
+++ b/docs/releases/sinon-2.0.0-pre.6.js
@@ -613,7 +613,7 @@ var callProto = {
         this.args[pos].apply(thisValue, args);
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1123,7 +1123,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3054,7 +3054,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":63}],28:[function(require,module,exports){
+},{formatio:63}],28:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3611,7 +3611,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
+var wloc = typeof window !== "undefined" ? window.location : { host: "localhost", protocol: "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {
@@ -3680,12 +3680,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -5992,7 +5992,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6012,7 +6012,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6098,7 +6098,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":64}],64:[function(require,module,exports){
+},{samsam:64}],64:[function(require,module,exports){
 ((typeof define === "function" && define.amd && function (m) { define("samsam", m); }) ||
  (typeof module === "object" &&
       function (m) { module.exports = m(); }) || // Node
@@ -7584,7 +7584,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":67}],67:[function(require,module,exports){
+},{isarray:67}],67:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };

--- a/docs/releases/sinon-2.0.0.js
+++ b/docs/releases/sinon-2.0.0.js
@@ -605,7 +605,7 @@ var callProto = {
         this.args[pos].apply(thisValue, args);
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1135,7 +1135,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3081,7 +3081,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":63}],28:[function(require,module,exports){
+},{formatio:63}],28:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3638,7 +3638,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
+var wloc = typeof window !== "undefined" ? window.location : { host: "localhost", protocol: "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {
@@ -3707,12 +3707,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6010,7 +6010,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6035,7 +6035,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6122,7 +6122,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":68}],64:[function(require,module,exports){
+},{samsam:68}],64:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7216,7 +7216,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":64}],67:[function(require,module,exports){
+},{isarray:64}],67:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.1.0.js
+++ b/docs/releases/sinon-2.1.0.js
@@ -613,7 +613,7 @@ var callProto = {
         this.args[pos].apply(thisValue, args);
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1143,7 +1143,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3105,7 +3105,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":63}],28:[function(require,module,exports){
+},{formatio:63}],28:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3662,7 +3662,7 @@ function responseArray(handler) {
     return response;
 }
 
-var wloc = typeof window !== "undefined" ? window.location : { "host": "localhost", "protocol": "http"};
+var wloc = typeof window !== "undefined" ? window.location : { host: "localhost", protocol: "http"};
 var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
 
 function matchOne(response, reqMethod, reqUrl) {
@@ -3731,12 +3731,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6012,7 +6012,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6032,7 +6032,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6118,7 +6118,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":64}],64:[function(require,module,exports){
+},{samsam:64}],64:[function(require,module,exports){
 ((typeof define === "function" && define.amd && function (m) { define("samsam", m); }) ||
  (typeof module === "object" &&
       function (m) { module.exports = m(); }) || // Node
@@ -7604,7 +7604,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":67}],67:[function(require,module,exports){
+},{isarray:67}],67:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };

--- a/docs/releases/sinon-2.2.0.js
+++ b/docs/releases/sinon-2.2.0.js
@@ -613,7 +613,7 @@ var callProto = {
         this.args[pos].apply(thisValue, args);
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1159,7 +1159,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3128,7 +3128,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":63}],28:[function(require,module,exports){
+},{formatio:63}],28:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3686,7 +3686,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3778,12 +3778,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6081,7 +6081,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6106,7 +6106,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6193,7 +6193,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":68}],64:[function(require,module,exports){
+},{samsam:68}],64:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7287,7 +7287,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":64}],67:[function(require,module,exports){
+},{isarray:64}],67:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.3.0.js
+++ b/docs/releases/sinon-2.3.0.js
@@ -635,7 +635,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1206,7 +1206,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3236,7 +3236,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":64}],29:[function(require,module,exports){
+},{formatio:64}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3794,7 +3794,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3886,12 +3886,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6189,7 +6189,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6214,7 +6214,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6301,7 +6301,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":69}],65:[function(require,module,exports){
+},{samsam:69}],65:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7395,7 +7395,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":65}],68:[function(require,module,exports){
+},{isarray:65}],68:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.3.1.js
+++ b/docs/releases/sinon-2.3.1.js
@@ -635,7 +635,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1206,7 +1206,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3236,7 +3236,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":64}],29:[function(require,module,exports){
+},{formatio:64}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3794,7 +3794,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3886,12 +3886,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6189,7 +6189,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6214,7 +6214,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6301,7 +6301,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":69}],65:[function(require,module,exports){
+},{samsam:69}],65:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7395,7 +7395,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":65}],68:[function(require,module,exports){
+},{isarray:65}],68:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.3.2.js
+++ b/docs/releases/sinon-2.3.2.js
@@ -635,7 +635,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1200,7 +1200,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3254,7 +3254,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":64}],29:[function(require,module,exports){
+},{formatio:64}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3812,7 +3812,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3907,12 +3907,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6202,7 +6202,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6227,7 +6227,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6314,7 +6314,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":69}],65:[function(require,module,exports){
+},{samsam:69}],65:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7408,7 +7408,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":65}],68:[function(require,module,exports){
+},{isarray:65}],68:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.3.3.js
+++ b/docs/releases/sinon-2.3.3.js
@@ -635,7 +635,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1200,7 +1200,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3254,7 +3254,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":64}],29:[function(require,module,exports){
+},{formatio:64}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3812,7 +3812,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3907,12 +3907,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6202,7 +6202,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6227,7 +6227,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6314,7 +6314,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":69}],65:[function(require,module,exports){
+},{samsam:69}],65:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7408,7 +7408,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":65}],68:[function(require,module,exports){
+},{isarray:65}],68:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.3.4.js
+++ b/docs/releases/sinon-2.3.4.js
@@ -635,7 +635,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1206,7 +1206,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3260,7 +3260,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":64}],29:[function(require,module,exports){
+},{formatio:64}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3818,7 +3818,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3913,12 +3913,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6208,7 +6208,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6233,7 +6233,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6320,7 +6320,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":69}],65:[function(require,module,exports){
+},{samsam:69}],65:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7414,7 +7414,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":65}],68:[function(require,module,exports){
+},{isarray:65}],68:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.3.5.js
+++ b/docs/releases/sinon-2.3.5.js
@@ -635,7 +635,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1215,7 +1215,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3269,7 +3269,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":64}],29:[function(require,module,exports){
+},{formatio:64}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3827,7 +3827,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3922,12 +3922,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6217,7 +6217,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6242,7 +6242,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6329,7 +6329,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":69}],65:[function(require,module,exports){
+},{samsam:69}],65:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7423,7 +7423,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":65}],68:[function(require,module,exports){
+},{isarray:65}],68:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.3.6.js
+++ b/docs/releases/sinon-2.3.6.js
@@ -635,7 +635,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1215,7 +1215,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3282,7 +3282,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":64}],29:[function(require,module,exports){
+},{formatio:64}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3840,7 +3840,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3935,12 +3935,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6230,7 +6230,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6255,7 +6255,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6342,7 +6342,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":69}],65:[function(require,module,exports){
+},{samsam:69}],65:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7436,7 +7436,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":65}],68:[function(require,module,exports){
+},{isarray:65}],68:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.3.7.js
+++ b/docs/releases/sinon-2.3.7.js
@@ -635,7 +635,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1215,7 +1215,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3285,7 +3285,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":64}],29:[function(require,module,exports){
+},{formatio:64}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3843,7 +3843,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3938,12 +3938,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6233,7 +6233,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6258,7 +6258,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6345,7 +6345,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":69}],65:[function(require,module,exports){
+},{samsam:69}],65:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7439,7 +7439,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":65}],68:[function(require,module,exports){
+},{isarray:65}],68:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.3.8.js
+++ b/docs/releases/sinon-2.3.8.js
@@ -639,7 +639,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1219,7 +1219,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3289,7 +3289,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":49}],29:[function(require,module,exports){
+},{formatio:49}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3847,7 +3847,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3942,12 +3942,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6826,7 +6826,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6851,7 +6851,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6938,7 +6938,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":54}],50:[function(require,module,exports){
+},{samsam:54}],50:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -8032,7 +8032,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":50}],53:[function(require,module,exports){
+},{isarray:50}],53:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.4.0.js
+++ b/docs/releases/sinon-2.4.0.js
@@ -639,7 +639,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1219,7 +1219,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3289,7 +3289,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":64}],29:[function(require,module,exports){
+},{formatio:64}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3847,7 +3847,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3942,12 +3942,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6237,7 +6237,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6262,7 +6262,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6349,7 +6349,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":69}],65:[function(require,module,exports){
+},{samsam:69}],65:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7443,7 +7443,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":65}],68:[function(require,module,exports){
+},{isarray:65}],68:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-2.4.1.js
+++ b/docs/releases/sinon-2.4.1.js
@@ -639,7 +639,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1219,7 +1219,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3295,7 +3295,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":49}],29:[function(require,module,exports){
+},{formatio:49}],29:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -3853,7 +3853,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -3948,12 +3948,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -6832,7 +6832,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6857,7 +6857,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6944,7 +6944,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":54}],50:[function(require,module,exports){
+},{samsam:54}],50:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -8038,7 +8038,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":50}],53:[function(require,module,exports){
+},{isarray:50}],53:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-3.0.0.js
+++ b/docs/releases/sinon-3.0.0.js
@@ -592,7 +592,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1172,7 +1172,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3110,7 +3110,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":36}],24:[function(require,module,exports){
+},{formatio:36}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5452,7 +5452,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5477,7 +5477,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5564,7 +5564,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":55}],37:[function(require,module,exports){
+},{samsam:55}],37:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -6592,7 +6592,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":36}],48:[function(require,module,exports){
+},{formatio:36}],48:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -6617,7 +6617,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -6712,12 +6712,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -8640,7 +8640,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":37}],54:[function(require,module,exports){
+},{isarray:37}],54:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-3.1.0.js
+++ b/docs/releases/sinon-3.1.0.js
@@ -602,7 +602,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1193,7 +1193,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3131,7 +3131,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":51}],24:[function(require,module,exports){
+},{formatio:51}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -4884,7 +4884,7 @@ function generateOptions(options, defaults) {
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -4909,7 +4909,7 @@ function generateOptions(options, defaults) {
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -4996,7 +4996,7 @@ function generateOptions(options, defaults) {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":70}],52:[function(require,module,exports){
+},{samsam:70}],52:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -5974,7 +5974,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":51}],62:[function(require,module,exports){
+},{formatio:51}],62:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -5999,7 +5999,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -6094,12 +6094,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -8072,7 +8072,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":52}],69:[function(require,module,exports){
+},{isarray:52}],69:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-3.2.0.js
+++ b/docs/releases/sinon-3.2.0.js
@@ -606,7 +606,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1210,7 +1210,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3153,7 +3153,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":36}],24:[function(require,module,exports){
+},{formatio:36}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5495,7 +5495,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5520,7 +5520,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5607,7 +5607,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":55}],37:[function(require,module,exports){
+},{samsam:55}],37:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -6635,7 +6635,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":36}],48:[function(require,module,exports){
+},{formatio:36}],48:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -6660,7 +6660,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -6755,12 +6755,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -8683,7 +8683,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":37}],54:[function(require,module,exports){
+},{isarray:37}],54:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-3.2.1.js
+++ b/docs/releases/sinon-3.2.1.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1212,7 +1212,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3155,7 +3155,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":36}],24:[function(require,module,exports){
+},{formatio:36}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5497,7 +5497,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5522,7 +5522,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5609,7 +5609,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":55}],37:[function(require,module,exports){
+},{samsam:55}],37:[function(require,module,exports){
 module.exports = extend;
 
 /*
@@ -6632,7 +6632,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":36}],47:[function(require,module,exports){
+},{formatio:36}],47:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -6657,7 +6657,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -6752,12 +6752,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -8680,7 +8680,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":53}],53:[function(require,module,exports){
+},{isarray:53}],53:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };

--- a/docs/releases/sinon-3.3.0.js
+++ b/docs/releases/sinon-3.3.0.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1219,7 +1219,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3184,7 +3184,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":37}],24:[function(require,module,exports){
+},{formatio:37}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5675,7 +5675,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5700,7 +5700,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5787,7 +5787,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":56}],38:[function(require,module,exports){
+},{samsam:56}],38:[function(require,module,exports){
 module.exports = extend;
 
 /*
@@ -7746,7 +7746,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":37}],49:[function(require,module,exports){
+},{formatio:37}],49:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7771,7 +7771,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7866,12 +7866,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9794,7 +9794,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":55}],55:[function(require,module,exports){
+},{isarray:55}],55:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };

--- a/docs/releases/sinon-4.0.0.js
+++ b/docs/releases/sinon-4.0.0.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1219,7 +1219,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3189,7 +3189,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":36}],24:[function(require,module,exports){
+},{formatio:36}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5494,7 +5494,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5519,7 +5519,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5606,7 +5606,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":56}],37:[function(require,module,exports){
+},{samsam:56}],37:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7570,7 +7570,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":36}],49:[function(require,module,exports){
+},{formatio:36}],49:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7595,7 +7595,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7690,12 +7690,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9665,7 +9665,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":37}],55:[function(require,module,exports){
+},{isarray:37}],55:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.0.1.js
+++ b/docs/releases/sinon-4.0.1.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1219,7 +1219,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3189,7 +3189,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":36}],24:[function(require,module,exports){
+},{formatio:36}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5494,7 +5494,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5519,7 +5519,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5606,7 +5606,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":56}],37:[function(require,module,exports){
+},{samsam:56}],37:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7570,7 +7570,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":36}],49:[function(require,module,exports){
+},{formatio:36}],49:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7595,7 +7595,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7690,12 +7690,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9665,7 +9665,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":37}],55:[function(require,module,exports){
+},{isarray:37}],55:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.0.2.js
+++ b/docs/releases/sinon-4.0.2.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1216,7 +1216,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3186,7 +3186,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":36}],24:[function(require,module,exports){
+},{formatio:36}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5491,7 +5491,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5516,7 +5516,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5603,7 +5603,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":56}],37:[function(require,module,exports){
+},{samsam:56}],37:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7517,7 +7517,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":36}],48:[function(require,module,exports){
+},{formatio:36}],48:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7550,7 +7550,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7645,12 +7645,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9700,7 +9700,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":37}],55:[function(require,module,exports){
+},{isarray:37}],55:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.1.0.js
+++ b/docs/releases/sinon-4.1.0.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1223,7 +1223,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3193,7 +3193,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":36}],24:[function(require,module,exports){
+},{formatio:36}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5498,7 +5498,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5523,7 +5523,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5610,7 +5610,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":56}],37:[function(require,module,exports){
+},{samsam:56}],37:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7574,7 +7574,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":36}],49:[function(require,module,exports){
+},{formatio:36}],49:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7599,7 +7599,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7694,12 +7694,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9669,7 +9669,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":37}],55:[function(require,module,exports){
+},{isarray:37}],55:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.1.1.js
+++ b/docs/releases/sinon-4.1.1.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1223,7 +1223,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3193,7 +3193,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":36}],24:[function(require,module,exports){
+},{formatio:36}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5498,7 +5498,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5523,7 +5523,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5610,7 +5610,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":56}],37:[function(require,module,exports){
+},{samsam:56}],37:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7574,7 +7574,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":36}],49:[function(require,module,exports){
+},{formatio:36}],49:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7599,7 +7599,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7694,12 +7694,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9669,7 +9669,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":37}],55:[function(require,module,exports){
+},{isarray:37}],55:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.1.2.js
+++ b/docs/releases/sinon-4.1.2.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1223,7 +1223,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3193,7 +3193,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":36}],24:[function(require,module,exports){
+},{formatio:36}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5498,7 +5498,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5523,7 +5523,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5610,7 +5610,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":56}],37:[function(require,module,exports){
+},{samsam:56}],37:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7551,7 +7551,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":36}],48:[function(require,module,exports){
+},{formatio:36}],48:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7584,7 +7584,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7679,12 +7679,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9734,7 +9734,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":37}],55:[function(require,module,exports){
+},{isarray:37}],55:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.1.3.js
+++ b/docs/releases/sinon-4.1.3.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1223,7 +1223,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3201,7 +3201,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":36}],24:[function(require,module,exports){
+},{formatio:36}],24:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5506,7 +5506,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5531,7 +5531,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5618,7 +5618,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":56}],37:[function(require,module,exports){
+},{samsam:56}],37:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7582,7 +7582,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":36}],49:[function(require,module,exports){
+},{formatio:36}],49:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7607,7 +7607,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7702,12 +7702,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9677,7 +9677,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":37}],55:[function(require,module,exports){
+},{isarray:37}],55:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.1.4.js
+++ b/docs/releases/sinon-4.1.4.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1223,7 +1223,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3237,7 +3237,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":37}],25:[function(require,module,exports){
+},{formatio:37}],25:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5542,7 +5542,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5567,7 +5567,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5654,7 +5654,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":57}],38:[function(require,module,exports){
+},{samsam:57}],38:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7595,7 +7595,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":37}],49:[function(require,module,exports){
+},{formatio:37}],49:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7628,7 +7628,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7723,12 +7723,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9778,7 +9778,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":38}],56:[function(require,module,exports){
+},{isarray:38}],56:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.1.5.js
+++ b/docs/releases/sinon-4.1.5.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1223,7 +1223,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3236,7 +3236,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":37}],25:[function(require,module,exports){
+},{formatio:37}],25:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5541,7 +5541,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5566,7 +5566,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5653,7 +5653,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":57}],38:[function(require,module,exports){
+},{samsam:57}],38:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7617,7 +7617,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":37}],50:[function(require,module,exports){
+},{formatio:37}],50:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7642,7 +7642,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7737,12 +7737,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9712,7 +9712,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":38}],56:[function(require,module,exports){
+},{isarray:38}],56:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.1.6.js
+++ b/docs/releases/sinon-4.1.6.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1223,7 +1223,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3236,7 +3236,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":37}],25:[function(require,module,exports){
+},{formatio:37}],25:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5578,7 +5578,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5603,7 +5603,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5690,7 +5690,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":57}],38:[function(require,module,exports){
+},{samsam:57}],38:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7732,7 +7732,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":37}],50:[function(require,module,exports){
+},{formatio:37}],50:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7765,7 +7765,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7860,12 +7860,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9853,7 +9853,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":38}],56:[function(require,module,exports){
+},{isarray:38}],56:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.2.0.js
+++ b/docs/releases/sinon-4.2.0.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1223,7 +1223,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3272,7 +3272,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":37}],25:[function(require,module,exports){
+},{formatio:37}],25:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5577,7 +5577,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5602,7 +5602,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5689,7 +5689,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":57}],38:[function(require,module,exports){
+},{samsam:57}],38:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7630,7 +7630,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":37}],49:[function(require,module,exports){
+},{formatio:37}],49:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7663,7 +7663,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7758,12 +7758,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9813,7 +9813,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":38}],56:[function(require,module,exports){
+},{isarray:38}],56:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.2.1.js
+++ b/docs/releases/sinon-4.2.1.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1223,7 +1223,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3272,7 +3272,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":37}],25:[function(require,module,exports){
+},{formatio:37}],25:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5577,7 +5577,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5602,7 +5602,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5689,7 +5689,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":57}],38:[function(require,module,exports){
+},{samsam:57}],38:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7630,7 +7630,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":37}],49:[function(require,module,exports){
+},{formatio:37}],49:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7663,7 +7663,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7758,12 +7758,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9813,7 +9813,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":38}],56:[function(require,module,exports){
+},{isarray:38}],56:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.2.2.js
+++ b/docs/releases/sinon-4.2.2.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1240,7 +1240,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3289,7 +3289,7 @@ format.setFormatter = function (aCustomFormatter) {
 
 module.exports = format;
 
-},{"formatio":37}],25:[function(require,module,exports){
+},{formatio:37}],25:[function(require,module,exports){
 "use strict";
 
 module.exports = function functionName(func) {
@@ -5594,7 +5594,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -5619,7 +5619,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -5706,7 +5706,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":57}],38:[function(require,module,exports){
+},{samsam:57}],38:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -7647,7 +7647,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":37}],49:[function(require,module,exports){
+},{formatio:37}],49:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -7680,7 +7680,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -7775,12 +7775,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -9830,7 +9830,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":38}],56:[function(require,module,exports){
+},{isarray:38}],56:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.2.3.js
+++ b/docs/releases/sinon-4.2.3.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1240,7 +1240,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3915,7 +3915,7 @@ exports.timers = {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":37}],37:[function(require,module,exports){
+},{samsam:37}],37:[function(require,module,exports){
 ((typeof define === "function" && define.amd && function (m) { define("samsam", m); }) ||
  (typeof module === "object" &&
       function (m) { module.exports = m(); }) || // Node
@@ -6283,7 +6283,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6308,7 +6308,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6395,7 +6395,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":59}],40:[function(require,module,exports){
+},{samsam:59}],40:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -8336,7 +8336,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":39}],51:[function(require,module,exports){
+},{formatio:39}],51:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -8369,7 +8369,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -8464,12 +8464,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -10519,7 +10519,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":40}],58:[function(require,module,exports){
+},{isarray:40}],58:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.3.0.js
+++ b/docs/releases/sinon-4.3.0.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1240,7 +1240,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3921,7 +3921,7 @@ exports.timers = {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":37}],37:[function(require,module,exports){
+},{samsam:37}],37:[function(require,module,exports){
 ((typeof define === "function" && define.amd && function (m) { define("samsam", m); }) ||
  (typeof module === "object" &&
       function (m) { module.exports = m(); }) || // Node
@@ -6289,7 +6289,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6314,7 +6314,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6401,7 +6401,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":59}],40:[function(require,module,exports){
+},{samsam:59}],40:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -8342,7 +8342,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":39}],51:[function(require,module,exports){
+},{formatio:39}],51:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -8375,7 +8375,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -8470,12 +8470,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -10525,7 +10525,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":40}],58:[function(require,module,exports){
+},{isarray:40}],58:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.4.0.js
+++ b/docs/releases/sinon-4.4.0.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         return this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1240,7 +1240,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3926,7 +3926,7 @@ exports.timers = {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":37}],37:[function(require,module,exports){
+},{samsam:37}],37:[function(require,module,exports){
 ((typeof define === "function" && define.amd && function (m) { define("samsam", m); }) ||
  (typeof module === "object" &&
       function (m) { module.exports = m(); }) || // Node
@@ -6294,7 +6294,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6319,7 +6319,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6406,7 +6406,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":59}],40:[function(require,module,exports){
+},{samsam:59}],40:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -8347,7 +8347,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":39}],51:[function(require,module,exports){
+},{formatio:39}],51:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -8380,7 +8380,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -8475,12 +8475,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -10530,7 +10530,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":40}],58:[function(require,module,exports){
+},{isarray:40}],58:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.4.1.js
+++ b/docs/releases/sinon-4.4.1.js
@@ -607,7 +607,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         return this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1240,7 +1240,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3926,7 +3926,7 @@ exports.timers = {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":37}],37:[function(require,module,exports){
+},{samsam:37}],37:[function(require,module,exports){
 ((typeof define === "function" && define.amd && function (m) { define("samsam", m); }) ||
  (typeof module === "object" &&
       function (m) { module.exports = m(); }) || // Node
@@ -6294,7 +6294,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6319,7 +6319,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6406,7 +6406,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":59}],40:[function(require,module,exports){
+},{samsam:59}],40:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -8347,7 +8347,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":39}],51:[function(require,module,exports){
+},{formatio:39}],51:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -8380,7 +8380,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -8475,12 +8475,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -10530,7 +10530,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":40}],58:[function(require,module,exports){
+},{isarray:40}],58:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-4.4.2.js
+++ b/docs/releases/sinon-4.4.2.js
@@ -610,7 +610,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         return this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 
@@ -1253,7 +1253,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },
@@ -3939,7 +3939,7 @@ exports.timers = {
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":37}],37:[function(require,module,exports){
+},{samsam:37}],37:[function(require,module,exports){
 ((typeof define === "function" && define.amd && function (m) { define("samsam", m); }) ||
  (typeof module === "object" &&
       function (m) { module.exports = m(); }) || // Node
@@ -6307,7 +6307,7 @@ return /******/ (function(modules) { // webpackBootstrap
         processed.push(array);
         var pieces = [];
         var i, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, array.length) : array.length;
 
         for (i = 0; i < l; ++i) {
@@ -6332,7 +6332,7 @@ return /******/ (function(modules) { // webpackBootstrap
         var pieces = [], properties = samsam.keys(object).sort();
         var length = 3;
         var prop, str, obj, i, k, l;
-        l = (this.limitChildrenCount > 0) ? 
+        l = (this.limitChildrenCount > 0) ?
             Math.min(this.limitChildrenCount, properties.length) : properties.length;
 
         for (i = 0; i < l; ++i) {
@@ -6419,7 +6419,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 
-},{"samsam":59}],40:[function(require,module,exports){
+},{samsam:59}],40:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
@@ -8360,7 +8360,7 @@ module.exports = function format() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-},{"formatio":39}],51:[function(require,module,exports){
+},{formatio:39}],51:[function(require,module,exports){
 "use strict";
 
 var fakeXhr = require("../fake-xhr");
@@ -8393,7 +8393,7 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { "host": "localhost", "protocol": "http" };
+    return { host: "localhost", protocol: "http" };
 }
 
 function getWindowLocation() {
@@ -8488,12 +8488,12 @@ var fakeServer = {
     configure: function (config) {
         var self = this;
         var whitelist = {
-            "autoRespond": true,
-            "autoRespondAfter": true,
-            "respondImmediately": true,
-            "fakeHTTPMethods": true,
-            "logger": true,
-            "unsafeHeadersEnabled": true
+            autoRespond: true,
+            autoRespondAfter: true,
+            respondImmediately: true,
+            fakeHTTPMethods: true,
+            logger: true,
+            unsafeHeadersEnabled: true
         };
 
         config = config || {};
@@ -10543,7 +10543,7 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
 }
 
-},{"isarray":40}],58:[function(require,module,exports){
+},{isarray:40}],58:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 

--- a/docs/releases/sinon-server-1.10.0.js
+++ b/docs/releases/sinon-server-1.10.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -606,10 +606,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -970,7 +970,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-server-1.10.1.js
+++ b/docs/releases/sinon-server-1.10.1.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -606,10 +606,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -970,7 +970,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-server-1.10.2.js
+++ b/docs/releases/sinon-server-1.10.2.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -606,10 +606,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -970,7 +970,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-server-1.10.3.js
+++ b/docs/releases/sinon-server-1.10.3.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -606,10 +606,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -970,7 +970,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-server-1.16.0.js
+++ b/docs/releases/sinon-server-1.16.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -93,7 +93,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -486,7 +486,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -610,7 +610,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -716,7 +716,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -793,7 +793,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -1016,7 +1016,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -1669,7 +1669,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -1769,7 +1769,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -1839,10 +1839,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -2016,7 +2016,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -2090,7 +2090,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;

--- a/docs/releases/sinon-server-1.16.1.js
+++ b/docs/releases/sinon-server-1.16.1.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -93,7 +93,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -486,7 +486,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -610,7 +610,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -716,7 +716,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -793,7 +793,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -1016,7 +1016,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -1669,7 +1669,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -1769,7 +1769,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -1839,10 +1839,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -2016,7 +2016,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -2090,7 +2090,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;

--- a/docs/releases/sinon-server-1.17.0.js
+++ b/docs/releases/sinon-server-1.17.0.js
@@ -1910,10 +1910,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 

--- a/docs/releases/sinon-server-1.17.1.js
+++ b/docs/releases/sinon-server-1.17.1.js
@@ -1910,10 +1910,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 

--- a/docs/releases/sinon-server-1.17.2.js
+++ b/docs/releases/sinon-server-1.17.2.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -94,7 +94,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -487,7 +487,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -611,7 +611,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -717,7 +717,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -804,7 +804,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -1027,7 +1027,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -1740,7 +1740,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -1840,7 +1840,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -1910,10 +1910,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -2087,7 +2087,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -2161,7 +2161,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;

--- a/docs/releases/sinon-server-1.17.3.js
+++ b/docs/releases/sinon-server-1.17.3.js
@@ -1925,10 +1925,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 

--- a/docs/releases/sinon-server-1.17.4.js
+++ b/docs/releases/sinon-server-1.17.4.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -94,7 +94,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -487,7 +487,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -611,7 +611,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -717,7 +717,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -805,7 +805,7 @@ if (typeof sinon === "undefined") {
  * @private
  */
 function getGlobal() {
-    
+
     return typeof window !== "undefined" ? window : global;
 }
 
@@ -819,7 +819,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -1042,7 +1042,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -1764,7 +1764,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -1864,7 +1864,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -1934,10 +1934,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -2111,7 +2111,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -2185,7 +2185,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;

--- a/docs/releases/sinon-server-1.17.5.js
+++ b/docs/releases/sinon-server-1.17.5.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -94,7 +94,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -487,7 +487,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -611,7 +611,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -717,7 +717,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -805,7 +805,7 @@ if (typeof sinon === "undefined") {
  * @private
  */
 function getGlobal() {
-    
+
     return typeof window !== "undefined" ? window : global;
 }
 
@@ -819,7 +819,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -1042,7 +1042,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -1778,7 +1778,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -1878,7 +1878,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -1948,10 +1948,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -2125,7 +2125,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -2199,7 +2199,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;

--- a/docs/releases/sinon-server-1.17.6.js
+++ b/docs/releases/sinon-server-1.17.6.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -94,7 +94,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -500,7 +500,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -624,7 +624,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -730,7 +730,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -818,7 +818,7 @@ if (typeof sinon === "undefined") {
  * @private
  */
 function getGlobal() {
-    
+
     return typeof window !== "undefined" ? window : global;
 }
 
@@ -832,7 +832,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -1055,7 +1055,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -1791,7 +1791,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -1891,7 +1891,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -1961,10 +1961,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -2138,7 +2138,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -2212,7 +2212,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;

--- a/docs/releases/sinon-server-1.17.7.js
+++ b/docs/releases/sinon-server-1.17.7.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -94,7 +94,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -509,7 +509,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -633,7 +633,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -739,7 +739,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -827,7 +827,7 @@ if (typeof sinon === "undefined") {
  * @private
  */
 function getGlobal() {
-    
+
     return typeof window !== "undefined" ? window : global;
 }
 
@@ -841,7 +841,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -1064,7 +1064,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -1800,7 +1800,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -1900,7 +1900,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -1970,10 +1970,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -2147,7 +2147,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -2221,7 +2221,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;

--- a/docs/releases/sinon-server-1.8.0.js
+++ b/docs/releases/sinon-server-1.8.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2013, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -571,10 +571,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -923,7 +923,7 @@ if (typeof sinon == "undefined") {
         },
 
         uploadError: function uploadError(error) {
-            this.upload.dispatchEvent(new CustomEvent("error", {"detail": error}));
+            this.upload.dispatchEvent(new CustomEvent("error", {detail: error}));
         }
     });
 

--- a/docs/releases/sinon-server-1.8.1.js
+++ b/docs/releases/sinon-server-1.8.1.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2013, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -571,10 +571,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -923,7 +923,7 @@ if (typeof sinon == "undefined") {
         },
 
         uploadError: function uploadError(error) {
-            this.upload.dispatchEvent(new CustomEvent("error", {"detail": error}));
+            this.upload.dispatchEvent(new CustomEvent("error", {detail: error}));
         }
     });
 

--- a/docs/releases/sinon-server-1.8.2.js
+++ b/docs/releases/sinon-server-1.8.2.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -572,10 +572,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -929,7 +929,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-server-1.9.0.js
+++ b/docs/releases/sinon-server-1.9.0.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -193,7 +193,7 @@ var sinon = (function (formatio) {
             }
 
             if (a instanceof RegExp && b instanceof RegExp) {
-              return (a.source === b.source) && (a.global === b.global) && 
+              return (a.source === b.source) && (a.global === b.global) &&
                 (a.ignoreCase === b.ignoreCase) && (a.multiline === b.multiline);
             }
 
@@ -596,10 +596,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -960,7 +960,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-server-1.9.1.js
+++ b/docs/releases/sinon-server-1.9.1.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -605,10 +605,10 @@ if (typeof sinon == "undefined") {
     // and uploadError.
     function UploadProgress() {
         this.eventListeners = {
-            "progress": [],
-            "load": [],
-            "abort": [],
-            "error": []
+            progress: [],
+            load: [],
+            abort: [],
+            error: []
         }
     }
 
@@ -969,7 +969,7 @@ if (typeof sinon == "undefined") {
 
         uploadError: function uploadError(error) {
             if (supportsCustomEvent) {
-                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {detail: error}));
             }
         }
     });

--- a/docs/releases/sinon-server.js
+++ b/docs/releases/sinon-server.js
@@ -5,13 +5,13 @@
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
  *
  * (The BSD License)
- * 
+ *
  * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright notice,
@@ -20,7 +20,7 @@
  *     * Neither the name of Christian Johansen nor the names of his contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@
 var sinon = (function () {
 "use strict";
  // eslint-disable-line no-unused-vars
-    
+
     var sinonModule;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -94,7 +94,7 @@ var sinon = (function () {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     var div = typeof document !== "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -509,7 +509,7 @@ var sinon = (function () {
  * @depend util/core.js
  */
 (function (sinonGlobal) {
-    
+
     function makeApi(sinon) {
 
         // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
@@ -633,7 +633,7 @@ if (typeof sinon === "undefined") {
 }
 
 (function () {
-    
+
     var push = [].push;
 
     function makeApi(sinon) {
@@ -739,7 +739,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal) {
-    
+
     // cache a reference to setTimeout, so that our reference won't be stubbed out
     // when using fake timers and errors will still get logged
     // https://github.com/cjohansen/Sinon.JS/issues/381
@@ -827,7 +827,7 @@ if (typeof sinon === "undefined") {
  * @private
  */
 function getGlobal() {
-    
+
     return typeof window !== "undefined" ? window : global;
 }
 
@@ -841,7 +841,7 @@ if (typeof sinon === "undefined") {
 
 // wrapper for global
 (function (global) {
-    
+
     var xdr = { XDomainRequest: global.XDomainRequest };
     xdr.GlobalXDomainRequest = global.XDomainRequest;
     xdr.supportsXDR = typeof xdr.GlobalXDomainRequest !== "undefined";
@@ -1064,7 +1064,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function (sinonGlobal, global) {
-    
+
     function getWorkingXHR(globalScope) {
         var supportsXHR = typeof globalScope.XMLHttpRequest !== "undefined";
         if (supportsXHR) {
@@ -1800,7 +1800,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2014 Christian Johansen
  */
 (function (sinonGlobal, formatio) {
-    
+
     function makeApi(sinon) {
         function valueFormatter(value) {
             return "" + value;
@@ -1900,7 +1900,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     var push = [].push;
 
     function responseArray(handler) {
@@ -1970,10 +1970,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 
@@ -2147,7 +2147,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(s, lol) {
         /*global lolex */
         var llx = typeof lolex !== "undefined" ? lolex : lol;
@@ -2221,7 +2221,7 @@ if (typeof sinon === "undefined") {
  * Copyright (c) 2010-2013 Christian Johansen
  */
 (function () {
-    
+
     function makeApi(sinon) {
         function Server() {}
         Server.prototype = sinon.fakeServer;

--- a/docs/releases/sinon.js
+++ b/docs/releases/sinon.js
@@ -2525,7 +2525,7 @@ var sinon = (function () {
                 this.args[pos].apply(thisValue, args);
             },
 
-            "yield": function () {
+            yield: function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 
@@ -5759,10 +5759,10 @@ if (typeof sinon === "undefined") {
             },
             configure: function (config) {
                 var whitelist = {
-                    "autoRespond": true,
-                    "autoRespondAfter": true,
-                    "respondImmediately": true,
-                    "fakeHTTPMethods": true
+                    autoRespond: true,
+                    autoRespondAfter: true,
+                    respondImmediately: true,
+                    fakeHTTPMethods: true
                 };
                 var setting;
 

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -129,7 +129,7 @@ var callProto = {
         throw this.args[pos];
     },
 
-    "yield": function () {
+    yield: function () {
         return this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
     },
 

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -60,7 +60,7 @@ function matchObject(expectation, actual) {
 }
 
 var TYPE_MAP = {
-    "function": function (m, expectation, message) {
+    function: function (m, expectation, message) {
         m.test = expectation;
         m.message = message || "match(" + functionName(expectation) + ")";
     },


### PR DESCRIPTION
#### Purpose

Remove unnecessary property quoting throughout the codebase except for places where this would lead to inconsistency (objects where some properties must be quoted). Also, this would unquote properties that are reserved words - according to the [specification, the "Reserved word usage" section](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar) it is safe to use them as object properties - they just can't be used as variable names

Also, there is a stuff that been done by eslint in precommit hook - it has removed a lot of redundant trailing spaces and (probably) fix line endings in a few files. I can't commit without that changes so I hope they wouldn't be a problem

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test-node`
4. `npm test-headless`

#### Checklist for author

- [x] `npm run lint` passes