### PR TITLE
Fix onCall(#) with chained behaviors

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -101,7 +101,7 @@ function callCallback(behavior, args) {
 
 var proto = {
     create: function create(stub) {
-        var behavior = extend({}, proto);
+        var behavior = extend(stub.bind(), proto);
         delete behavior.create;
         delete behavior.addBehavior;
         delete behavior.createBehavior;
@@ -219,7 +219,7 @@ function createBehavior(behaviorMethod) {
 function addBehavior(stub, name, fn) {
     proto[name] = function () {
         fn.apply(this, [this].concat([].slice.call(arguments)));
-        return this.stub || this;
+        return this;
     };
 
     stub[name] = createBehavior(name);

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -420,4 +420,21 @@ describe("issues", function () {
             refute.isTrue(spyProp.get.called);
         });
     });
+
+    describe("#1736 - onCall + yield + returns", function () {
+        it("should return the correct value without onCall", function () {
+            var stub = sinon.stub().yields("yield val").returns("return val");
+            var cb = sinon.spy();
+            var ret = stub(cb);
+            assert.equals(ret, "return val");
+            assert.equals(cb.args, [["yield val"]]);
+        });
+        it("should return the correct value with onCall", function () {
+            var stub = sinon.stub().onCall(0).yields("yield val").returns("return val");
+            var cb = sinon.spy();
+            var ret = stub(cb);
+            assert.equals(ret, "return val");
+            assert.equals(cb.args, [["yield val"]]);
+        });
+    });
 });

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -425,16 +425,37 @@ describe("issues", function () {
         it("should return the correct value without onCall", function () {
             var stub = sinon.stub().yields("yield val").returns("return val");
             var cb = sinon.spy();
+
             var ret = stub(cb);
+
             assert.equals(ret, "return val");
             assert.equals(cb.args, [["yield val"]]);
         });
         it("should return the correct value with onCall", function () {
             var stub = sinon.stub().onCall(0).yields("yield val").returns("return val");
             var cb = sinon.spy();
+
             var ret = stub(cb);
+
             assert.equals(ret, "return val");
             assert.equals(cb.args, [["yield val"]]);
+        });
+        it("should return the correct value with multiple onCalls", function () {
+            var stub = sinon.stub()
+                .onCall(0).yields("yield val").returns("return val")
+                .onCall(1).yields("second yield val").returns("second return val");
+            var cb = sinon.spy();
+            var cb2 = sinon.spy();
+
+            var ret = stub(cb);
+            var ret2 = stub(cb2);
+
+
+            assert.equals(ret, "return val");
+            assert.equals(cb.args, [["yield val"]]);
+
+            assert.equals(ret2, "second return val");
+            assert.equals(cb2.args, [["second yield val"]]);
         });
     });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Restores previous Sinon behavior and fixes issue #1736 by making all chained behaviors (yields, returns, throws, etc.) added after an `.onCall(#)` apply to that call rather than only the first behavior applying, and subsequent ones reverting to the default behavior.


#### Background (Problem in detail)  - optional
As mentioned in the original issue, in previous versions of Sinon, the following code added a `yeilds` and a `returns` behavior to call 0:

```js
stub.onCall(0).yields(x).returns(y);
```

However, in the current release of Sinon, that code would cause the first call to yield x and return undefined, and then all subsequent calls would return y.

The codebase I'm working on currently, uses the above pattern in numerous places for mocking `http.request` (which both returns and yields), and upgrading to the current version of Sinon caused a number of tests to start failing.

#### Solution  - optional

behaviorMethods always return `this` (the behavior object) instead of the original stub. I also changed the behavior object to be a function that calls through to the original stub.


#### WARNING

It's possible that some users inadvertently depend on the buggy behavior with code such as this:

```js
var stub = sinon.stub().onCall(0).returns('foo');
stub.returns('bar');
```
In the current release, the first call will return 'foo', and subsequent calls will return 'bar'. With the fix, it will return 'bar' and then undefined. However, I would argue that the above code is buggy and this fix merely exposes that bug, and therfore this fix shouldn't constitute a breaking change.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
