### PR TITLE
Add test for #1796, failing to stub Array.prototype.sort

### DIFF
--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -508,4 +508,12 @@ describe("issues", function () {
             sinon.assert.calledWith(spy, secondObj);
         });
     });
+
+    describe("#1796 - cannot stub Array.prototype.sort", function () {
+        it("it should not fail with RangeError", function () {
+            var stub = sinon.stub(Array.prototype, "sort");
+            [1, 2, 3].sort();
+            stub.restore();
+        });
+    });
 });

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -511,9 +511,11 @@ describe("issues", function () {
 
     describe("#1796 - cannot stub Array.prototype.sort", function () {
         it("it should not fail with RangeError", function () {
-            var stub = sinon.stub(Array.prototype, "sort");
-            [1, 2, 3].sort();
-            stub.restore();
+            refute.exception(function () {
+                var stub = sinon.stub(Array.prototype, "sort");
+                [1, 2, 3].sort();
+                stub.restore();
+            });
         });
     });
 });

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -511,11 +511,13 @@ describe("issues", function () {
 
     describe("#1796 - cannot stub Array.prototype.sort", function () {
         it("it should not fail with RangeError", function () {
+            var stub = sinon.stub(Array.prototype, "sort");
+
             refute.exception(function () {
-                var stub = sinon.stub(Array.prototype, "sort");
                 [1, 2, 3].sort();
-                stub.restore();
             });
+
+            stub.restore();
         });
     });
 });


### PR DESCRIPTION
This PR shows that the issue described in #1796 has been fixed (in c2c78143ffd381418b9847e8518cadd0741dfddc)

Once this is merged, we should create a new release.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
