### PR TITLE
Add SemVer compatibility badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 <a href="#sponsors"><img src="https://opencollective.com/sinon/sponsors/badge.svg" alt="OpenCollective"></a>
 <a href="https://www.npmjs.com/package/sinon" target="_blank"><img src="https://img.shields.io/npm/dm/sinon.svg" alt="npm downloads per month"></a>
 <a href="https://cdnjs.com/libraries/sinon.js" target="_blank"><img src="https://img.shields.io/cdnjs/v/sinon.js.svg" alt="CDNJS version"></a>
+<a href="https://dependabot.com/compatibility-score.html?dependency-name=sinon&package-manager=npm_and_yarn&version-scheme=semver" target="_blank"><img src="https://api.dependabot.com/badges/compatibility_score?dependency-name=sinon&package-manager=npm_and_yarn&version-scheme=semver" alt="SemVer compatibility"></a>
 </p>
 
 <p align=center>


### PR DESCRIPTION
#### Purpose (TL;DR)

Add a README badge that displays SemVer compatibility, calculated using the test suites of sinon users.

#### Background (Problem in detail)

First up, thanks for sinon!

Would you be up for adding a badge that shows how SemVer compliant / bug free new releases are? I was looking through the data we gather at Dependabot and realised we could put one together, so threw together the below:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=sinon&package-manager=npm_and_yarn&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=sinon&package-manager=npm_and_yarn&version-scheme=semver)

Would love your opinion - is it useful? Anything you'd change about it? If you click it there's an explanation of how it's calculated.

Any feedback super appreciated!
