### PR TITLE
Discussion: turn examples into runnable, testable fragments of code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,9 @@ before_script:
   - if [ "x$TRAVIS_NODE_VERSION" = "x10" ]; then npm run test-esm-bundle; fi
   - if [ "x$TRAVIS_NODE_VERSION" = "x10" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test-cloud; fi
 
-script: npm run test-node
+script:
+  - npm run test-examples
+  - npm run test-node
 
 after_success:
   - if [ "x$TRAVIS_NODE_VERSION" = "x10" ]; then npm run test-coverage -- --allow-chrome-as-root && cat ./coverage/lcov.info | coveralls lib; fi

--- a/docs/_includes/examples/.eslintrc.yml
+++ b/docs/_includes/examples/.eslintrc.yml
@@ -1,0 +1,23 @@
+env:
+  mocha: true
+
+plugins:
+  - mocha
+
+rules:
+  no-console: off
+  max-nested-callbacks: off
+  no-restricted-syntax: [error, 'TryStatement']
+
+  # Mocha Plugin - https://github.com/lo1tuma/eslint-plugin-mocha
+  mocha/handle-done-callback: error
+  mocha/no-exclusive-tests: error
+  mocha/no-global-tests: error
+  mocha/no-hooks-for-single-case: off
+  mocha/no-identical-title: error
+  mocha/no-mocha-arrows: error
+  mocha/no-nested-tests: error
+  mocha/no-return-and-callback: error
+  mocha/no-sibling-hooks: error
+  mocha/no-skipped-tests: warn
+  mocha/no-top-level-hooks: error

--- a/docs/_includes/examples/.eslintrc.yml
+++ b/docs/_includes/examples/.eslintrc.yml
@@ -7,7 +7,7 @@ plugins:
 rules:
   no-console: off
   max-nested-callbacks: off
-  no-restricted-syntax: [error, TryStatement]
+  no-restricted-syntax: [off, TryStatement]
 
   # Mocha Plugin - https://github.com/lo1tuma/eslint-plugin-mocha
   mocha/handle-done-callback: error

--- a/docs/_includes/examples/.eslintrc.yml
+++ b/docs/_includes/examples/.eslintrc.yml
@@ -7,7 +7,7 @@ plugins:
 rules:
   no-console: off
   max-nested-callbacks: off
-  no-restricted-syntax: [error, 'TryStatement']
+  no-restricted-syntax: [error, TryStatement]
 
   # Mocha Plugin - https://github.com/lo1tuma/eslint-plugin-mocha
   mocha/handle-done-callback: error

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -1,0 +1,42 @@
+"use strict";
+
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("../../../../lib/sinon");
+
+describe("`fake` examples", function () {
+    beforeEach(function () {
+        sinon.replace(global.console, "log", sinon.fake());
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    // basic.js
+    describe("basic invocation", function () {
+        it("should output `1` on the console", function () {
+            proxyquire("./basic", {
+                "sinon": {
+                    fake: sinon.fake
+                }
+            });
+
+            sinon.assert.calledOnce(global.console.log);
+            sinon.assert.calledWith(global.console.log, 1);
+        });
+    });
+
+    // returns.js
+    describe("returns", function () {
+        it("should output 'apple pie' on the console", function () {
+            proxyquire("./returns", {
+                "sinon": {
+                    fake: sinon.fake
+                }
+            });
+
+            sinon.assert.calledOnce(global.console.log);
+            sinon.assert.calledWith(global.console.log, "apple pie");
+        });
+    });
+});

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -3,6 +3,12 @@
 var proxyquire = require("proxyquire").noCallThru();
 var sinon = require("../../../../lib/sinon");
 var assert = require("@sinonjs/referee").assert;
+var stubs = {
+    "sinon": {
+        fake: sinon.fake,
+        replace: sinon.replace
+    }
+};
 
 describe("`fake` examples", function () {
     beforeEach(function () {
@@ -16,11 +22,7 @@ describe("`fake` examples", function () {
     // basic.js
     describe("basic invocation", function () {
         it("should output `1` on the console", function () {
-            proxyquire("./basic", {
-                "sinon": {
-                    fake: sinon.fake
-                }
-            });
+            proxyquire("./basic", stubs);
 
             sinon.assert.calledOnce(global.console.log);
             sinon.assert.calledWithExactly(global.console.log, 1);
@@ -30,11 +32,7 @@ describe("`fake` examples", function () {
     // returns.js
     describe("returns", function () {
         it("should output 'apple pie' on the console", function () {
-            proxyquire("./returns", {
-                "sinon": {
-                    fake: sinon.fake
-                }
-            });
+            proxyquire("./returns", stubs);
 
             sinon.assert.calledOnce(global.console.log);
             sinon.assert.calledWithExactly(global.console.log, "apple pie");
@@ -45,11 +43,7 @@ describe("`fake` examples", function () {
     describe("throws", function () {
         it("should throw Error with message: 'not apple pie'", function () {
             try {
-                proxyquire("./throws", {
-                    "sinon": {
-                        fake: sinon.fake
-                    }
-                });
+                proxyquire("./throws", stubs);
             } catch (error) {
                 assert.equals(error.message, "not apple pie");
             }
@@ -65,11 +59,7 @@ describe("`fake` examples", function () {
                 done();
             }, 0);
 
-            proxyquire("./resolves", {
-                "sinon": {
-                    fake: sinon.fake
-                }
-            });
+            proxyquire("./resolves", stubs);
         });
     });
 
@@ -82,22 +72,14 @@ describe("`fake` examples", function () {
                 done();
             }, 0);
 
-            proxyquire("./rejects", {
-                "sinon": {
-                    fake: sinon.fake
-                }
-            });
+            proxyquire("./rejects", stubs);
         });
     });
 
     // yields.js
     describe("yields", function () {
         it("should output 'lemon pie' on the console", function () {
-            proxyquire("./yields", {
-                "sinon": {
-                    fake: sinon.fake
-                }
-            });
+            proxyquire("./yields", stubs);
 
             sinon.assert.calledOnce(global.console.log);
             sinon.assert.calledWithExactly(global.console.log, "lemon pie", "key lime pie");
@@ -107,11 +89,7 @@ describe("`fake` examples", function () {
     // yields-async.js
     describe("yieldsAsync", function () {
         it("should output 'lemon pie' on the console", function (done) {
-            proxyquire("./yields-async", {
-                "sinon": {
-                    fake: sinon.fake
-                }
-            });
+            proxyquire("./yields-async", stubs);
 
             sinon.assert.notCalled(global.console.log);
 
@@ -127,11 +105,7 @@ describe("`fake` examples", function () {
     // wrap-func.js
     describe("wrapping a function example", function () {
         it("should allow existing behavior", function () {
-            proxyquire("./wrap-func", {
-                "sinon": {
-                    fake: sinon.fake
-                }
-            });
+            proxyquire("./wrap-func", stubs);
 
             sinon.assert.calledTwice(global.console.log);
 
@@ -143,11 +117,7 @@ describe("`fake` examples", function () {
     // callback.js
     describe(".callback convenience", function () {
         it("should output 'true' on the console", function () {
-            proxyquire("./callback", {
-                "sinon": {
-                    fake: sinon.fake
-                }
-            });
+            proxyquire("./callback", stubs);
 
             sinon.assert.calledOnce(global.console.log);
             sinon.assert.calledWithExactly(global.console.log, true);
@@ -157,11 +127,7 @@ describe("`fake` examples", function () {
     // last-arg.js
     describe(".lastArg convenience", function () {
         it("should output 'true' on the console", function () {
-            proxyquire("./last-arg", {
-                "sinon": {
-                    fake: sinon.fake
-                }
-            });
+            proxyquire("./last-arg", stubs);
 
             sinon.assert.calledOnce(global.console.log);
             sinon.assert.calledWithExactly(global.console.log, true);
@@ -171,12 +137,7 @@ describe("`fake` examples", function () {
     // replace.js
     describe("sinon.replace example", function () {
         it("should output '42' on the console", function () {
-            proxyquire("./replace", {
-                "sinon": {
-                    fake: sinon.fake,
-                    replace: sinon.replace
-                }
-            });
+            proxyquire("./replace", stubs);
 
             sinon.assert.calledOnce(global.console.log);
             sinon.assert.calledWithExactly(global.console.log, 42);

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -139,4 +139,18 @@ describe("`fake` examples", function () {
             assert.equals(global.console.log.secondCall.args, ["fake.calledOnce", true]);
         });
     });
+
+    // callback.js
+    describe(".callback convenience", function () {
+        it("should output 'true' on the console", function () {
+            proxyquire("./callback", {
+                "sinon": {
+                    fake: sinon.fake
+                }
+            });
+
+            sinon.assert.calledOnce(global.console.log);
+            sinon.assert.calledWithExactly(global.console.log, true);
+        });
+    });
 });

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -22,7 +22,7 @@ describe("`fake` examples", function () {
             });
 
             sinon.assert.calledOnce(global.console.log);
-            sinon.assert.calledWith(global.console.log, 1);
+            sinon.assert.calledWithExactly(global.console.log, 1);
         });
     });
 
@@ -36,7 +36,7 @@ describe("`fake` examples", function () {
             });
 
             sinon.assert.calledOnce(global.console.log);
-            sinon.assert.calledWith(global.console.log, "apple pie");
+            sinon.assert.calledWithExactly(global.console.log, "apple pie");
         });
     });
 });

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -2,6 +2,7 @@
 
 var proxyquire = require("proxyquire").noCallThru();
 var sinon = require("../../../../lib/sinon");
+var assert = require("@sinonjs/referee").assert;
 
 describe("`fake` examples", function () {
     beforeEach(function () {
@@ -37,6 +38,21 @@ describe("`fake` examples", function () {
 
             sinon.assert.calledOnce(global.console.log);
             sinon.assert.calledWithExactly(global.console.log, "apple pie");
+        });
+    });
+
+    // throws.js
+    describe("throws", function () {
+        it("should throw Error with message: 'not apple pie'", function () {
+            try {
+                proxyquire("./throws", {
+                    "sinon": {
+                        fake: sinon.fake
+                    }
+                });
+            } catch (error) {
+                assert.equals(error.message, "not apple pie");
+            }
         });
     });
 });

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -89,4 +89,18 @@ describe("`fake` examples", function () {
             });
         });
     });
+
+    // yields.js
+    describe("yields", function () {
+        it("should output 'lemon pie' on the console", function () {
+            proxyquire("./yields", {
+                "sinon": {
+                    fake: sinon.fake
+                }
+            });
+
+            sinon.assert.calledOnce(global.console.log);
+            sinon.assert.calledWithExactly(global.console.log, "lemon pie", "key lime pie");
+        });
+    });
 });

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -55,4 +55,21 @@ describe("`fake` examples", function () {
             }
         });
     });
+
+    // resolves.js
+    describe("resolves", function () {
+        it("should output 'cherry pie' on the console", function (done) {
+            setTimeout(function () {
+                sinon.assert.calledOnce(global.console.log);
+                sinon.assert.calledWithExactly(global.console.log, "cherry pie");
+                done();
+            }, 0);
+
+            proxyquire("./resolves", {
+                "sinon": {
+                    fake: sinon.fake
+                }
+            });
+        });
+    });
 });

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -167,4 +167,19 @@ describe("`fake` examples", function () {
             sinon.assert.calledWithExactly(global.console.log, true);
         });
     });
+
+    // replace.js
+    describe("sinon.replace example", function () {
+        it("should output '42' on the console", function () {
+            proxyquire("./replace", {
+                "sinon": {
+                    fake: sinon.fake,
+                    replace: sinon.replace
+                }
+            });
+
+            sinon.assert.calledOnce(global.console.log);
+            sinon.assert.calledWithExactly(global.console.log, 42);
+        });
+    });
 });

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -72,4 +72,21 @@ describe("`fake` examples", function () {
             });
         });
     });
+
+    // rejects.js
+    describe("rejects", function () {
+        it("should output 'not cherry pie' on the console", function (done) {
+            setTimeout(function () {
+                sinon.assert.calledOnce(global.console.log);
+                sinon.assert.calledWithExactly(global.console.log, "not cherry pie");
+                done();
+            }, 0);
+
+            proxyquire("./rejects", {
+                "sinon": {
+                    fake: sinon.fake
+                }
+            });
+        });
+    });
 });

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -153,4 +153,18 @@ describe("`fake` examples", function () {
             sinon.assert.calledWithExactly(global.console.log, true);
         });
     });
+
+    // last-arg.js
+    describe(".lastArg convenience", function () {
+        it("should output 'true' on the console", function () {
+            proxyquire("./last-arg", {
+                "sinon": {
+                    fake: sinon.fake
+                }
+            });
+
+            sinon.assert.calledOnce(global.console.log);
+            sinon.assert.calledWithExactly(global.console.log, true);
+        });
+    });
 });

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -103,4 +103,24 @@ describe("`fake` examples", function () {
             sinon.assert.calledWithExactly(global.console.log, "lemon pie", "key lime pie");
         });
     });
+
+    // yields-async.js
+    describe("yieldsAsync", function () {
+        it("should output 'lemon pie' on the console", function (done) {
+            proxyquire("./yields-async", {
+                "sinon": {
+                    fake: sinon.fake
+                }
+            });
+
+            sinon.assert.notCalled(global.console.log);
+
+            setTimeout(function () {
+                sinon.assert.calledOnce(global.console.log);
+                sinon.assert.calledWithExactly(global.console.log, "strawberry pie");
+
+                done();
+            }, 0);
+        });
+    });
 });

--- a/docs/_includes/examples/fakes/__tests.js
+++ b/docs/_includes/examples/fakes/__tests.js
@@ -123,4 +123,20 @@ describe("`fake` examples", function () {
             }, 0);
         });
     });
+
+    // wrap-func.js
+    describe("wrapping a function example", function () {
+        it("should allow existing behavior", function () {
+            proxyquire("./wrap-func", {
+                "sinon": {
+                    fake: sinon.fake
+                }
+            });
+
+            sinon.assert.calledTwice(global.console.log);
+
+            assert.equals(global.console.log.firstCall.args[0], 4);
+            assert.equals(global.console.log.secondCall.args, ["fake.calledOnce", true]);
+        });
+    });
 });

--- a/docs/_includes/examples/fakes/basic.js
+++ b/docs/_includes/examples/fakes/basic.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var sinon = require("sinon");
+
+// create a basic fake, with no behavior
+var fake = sinon.fake();
+
+fake();
+
+console.log(fake.callCount);
+// 1

--- a/docs/_includes/examples/fakes/callback.js
+++ b/docs/_includes/examples/fakes/callback.js
@@ -1,0 +1,11 @@
+"use strict";
+var sinon = require("sinon");
+var f = sinon.fake();
+var cb1 = function () {};
+var cb2 = function () {};
+
+f(1, 2, 3, cb1);
+f(1, 2, 3, cb2);
+
+console.log(f.callback === cb2);
+// true

--- a/docs/_includes/examples/fakes/last-arg.js
+++ b/docs/_includes/examples/fakes/last-arg.js
@@ -1,0 +1,11 @@
+"use strict";
+var sinon = require("sinon");
+var f = sinon.fake();
+var date1 = new Date();
+var date2 = new Date();
+
+f(1, 2, date1);
+f(1, 2, date2);
+
+console.log(f.lastArg === date2);
+// true

--- a/docs/_includes/examples/fakes/rejects.js
+++ b/docs/_includes/examples/fakes/rejects.js
@@ -1,0 +1,8 @@
+"use strict";
+var sinon = require("sinon");
+var fake = sinon.fake.rejects("not cherry pie");
+
+fake().catch(function (error) {
+    console.log(error.message);
+    // not cherry pie
+});

--- a/docs/_includes/examples/fakes/replace.js
+++ b/docs/_includes/examples/fakes/replace.js
@@ -1,0 +1,14 @@
+"use strict";
+var sinon = require("sinon");
+var fake = sinon.fake.returns(42);
+
+var API = {
+    greet: function (name) {
+        return "Hello " + name;
+    }
+};
+
+sinon.replace(API, "greet", fake);
+
+console.log(API.greet("world"));
+// 42

--- a/docs/_includes/examples/fakes/resolves.js
+++ b/docs/_includes/examples/fakes/resolves.js
@@ -1,0 +1,8 @@
+"use strict";
+var sinon = require("sinon");
+var fake = sinon.fake.resolves("cherry pie");
+
+fake().then(function (value) {
+    console.log(value);
+    // cherry pie
+});

--- a/docs/_includes/examples/fakes/returns.js
+++ b/docs/_includes/examples/fakes/returns.js
@@ -1,0 +1,6 @@
+"use strict";
+var sinon = require("sinon");
+var fake = sinon.fake.returns("apple pie");
+
+console.log(fake());
+// apple pie

--- a/docs/_includes/examples/fakes/throws.js
+++ b/docs/_includes/examples/fakes/throws.js
@@ -1,0 +1,6 @@
+"use strict";
+var sinon = require("sinon");
+var fake = sinon.fake.throws(new Error("not apple pie"));
+
+fake();
+// Error: not apple pie

--- a/docs/_includes/examples/fakes/wrap-func.js
+++ b/docs/_includes/examples/fakes/wrap-func.js
@@ -1,0 +1,14 @@
+"use strict";
+var sinon = require("sinon");
+
+function double(value) {
+    return 2 * value;
+}
+
+var fake = sinon.fake(double);
+
+console.log(fake(2));
+// 4
+
+console.log("fake.calledOnce", fake.calledOnce);
+// true

--- a/docs/_includes/examples/fakes/yields-async.js
+++ b/docs/_includes/examples/fakes/yields-async.js
@@ -1,0 +1,6 @@
+"use strict";
+var sinon = require("sinon");
+var fake = sinon.fake.yieldsAsync("strawberry pie");
+
+fake(console.log);
+// strawberry pie

--- a/docs/_includes/examples/fakes/yields.js
+++ b/docs/_includes/examples/fakes/yields.js
@@ -1,0 +1,6 @@
+"use strict";
+var sinon = require("sinon");
+var fake = sinon.fake.yields("lemon pie", "key lime pie");
+
+fake(console.log);
+// lemon pie key lime pie

--- a/docs/_releases/v5.0.7/fakes.md
+++ b/docs/_releases/v5.0.7/fakes.md
@@ -49,6 +49,10 @@ If an `Error` is passed as the `value` argument, then that will be the thrown va
 
 Creates a fake that returns a resolved `Promise` for the passed value.
 
+```js
+{% include examples/fakes/resolves.js %}
+```
+
 #### `sinon.fake.rejects(value);`
 
 Creates a fake that returns a rejected `Promise` for the passed value.

--- a/docs/_releases/v5.0.7/fakes.md
+++ b/docs/_releases/v5.0.7/fakes.md
@@ -42,10 +42,7 @@ Creates a fake that throws an `Error` with the provided value as the `message` p
 If an `Error` is passed as the `value` argument, then that will be the thrown value. If any other value is passed, then that will be used for the `message` property of the thrown `Error`.
 
 ```js
-var fake = sinon.fake.throws(new Error('not apple pie'));
-
-fake();
-// Error: not apple pie
+{% include examples/fakes/throws.js %}
 ```
 
 #### `sinon.fake.resolves(value);`

--- a/docs/_releases/v5.0.7/fakes.md
+++ b/docs/_releases/v5.0.7/fakes.md
@@ -76,10 +76,7 @@ If an `Error` is passed as the `value` argument, then that will be the value of 
 `fake` expects the last argument to be a callback and will invoke it asynchronously with the given arguments.
 
 ```js
-var fake = sinon.fake.yieldsAsync('hello world');
-
-fake(console.log);
-// hello world
+{% include examples/fakes/yields-async.js %}
 ```
 
 #### `sinon.fake(func);`

--- a/docs/_releases/v5.0.7/fakes.md
+++ b/docs/_releases/v5.0.7/fakes.md
@@ -138,12 +138,7 @@ Unlike `sinon.spy` and `sinon.stub`, `sinon.fake` only knows about creating fake
 To replace a property, you can use the [`sinon.replace`](../sandbox/#sandboxreplaceobject-property-replacement) method.
 
 ```js
-var fake = sinon.fake.returns('42');
-
-sinon.replace(console, 'log', fake);
-
-console.log('apple pie');
-// 42
+{% include examples/fakes/replace.js %}
 ```
 
 When you want to restore the replaced properties, simply call the `sinon.restore` method.

--- a/docs/_releases/v5.0.7/fakes.md
+++ b/docs/_releases/v5.0.7/fakes.md
@@ -20,13 +20,7 @@ Unlike [`sinon.spy`][spies] and [`sinon.stub`][stubs] methods, the `sinon.fake` 
 ### Creating a fake
 
 ```js
-// create a basic fake, with no behavior
-var fake = sinon.fake();
-
-fake();
-
-console.log(fake.callCount);
-// 1
+{% include examples/fakes/basic.js %}
 ```
 
 ### Fakes with behavior
@@ -38,10 +32,7 @@ Fakes can be created with behavior, which cannot be changed once the fake has be
 Creates a fake that returns the `value` argument
 
 ```js
-var fake = sinon.fake.returns('apple pie');
-
-fake();
-// apple pie
+{% include examples/fakes/returns.js %}
 ```
 
 #### `sinon.fake.throws(value);`
@@ -57,11 +48,11 @@ fake();
 // Error: not apple pie
 ```
 
-#### `sinon.fakes.resolves(value);`
+#### `sinon.fake.resolves(value);`
 
 Creates a fake that returns a resolved `Promise` for the passed value.
 
-#### `sinon.fakes.rejects(value);`
+#### `sinon.fake.rejects(value);`
 
 Creates a fake that returns a rejected `Promise` for the passed value.
 

--- a/docs/_releases/v5.0.7/fakes.md
+++ b/docs/_releases/v5.0.7/fakes.md
@@ -85,6 +85,11 @@ Wraps an existing `Function` to record all interactions, while leaving it up to 
 
 This is useful when complex behavior not covered by the `sinon.fake.*` methods is required or when wrapping an existing function or method.
 
+```js
+{% include examples/fakes/wrap-func.js %}
+```
+
+
 ### Instance properties
 
 #### `f.callback`

--- a/docs/_releases/v5.0.7/fakes.md
+++ b/docs/_releases/v5.0.7/fakes.md
@@ -97,15 +97,7 @@ This is useful when complex behavior not covered by the `sinon.fake.*` methods i
 This property is a convenience to easily get a reference to the last callback passed in the last to the fake.
 
 ```js
-var f = sinon.fake();
-var cb1 = function () {};
-var cb2 = function () {};
-
-f(1, 2, 3, cb1);
-f(1, 2, 3, cb2);
-
-f.callback === cb2;
-// true
+{% include examples/fakes/wrap-func.js %}
 ```
 
 The same convenience has been added to [spy calls][../spy-call]:

--- a/docs/_releases/v5.0.7/fakes.md
+++ b/docs/_releases/v5.0.7/fakes.md
@@ -68,10 +68,7 @@ If an `Error` is passed as the `value` argument, then that will be the value of 
 `fake` expects the last argument to be a callback and will invoke it with the given arguments.
 
 ```js
-var fake = sinon.fake.yields('hello world');
-
-fake(console.log);
-// hello world
+{% include examples/fakes/yields.js %}
 ```
 
 #### `sinon.fake.yieldsAsync(callback[, value1, ..., valueN]);`

--- a/docs/_releases/v5.0.7/fakes.md
+++ b/docs/_releases/v5.0.7/fakes.md
@@ -59,6 +59,10 @@ Creates a fake that returns a rejected `Promise` for the passed value.
 
 If an `Error` is passed as the `value` argument, then that will be the value of the promise. If any other value is passed, then that will be used for the `message` property of the `Error` returned by the promise.
 
+```js
+{% include examples/fakes/rejects.js %}
+```
+
 #### `sinon.fake.yields(callback[, value1, ..., valueN]);`
 
 `fake` expects the last argument to be a callback and will invoke it with the given arguments.

--- a/docs/_releases/v5.0.7/fakes.md
+++ b/docs/_releases/v5.0.7/fakes.md
@@ -115,15 +115,7 @@ f.lastCall.callback === cb2;
 This property is a convenient way to get a reference to the last argument passed in the last call to the fake.
 
 ```js
-var f = sinon.fake();
-var date1 = new Date();
-var date2 = new Date();
-
-f(1, 2, date1);
-f(1, 2, date2);
-
-f.lastArg === date2;
-// true
+{% include examples/fakes/last-arg.js %}
 ```
 
 The same convenience has been added to [spy calls][../spy-call]:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
+    "test-examples": "mocha -R dot docs/_includes/**/__tests.js",
     "test-node": "mocha --recursive -R dot test/**-test.js",
     "test-dev": "npm run test-node -- --watch -R min",
     "test-headless": "mochify --recursive -R dot --grep WebWorker --invert --plugin [ proxyquire-universal ] test/**-test.js",


### PR DESCRIPTION
🚧 do not merge 🚧 

This PR is just an opening for a discussion of how we can turn the API examples into runnable, testable code.

It often happens that when you try to learn to use a new JS package, that the examples our outdated or have typos in them. Sinon is no exception to that.

I'd like to fix this, by making all the examples used in the API documentation for `sinon@5.x` be runnable and have a basic unit test.

The changes should go into `release-source/`, I am just using the `5.0.7` as a working copy, as `release-source/` does not get built by Jekyll.

🚧 do not merge 🚧 

#### How to verify
1. Check out this branch
1. `cd docs`
1. `bundle exec jekyll serve`
1. Navigate to http://localhost:4000/releases/v5.0.7/fakes/
1. Observe the slightly updated examples
1. `npm run test-examples`
1. Observe that the tests pass
