### PR TITLE
Typo'd `fake` to `fakes`

### DIFF
--- a/docs/release-source/release/fakes.md
+++ b/docs/release-source/release/fakes.md
@@ -57,11 +57,11 @@ fake();
 // Error: not apple pie
 ```
 
-#### `sinon.fakes.resolves(value);`
+#### `sinon.fake.resolves(value);`
 
 Creates a fake that returns a resolved `Promise` for the passed value.
 
-#### `sinon.fakes.rejects(value);`
+#### `sinon.fake.rejects(value);`
 
 Creates a fake that returns a rejected `Promise` for the passed value.
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fixes typo in documentation. The docs say `fakes` where they meant `fake`.

#### How to verify - mandatory
1. The generated docs contain `sinon.fakes.resolves` instead of `sinon.fake.resolves`.
2. The generated docs contain `sinon.fakes.rejects ` instead of `sinon.fake.rejects `.

#### Checklist for author

Docs now contain `sinon.fake.resolves` instead.
Docs now contain `sinon.fake.rejects` instead.