### PR TITLE
Add in matcher

### DIFF
--- a/docs/release-source/release/matchers.md
+++ b/docs/release-source/release/matchers.md
@@ -181,6 +181,10 @@ Requires the value to be a `Date` object.
 
 Requires the value to be a `Symbol`.
 
+#### `sinon.match.in(array)`
+
+Requires the value to be in the `array`.
+
 *Since `sinon@2.0.0`*
 
 #### `sinon.match.same(ref)`

--- a/docs/release-source/release/matchers.md
+++ b/docs/release-source/release/matchers.md
@@ -49,18 +49,15 @@ Requires the value to be == to the given number.
 
 Requires the value to be a string and have the expectation as a substring.
 
-
 #### `sinon.match(regexp);`
 
 Requires the value to be a string and match the given regular expression.
-
 
 #### `sinon.match(object);`
 
 Requires the value to be not `null` or `undefined` and have at least the same properties as `expectation`.
 
 This supports nested matchers.
-
 
 #### `sinon.match(function)`
 
@@ -146,7 +143,6 @@ Requires the value to be a `Map`.
 
 Requires a `Map` to be deep equal another one.
 
-
 #### `sinon.match.map.contains(map)`
 
 Requires a `Map` to contain each one of the items the given map has.
@@ -185,12 +181,9 @@ Requires the value to be a `Symbol`.
 
 Requires the value to be in the `array`.
 
-*Since `sinon@2.0.0`*
-
 #### `sinon.match.same(ref)`
 
 Requires the value to strictly equal `ref`.
-
 
 #### `sinon.match.typeOf(type)`
 
@@ -211,7 +204,6 @@ Requires the value to be of the given type, where `type` can be one of
 #### `sinon.match.instanceOf(type)`
 
 Requires the value to be an instance of the given `type`.
-
 
 #### `sinon.match.has(property[, expectation])`
 

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -179,7 +179,7 @@ match.same = function (expectation) {
 };
 
 match.in = function (arrayOfExpectations) {
-    if (!(arrayOfExpectations instanceof Array)) {
+    if (!Array.isArray(arrayOfExpectations)) {
         throw new TypeError("array expected");
     }
 

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -178,6 +178,18 @@ match.same = function (expectation) {
     }, "same(" + valueToString(expectation) + ")");
 };
 
+match.in = function (arrayOfExpectations) {
+    if (!(arrayOfExpectations instanceof Array)) {
+        throw new TypeError("array expected");
+    }
+
+    return match(function (actual) {
+        return arrayOfExpectations.some(function (expectation) {
+            return expectation === actual;
+        });
+    }, "in(" + valueToString(arrayOfExpectations) + ")");
+};
+
 match.typeOf = function (type) {
     assertType(type, "string", "type");
     return match(function (actual) {

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -446,17 +446,15 @@ describe("sinonMatch", function () {
             assert(sinonMatch.isMatcher(inMatcher));
         });
 
-        context("when the test is called with non array argument", function () {
-            it("throws TypeError (array expected)", function () {
-                var arg = "not-array";
+        it("throws if given argument is not an array", function () {
+            var arg = "not-array";
 
-                assert.exception(function () {
-                    sinonMatch.in(arg);
-                }, {name: "TypeError", message: "array expected"});
-            });
+            assert.exception(function () {
+                sinonMatch.in(arg);
+            }, {name: "TypeError", message: "array expected"});
         });
 
-        context("when the test is called with an array", function () {
+        describe("when given argument is an array", function () {
             var arrays = [
                 [1, 2, 3],
                 ["a", "b", "c"],
@@ -465,21 +463,17 @@ describe("sinonMatch", function () {
                 [null, undefined]
             ];
 
-            context("and one of the elements is the same as the actual", function () {
-                it("returns true", function () {
-                    arrays.forEach(function (array) {
-                        var inMatcher = sinonMatch.in(array);
-                        assert.isTrue(inMatcher.test(array[0]));
-                    });
+            it("returns true if the tested value in the given array", function () {
+                arrays.forEach(function (array) {
+                    var inMatcher = sinonMatch.in(array);
+                    assert.isTrue(inMatcher.test(array[0]));
                 });
             });
 
-            context("and none of the elements is the same as the actual", function () {
-                it("returns false", function () {
-                    arrays.forEach(function (array) {
-                        var inMatcher = sinonMatch.in(array);
-                        assert.isFalse(inMatcher.test("something else"));
-                    });
+            it("returns false if the tested value not in the given array", function () {
+                arrays.forEach(function (array) {
+                    var inMatcher = sinonMatch.in(array);
+                    assert.isFalse(inMatcher.test("something else"));
                 });
             });
 

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -452,7 +452,7 @@ describe("sinonMatch", function () {
 
                 assert.exception(function () {
                     sinonMatch.in(arg);
-                }, {name: "TypeError"});
+                }, {name: "TypeError", message: "array expected"});
             });
         });
 
@@ -469,13 +469,13 @@ describe("sinonMatch", function () {
                 it("returns true", function () {
                     arrays.forEach(function (array) {
                         var inMatcher = sinonMatch.in(array);
-                        assert(inMatcher.test(array[0]));
+                        assert.isTrue(inMatcher.test(array[0]));
                     });
                 });
             });
 
             context("and none of the elements is the same as the actual", function () {
-                it("returns true", function () {
+                it("returns false", function () {
                     arrays.forEach(function (array) {
                         var inMatcher = sinonMatch.in(array);
                         assert.isFalse(inMatcher.test("something else"));

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -440,6 +440,52 @@ describe("sinonMatch", function () {
         });
     });
 
+    describe(".in", function () {
+        it("returns matcher", function () {
+            var inMatcher = sinonMatch.in([]);
+            assert(sinonMatch.isMatcher(inMatcher));
+        });
+
+        context("when the test is called with non array argument", function () {
+            it("throws TypeError (array expected)", function () {
+                var arg = "not-array";
+
+                assert.exception(function () {
+                    sinonMatch.in(arg);
+                }, {name: "TypeError"});
+            });
+        });
+
+        context("when the test is called with an array", function () {
+            var arrays = [
+                [1, 2, 3],
+                ["a", "b", "c"],
+                [{ a: "a" }, { b: "b"}],
+                [function () {}, function () {}],
+                [null, undefined]
+            ];
+
+            context("and one of the elements is the same as the actual", function () {
+                it("returns true", function () {
+                    arrays.forEach(function (array) {
+                        var inMatcher = sinonMatch.in(array);
+                        assert(inMatcher.test(array[0]));
+                    });
+                });
+            });
+
+            context("and none of the elements is the same as the actual", function () {
+                it("returns true", function () {
+                    arrays.forEach(function (array) {
+                        var inMatcher = sinonMatch.in(array);
+                        assert.isFalse(inMatcher.test("something else"));
+                    });
+                });
+            });
+
+        });
+    });
+
     describe(".typeOf", function () {
         it("throws if given argument is not a string", function () {
             assert.exception(function () {


### PR DESCRIPTION
#### Purpose (TL;DR)

Add `sinon.match.in` matcher


#### Background (Problem in detail)

I had a case where I wanted to match a computed value (a value that I don't know exactly what it is), but I knew the possibilities of that value.

so I had to do something like this:
`sinon.match.same('something').or(sinon.match.same('something_else'))`

```js
const expectedPayload = {
    experiment_uuid: 'target1',
    uuid: 'fake-uuid',
    variation: sinon.match.same('control').or(sinon.match.same('group1'))
};

```

I know also there is array.contains matcher.. but the case above, that payload is used in different places where I check if a function called with it, and I thought it would be much easier if I have  something like this: `sinon.match.in([v1, v2, v3])`

#### Solution
*sinon.match.in* matcher.
Allows to match a value to one of the elements of an array.
And it can be useful when the the value is not known,
but could be one of few possibilities provided as an array.

Usage:
sinon.match.in([p1, p2, p3, ..])


#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
