### PR TITLE
Improve documentation of fakes

### DIFF
--- a/docs/_releases/v5.0.1/fakes.md
+++ b/docs/_releases/v5.0.1/fakes.md
@@ -6,22 +6,21 @@ breadcrumb: fakes
 
 ### Introduction
 
-Fakes are a new concept to Sinon, simplifying and merging the concepts from `spies` and `stubs`.
+`fake` was introduced with Sinon with v5. It simplifies and merges concepts from [`spies`][spies] and [`stubs`][stubs].
 
-A test fake is a `Function` that records arguments, return value, the value of
-`this` and exception thrown (if any) for all its calls.
+In Sinon, a `fake` is a `Function` that records arguments, return value, the value of `this` and exception thrown (if any) for all of its calls.
 
-Fakes can be created with or without behaviour.
+It can be created with or without behavior; it can wrap an existing function.
 
-All fakes are immutable: once created, their behaviour will not change.
+A fake is immutable: once created, the behavior will not change.
 
-Unlike `sinon.spy` and `sinon.stub` APIs, the `sinon.fake` API knows only how to create fakes, and doesn't concern itself with plugging them into the system under test. To plug the fakes into the system under test, you can use the [`sinon.replace*`](../sandbox#replace) methods.
+Unlike [`sinon.spy`][spies] and [`sinon.stub`][stubs] methods, the `sinon.fake` API knows only how to create fakes, and doesn't concern itself with plugging them into the system under test. To plug the fakes into the system under test, you can use the [`sinon.replace*`](../sandbox#sandboxreplaceobject-property-replacement) methods.
 
 
 ### Creating a fake
 
 ```js
-// create a basic fake, with no behaviour
+// create a basic fake, with no behavior
 var fake = sinon.fake();
 
 fake();
@@ -30,9 +29,9 @@ console.log(fake.callCount);
 // 1
 ```
 
-### Fakes with behaviour
+### Fakes with behavior
 
-Fakes can be created with behaviour, which cannot be changed once the fake has been created.
+Fakes can be created with behavior, which cannot be changed once the fake has been created.
 
 #### `sinon.fake.returns(value);`
 
@@ -90,11 +89,11 @@ fake(console.log);
 // hello world
 ```
 
-### `sinon.fake(func);`
+#### `sinon.fake(func);`
 
-Wraps an existing `Function` to record all interactions, while leaving it up to the `func` to provide the behaviour.
+Wraps an existing `Function` to record all interactions, while leaving it up to the `func` to provide the behavior.
 
-This is useful when complex behaviour not covered by the `sinon.fake.*` methods is required or when wrapping an existing function or method.
+This is useful when complex behavior not covered by the `sinon.fake.*` methods is required or when wrapping an existing function or method.
 
 ### Instance properties
 
@@ -171,6 +170,9 @@ console.log('apple pie');
 When you want to restore the replaced properties, simply call the `sinon.restore` method.
 
 ```js
-// restores all replaced properties set by sinon methods (restore, spy, stub)
+// restores all replaced properties set by sinon methods (replace, spy, stub)
 sinon.restore();
 ```
+
+[spies]: ../spies
+[stubs]: ../stubs

--- a/docs/index.md
+++ b/docs/index.md
@@ -233,7 +233,7 @@ it('calls callback after 100ms', function () {
 
     // Also:
     // assert.equals(new Date().getTime(), 100);
-}
+});
 ```
 
 As before, Sinon.JS provides utilities that help test frameworks reduce the boiler-plate. [Learn more about fake time][clock].

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
   layout: homepage
-  title: Sinon.JS - Standalone test spies, stubs and mocks for JavaScript. Works with any unit testing framework.
+  title: Sinon.JS - Standalone test fakes, spies, stubs and mocks for JavaScript. Works with any unit testing framework.
 ---
 {% assign current_release = site.sinon.current_release %}
 
@@ -36,13 +36,13 @@ function once(fn) {
 }
 ```
 
-### Spies
+### Fakes
 
-Testing this function can be quite elegantly achieved with a [test spy][spies]:
+Testing this function can be quite elegantly achieved with a [test fake][fakes]:
 
 ```javascript
 it('calls the original function', function () {
-    var callback = sinon.spy();
+    var callback = sinon.fake();
     var proxy = once(callback);
 
     proxy();
@@ -55,7 +55,7 @@ The fact that the function was only called once is important:
 
 ```javascript
 it('calls the original function only once', function () {
-    var callback = sinon.spy();
+    var callback = sinon.fake();
     var proxy = once(callback);
 
     proxy();
@@ -71,7 +71,7 @@ We also care about the `this` value and arguments:
 
 ```javascript
 it('calls original function with right this and args', function () {
-    var callback = sinon.spy();
+    var callback = sinon.fake();
     var proxy = once(callback);
     var obj = {};
 
@@ -82,24 +82,24 @@ it('calls original function with right this and args', function () {
 });
 ```
 
-[Learn more about spies][spies].
+[Learn more about fakes][fakes].
 
-### Stubs
+### Behavior
 
-The function returned by `once` should return whatever the original function returns. To test this, we create a stub:
+The function returned by `once` should return whatever the original function returns. To test this, we create a fake with behavior:
 
 ```javascript
 it("returns the return value from the original function", function () {
-    var callback = sinon.stub().returns(42);
+    var callback = sinon.fake.returns(42);
     var proxy = once(callback);
 
     assert.equals(proxy(), 42);
 });
 ```
 
-Conveniently, stubs can also be used as spies, e.g. we can query them for their callCount, received args and more.
+Conveniently, we can query fakes for their callCount, received args and more.
 
-[Learn more about stubs][stubs].
+[Learn more about fakes][fakes].
 
 ### Testing Ajax
 
@@ -117,7 +117,7 @@ function getTodos(listId, callback) {
 }
 ```
 
-To test this function without triggering network activity we could stub `jQuery.ajax`
+To test this function without triggering network activity we could replace `jQuery.ajax`
 
 ```javascript
 after(function () {
@@ -128,8 +128,8 @@ after(function () {
 });
 
 it('makes a GET request for todo items', function () {
-    sinon.stub(jQuery, 'ajax');
-    getTodos(42, sinon.spy());
+    sinon.replace(jQuery, 'ajax', sinon.fake());
+    getTodos(42, sinon.fake());
 
     assert(jQuery.ajax.calledWithMatch({ url: '/todo/42/items' }));
 });
@@ -154,7 +154,7 @@ after(function () {
 });
 
 it("makes a GET request for todo items", function () {
-    getTodos(42, sinon.spy());
+    getTodos(42, sinon.fake());
 
     assert.equals(requests.length, 1);
     assert.match(requests[0].url, "/todo/42/items");
@@ -174,7 +174,7 @@ before(function () { server = sinon.fakeServer.create(); });
 after(function () { server.restore(); });
 
 it("calls callback with deserialized data", function () {
-    var callback = sinon.spy();
+    var callback = sinon.fake();
     getTodos(42, callback);
 
     // This is part of the FakeXMLHttpRequest API
@@ -220,7 +220,7 @@ before(function () { clock = sinon.useFakeTimers(); });
 after(function () { clock.restore(); });
 
 it('calls callback after 100ms', function () {
-    var callback = sinon.spy();
+    var callback = sinon.fake();
     var throttled = debounce(callback);
 
     throttled();
@@ -254,8 +254,7 @@ You've seen the most common tasks people tackle with Sinon.JS, yet we've only sc
 
 Christian Johansen's book [Test-Driven JavaScript Development][tddjs] covers some of the design philosophy and initial sketches for Sinon.JS.
 
-[spies]: /releases/{{current_release}}/spies
-[stubs]: /releases/{{current_release}}/stubs
+[fakes]: /releases/{{current_release}}/fakes
 [fakexhr]: /releases/{{current_release}}/fake-xhr-and-server
 [fakeServer]: /releases/{{current_release}}/fake-xhr-and-server#fake-server
 [clock]: /releases/{{current_release}}/fake-timers

--- a/docs/index.md
+++ b/docs/index.md
@@ -259,5 +259,4 @@ Christian Johansen's book [Test-Driven JavaScript Development][tddjs] covers som
 [fakeServer]: /releases/{{current_release}}/fake-xhr-and-server#fake-server
 [clock]: /releases/{{current_release}}/fake-timers
 [api-docs]: /releases/{{current_release}}
-[sinon-group]: http://groups.google.com/group/sinonjs
 [tddjs]: http://tddjs.com/

--- a/docs/release-source/release/fakes.md
+++ b/docs/release-source/release/fakes.md
@@ -6,22 +6,21 @@ breadcrumb: fakes
 
 ### Introduction
 
-Fakes are a new concept to Sinon, simplifying and merging the concepts from `spies` and `stubs`.
+`fake` was introduced with Sinon with v5. It simplifies and merges concepts from [`spies`][spies] and [`stubs`][stubs].
 
-A test fake is a `Function` that records arguments, return value, the value of
-`this` and exception thrown (if any) for all its calls.
+In Sinon, a `fake` is a `Function` that records arguments, return value, the value of `this` and exception thrown (if any) for all of its calls.
 
-Fakes can be created with or without behaviour.
+It can be created with or without behavior; it can wrap an existing function.
 
-All fakes are immutable: once created, their behaviour will not change.
+A fake is immutable: once created, the behavior will not change.
 
-Unlike `sinon.spy` and `sinon.stub` APIs, the `sinon.fake` API knows only how to create fakes, and doesn't concern itself with plugging them into the system under test. To plug the fakes into the system under test, you can use the [`sinon.replace*`](../sandbox#replace) methods.
+Unlike [`sinon.spy`][spies] and [`sinon.stub`][stubs] methods, the `sinon.fake` API knows only how to create fakes, and doesn't concern itself with plugging them into the system under test. To plug the fakes into the system under test, you can use the [`sinon.replace*`](../sandbox#sandboxreplaceobject-property-replacement) methods.
 
 
 ### Creating a fake
 
 ```js
-// create a basic fake, with no behaviour
+// create a basic fake, with no behavior
 var fake = sinon.fake();
 
 fake();
@@ -30,9 +29,9 @@ console.log(fake.callCount);
 // 1
 ```
 
-### Fakes with behaviour
+### Fakes with behavior
 
-Fakes can be created with behaviour, which cannot be changed once the fake has been created.
+Fakes can be created with behavior, which cannot be changed once the fake has been created.
 
 #### `sinon.fake.returns(value);`
 
@@ -90,11 +89,11 @@ fake(console.log);
 // hello world
 ```
 
-### `sinon.fake(func);`
+#### `sinon.fake(func);`
 
-Wraps an existing `Function` to record all interactions, while leaving it up to the `func` to provide the behaviour.
+Wraps an existing `Function` to record all interactions, while leaving it up to the `func` to provide the behavior.
 
-This is useful when complex behaviour not covered by the `sinon.fake.*` methods is required or when wrapping an existing function or method.
+This is useful when complex behavior not covered by the `sinon.fake.*` methods is required or when wrapping an existing function or method.
 
 ### Instance properties
 
@@ -171,6 +170,9 @@ console.log('apple pie');
 When you want to restore the replaced properties, simply call the `sinon.restore` method.
 
 ```js
-// restores all replaced properties set by sinon methods (restore, spy, stub)
+// restores all replaced properties set by sinon methods (replace, spy, stub)
 sinon.restore();
 ```
+
+[spies]: ../spies
+[stubs]: ../stubs


### PR DESCRIPTION
This PR attempts to improve documentation for fakes, and changes the examples on the front page to use fakes instead of spies and stubs.

Reviewers are encouraged to read commits separately, or roll a -3 sanity check.