### PR TITLE
Fix incorrect usage of referee's assert.exception

### DIFF
--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -65,7 +65,7 @@ describe("assert", function () {
 
             assert.exception(function () {
                 sinonAssert.fail("Some message");
-            }, "RetardError");
+            }, {name: "RetardError"});
         });
     });
 
@@ -1227,13 +1227,13 @@ describe("assert", function () {
         it("throws if target is undefined", function () {
             assert.exception(function () {
                 sinonAssert.expose();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws if target is null", function () {
             assert.exception(function () {
                 sinonAssert.expose(null);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
     });
 

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -232,7 +232,7 @@ describe("sinonSpy.call", function () {
 
             assert.exception(function () {
                 call.callArg();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("returns callbacks return value", function () {
@@ -251,7 +251,7 @@ describe("sinonSpy.call", function () {
 
             assert.exception(function () {
                 call.callArg({});
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
     });
 
@@ -297,7 +297,7 @@ describe("sinonSpy.call", function () {
 
             assert.exception(function () {
                 call.callArgOn({}, thisObj);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
     });
 
@@ -351,7 +351,7 @@ describe("sinonSpy.call", function () {
 
             assert.exception(function () {
                 call.callArgWith();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws if index is not number", function () {
@@ -359,7 +359,7 @@ describe("sinonSpy.call", function () {
 
             assert.exception(function () {
                 call.callArgWith({});
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
     });
 
@@ -431,7 +431,7 @@ describe("sinonSpy.call", function () {
 
             assert.exception(function () {
                 call.callArgOnWith({}, thisObj);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
     });
 

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -16,10 +16,10 @@ function propertyMatcherTests(matcher, additionalTests) {
         it("throws if first argument is not string", function () {
             assert.exception(function () {
                 matcher();
-            }, "TypeError");
+            }, {name: "TypeError"});
             assert.exception(function () {
                 matcher(123);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("returns false if value is undefined or null", function () {
@@ -444,10 +444,10 @@ describe("sinonMatch", function () {
         it("throws if given argument is not a string", function () {
             assert.exception(function () {
                 sinonMatch.typeOf();
-            }, "TypeError");
+            }, {name: "TypeError"});
             assert.exception(function () {
                 sinonMatch.typeOf(123);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("returns matcher", function () {
@@ -493,10 +493,10 @@ describe("sinonMatch", function () {
         it("throws if given argument is not a function", function () {
             assert.exception(function () {
                 sinonMatch.instanceOf();
-            }, "TypeError");
+            }, {name: "TypeError"});
             assert.exception(function () {
                 sinonMatch.instanceOf("foo");
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         if (typeof Symbol !== "undefined" && typeof Symbol.hasInstance !== "undefined") {
@@ -621,13 +621,13 @@ describe("sinonMatch", function () {
         it("throws if given argument is not a matcher", function () {
             assert.exception(function () {
                 sinonMatch.every({});
-            }, "TypeError");
+            }, {name: "TypeError"});
             assert.exception(function () {
                 sinonMatch.every(123);
-            }, "TypeError");
+            }, {name: "TypeError"});
             assert.exception(function () {
                 sinonMatch.every("123");
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("returns matcher", function () {
@@ -700,13 +700,13 @@ describe("sinonMatch", function () {
         it("throws if given argument is not a matcher", function () {
             assert.exception(function () {
                 sinonMatch.some({});
-            }, "TypeError");
+            }, {name: "TypeError"});
             assert.exception(function () {
                 sinonMatch.some(123);
-            }, "TypeError");
+            }, {name: "TypeError"});
             assert.exception(function () {
                 sinonMatch.some("123");
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("returns matcher", function () {
@@ -1188,7 +1188,7 @@ describe("sinonMatch", function () {
         it("requires matcher argument", function () {
             assert.exception(function () {
                 sinonMatch.instanceOf(Error).or();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("will coerce argument to matcher", function () {
@@ -1233,7 +1233,7 @@ describe("sinonMatch", function () {
         it("requires matcher argument", function () {
             assert.exception(function () {
                 sinonMatch.instanceOf(Error).and();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("will coerce to matcher", function () {

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -30,7 +30,7 @@ describe("sinonMock", function () {
         it("throws without object", function () {
             assert.exception(function () {
                 sinonMock.create();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
     });
 
@@ -44,7 +44,7 @@ describe("sinonMock", function () {
 
             assert.exception(function () {
                 mock.expects();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("returns expectation", function () {
@@ -130,7 +130,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("throw readable error", function () {
@@ -150,7 +150,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("returns expectation for chaining", function () {
@@ -166,7 +166,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("returns expectation for chaining", function () {
@@ -183,7 +183,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("returns expectation for chaining", function () {
@@ -201,7 +201,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("returns expectation for chaining", function () {
@@ -218,7 +218,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("returns expectation for chaining", function () {
@@ -230,7 +230,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation.exactly();
-                }, "TypeError");
+                }, {name: "TypeError"});
             });
 
             it("throws without number", function () {
@@ -238,7 +238,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation.exactly("12");
-                }, "TypeError");
+                }, {name: "TypeError"});
             });
 
             it("throws with Symbol", function () {
@@ -260,7 +260,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation.atLeast();
-                }, "TypeError");
+                }, {name: "TypeError"});
             });
 
             it("throws without number", function () {
@@ -268,7 +268,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation.atLeast({});
-                }, "TypeError");
+                }, {name: "TypeError"});
             });
 
             it("throws with Symbol", function () {
@@ -357,7 +357,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation.atMost();
-                }, "TypeError");
+                }, {name: "TypeError"});
             });
 
             it("throws without number", function () {
@@ -365,7 +365,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation.atMost({});
-                }, "TypeError");
+                }, {name: "TypeError"});
             });
 
             it("throws with Symbol", function () {
@@ -416,7 +416,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
 
                 assert.isFalse(this.expectation.met());
             });
@@ -457,7 +457,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
         });
 
@@ -510,7 +510,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("throws when called with too few args", function () {
@@ -519,7 +519,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation(1, 2);
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("throws when called with wrong args", function () {
@@ -569,7 +569,7 @@ describe("sinonMock", function () {
                 this.expectation.withArgs(sinonMatch.number, sinonMatch.string, sinonMatch.func);
                 assert.exception(function () {
                     expectation(1, 2, 3);
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
         });
 
@@ -591,7 +591,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("throws when called with too few args", function () {
@@ -600,7 +600,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation(1, 2);
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("throws when called with wrong args", function () {
@@ -609,7 +609,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation(2, 2, 3);
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("should not allow excessive args", function () {
@@ -618,7 +618,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation(1, 2, 3, 4);
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("accepts call with no expected args", function () {
@@ -634,7 +634,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation(1, 2, 3);
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
         });
 
@@ -656,7 +656,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("throws if calls on wrong Symbol", function () {
@@ -690,7 +690,7 @@ describe("sinonMock", function () {
 
                 assert.exception(function () {
                     expectation.verify();
-                }, "ExpectationError");
+                }, {name: "ExpectationError"});
             });
 
             it("throws readable error", function () {
@@ -740,7 +740,7 @@ describe("sinonMock", function () {
 
             assert.exception(function () {
                 mock.verify();
-            }, "ExpectationError");
+            }, {name: "ExpectationError"});
 
             assert.same(this.object.method, this.method);
         });
@@ -927,7 +927,7 @@ describe("sinonMock", function () {
 
             assert.exception(function () {
                 mock.verify();
-            }, "ExpectationError");
+            }, {name: "ExpectationError"});
         });
 
         it("does not call pass if no expectations", function () {
@@ -996,7 +996,7 @@ describe("sinonMock", function () {
 
             assert.exception(function () {
                 assert(mock.verify());
-            }, "ExpectationError");
+            }, {name: "ExpectationError"});
         });
     });
 
@@ -1024,7 +1024,7 @@ describe("sinonMock", function () {
 
             assert.exception(function () {
                 object.method();
-            }, "ExpectationError");
+            }, {name: "ExpectationError"});
         });
 
         it("fails on last expectation", function () {
@@ -1034,7 +1034,7 @@ describe("sinonMock", function () {
 
             assert.exception(function () {
                 object.method();
-            }, "ExpectationError");
+            }, {name: "ExpectationError"});
         });
 
         it("allows mock calls in any order", function () {

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2109,7 +2109,7 @@ describe("spy", function () {
 
             assert.exception(function () {
                 spy.callArg(1);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws if spy was not yet invoked", function () {
@@ -2145,7 +2145,7 @@ describe("spy", function () {
 
             assert.exception(function () {
                 spy.callArg("");
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("passs additional arguments", function () {
@@ -2207,7 +2207,7 @@ describe("spy", function () {
 
             assert.exception(function () {
                 spy.callArgOn(1, thisObj);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws if spy was not yet invoked", function () {
@@ -2246,7 +2246,7 @@ describe("spy", function () {
 
             assert.exception(function () {
                 spy.callArg("", thisObj);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("pass additional arguments", function () {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -363,7 +363,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 stub.returnsArg();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
     });
 
@@ -391,7 +391,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 stub.throwsArg();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("should throw without enough arguments", function () {
@@ -694,7 +694,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 this.stub(1);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws if no index is specified", function () {
@@ -702,7 +702,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 stub.callsArg();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws if index is not number", function () {
@@ -710,7 +710,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 stub.callsArg({});
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("returns result of invocant", function () {
@@ -768,7 +768,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 stub.callsArgWith();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws if index is not number", function () {
@@ -776,7 +776,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 stub.callsArgWith({});
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("returns result of invocant", function () {
@@ -837,7 +837,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 this.stub(1);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws if no index is specified", function () {
@@ -845,7 +845,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 stub.callsArgOn();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws if index is not number", function () {
@@ -853,7 +853,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 stub.callsArgOn(this.fakeContext, 2);
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("returns result of invocant", function () {
@@ -960,7 +960,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 stub.callsArgOnWith();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws if index is not number", function () {
@@ -968,7 +968,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 stub.callsArgOnWith({});
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("returns result of invocant", function () {
@@ -1028,7 +1028,7 @@ describe("stub", function () {
 
             assert.exception(function () {
                 createStub(object, "method", 1);
-            }, {message: "stub(obj, 'meth', fn) has been removed, see documentation"}, "TypeError");
+            }, {message: "stub(obj, 'meth', fn) has been removed, see documentation"}, {name: "TypeError"});
         });
 
         it("stubbed method should be proper stub", function () {
@@ -1485,7 +1485,7 @@ describe("stub", function () {
         it("throws if no context is specified", function () {
             assert.exception(function () {
                 this.stub.yieldsOn();
-            }, "TypeError");
+            }, {name: "TypeError"});
         });
 
         it("throws understandable error if no callback is passed", function () {

--- a/test/util/core/wrap-method-test.js
+++ b/test/util/core/wrap-method-test.js
@@ -27,7 +27,7 @@ describe("util/core/wrapMethod", function () {
     it("throws if first argument is not object", function () {
         assert.exception(function () {
             wrapMethod();
-        }, "TypeError");
+        }, {name: "TypeError"});
     });
 
     it("throws if object defines property but is not function", function () {
@@ -36,7 +36,7 @@ describe("util/core/wrapMethod", function () {
 
         assert.exception(function () {
             wrapMethod(object, "prop", function () {});
-        }, "TypeError");
+        }, {name: "TypeError"});
     });
 
     it("throws Symbol() if object defines property but is not function", function () {
@@ -75,7 +75,7 @@ describe("util/core/wrapMethod", function () {
 
         assert.exception(function () {
             wrapMethod(object, "method");
-        }, "TypeError");
+        }, {name: "TypeError"});
     });
 
     it("throws if third argument is not a function or a property descriptor", function () {
@@ -83,7 +83,7 @@ describe("util/core/wrapMethod", function () {
 
         assert.exception(function () {
             wrapMethod(object, "method", 1);
-        }, "TypeError");
+        }, {name: "TypeError"});
     });
 
     it("replaces object method", function () {
@@ -114,7 +114,7 @@ describe("util/core/wrapMethod", function () {
 
         assert.exception(function () {
             wrapMethod(this.object, "method", function () {});
-        }, "TypeError");
+        }, {name: "TypeError"});
     });
 
     it("throws Symbol if method is already wrapped", function () {
@@ -137,7 +137,7 @@ describe("util/core/wrapMethod", function () {
 
         assert.exception(function () {
             wrapMethod(this.object, "property", { get: function () {} });
-        }, "TypeError");
+        }, {name: "TypeError"});
     });
 
     it("throws if method is already a spy", function () {
@@ -145,7 +145,7 @@ describe("util/core/wrapMethod", function () {
 
         assert.exception(function () {
             wrapMethod(object, "method", function () {});
-        }, "TypeError");
+        }, {name: "TypeError"});
     });
 
     it("throws if Symbol method is already a spy", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
This PR addresses issue #1702 by wrapping `assert.exception` matchers in the way that `referee` prescribes. For example, all relevant instances of `"TypeError"` in the unit tests are now written as `"{name: "TypeError"}"`, which causes the matcher to be correctly handled by `referee`.

#### How to verify - mandatory
Change one of the unit tests to expect the wrong exception type, e.g. "{name: "ExpectationError"}"` instead of "{name: "TypeError"}"`. Compared to the previous format, this will now correctly fail the unit test.

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
