### PR TITLE
Remove links to legacy site

### DIFF
--- a/docs/_releases/v2.0.0.md
+++ b/docs/_releases/v2.0.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.1.0.md
+++ b/docs/_releases/v2.1.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.2.0.md
+++ b/docs/_releases/v2.2.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.3.0.md
+++ b/docs/_releases/v2.3.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.3.1.md
+++ b/docs/_releases/v2.3.1.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.3.2.md
+++ b/docs/_releases/v2.3.2.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.3.3.md
+++ b/docs/_releases/v2.3.3.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.3.4.md
+++ b/docs/_releases/v2.3.4.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.3.5.md
+++ b/docs/_releases/v2.3.5.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.3.6.md
+++ b/docs/_releases/v2.3.6.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.3.7.md
+++ b/docs/_releases/v2.3.7.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.3.8.md
+++ b/docs/_releases/v2.3.8.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.4.0.md
+++ b/docs/_releases/v2.4.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v2.4.1.md
+++ b/docs/_releases/v2.4.1.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v3.0.0.md
+++ b/docs/_releases/v3.0.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v3.1.0.md
+++ b/docs/_releases/v3.1.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v3.2.0.md
+++ b/docs/_releases/v3.2.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v3.2.1.md
+++ b/docs/_releases/v3.2.1.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v3.3.0.md
+++ b/docs/_releases/v3.3.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.0.0.md
+++ b/docs/_releases/v4.0.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.0.1.md
+++ b/docs/_releases/v4.0.1.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.0.2.md
+++ b/docs/_releases/v4.0.2.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.1.0.md
+++ b/docs/_releases/v4.1.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.1.1.md
+++ b/docs/_releases/v4.1.1.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.1.2.md
+++ b/docs/_releases/v4.1.2.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.1.3.md
+++ b/docs/_releases/v4.1.3.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.1.4.md
+++ b/docs/_releases/v4.1.4.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.1.5.md
+++ b/docs/_releases/v4.1.5.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.1.6.md
+++ b/docs/_releases/v4.1.6.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.2.0.md
+++ b/docs/_releases/v4.2.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.2.1.md
+++ b/docs/_releases/v4.2.1.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.2.2.md
+++ b/docs/_releases/v4.2.2.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.2.3.md
+++ b/docs/_releases/v4.2.3.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.3.0.md
+++ b/docs/_releases/v4.3.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.0.md
+++ b/docs/_releases/v4.4.0.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.1.md
+++ b/docs/_releases/v4.4.1.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.10.md
+++ b/docs/_releases/v4.4.10.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.2.md
+++ b/docs/_releases/v4.4.2.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.3.md
+++ b/docs/_releases/v4.4.3.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.4.md
+++ b/docs/_releases/v4.4.4.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.5.md
+++ b/docs/_releases/v4.4.5.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.6.md
+++ b/docs/_releases/v4.4.6.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.7.md
+++ b/docs/_releases/v4.4.7.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.8.md
+++ b/docs/_releases/v4.4.8.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.4.9.md
+++ b/docs/_releases/v4.4.9.md
@@ -40,7 +40,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v4.5.0.md
+++ b/docs/_releases/v4.5.0.md
@@ -41,7 +41,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.0.1.md
+++ b/docs/_releases/v5.0.1.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.0.10.md
+++ b/docs/_releases/v5.0.10.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.0.2.md
+++ b/docs/_releases/v5.0.2.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.0.3.md
+++ b/docs/_releases/v5.0.3.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.0.4.md
+++ b/docs/_releases/v5.0.4.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.0.5.md
+++ b/docs/_releases/v5.0.5.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.0.6.md
+++ b/docs/_releases/v5.0.6.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.0.7.md
+++ b/docs/_releases/v5.0.7.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.0.8.md
+++ b/docs/_releases/v5.0.8.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.0.9.md
+++ b/docs/_releases/v5.0.9.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v5.1.0.md
+++ b/docs/_releases/v5.1.0.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v6.0.0.md
+++ b/docs/_releases/v6.0.0.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v6.0.1.md
+++ b/docs/_releases/v6.0.1.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v6.1.0.md
+++ b/docs/_releases/v6.1.0.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v6.1.1.md
+++ b/docs/_releases/v6.1.1.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v6.1.2.md
+++ b/docs/_releases/v6.1.2.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v6.1.3.md
+++ b/docs/_releases/v6.1.3.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 

--- a/docs/_releases/v6.1.4.md
+++ b/docs/_releases/v6.1.4.md
@@ -42,7 +42,7 @@ Sinon `{{page.release_id}}` is written as [ES5.1][ES5] and requires no transpile
 
 There should not be any issues with using Sinon `{{page.release_id}}` in newer versions of the same runtimes.
 
-If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment. If that fails, we recommend [getting a legacy releases of Sinon][legacy-site].
+If you need to support very old runtimes that have incomplete support for [ES5.1][ES5] you might get away with using loading [`es5-shim`][es5-shim] in your test environment.
 
 {% include docs/contribute.md %}
 


### PR DESCRIPTION
This was removed in release-source in 405701dde53d29c78605a814155248707e414fe7, but not in all the existing releases

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. <your-steps-here>

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
