### PR TITLE
Add example of default sandbox usage

### DIFF
--- a/docs/_releases/v6.1.4/sandbox.md
+++ b/docs/_releases/v6.1.4/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.


### PR DESCRIPTION
#### Purpose

In reading [the docs for Sandboxes](https://sinonjs.org/releases/v6.1.4/sandbox/), the page states:

> the sinon object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.

However, no example of doing this is given, so the recommended basic usage behavior here feels like it is relegated to a footnote, easily missed. If this is the most common usage, I strongly think there should be an example of that _first_, before proceeding on to the API for creating other sandboxes.

#### How to verify
1. Check out this branch
2. Navigate to `/docs` and run the docs server
3. Inspect the Sandbox API page here: http://localhost:4000/releases/v6.1.4/sandbox/

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).