### PR TITLE
Add documentation for stub.yieldsRight

### DIFF
--- a/docs/_releases/v1.17.6/stubs.md
+++ b/docs/_releases/v1.17.6/stubs.md
@@ -250,12 +250,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v1.17.7/stubs.md
+++ b/docs/_releases/v1.17.7/stubs.md
@@ -244,12 +244,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.0.0/stubs.md
+++ b/docs/_releases/v2.0.0/stubs.md
@@ -341,12 +341,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.2.0/stubs.md
+++ b/docs/_releases/v2.2.0/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.3.0/stubs.md
+++ b/docs/_releases/v2.3.0/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.3.1/stubs.md
+++ b/docs/_releases/v2.3.1/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.3.2/stubs.md
+++ b/docs/_releases/v2.3.2/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.3.3/stubs.md
+++ b/docs/_releases/v2.3.3/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.3.4/stubs.md
+++ b/docs/_releases/v2.3.4/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.3.5/stubs.md
+++ b/docs/_releases/v2.3.5/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.3.6/stubs.md
+++ b/docs/_releases/v2.3.6/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.3.7/stubs.md
+++ b/docs/_releases/v2.3.7/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.3.8/stubs.md
+++ b/docs/_releases/v2.3.8/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.4.0/stubs.md
+++ b/docs/_releases/v2.4.0/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v2.4.1/stubs.md
+++ b/docs/_releases/v2.4.1/stubs.md
@@ -362,12 +362,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v3.0.0/stubs.md
+++ b/docs/_releases/v3.0.0/stubs.md
@@ -366,12 +366,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v3.1.0/stubs.md
+++ b/docs/_releases/v3.1.0/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v3.2.0/stubs.md
+++ b/docs/_releases/v3.2.0/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v3.2.1/stubs.md
+++ b/docs/_releases/v3.2.1/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v3.3.0/stubs.md
+++ b/docs/_releases/v3.3.0/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.0.0/stubs.md
+++ b/docs/_releases/v4.0.0/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.0.1/stubs.md
+++ b/docs/_releases/v4.0.1/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.0.2/stubs.md
+++ b/docs/_releases/v4.0.2/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.1.0/stubs.md
+++ b/docs/_releases/v4.1.0/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.1.1/stubs.md
+++ b/docs/_releases/v4.1.1/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.1.2/stubs.md
+++ b/docs/_releases/v4.1.2/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.1.3/stubs.md
+++ b/docs/_releases/v4.1.3/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.1.4/stubs.md
+++ b/docs/_releases/v4.1.4/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.1.5/stubs.md
+++ b/docs/_releases/v4.1.5/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.1.6/stubs.md
+++ b/docs/_releases/v4.1.6/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.2.0/stubs.md
+++ b/docs/_releases/v4.2.0/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.2.1/stubs.md
+++ b/docs/_releases/v4.2.1/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.2.2/stubs.md
+++ b/docs/_releases/v4.2.2/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.2.3/stubs.md
+++ b/docs/_releases/v4.2.3/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.3.0/stubs.md
+++ b/docs/_releases/v4.3.0/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.0/stubs.md
+++ b/docs/_releases/v4.4.0/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.1/stubs.md
+++ b/docs/_releases/v4.4.1/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.10/stubs.md
+++ b/docs/_releases/v4.4.10/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.2/stubs.md
+++ b/docs/_releases/v4.4.2/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.3/stubs.md
+++ b/docs/_releases/v4.4.3/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.4/stubs.md
+++ b/docs/_releases/v4.4.4/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.5/stubs.md
+++ b/docs/_releases/v4.4.5/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.6/stubs.md
+++ b/docs/_releases/v4.4.6/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.7/stubs.md
+++ b/docs/_releases/v4.4.7/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.8/stubs.md
+++ b/docs/_releases/v4.4.8/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.4.9/stubs.md
+++ b/docs/_releases/v4.4.9/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v4.5.0/stubs.md
+++ b/docs/_releases/v4.5.0/stubs.md
@@ -371,12 +371,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.0.1/stubs.md
+++ b/docs/_releases/v5.0.1/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.0.10/stubs.md
+++ b/docs/_releases/v5.0.10/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.0.2/stubs.md
+++ b/docs/_releases/v5.0.2/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.0.3/stubs.md
+++ b/docs/_releases/v5.0.3/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.0.4/stubs.md
+++ b/docs/_releases/v5.0.4/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.0.5/stubs.md
+++ b/docs/_releases/v5.0.5/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.0.6/stubs.md
+++ b/docs/_releases/v5.0.6/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.0.7/stubs.md
+++ b/docs/_releases/v5.0.7/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.0.8/stubs.md
+++ b/docs/_releases/v5.0.8/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.0.9/stubs.md
+++ b/docs/_releases/v5.0.9/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v5.1.0/stubs.md
+++ b/docs/_releases/v5.1.0/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v6.0.0/stubs.md
+++ b/docs/_releases/v6.0.0/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v6.0.1/stubs.md
+++ b/docs/_releases/v6.0.1/stubs.md
@@ -383,12 +383,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v6.1.0/stubs.md
+++ b/docs/_releases/v6.1.0/stubs.md
@@ -393,12 +393,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v6.1.1/stubs.md
+++ b/docs/_releases/v6.1.1/stubs.md
@@ -393,12 +393,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v6.1.2/stubs.md
+++ b/docs/_releases/v6.1.2/stubs.md
@@ -393,12 +393,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v6.1.3/stubs.md
+++ b/docs/_releases/v6.1.3/stubs.md
@@ -393,12 +393,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v6.1.4/stubs.md
+++ b/docs/_releases/v6.1.4/stubs.md
@@ -417,12 +417,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/_releases/v6.1.5/stubs.md
+++ b/docs/_releases/v6.1.5/stubs.md
@@ -417,12 +417,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/api/v2.0.0/stubs/index.md
+++ b/docs/api/v2.0.0/stubs/index.md
@@ -252,12 +252,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -417,12 +417,17 @@ Similar to `callsArg`.
 
 Causes the stub to call the first callback it receives with the provided arguments (if any).
 
-If a method accepts more than one callback, you need to use `callsArg` to have the stub invoke other callbacks than the first one.
+If a method accepts more than one callback, you need to use `yieldsRight` to call the last callback or `callsArg` to have the stub invoke other callbacks than the first or last one.
+
+
+#### `stub.yieldsRight([arg1, arg2, ...])`
+
+Like `yields` but calls the last callback it receives.
 
 
 #### `stub.yieldsOn(context, [arg1, arg2, ...])`
 
-Like above but with an additional parameter to pass the `this` context.
+Like `yields` but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yieldsTo(property, [arg1, arg2, ...])`


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Adding missing documentation for `stub.yieldsRight`.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Review the stub docs.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
