### PR TITLE
Fixed remaining ESLint failures

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 "use strict";
+/* eslint-disable local-rules/no-prototype-methods */
 
 var fs = require("fs");
 var browserify = require("browserify");

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -2,9 +2,12 @@ env:
   mocha: true
 
 plugins:
+  - local-rules
   - mocha
 
 rules:
+  local-rules/no-prototype-methods: off
+
   max-nested-callbacks: off
   no-restricted-syntax: [error, 'TryStatement']
 

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -230,7 +230,8 @@ describe("Sandbox", function () {
 
             for (var i = 0; i < types.length; i++) {
                 // yes, it's silly to create functions in a loop, it's also a test
-                assert.exception(function () { // eslint-disable-line no-loop-func
+                /* eslint-disable-next-line ie11/no-loop-func, no-loop-func */
+                assert.exception(function () {
                     this.sandbox.createStubInstance(types[i]);
                 });
             }


### PR DESCRIPTION
This PR is mostly for tracking purposes (instead of committing directly to master).

* Disabled new ESLint rule for `tests` directory and `build.js`
* Disabled an *unrelated* warning (`ie11/no-loop-func`) that has existed for a long time

Now `eslint .` is perfectly silent. \o/ :fireworks: :champagne: \o/