### PR TITLE
Fix  #1801: spied fakeTimers are not restored correctly

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -24,10 +24,7 @@ var apiMethods = {
     setFormatter: format.setFormatter,
 
     // fake timers
-    useFakeTimers: fakeTimers.useFakeTimers,
-    clock: fakeTimers.clock,
     timers: fakeTimers.timers,
-
 
     // fake XHR
     xhr: nise.fakeXhr.xhr,

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -17,6 +17,7 @@ var fakeXhr = require("nise").fakeXhr;
 var usePromiseLibrary = require("./util/core/use-promise-library");
 
 // cache original versions, to prevent issues when they are stubbed in user space
+var reverse = Array.prototype.reverse;
 var push = Array.prototype.push;
 var filter = Array.prototype.filter;
 var forEach = Array.prototype.filter;
@@ -132,7 +133,8 @@ function Sandbox() {
             throw new Error("sandbox.restore() does not take any parameters. Perhaps you meant stub.restore()");
         }
 
-        applyOnEach(collection.reverse(), "restore");
+        reverse.call(collection);
+        applyOnEach(collection, "restore");
         collection = [];
 
         forEach.call(fakeRestorers, function (restorer) {

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -132,7 +132,7 @@ function Sandbox() {
             throw new Error("sandbox.restore() does not take any parameters. Perhaps you meant stub.restore()");
         }
 
-        applyOnEach(collection, "restore");
+        applyOnEach(collection.reverse(), "restore");
         collection = [];
 
         forEach.call(fakeRestorers, function (restorer) {

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -467,7 +467,7 @@ describe("issues", function () {
         });
     });
 
-    describe("sinon.restore spied fakeTimers", function () {
+    describe("#1801 - sinon.restore spied fakeTimers", function () {
         it("should restore spied fake timers", function () {
             var originalSetTimeout = setTimeout;
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -466,4 +466,17 @@ describe("issues", function () {
             // TypeError: Attempted to wrap someMethod which is already wrapped
         });
     });
+
+    describe("sinon.restore spied fakeTimers", function () {
+        it("should restore spied fake timers", function () {
+            var originalSetTimeout = setTimeout;
+
+            sinon.useFakeTimers();
+            sinon.spy(global, "setTimeout");
+
+            sinon.restore();
+
+            assert.same(originalSetTimeout, global.setTimeout, "fakeTimers restored");
+        });
+    });
 });

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -933,6 +933,17 @@ describe("Sandbox", function () {
 
             assert.same(setTimeout, originalSetTimeout, "fakeTimers restored");
         });
+
+        it("restores spied fake timers when then sanddox is restored", function () {
+            var originalSetTimeout = setTimeout;
+
+            this.sandbox.useFakeTimers();
+            this.sandbox.spy(global, "setTimeout");
+
+            this.sandbox.restore();
+
+            assert.same(originalSetTimeout, global.setTimeout, "fakeTimers restored");
+        });
     });
 
     describe(".usingPromise", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

When a fakeTimer is spied, sandbox.restore()/sinon.restore() does not restore setTimeout to the original function.

#### Background (Problem in detail) 

See #1801

When `sandbox.useFakeTimers()` is called, the original `setTimeout` and other methods are replaced with fake methods. When such fake method is spied it's replaced again with another fake. To make sure that `sandbox.restore()` reverts `setTimeout` and other methods to the original state these fakes should be restored in reverse order to make sure each fake is restored to its predecessor when calling fake.restore().

What is more the default sandbox doesn't use `sandbox.useFakeTimers`(see also #1775) and `sandbox.clock` (see #1780). To make the fix work in default sandbox it should pass `useFakeTimers` through to the sandbox method. Using `sandbox.clock` in the default sandbox added for consistency. 

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`


