### PR TITLE
Default sandbox fake request

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -28,7 +28,6 @@ var apiMethods = {
     // fake XHR
     xhr: nise.fakeXhr.xhr,
     FakeXMLHttpRequest: nise.fakeXhr.FakeXMLHttpRequest,
-    useFakeXMLHttpRequest: nise.fakeXhr.useFakeXMLHttpRequest,
 
     // fake server
     fakeServer: nise.fakeServer,

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -371,7 +371,8 @@ function Sandbox() {
 
     sandbox.useFakeXMLHttpRequest = function useFakeXMLHttpRequest() {
         var xhr = fakeXhr.useFakeXMLHttpRequest();
-        return push.call(collection, xhr);
+        push.call(collection, xhr);
+        return xhr;
     };
 
     sandbox.usingPromise = function usingPromise(promiseLibrary) {

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -483,7 +483,6 @@ describe("issues", function () {
     });
 
     describe("#1840 - sinon.restore useFakeXMLHttpRequest", function () {
-
         it("should restore XMLHttpRequest and ActiveXObject", function () {
             sinon.useFakeXMLHttpRequest();
             sinon.restore();

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -5,6 +5,8 @@ var sinon = require("../../lib/sinon");
 var createStub = require("../../lib/sinon/stub");
 var assert = referee.assert;
 var refute = referee.refute;
+var globalXHR = global.XMLHttpRequest;
+var globalAXO = global.ActiveXObject;
 
 describe("issues", function () {
     beforeEach(function () {
@@ -478,5 +480,17 @@ describe("issues", function () {
 
             assert.same(originalSetTimeout, global.setTimeout, "fakeTimers restored");
         });
+    });
+
+    describe("#1840 - sinon.restore useFakeXMLHttpRequest", function () {
+
+        it("should restore XMLHttpRequest and ActiveXObject", function () {
+            sinon.useFakeXMLHttpRequest();
+            sinon.restore();
+
+            assert.same(global.XMLHttpRequest, globalXHR);
+            assert.same(global.ActiveXObject, globalAXO);
+        });
+
     });
 });

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1174,6 +1174,16 @@ describe("Sandbox", function () {
                 });
 
                 it("calls sinon.useFakeXMLHttpRequest", function () {
+                    var stubXhr = { restore: function () {} };
+
+                    this.sandbox.stub(fakeXhr, "useFakeXMLHttpRequest").returns(stubXhr);
+                    var returnedXhr = this.sandbox.useFakeXMLHttpRequest();
+
+                    assert(fakeXhr.useFakeXMLHttpRequest.called);
+                    assert.equals(stubXhr, returnedXhr);
+                });
+
+                it("returns fake xhr object created by nise", function () {
                     this.sandbox.stub(fakeXhr, "useFakeXMLHttpRequest").returns({ restore: function () {} });
                     this.sandbox.useFakeXMLHttpRequest();
 

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -114,19 +114,25 @@ describe("sinon module", function () {
         });
 
         describe("useFakeXMLHttpRequest", function () {
-            it("should be the fakeXhr.useFakeXMLHttpRequest export from nise", function () {
+            var nise;
+
+            beforeEach(function () {
                 // use full sinon for this test as it compares sinon instance
                 // proxyquire changes the instance, so `actual instanceof Sandbox` returns `false`
                 // see https://github.com/sinonjs/sinon/pull/1586#issuecomment-354457231
                 sinon = require("../lib/sinon");
 
-                var nise = require("nise");
+                nise = require("nise");
+            });
 
+            afterEach(function () {
+                nise.fakeXhr.useFakeXMLHttpRequest.restore();
+            });
+
+            it("should be the fakeXhr.useFakeXMLHttpRequest export from nise", function () {
                 sinon.spy(nise.fakeXhr, "useFakeXMLHttpRequest");
                 sinon.useFakeXMLHttpRequest();
                 assert.isTrue(nise.fakeXhr.useFakeXMLHttpRequest.called);
-
-                nise.fakeXhr.useFakeXMLHttpRequest.restore();
             });
         });
     });

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -113,5 +113,21 @@ describe("sinon module", function () {
             });
         });
 
+        describe("useFakeXMLHttpRequest", function () {
+            it("should be the fakeXhr.useFakeXMLHttpRequest export from nise", function () {
+                // use full sinon for this test as it compares sinon instance
+                // proxyquire changes the instance, so `actual instanceof Sandbox` returns `false`
+                // see https://github.com/sinonjs/sinon/pull/1586#issuecomment-354457231
+                sinon = require("../lib/sinon");
+
+                var nise = require("nise");
+
+                sinon.spy(nise.fakeXhr, "useFakeXMLHttpRequest");
+                sinon.useFakeXMLHttpRequest();
+                assert.isTrue(nise.fakeXhr.useFakeXMLHttpRequest.called);
+
+                nise.fakeXhr.useFakeXMLHttpRequest.restore();
+            });
+        });
     });
 });

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -113,10 +113,5 @@ describe("sinon module", function () {
             });
         });
 
-        describe("useFakeXMLHttpRequest", function () {
-            it("should be the fakeXhr.useFakeXMLHttpRequest export from nise", function () {
-                assert.equals(sinon.useFakeXMLHttpRequest, fakeNise.fakeXhr.useFakeXMLHttpRequest);
-            });
-        });
     });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix for #1840

#### Solution  - optional

Use useFakeXMLHttpRequest from Sandbox class.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`
