### PR TITLE
Prettify error message for sinon.assert.match

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -172,13 +172,8 @@ assert = {
         if (matcher.test(actual)) {
             assert.pass("match");
         } else {
-            var formatted = [
-                "expected value to match",
-                "    expected = " + format(expectation),
-                "    actual = " + format(actual)
-            ];
-
-            failAssertion(this, join(formatted, "\n"));
+            var diff = jsDiff.diffJson(actual, expectation);
+            failAssertion(this, colorDiffText(diff));
         }
     }
 };


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Print out a part of different when sinon.assert.match is failed.


#### How to verify - mandatory
--
