### PR TITLE
Fix inconsistent newline usage %D

### DIFF
--- a/lib/sinon/spy-formatters.js
+++ b/lib/sinon/spy-formatters.js
@@ -48,10 +48,7 @@ module.exports = {
         for (var i = 0, l = spyInstance.callCount; i < l; ++i) {
             // describe multiple calls
             if (l > 1) {
-                if (i > 0) {
-                    message += "\n";
-                }
-                message += "Call " + (i + 1) + ":";
+                message += "\nCall " + (i + 1) + ":";
             }
             var calledArgs = spyInstance.getCall(i).args;
             for (var j = 0; j < calledArgs.length || j < args.length; ++j) {

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1463,7 +1463,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 3, "not");
 
             assert.equals(this.message("calledWith", this.obj.doSomething, 1, 3, "hey").replace(/ at.*/g, ""),
-                "expected doSomething to be called with arguments " +
+                "expected doSomething to be called with arguments \n" +
                         "Call 1:\n" +
                         color.red("4") + " " + color.green("1") + " \n" +
                         "3\n" +
@@ -1652,7 +1652,8 @@ describe("assert", function () {
             this.obj.doSomething(1, "hey");
 
             assert.equals(this.message("alwaysCalledWith", this.obj.doSomething, 1, "hey").replace(/ at.*/g, ""),
-                "expected doSomething to always be called with arguments Call 1:\n" +
+                "expected doSomething to always be called with arguments \n" +
+                          "Call 1:\n" +
                           "1\n" +
                           color.red("3") + " " + color.green("hey") + " \n" +
                           color.red("hey") + "\n" +
@@ -1667,7 +1668,8 @@ describe("assert", function () {
 
             assert.equals(
                 this.message("alwaysCalledWithMatch", this.obj.doSomething, 1, "hey").replace(/ at.*/g, ""),
-                "expected doSomething to always be called with match Call 1:\n" +
+                "expected doSomething to always be called with match \n" +
+                          "Call 1:\n" +
                           "1\n" +
                           color.red("3") + " " + color.green("hey") + " \n" +
                           color.red("hey") + "\n" +
@@ -1691,7 +1693,8 @@ describe("assert", function () {
             this.obj.doSomething(1, 3);
 
             assert.equals(this.message("alwaysCalledWithExactly", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
-                "expected doSomething to always be called with exact arguments Call 1:\n" +
+                "expected doSomething to always be called with exact arguments \n" +
+                          "Call 1:\n" +
                           "1\n" +
                           "3\n" +
                           color.red("hey") + "\n" +

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var color = require("../lib/sinon/color");
 var referee = require("@sinonjs/referee");
 var sinonSpyCall = require("../lib/sinon/call");
 var sinonSpy = require("../lib/sinon/spy");
@@ -1429,6 +1430,73 @@ describe("sinonSpy.call", function () {
                 "1.4567, a, true, {  }, [], undefined, null"
             );
             assert.equals(spy.printf("%*", "a", "b", "c"), "a, b, c");
+        });
+
+        describe("arguments", function () {
+            it("no calls", function () {
+                var spy = sinonSpy();
+
+                assert.equals(spy.printf("%D"), "");
+            });
+
+            it("single call with arguments", function () {
+                var spy = sinonSpy();
+
+                spy(1, "a", true, false, [], {}, null, undefined);
+
+                assert.equals(
+                    spy.printf("%D"),
+                    "\n" + color.red("1") +
+                    "\n" + color.red("a") +
+                    "\n" + color.red("true") +
+                    "\n" + color.red("false") +
+                    "\n" + color.red("[]") +
+                    "\n" + color.red("{  }") +
+                    "\n" + color.red("null") +
+                    "\n" + color.red("undefined")
+                );
+            });
+
+            it("single call without arguments", function () {
+                var spy = sinonSpy();
+
+                spy();
+
+                assert.equals(spy.printf("%D"), "");
+            });
+
+            it("multiple calls with arguments", function () {
+                var spy = sinonSpy();
+
+                spy(1, "a", true);
+                spy(false, [], {});
+                spy(null, undefined);
+
+                assert.equals(
+                    spy.printf("%D"),
+                    "\nCall 1:" +
+                    "\n" + color.red("1") +
+                    "\n" + color.red("a") +
+                    "\n" + color.red("true") +
+                    "\nCall 2:" +
+                    "\n" + color.red("false") +
+                    "\n" + color.red("[]") +
+                    "\n" + color.red("{  }") +
+                    "\nCall 3:" +
+                    "\n" + color.red("null") +
+                    "\n" + color.red("undefined")
+                );
+            });
+
+            it("multiple calls without arguments", function () {
+                var spy = sinonSpy();
+
+                spy();
+                spy();
+                spy();
+
+                assert.equals(spy.printf("%D"), "\nCall 1:\nCall 2:\nCall 3:");
+            });
         });
     });
 


### PR DESCRIPTION
- Fix inconsistent newline usage %D
- Update affected unit tests
- Add tests for spy.printf %D text replacement

#### Purpose (TL;DR) - mandatory
See #1717 for the detailed bug report.  This PR should resolve #1717.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Make sure that `%D` always returns `\n` as its first character.
```js
const Sinon = require('sinon');
const spy = Sinon.spy();
spy(1, 2, 3);
console.log(spy.printf('%D').charCodeAt(0));  // => 10
spy(4, 5, 6);
console.log(spy.printf('%D').charCodeAt(0));  // => 10
```
Or just run `npm test`, which should pass.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

(That second checklist item isn't really applicable to these changes.)