### PR TITLE
Fix #1781: Reject non-function values a f argument to fake

### DIFF
--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -54,8 +54,8 @@ function wrapFunc(f) {
 }
 
 function fake(f) {
-    if (typeof func !== "undefined" && typeof func !== "function") {
-        throw new TypeError("Expected func argument to be a Function");
+    if (arguments.length > 0 && typeof f !== "function") {
+        throw new TypeError("Expected f argument to be a Function");
     }
 
     return wrapFunc(f);

--- a/test/fake-test.js
+++ b/test/fake-test.js
@@ -23,7 +23,7 @@ referee.add("isProxy", {
 
 function verifyProxy(func, argument) {
     it("should return a Sinon proxy", function () {
-        var actual = func(argument);
+        var actual = argument ? func(argument) : func();
 
         assert.isProxy(actual);
     });
@@ -49,6 +49,16 @@ describe("fake", function () {
 
     describe("when passed no value", function () {
         verifyProxy(fake);
+    });
+
+    it("should reject non-Function argument", function () {
+        var nonFuncs = ["", 123, new Date(), {}, false, undefined, true, null];
+
+        nonFuncs.forEach(function (nf) {
+            assert.exception(function () {
+                fake(nf);
+            });
+        });
     });
 
     describe(".callback", function () {


### PR DESCRIPTION
This PR is a fix for #1781. It is the same fix as #1782, but with tests.
