### PR TITLE
Fix mocha test file pattern to match subdirectories correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "test-node": "mocha --recursive -R dot test/**-test.js",
+    "test-node": "mocha --recursive -R dot 'test/**/*-test.js'",
     "test-dev": "npm run test-node -- --watch -R min",
-    "test-headless": "mochify --recursive -R dot --grep WebWorker --invert --plugin [ proxyquire-universal ] test/**-test.js",
+    "test-headless": "mochify --recursive -R dot --grep WebWorker --invert --plugin [ proxyquire-universal ] 'test/**/*-test.js'",
     "test-coverage": "mochify --recursive -R dot --grep WebWorker --invert --plugin [ proxyquire-universal ] --plugin [ mochify-istanbul --exclude '**/test/**' --report text --report lcovonly --dir ./coverage ] test/**-test.js",
     "test-cloud": "npm run test-headless -- --wd",
     "test-webworker": "mochify --https-server 8080 test/webworker/webworker-support-assessment.js",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "test-node": "mocha --recursive -R dot 'test/**/*-test.js'",
+    "test-node": "mocha --recursive -R dot \"test/**/*-test.js\"",
     "test-dev": "npm run test-node -- --watch -R min",
-    "test-headless": "mochify --recursive -R dot --grep WebWorker --invert --plugin [ proxyquire-universal ] 'test/**/*-test.js'",
+    "test-headless": "mochify --recursive -R dot --grep WebWorker --invert --plugin [ proxyquire-universal ] \"test/**/*-test.js\"",
     "test-coverage": "mochify --recursive -R dot --grep WebWorker --invert --plugin [ proxyquire-universal ] --plugin [ mochify-istanbul --exclude '**/test/**' --report text --report lcovonly --dir ./coverage ] test/**-test.js",
     "test-cloud": "npm run test-headless -- --wd",
     "test-webworker": "mochify --https-server 8080 test/webworker/webworker-support-assessment.js",


### PR DESCRIPTION
#### Purpose (TL;DR) 

The current test file pattern passed to mocha is not picking up subdirectories correctly (e.g. `issues-test.js` is not included). See also https://github.com/mochajs/mocha/issues/1828.

Running `npm test` before: `1260 passing (515ms)`
Running `npm test` after: `1503 passing (754ms)`

TODO:
- [x] use escaped double quotes