### PR TITLE
Add isSealed check to is-es-module.

### DIFF
--- a/lib/sinon/util/core/is-es-module.js
+++ b/lib/sinon/util/core/is-es-module.js
@@ -11,6 +11,7 @@ module.exports = function (object) {
     return (
         object &&
         typeof Symbol !== "undefined" &&
-        object[Symbol.toStringTag] === "Module"
+        object[Symbol.toStringTag] === "Module" &&
+        Object.isSealed(object)
     );
 };

--- a/test/es2015/a-module-with-to-string-tag.mjs
+++ b/test/es2015/a-module-with-to-string-tag.mjs
@@ -1,0 +1,4 @@
+export default {
+    [Symbol.toStringTag]: "Module",
+    anExport() { return 42; }
+};

--- a/test/es2015/module-support-assessment-test.mjs
+++ b/test/es2015/module-support-assessment-test.mjs
@@ -1,6 +1,7 @@
 import referee from "@sinonjs/referee";
 import sinon from "../../lib/sinon";
 import * as aModule from "./a-module";
+import aModuleWithToStringTag from "./a-module-with-to-string-tag";
 import aModuleWithDefaultExport from "./a-module-with-default";
 
 // Usually one would import the default module, but one can make a form of wrapper like this
@@ -23,6 +24,12 @@ function createTestSuite(action) {
             it("should NOT result in error", function () {
                 refute.exception(function () {
                     stub = sinon[action](aModuleWithDefaultExport, "anExport");
+                });
+            });
+
+            it("should NOT result in error with a custom toStringTag", function () {
+                refute.exception(function () {
+                    stub = sinon[action](aModuleWithToStringTag, "anExport");
                 });
             });
 


### PR DESCRIPTION
This PR adds an `Object.isSealed` check to the `isESModule` helper. This allows objects that may have the `toStringTag` of `Module` to be mocked as long as they aren't sealed _(ES namespace objects are sealed)_.