### PR TITLE
Use https everywhere and remove legacy links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ There are several ways of contributing to Sinon.JS
 
 * Look into [issues tagged `help-wanted`](https://github.com/sinonjs/sinon/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22)
 * Help [improve the documentation](https://github.com/sinonjs/sinon/tree/master/docs) published
-  at [the Sinon.JS website](http://sinonjs.org). [Documentation issues](https://github.com/sinonjs/sinon/issues?q=is%3Aopen+is%3Aissue+label%3ADocumentation).
+  at [the Sinon.JS website](https://sinonjs.org). [Documentation issues](https://github.com/sinonjs/sinon/issues?q=is%3Aopen+is%3Aissue+label%3ADocumentation).
 * Help someone understand and use Sinon.JS on [Stack Overflow](https://stackoverflow.com/questions/tagged/sinon)
 * Report an issue, please read instructions below
 * Help with triaging the [issues](https://github.com/sinonjs/sinon/issues). The clearer they are, the more likely they are to be fixed soon.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align=center>
-    <a href="http://sinonjs.org" title="Sinon.JS">
-        <img alt="Sinon.JS" src="http://sinonjs.org/assets/images/logo.png">
+    <a href="https://sinonjs.org" title="Sinon.JS">
+        <img alt="Sinon.JS" src="https://sinonjs.org/assets/images/logo.png">
     </a>
     <br>
     Sinon.JS
@@ -32,11 +32,11 @@ via [npm](https://github.com/npm/npm)
 
     $ npm install sinon
 
-or via sinon's browser builds available for download on the [homepage](http://sinonjs.org/releases/). There are also [npm based CDNs](http://sinonjs.org/releases#npm-cdns) one can use.
+or via sinon's browser builds available for download on the [homepage](https://sinonjs.org/releases/). There are also [npm based CDNs](https://sinonjs.org/releases#npm-cdns) one can use.
 
 ## Usage
 
-See the [sinon project homepage](http://sinonjs.org/) for documentation on usage.
+See the [sinon project homepage](https://sinonjs.org/) for documentation on usage.
 
 If you have questions that are not covered by the documentation, you can [check out the `sinon` tag on Stack Overflow](https://stackoverflow.com/questions/tagged/sinon) or drop by <a href="irc://irc.freenode.net:6667/sinon.js">#sinon.js on irc.freenode.net:6667</a>.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ published: false
 
 # Docs
 
-This folder structure contains the markdown files that becomes the Sinon.JS documentation site published to GitHub Pages. Eventually this will replace the current site at http://sinonjs.org.
+This folder structure contains the markdown files that becomes the Sinon.JS documentation site published to GitHub Pages. Eventually this will replace the current site at https://sinonjs.org.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on contributing documentation to Sinon.JS.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,12 +14,6 @@ To install the current release (`{{current_release}}`) of Sinon:
 npm install sinon
 ```
 
-If you (for some reason) really want the old version of Sinon, head over to the [legacy docs](http://legacy.sinonjs.org/) and do:
-
-```shell
-npm install sinon@1
-```
-
 ## Try It Out
 The following function takes a function as its argument and returns a new function. You can call the resulting function as many times as you want, but the original function will only be called once:
 

--- a/docs/release-source/release.md
+++ b/docs/release-source/release.md
@@ -42,10 +42,9 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 
 [ES5]: http://www.ecma-international.org/ecma-262/5.1/
 [es5-shim]: https://github.com/es-shims/es5-shim
-[legacy-site]: http://legacy.sinonjs.org

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sinon",
   "description": "JavaScript test spies, stubs and mocks.",
   "version": "6.1.4",
-  "homepage": "http://sinonjs.org/",
+  "homepage": "https://sinonjs.org/",
   "author": "Christian Johansen",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Latest Google Chrome now shows a non-https pages as "not secure". Since we now have a valid certificate, we should link to the `https` version of the site everywhere. I already changed the repo description link and the org homepage URL.

While going through the docs I noticed that the <http://legacy.sinonjs.org> URL does not work anymore. Since nobody complained about that, I think it's time to remove it.
