### PR TITLE
add scripts to the files array in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "files": [
     "lib",
     "pkg",
+    "scripts",
     "AUTHORS",
     "CONTRIBUTING.md",
     "History.md",


### PR DESCRIPTION
#### Purpose (TL;DR)
Fixes issue #1743 by adding to the `scripts` directory to the files array

#### Background (Problem in detail)
On the last release, we rely on a `postInstall` script that is not packed with `npm`.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. <your-steps-here>

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
