### PR TITLE
 Document/test call ordering checks

### DIFF
--- a/docs/release-source/release/spy-call.md
+++ b/docs/release-source/release/spy-call.md
@@ -73,6 +73,28 @@ Returns `true` if call threw exception of provided type.
 Returns `true` if call threw provided exception object.
 
 
+### `spyCall.calledBefore(otherCall)`
+
+Returns `true` if the spy call occurred before another spy call.
+
+
+### `spyCall.calledAfter(otherCall)`
+
+Returns `true` if the spy call occurred after another spy call.
+
+
+### `spyCall.calledImmediatelyBefore(otherCall)`
+
+Returns `true` if the spy call occurred before another call, and no calls to any
+other spy occurred in-between.
+
+
+### `spyCall.calledImmediatelyAfter(otherCall)`
+
+Returns `true` if the spy call occurred after another call, and no calls to any
+other spy occurred in-between.
+
+
 ### `spyCall.thisValue`
 
 The call's `this` value.

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -147,6 +147,31 @@ describe("sinonSpy.call", function () {
 
             assert.same(spy.getCall(0).thisValue, obj);
         });
+
+        it("has methods to test relative ordering", function () {
+            var spy = sinonSpy();
+            for (var i = 0; i < 4; i++) {
+                spy.call({});
+            }
+
+            var calls = [0, 1, 2, 3].map(function (idx) {
+                return spy.getCall(idx);
+            });
+
+            assert.equals(calls[1].calledBefore(calls[3]), true);
+            assert.equals(calls[1].calledBefore(calls[0]), false);
+
+            assert.equals(calls[3].calledAfter(calls[1]), true);
+            assert.equals(calls[1].calledAfter(calls[3]), false);
+
+            assert.equals(calls[0].calledImmediatelyBefore(calls[2]), false);
+            assert.equals(calls[1].calledImmediatelyBefore(calls[2]), true);
+            assert.equals(calls[3].calledImmediatelyBefore(calls[1]), false);
+
+            assert.equals(calls[3].calledImmediatelyAfter(calls[1]), false);
+            assert.equals(calls[2].calledImmediatelyAfter(calls[1]), true);
+            assert.equals(calls[1].calledImmediatelyAfter(calls[3]), false);
+        });
     });
 
     describe("call calledOn", function () {


### PR DESCRIPTION
#### Purpose
Add documentation for call-level methods that check for relative call ordering

#### Background
Based on the documentation, I was struggling to find ways to determine call ordering of specific calls. I noticed `callId` could be used by looking through the code for `spy.prototype.calledBefore` and thought it'd be useful to add a similar set of `called(Immediately)?(Before|After)` methods for spy calls. To my surprise, my tests passed without me having to add any code, so apparently these methods already exist and just aren't documented.

#### Checklist for author
- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
