### PR TITLE
Fix #1781: by fixing sinnon.fake() typo 

### DIFF
--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -54,8 +54,8 @@ function wrapFunc(f) {
 }
 
 function fake(f) {
-    if (typeof func !== "undefined" && typeof func !== "function") {
-        throw new TypeError("Expected func argument to be a Function");
+    if (typeof f !== "undefined" && typeof f !== "function") {
+        throw new TypeError("Expected f argument to be a Function");
     }
 
     return wrapFunc(f);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix issue #1781 by fixing typo.
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->


<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. provide sinon.fake() argument to not function.
<img width="814" alt="2018-05-05 23 16 32" src="https://user-images.githubusercontent.com/18458057/39664175-68980848-50ba-11e8-9ca3-881c8d70d375.png">



#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
