### PR TITLE
Append named exports to the generated esm bundle

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,11 +3,14 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import builtins from "rollup-plugin-node-builtins";
 import globals from "rollup-plugin-node-globals";
 
+const sinon = require("./lib/sinon.js");
+
 export default {
     input: "./lib/sinon.js",
     output: {
         file: "pkg/sinon-esm.js",
-        format: "es"
+        format: "es",
+        outro: Object.keys(sinon).map((key) => `const _${key} = sinon.${key};\nexport { _${key} as ${key} };`).join('\n')
     },
     plugins: [
         nodeResolve({

--- a/test/es2015/check-esm-bundle-is-runnable.js
+++ b/test/es2015/check-esm-bundle-is-runnable.js
@@ -7,13 +7,18 @@ const port = 3876;
 
 const htmlWithModuleScript = `
 <script type="module">
-import sinon from '/sinon-esm.js';
+import sinon, { spy } from '/sinon-esm.js';
 
 const assert = (result) => { if(!result) throw new Error("Failed test"); };
 
 try {
     const stub = sinon.stub().returns(42);
     assert(42 === stub());
+
+    const calledSpy = spy();
+    calledSpy();
+    assert(1 === calledSpy.callCount);
+
     console.log('sinon-result:works');
 } catch(err) {
     console.log('sinon-result:fails Assertion incorrect' );


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

This pull request will add named exports to the ESM bundle to allow parts of sinon to be imported like this:

```javascript
import { spy } from 'sinon';
```

It fixes issue ##1833.

As a byproduct it will also equalize the following to import statements:

```javascript
import * as sinon from 'sinon';
import sinon from 'sinon';
```

<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

It works by appending all named exports to the bundle generated by rollup. With the current API the following code block gets appended:

```javascript
const _serverPrototype = sinon.serverPrototype;
export { _serverPrototype as serverPrototype };
const _getFakes = sinon.getFakes;
export { _getFakes as getFakes };
const _getRestorers = sinon.getRestorers;
export { _getRestorers as getRestorers };
const _createStubInstance = sinon.createStubInstance;
export { _createStubInstance as createStubInstance };
const _inject = sinon.inject;
export { _inject as inject };
const _mock = sinon.mock;
export { _mock as mock };
const _reset = sinon.reset;
export { _reset as reset };
const _resetBehavior = sinon.resetBehavior;
export { _resetBehavior as resetBehavior };
const _resetHistory = sinon.resetHistory;
export { _resetHistory as resetHistory };
const _restore = sinon.restore;
export { _restore as restore };
const _restoreContext = sinon.restoreContext;
export { _restoreContext as restoreContext };
const _replace = sinon.replace;
export { _replace as replace };
const _replaceGetter = sinon.replaceGetter;
export { _replaceGetter as replaceGetter };
const _replaceSetter = sinon.replaceSetter;
export { _replaceSetter as replaceSetter };
const _spy = sinon.spy;
export { _spy as spy };
const _stub = sinon.stub;
export { _stub as stub };
const _useFakeTimers = sinon.useFakeTimers;
export { _useFakeTimers as useFakeTimers };
const _verify = sinon.verify;
export { _verify as verify };
const _verifyAndRestore = sinon.verifyAndRestore;
export { _verifyAndRestore as verifyAndRestore };
const _useFakeServer = sinon.useFakeServer;
export { _useFakeServer as useFakeServer };
const _useFakeXMLHttpRequest = sinon.useFakeXMLHttpRequest;
export { _useFakeXMLHttpRequest as useFakeXMLHttpRequest };
const _usingPromise = sinon.usingPromise;
export { _usingPromise as usingPromise };
const _sandbox = sinon.sandbox;
export { _sandbox as sandbox };
const _createSandbox = sinon.createSandbox;
export { _createSandbox as createSandbox };
const _assert = sinon.assert;
export { _assert as assert };
const _fake = sinon.fake;
export { _fake as fake };
const _match = sinon.match;
export { _match as match };
const _spyCall = sinon.spyCall;
export { _spyCall as spyCall };
const _expectation = sinon.expectation;
export { _expectation as expectation };
const _defaultConfig = sinon.defaultConfig;
export { _defaultConfig as defaultConfig };
const _setFormatter = sinon.setFormatter;
export { _setFormatter as setFormatter };
const _timers = sinon.timers;
export { _timers as timers };
const _xhr = sinon.xhr;
export { _xhr as xhr };
const _FakeXMLHttpRequest = sinon.FakeXMLHttpRequest;
export { _FakeXMLHttpRequest as FakeXMLHttpRequest };
const _fakeServer = sinon.fakeServer;
export { _fakeServer as fakeServer };
const _fakeServerWithClock = sinon.fakeServerWithClock;
export { _fakeServerWithClock as fakeServerWithClock };
const _createFakeServer = sinon.createFakeServer;
export { _createFakeServer as createFakeServer };
const _createFakeServerWithClock = sinon.createFakeServerWithClock;
export { _createFakeServerWithClock as createFakeServerWithClock };
const _addBehavior = sinon.addBehavior;
export { _addBehavior as addBehavior };
```

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run build`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
