### PR TITLE
Using promise for sandbox mocks

### DIFF
--- a/docs/release-source/release/mocks.md
+++ b/docs/release-source/release/mocks.md
@@ -83,6 +83,14 @@ If any expectation is not satisfied, an exception is thrown.
 
 Also restores the mocked methods.
 
+#### `mock.usingPromise(promiseLibrary);`
+
+Causes all expectations created from the mock to return promises using a specific
+Promise library instead of the global one when using `expectation.rejects` or
+`expectation.resolves`. Returns the mock object to allow chaining.
+
+*Since `sinon@6.2.0`*
+
 
 ### Expectations
 

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -252,7 +252,7 @@ Access requests through `sandbox.requests` and server through `sandbox.server`
 
 #### `sandbox.usingPromise(promiseLibrary);`
 
-Causes all stubs created from the sandbox to return promises using a specific
+Causes all stubs and mocks created from the sandbox to return promises using a specific
 Promise library instead of the global one when using `stub.rejects` or
 `stub.resolves`. Returns the stub to allow chaining.
 

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -7,6 +7,7 @@ var extend = require("./util/core/extend");
 var match = require("./match");
 var deepEqual = require("./util/core/deep-equal").use(match);
 var wrapMethod = require("./util/core/wrap-method");
+var usePromiseLibrary = require("./util/core/use-promise-library");
 
 var concat = arrayProto.concat;
 var filter = arrayProto.filter;
@@ -80,6 +81,7 @@ extend(mock, {
         var expectation = mockExpectation.create(method);
         extend(expectation, this.object[method]);
         push(this.expectations[method], expectation);
+        usePromiseLibrary(this.promiseLibrary, expectation);
 
         return expectation;
     },
@@ -118,6 +120,12 @@ extend(mock, {
         }
 
         return true;
+    },
+
+    usingPromise: function usingPromise(promiseLibrary) {
+        this.promiseLibrary = promiseLibrary;
+
+        return this;
     },
 
     invokeMethod: function invokeMethod(method, thisValue, args) {

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -89,6 +89,7 @@ function Sandbox() {
         var m = sinonMock.apply(null, arguments);
 
         push(collection, m);
+        usePromiseLibrary(promiseLib, m);
 
         return m;
     };

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -945,6 +945,45 @@ describe("sinonMock", function () {
         });
     });
 
+    describe(".usingPromise", function () {
+        beforeEach(function () {
+            this.method = function () {};
+            this.object = { method: this.method };
+            this.mock = sinonMock.create(this.object);
+        });
+
+        it("must be a function", function () {
+            assert.isFunction(this.mock.usingPromise);
+        });
+
+        it("must return the mock", function () {
+            var mockPromise = {};
+
+            var actual = this.mock.usingPromise(mockPromise);
+
+            assert.same(actual, this.mock);
+        });
+
+        it("must set all expectations with mockPromise", function () {
+            if (!global.Promise) { return this.skip(); }
+
+            var resolveValue = {};
+            var mockPromise = {
+                resolve: sinonStub.create().resolves(resolveValue)
+            };
+
+            this.mock.usingPromise(mockPromise);
+            this.mock.expects("method").resolves({});
+
+            return this.object.method()
+                .then(function (action) {
+
+                    assert.same(resolveValue, action);
+                    assert(mockPromise.resolve.calledOnce);
+                });
+        });
+    });
+
     describe("mock object", function () {
         beforeEach(function () {
             this.method = function () {};

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1267,6 +1267,31 @@ describe("Sandbox", function () {
                     assert(mockPromise.resolve.calledOnce);
                 });
         });
+
+        it("must set all mocks created from sandbox with mockPromise", function () {
+            if (!supportPromise) { return this.skip(); }
+
+            var resolveValue = {};
+            var mockPromise = {
+                resolve: sinonStub.create().resolves(resolveValue)
+            };
+            var mockedObject = {
+                mockedMethod: function () {
+                    return;
+                }
+            };
+
+            this.sandbox.usingPromise(mockPromise);
+            var mock = this.sandbox.mock(mockedObject);
+            mock.expects("mockedMethod").resolves({});
+
+            return mockedObject.mockedMethod()
+                .then(function (action) {
+
+                    assert.same(resolveValue, action);
+                    assert(mockPromise.resolve.calledOnce);
+                });
+        });
     });
 
     // These were not run in browsers before, as we were only testing in node


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix issue #1863 by adding `mock.usingPromise(promiseLibrary)` and calling this from `sandbox.mock`

#### Solution  - optional
There did not appear to be an existing way to influence the Promise library for all expectations on a mock, so I introduced `mock.usingPromise(promiseLibrary)` as an API method and used this to pass the promise library from the sandbox through to mock expectations.

It would be possible to do this without introducing an API method by setting fields on `mock` directly from `sandbox`, if introducing this new API is not okay.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

or original steps from #1863:

```js
const sinon = require('sinon');

// Set up a sandbox using bluebird as the promise library
const sandbox = sinon.createSandbox().usingPromise(require('bluebird'));

// Call a stub which returns a resolved promise
const stubPromise = sandbox.stub().resolves('value for stub')();
// Call bluebird API methods on the returned Promise object
stubPromise.tap(console.log).return('final value for stub').then(console.log);
// Works :)

// Call a mock which returns a resolved promise
const mockPromise = sandbox.mock().resolves('value for mock')();
// Call bluebird API methods on the returned Promise object
mockPromise.tap(console.log).return('final value for mock').then(console.log);
// Works :)

// Call a method on a mock which returns a resolved promise
const objectToMock = { method: function() {} };
sandbox.mock(objectToMock).expects('method').resolves('value for mock method');
const mockMethodPromise = objectToMock.method();
// Call bluebird API methods on the returned Promise object
mockMethodPromise.tap(console.log).return('final value for mock method').then(console.log);
// Works :)
```

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
