### PR TITLE
Fix #1746 by removing library

### DIFF
--- a/scripts/support-sinon.js
+++ b/scripts/support-sinon.js
@@ -1,12 +1,17 @@
 "use strict";
 /* eslint-disable no-console */
 
-var color = require("../lib/sinon/color");
+var green = "\u001b[32m";
+var white = "\u001b[22m\u001b[39m";
+var boldCyan = "\u001b[96m\u001b[1m";
+var reset = "\u001b[0m";
 
 var output =
-    color.green(
-        "Have some ❤️  for Sinon? You can support the project via Open Collective:"
-    ) +
-    color.white("\n > ") +
-    color.cyan(color.bold("https://opencollective.com/sinon/donate\n"));
+    green +
+    "Have some ❤️  for Sinon? You can support the project via Open Collective:" +
+    white +
+    "\n > " +
+    boldCyan +
+    "https://opencollective.com/sinon/donate\n" +
+    reset;
 console.log(output);

--- a/scripts/support-sinon.js
+++ b/scripts/support-sinon.js
@@ -14,4 +14,7 @@ var output =
     boldCyan +
     "https://opencollective.com/sinon/donate\n" +
     reset;
-console.log(output);
+
+if (!("NO_SUPPORT_MESSAGE" in process.env)) {
+    console.log(output);
+}


### PR DESCRIPTION
Basically fixes #1746 by removing a library dependency in the postinstall to avoid
breaking installs on Node versions < 4.

*Also* (and this is up for concideration), supports a use case where users can disable the support message, in case they rely on formatting being consistent in the output for parsing. This would be used like: `NO_SUPPORT_MESSAGE='' npm run postinstall -s`. I can remove this commit, but I think this strikes an ok compromise, as you _know_ people have read the message in case they explicitly want to turn it off. Unless this just turns into a standard flag convention in other packages, but that is getting ahead of things :smile: 