### PR TITLE
Fix spy documentation and fix contributing typo

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contribruting to documentation
+# Contributing to documentation
 
 ## Documenting the next release
 

--- a/docs/_releases/v1.17.6/spies.md
+++ b/docs/_releases/v1.17.6/spies.md
@@ -231,7 +231,7 @@ Returns `true` if the spy was called after `anotherSpy`
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -328,7 +328,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -414,3 +414,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v1.17.6/spy-call.md
+++ b/docs/_releases/v1.17.6/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v1.17.7/spies.md
+++ b/docs/_releases/v1.17.7/spies.md
@@ -231,7 +231,7 @@ Returns `true` if the spy was called after `anotherSpy`
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -328,7 +328,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -415,3 +415,4 @@ Returns the passed format string with the following replacements performed:
 
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v1.17.7/spy-call.md
+++ b/docs/_releases/v1.17.7/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.0.0/spies.md
+++ b/docs/_releases/v2.0.0/spies.md
@@ -229,7 +229,7 @@ Returns `true` if the spy was called after `anotherSpy`
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -326,7 +326,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -413,3 +413,4 @@ Returns the passed format string with the following replacements performed:
 
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.0.0/spy-call.md
+++ b/docs/_releases/v2.0.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.1.0/spies.md
+++ b/docs/_releases/v2.1.0/spies.md
@@ -229,7 +229,7 @@ Returns `true` if the spy was called after `anotherSpy`
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -326,7 +326,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -412,3 +412,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.1.0/spy-call.md
+++ b/docs/_releases/v2.1.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.2.0/spies.md
+++ b/docs/_releases/v2.2.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.2.0/spy-call.md
+++ b/docs/_releases/v2.2.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.0/spies.md
+++ b/docs/_releases/v2.3.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -425,3 +425,4 @@ Returns the passed format string with the following replacements performed:
 
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.0/spy-call.md
+++ b/docs/_releases/v2.3.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.1/spies.md
+++ b/docs/_releases/v2.3.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.1/spy-call.md
+++ b/docs/_releases/v2.3.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.2/spies.md
+++ b/docs/_releases/v2.3.2/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -425,3 +425,4 @@ Returns the passed format string with the following replacements performed:
 
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.2/spy-call.md
+++ b/docs/_releases/v2.3.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.3/spies.md
+++ b/docs/_releases/v2.3.3/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.3/spy-call.md
+++ b/docs/_releases/v2.3.3/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.4/spies.md
+++ b/docs/_releases/v2.3.4/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -425,3 +425,4 @@ Returns the passed format string with the following replacements performed:
 
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.4/spy-call.md
+++ b/docs/_releases/v2.3.4/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.5/spies.md
+++ b/docs/_releases/v2.3.5/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.5/spy-call.md
+++ b/docs/_releases/v2.3.5/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.6/spies.md
+++ b/docs/_releases/v2.3.6/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -425,3 +425,4 @@ Returns the passed format string with the following replacements performed:
 
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.6/spy-call.md
+++ b/docs/_releases/v2.3.6/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.7/spies.md
+++ b/docs/_releases/v2.3.7/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.7/spy-call.md
+++ b/docs/_releases/v2.3.7/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.8/spies.md
+++ b/docs/_releases/v2.3.8/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -442,7 +442,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 #### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spyCall.calledWith(arg1, arg2, ...);`
@@ -475,7 +475,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 #### `spyCall.threw();`
 
@@ -512,3 +512,4 @@ Exception thrown, if any.
 Return value.
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.3.8/spy-call.md
+++ b/docs/_releases/v2.3.8/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.4.0/spies.md
+++ b/docs/_releases/v2.4.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.4.0/spy-call.md
+++ b/docs/_releases/v2.4.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v2.4.1/spies.md
+++ b/docs/_releases/v2.4.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v2.4.1/spy-call.md
+++ b/docs/_releases/v2.4.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v3.0.0/spies.md
+++ b/docs/_releases/v3.0.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -442,7 +442,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 #### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spyCall.calledWith(arg1, arg2, ...);`
@@ -475,7 +475,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 #### `spyCall.threw();`
 
@@ -512,3 +512,4 @@ Exception thrown, if any.
 Return value.
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v3.0.0/spy-call.md
+++ b/docs/_releases/v3.0.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v3.1.0/spies.md
+++ b/docs/_releases/v3.1.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v3.1.0/spy-call.md
+++ b/docs/_releases/v3.1.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v3.2.0/spies.md
+++ b/docs/_releases/v3.2.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v3.2.0/spy-call.md
+++ b/docs/_releases/v3.2.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v3.2.1/spies.md
+++ b/docs/_releases/v3.2.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v3.2.1/spy-call.md
+++ b/docs/_releases/v3.2.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v3.3.0/spies.md
+++ b/docs/_releases/v3.3.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v3.3.0/spy-call.md
+++ b/docs/_releases/v3.3.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.0.0/spies.md
+++ b/docs/_releases/v4.0.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.0.0/spy-call.md
+++ b/docs/_releases/v4.0.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.0.1/spies.md
+++ b/docs/_releases/v4.0.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.0.1/spy-call.md
+++ b/docs/_releases/v4.0.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.0.2/spies.md
+++ b/docs/_releases/v4.0.2/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.0.2/spy-call.md
+++ b/docs/_releases/v4.0.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.0/spies.md
+++ b/docs/_releases/v4.1.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.0/spy-call.md
+++ b/docs/_releases/v4.1.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.1/spies.md
+++ b/docs/_releases/v4.1.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.1/spy-call.md
+++ b/docs/_releases/v4.1.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.2/spies.md
+++ b/docs/_releases/v4.1.2/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.2/spy-call.md
+++ b/docs/_releases/v4.1.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.3/spies.md
+++ b/docs/_releases/v4.1.3/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.3/spy-call.md
+++ b/docs/_releases/v4.1.3/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.4/spies.md
+++ b/docs/_releases/v4.1.4/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.4/spy-call.md
+++ b/docs/_releases/v4.1.4/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.5/spies.md
+++ b/docs/_releases/v4.1.5/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.5/spy-call.md
+++ b/docs/_releases/v4.1.5/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.6/spies.md
+++ b/docs/_releases/v4.1.6/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.1.6/spy-call.md
+++ b/docs/_releases/v4.1.6/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.2.0/spies.md
+++ b/docs/_releases/v4.2.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.2.0/spy-call.md
+++ b/docs/_releases/v4.2.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.2.1/spies.md
+++ b/docs/_releases/v4.2.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.2.1/spy-call.md
+++ b/docs/_releases/v4.2.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.2.2/spies.md
+++ b/docs/_releases/v4.2.2/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.2.2/spy-call.md
+++ b/docs/_releases/v4.2.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.2.3/spies.md
+++ b/docs/_releases/v4.2.3/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.2.3/spy-call.md
+++ b/docs/_releases/v4.2.3/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.3.0/spies.md
+++ b/docs/_releases/v4.3.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -432,3 +432,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.3.0/spy-call.md
+++ b/docs/_releases/v4.3.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.0/spies.md
+++ b/docs/_releases/v4.4.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -432,3 +432,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.0/spy-call.md
+++ b/docs/_releases/v4.4.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.1/spies.md
+++ b/docs/_releases/v4.4.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -432,3 +432,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.1/spy-call.md
+++ b/docs/_releases/v4.4.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.10/spies.md
+++ b/docs/_releases/v4.4.10/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.10/spy-call.md
+++ b/docs/_releases/v4.4.10/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.2/spies.md
+++ b/docs/_releases/v4.4.2/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -450,7 +450,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 #### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spyCall.calledWith(arg1, arg2, ...);`
@@ -483,7 +483,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 #### `spyCall.threw();`
 
@@ -520,3 +520,4 @@ Exception thrown, if any.
 Return value.
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.2/spy-call.md
+++ b/docs/_releases/v4.4.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.3/spies.md
+++ b/docs/_releases/v4.4.3/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.3/spy-call.md
+++ b/docs/_releases/v4.4.3/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.4/spies.md
+++ b/docs/_releases/v4.4.4/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.4/spy-call.md
+++ b/docs/_releases/v4.4.4/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.5/spies.md
+++ b/docs/_releases/v4.4.5/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.5/spy-call.md
+++ b/docs/_releases/v4.4.5/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.6/spies.md
+++ b/docs/_releases/v4.4.6/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.6/spy-call.md
+++ b/docs/_releases/v4.4.6/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.7/spies.md
+++ b/docs/_releases/v4.4.7/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.7/spy-call.md
+++ b/docs/_releases/v4.4.7/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.8/spies.md
+++ b/docs/_releases/v4.4.8/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.8/spy-call.md
+++ b/docs/_releases/v4.4.8/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.9/spies.md
+++ b/docs/_releases/v4.4.9/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.4.9/spy-call.md
+++ b/docs/_releases/v4.4.9/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -91,3 +91,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue;`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v4.5.0/spies.md
+++ b/docs/_releases/v4.5.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v4.5.0/spy-call.md
+++ b/docs/_releases/v4.5.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.1/spies.md
+++ b/docs/_releases/v5.0.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.1/spy-call.md
+++ b/docs/_releases/v5.0.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.10/spies.md
+++ b/docs/_releases/v5.0.10/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.10/spy-call.md
+++ b/docs/_releases/v5.0.10/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.2/spies.md
+++ b/docs/_releases/v5.0.2/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.2/spy-call.md
+++ b/docs/_releases/v5.0.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.3/spies.md
+++ b/docs/_releases/v5.0.3/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.3/spy-call.md
+++ b/docs/_releases/v5.0.3/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.4/spies.md
+++ b/docs/_releases/v5.0.4/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.4/spy-call.md
+++ b/docs/_releases/v5.0.4/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.5/spies.md
+++ b/docs/_releases/v5.0.5/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.5/spy-call.md
+++ b/docs/_releases/v5.0.5/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.6/spies.md
+++ b/docs/_releases/v5.0.6/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.6/spy-call.md
+++ b/docs/_releases/v5.0.6/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.7/spies.md
+++ b/docs/_releases/v5.0.7/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.7/spy-call.md
+++ b/docs/_releases/v5.0.7/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.8/spies.md
+++ b/docs/_releases/v5.0.8/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.8/spy-call.md
+++ b/docs/_releases/v5.0.8/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.9/spies.md
+++ b/docs/_releases/v5.0.9/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.0.9/spy-call.md
+++ b/docs/_releases/v5.0.9/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v5.1.0/spies.md
+++ b/docs/_releases/v5.1.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v5.1.0/spy-call.md
+++ b/docs/_releases/v5.1.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -121,3 +121,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.0.0/spies.md
+++ b/docs/_releases/v6.0.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.0.0/spy-call.md
+++ b/docs/_releases/v6.0.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.0.1/spies.md
+++ b/docs/_releases/v6.0.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.0.1/spy-call.md
+++ b/docs/_releases/v6.0.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.0/spies.md
+++ b/docs/_releases/v6.1.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.0/spy-call.md
+++ b/docs/_releases/v6.1.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.1/spies.md
+++ b/docs/_releases/v6.1.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.1/spy-call.md
+++ b/docs/_releases/v6.1.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.2/spies.md
+++ b/docs/_releases/v6.1.2/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.2/spy-call.md
+++ b/docs/_releases/v6.1.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.3/spies.md
+++ b/docs/_releases/v6.1.3/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.3/spy-call.md
+++ b/docs/_releases/v6.1.3/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
* Fix `matchers` link in `spies.md` and `spy-call.md` across all versions
* Fix typo in `docs/CONTRIBUTING`

#### Background (Problem in detail)  - optional
When I click `see matchers`, I would expect the link to take me to the `matchers` page, but this instead sets an anchor that doesn't exist on the page. Correct me if I'm missing something here.

In addition, the links don't work in Github's markdown viewer, but I assume something with how the doc paths are reconciled makes this work in the actual doc viewer. To try and ensure the correct path, I took a look at the `[calls]: ../spy-call` link which appears to work in the actual documentation. Let me know if this is not the case and I'll be happy to update. :smile: 

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Validate docs for `spies.md` and `spy-call.md` from the `v1.17.6-v6.1.3`

#### Checklist for author

- [x] `npm run lint` passes
  - NOTE: One warning, but it looks unrelated: 
```
sinon/test/sandbox-test.js
  217:34  warning  Do not create function within loops (IE11 compatibility)  ie11/no-loop-func
```
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

![](https://media.giphy.com/media/toXKzaJP3WIgM/giphy.gif)