### PR TITLE
Use migration guide include in guide index

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ DEPENDENCIES
   minima (~> 2.0)
 
 RUBY VERSION
-   ruby 2.4.0p0
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.13.7
+   1.16.1

--- a/docs/_includes/docs/migration-guides.md
+++ b/docs/_includes/docs/migration-guides.md
@@ -4,3 +4,5 @@
 * Migrating from [v2.x to v3.0](/guides/migrating-to-3.0)
 * Migrating from [v3.x to v4.0](/guides/migrating-to-4.0)
 * Migrating from [v4.x to v5.0](/guides/migrating-to-5.0)
+* Migrating from [v5.x to v6.0](/guides/migrating-to-6.0)
+

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -4,10 +4,4 @@ title: Guides
 breadcrumb: guides
 ---
 
-## Migration guides
-
-* [Migrating to v6.0](./migrating-to-6.0)
-* [Migrating to v5.0](./migrating-to-5.0)
-* [Migrating to v4.0](./migrating-to-4.0)
-* [Migrating to v3.0](./migrating-to-3.0)
-* [Migrating to v2.0](./migrating-to-2.0)
+{% include docs/migration-guides.md %}


### PR DESCRIPTION
#### Purpose (TL;DR) 
Avoids landing in the situation [where we remember to update one place, but not the other](https://github.com/sinonjs/sinon/pull/1829#issuecomment-396529641).


#### How to verify 
1. `bundle install && (cd docs && bundle exec jekyll serve)`
2. Open http://localhost:4000/guides/ 
3. Open http://localhost/releases/v6.0.0 and check the "Migration guides" paragraph is the same as in the previous bullet point