### PR TITLE
Custom eslint rule to detect prototype method usage

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,4 +1,4 @@
-extends: 'eslint-config-sinon'
+extends: sinon
 
 globals:
   ArrayBuffer: false
@@ -9,9 +9,11 @@ globals:
 
 plugins:
   - ie11
+  - local-rules
 
 rules:
   ie11/no-collection-args: error
   ie11/no-for-in-const: error
   ie11/no-loop-func: warn
   ie11/no-weak-collections: error
+  local-rules/no-prototype-methods: error

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,0 +1,75 @@
+"use strict";
+
+function getPrototypeMethods(prototype) {
+    /* eslint-disable local-rules/no-prototype-methods */
+    return Object.getOwnPropertyNames(prototype).filter(function (name) {
+        return typeof prototype[name] === "function" && prototype.hasOwnProperty(name);
+    });
+}
+
+var DISALLOWED_ARRAY_PROPS = getPrototypeMethods(Array.prototype);
+
+var DISALLOWED_OBJECT_PROPS = getPrototypeMethods(Object.prototype);
+
+module.exports = {
+    // rule to disallow direct use of prototype methods of builtins
+    "no-prototype-methods": {
+        meta: {
+            docs: {
+                description: "disallow calling prototype methods directly",
+                category: "Possible Errors",
+                recommended: false,
+                url: "https://eslint.org/docs/rules/no-prototype-builtins"
+            },
+
+            schema: []
+        },
+
+        create: function (context) {
+            /**
+            * Reports if a disallowed property is used in a CallExpression
+            * @param {ASTNode} node The CallExpression node.
+            * @returns {void}
+            */
+            function disallowBuiltIns(node) {
+                if (
+                    node.callee.type !== "MemberExpression"
+                    || node.callee.computed
+                    // allow static method calls
+                    || node.callee.object.name === "Array"
+                    || node.callee.object.name === "Object"
+                ) {
+                    return;
+                }
+                var propName = node.callee.property.name;
+
+                if (DISALLOWED_OBJECT_PROPS.indexOf(propName) > -1) {
+                    context.report({
+                        message: "Do not access {{obj}} prototype method '{{prop}}' from target object.",
+                        loc: node.callee.property.loc.start,
+                        data: {
+                            obj: "Object",
+                            prop: propName
+                        },
+                        node: node
+                    });
+                }
+                else if (DISALLOWED_ARRAY_PROPS.indexOf(propName) > -1) {
+                    context.report({
+                        message: "Do not access {{obj}} prototype method '{{prop}}' from target object.",
+                        loc: node.callee.property.loc.start,
+                        data: {
+                            obj: "Array",
+                            prop: propName
+                        },
+                        node: node
+                    });
+                }
+            }
+
+            return {
+                CallExpression: disallowBuiltIns
+            };
+        }
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,6 +1694,12 @@
         "requireindex": "~1.1.0"
       }
     },
+    "eslint-plugin-local-rules": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-0.1.0.tgz",
+      "integrity": "sha1-aAi7TBuaQy9uVP9N+ykAc+HN9wA=",
+      "dev": true
+    },
     "eslint-plugin-mocha": {
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-4.12.1.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint": "^4.19.1",
     "eslint-config-sinon": "^1.0.0",
     "eslint-plugin-ie11": "^1.0.0",
+    "eslint-plugin-local-rules": "^0.1.0",
     "eslint-plugin-mocha": "^4.2.0",
     "esm": "3.0.37",
     "husky": "^0.14.2",


### PR DESCRIPTION
This will help to prevent errors going forward. This was inspired by discussions in #1826. The code for the rule started life as the built-in [no-prototype-builtins](https://github.com/eslint/eslint/blob/master/lib/rules/no-prototype-builtins.js). I modified it slightly to make it work for our purposes. I didn't do all the things required to make it a real big boy rule/plugin. This seemed like a valid shortcut for now.

Note: This new file could contain other custom rules as well.