### PR TITLE
Fix #1746: Remove dependency on ES2015 code from post-install script

### DIFF
--- a/scripts/support-sinon.js
+++ b/scripts/support-sinon.js
@@ -1,12 +1,18 @@
 "use strict";
 /* eslint-disable no-console */
 
-var color = require("../lib/sinon/color");
+var green = "\u001b[32m";
+var white = "\u001b[22m\u001b[39m";
+var boldCyan = "\u001b[96m\u001b[1m";
+var reset = "\u001b[0m";
 
 var output =
-    color.green(
-        "Have some ❤️  for Sinon? You can support the project via Open Collective:"
-    ) +
-    color.white("\n > ") +
-    color.cyan(color.bold("https://opencollective.com/sinon/donate\n"));
+    green +
+    "Have some ❤️  for Sinon? You can support the project via Open Collective:" +
+    white +
+    "\n > " +
+    boldCyan +
+    "https://opencollective.com/sinon/donate\n" +
+    reset;
+
 console.log(output);


### PR DESCRIPTION
This allows Sinon to be installed using legacy node, does not add any external dependencies, doesn't call OpenCollective servers.

It's basically just the PR that @fatso83 made a few days ago, without the support for turning the banner off.

This is as much support I am willing to give to legacy node. If users of legacy node can install Sinon and still get benefit from it, despite a few things not working, then that's great.

Let's stick with this version for awhile.

#### How to verify - mandatory
1. Check out this branch
1. `nvm use 0.10`
1. `npm run postinstall`
1. Observe the beautiful banner with emoji and colours
1. Observe there are no errors in the console

![2018-03-27 at 08 12](https://user-images.githubusercontent.com/20321/37949845-9527f82a-3196-11e8-8bf1-3fa064185b6c.png)