### PR TITLE
docs(general setup): Describe how to restore the default sandbox

### DIFF
--- a/docs/_releases/v5.0.1.md
+++ b/docs/_releases/v5.0.1.md
@@ -6,8 +6,9 @@ release_id: v5.0.1
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.0.1/general-setup.md
+++ b/docs/_releases/v5.0.1/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v5.0.10.md
+++ b/docs/_releases/v5.0.10.md
@@ -6,8 +6,9 @@ release_id: v5.0.10
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.0.10/general-setup.md
+++ b/docs/_releases/v5.0.10/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v5.0.2.md
+++ b/docs/_releases/v5.0.2.md
@@ -6,8 +6,9 @@ release_id: v5.0.2
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.0.2/general-setup.md
+++ b/docs/_releases/v5.0.2/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v5.0.3.md
+++ b/docs/_releases/v5.0.3.md
@@ -6,8 +6,9 @@ release_id: v5.0.3
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.0.3/general-setup.md
+++ b/docs/_releases/v5.0.3/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v5.0.4.md
+++ b/docs/_releases/v5.0.4.md
@@ -6,8 +6,9 @@ release_id: v5.0.4
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.0.4/general-setup.md
+++ b/docs/_releases/v5.0.4/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v5.0.5.md
+++ b/docs/_releases/v5.0.5.md
@@ -6,8 +6,9 @@ release_id: v5.0.5
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.0.5/general-setup.md
+++ b/docs/_releases/v5.0.5/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v5.0.6.md
+++ b/docs/_releases/v5.0.6.md
@@ -6,8 +6,9 @@ release_id: v5.0.6
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.0.6/general-setup.md
+++ b/docs/_releases/v5.0.6/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v5.0.7.md
+++ b/docs/_releases/v5.0.7.md
@@ -6,8 +6,9 @@ release_id: v5.0.7
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.0.7/general-setup.md
+++ b/docs/_releases/v5.0.7/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v5.0.8.md
+++ b/docs/_releases/v5.0.8.md
@@ -6,8 +6,9 @@ release_id: v5.0.8
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.0.8/general-setup.md
+++ b/docs/_releases/v5.0.8/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v5.0.9.md
+++ b/docs/_releases/v5.0.9.md
@@ -6,8 +6,9 @@ release_id: v5.0.9
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.0.9/general-setup.md
+++ b/docs/_releases/v5.0.9/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v5.1.0.md
+++ b/docs/_releases/v5.1.0.md
@@ -6,8 +6,9 @@ release_id: v5.1.0
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v5.1.0/general-setup.md
+++ b/docs/_releases/v5.1.0/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v6.0.0.md
+++ b/docs/_releases/v6.0.0.md
@@ -6,8 +6,9 @@ release_id: v6.0.0
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v6.0.0/general-setup.md
+++ b/docs/_releases/v6.0.0/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v6.0.1.md
+++ b/docs/_releases/v6.0.1.md
@@ -6,8 +6,9 @@ release_id: v6.0.1
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v6.0.1/general-setup.md
+++ b/docs/_releases/v6.0.1/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v6.1.0.md
+++ b/docs/_releases/v6.1.0.md
@@ -6,8 +6,9 @@ release_id: v6.1.0
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v6.1.0/general-setup.md
+++ b/docs/_releases/v6.1.0/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v6.1.1.md
+++ b/docs/_releases/v6.1.1.md
@@ -6,8 +6,9 @@ release_id: v6.1.1
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v6.1.1/general-setup.md
+++ b/docs/_releases/v6.1.1/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v6.1.2.md
+++ b/docs/_releases/v6.1.2.md
@@ -6,8 +6,9 @@ release_id: v6.1.2
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v6.1.2/general-setup.md
+++ b/docs/_releases/v6.1.2/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v6.1.3.md
+++ b/docs/_releases/v6.1.3.md
@@ -6,8 +6,9 @@ release_id: v6.1.3
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v6.1.3/general-setup.md
+++ b/docs/_releases/v6.1.3/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/_releases/v6.1.4.md
+++ b/docs/_releases/v6.1.4.md
@@ -6,8 +6,9 @@ release_id: v6.1.4
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/_releases/v6.1.4/general-setup.md
+++ b/docs/_releases/v6.1.4/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/docs/release-source/release.md
+++ b/docs/release-source/release.md
@@ -8,6 +8,7 @@ release_id: master
 
 This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
 
+* [General setup](./general-setup)
 * [Fakes](./fakes)
 * [Spies](./spies)
 * [Stubs](./stubs)

--- a/docs/release-source/release.md
+++ b/docs/release-source/release.md
@@ -6,7 +6,7 @@ release_id: master
 
 # {{page.title}} - `{{page.release_id}}`
 
-This page contains the entire Sinon.JS API documentation along with brief    introductions to the concepts Sinon implements.
+This page contains the entire Sinon.JS API documentation along with brief introductions to the concepts Sinon implements.
 
 * [General setup](./general-setup)
 * [Fakes](./fakes)

--- a/docs/release-source/release/general-setup.md
+++ b/docs/release-source/release/general-setup.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: General setup - Sinon.JS
+breadcrumb: general-setup
+---
+
+We will be making fakes, spies and stubs. By default these are created in the _default sandbox_.
+Be sure to `restore` this sandbox after each test.
+
+For example, if you're using mocha you can place this in a test file at the root level:
+
+```js
+afterEach(() => {
+  // Restore the default sandbox here
+  sinon.restore();
+});
+```
+
+Or in Jasmine you should place it in each describe:
+
+```js
+describe('My test suite', () => {
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+});
+```
+
+Forgetting to restore your sandbox results in a memory leak.
+
+For more advanced setups using multiple sandboxes, please see [sandbox](../sandbox)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2110,13 +2110,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2133,19 +2135,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2276,7 +2281,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2290,6 +2296,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2306,6 +2313,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2314,13 +2322,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2341,6 +2351,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2429,7 +2440,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2443,6 +2455,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2580,6 +2593,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Describe how to restore the default sandbox, right at the start of the documentation.

Fixes #1866 

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. <your-steps-here>

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

`npm run lint` resulted in 

```
> sinon@6.1.4 lint-markdown C:\z\github\sinonjs\sinon
> find docs -type f -name '*.md' ! -name 'changelog.md' | xargs markdownlint

xargs: environment is too large for exec
find: ‘standard output’
find: write error
```

Anyone know how to fix that?