### PR TITLE
Add postinstall banner pointing to Open Collective

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "prebuild": "rimraf pkg && npm run check-dependencies",
     "prepublishOnly": "npm run build",
     "preversion": "./scripts/preversion.sh",
-    "postversion": "./scripts/postversion.sh"
+    "postversion": "./scripts/postversion.sh",
+    "postinstall": "node -e \"console.log('\\u001b[32mLove sinon? You can now support the project via the open collective:\\u001b[22m\\u001b[39m\\n > \\u001b[96m\\u001b[1mhttps://opencollective.com/sinon/donate\\u001b[0m\\n')\" || exit 0"
   },
   "lint-staged": {
     "*.js": "eslint",


### PR DESCRIPTION
Inspired by https://remysharp.com/2018/01/10/open-source-with-a-cap-in-hand

Implementation shamelessly copied from https://github.com/remy/nodemon/blob/9d498523d750496aba1fb0f44c2befe42cb9d9f7/package.json#L42

This commit was cherry picked from the `next` branch in order to try to improve momentum for our Open Collective campaign sooner.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Observe that the banner (screenshot below) is shown at the end of the install process

![2018-03-12 at 08 53](https://user-images.githubusercontent.com/20321/37271380-fb4b94ba-25d2-11e8-9e81-2e3cc5c4f5d9.png)


#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).