### PR TITLE
Skip tests in browsers without native Promise support

### DIFF
--- a/test/fake-test.js
+++ b/test/fake-test.js
@@ -31,6 +31,12 @@ function verifyProxy(func, argument) {
 
 function noop() {}
 
+function requirePromiseSupport() {
+    if (typeof Promise !== "function") {
+        this.skip();
+    }
+}
+
 var hasFunctionNameSupport = noop.name === "noop";
 
 describe("fake", function () {
@@ -183,6 +189,8 @@ describe("fake", function () {
     });
 
     describe(".resolves", function () {
+        before(requirePromiseSupport);
+
         it("should return a function that resolves to the argument", function () {
             var expected = 42;
             var myFake = fake.resolves(expected);
@@ -196,6 +204,8 @@ describe("fake", function () {
     });
 
     describe(".rejects", function () {
+        before(requirePromiseSupport);
+
         it("should return a function that rejects to the argument", function () {
             var expectedMessage = "42";
             var myFake = fake.rejects(expectedMessage);


### PR DESCRIPTION
[IE 11 doesn't support `Promise`s natively](https://travis-ci.org/sinonjs/sinon/jobs/386068462#L1995-L2034). This skips tests where `Promise` is not supported.