### PR TITLE
Fix stub id prefix

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -105,8 +105,8 @@ var proto = {
         };
 
         var orig = functionStub;
-        functionStub.id = "stub#" + uuid++;
         functionStub = spy.create(functionStub, stubLength);
+        functionStub.id = "stub#" + uuid++;
         functionStub.func = orig;
 
         extend(functionStub, stub);

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2783,5 +2783,13 @@ describe("spy", function () {
             ]);
         });
     });
+
+    describe(".id", function () {
+        it("should start with 'spy#'", function () {
+            for (var i = 0; i < 10; i++) {
+                assert.isTrue(createSpy().id.indexOf("spy#") === 0);
+            }
+        });
+    });
 });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2961,4 +2961,12 @@ describe("stub", function () {
             assert.equals(myObj.prop, "newString");
         });
     });
+
+    describe(".id", function () {
+        it("should start with 'stub#'", function () {
+            for (var i = 0; i < 10; i++) {
+                assert.isTrue(createStub().id.indexOf("stub#") === 0);
+            }
+        });
+    });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Each spy, stub and fake exposes an `id` property which should be named `spy#{n}`, `stub#{n}` and `fake#{n}` with `{n}` being incremented for each new instance. In case of a stub this property is generated but then replaced with `spy#{n}` due to a wrong function call order. This pull request fixes this and adds missing test cases (there was one for fakes, but none for spy or stub).

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
