### PR TITLE
Fix links in documentation

### DIFF
--- a/docs/_releases/v3.3.0/matchers.md
+++ b/docs/_releases/v3.3.0/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.0.0/matchers.md
+++ b/docs/_releases/v4.0.0/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.0.1/matchers.md
+++ b/docs/_releases/v4.0.1/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.0.2/matchers.md
+++ b/docs/_releases/v4.0.2/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.1.0/matchers.md
+++ b/docs/_releases/v4.1.0/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.1.1/matchers.md
+++ b/docs/_releases/v4.1.1/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.1.2/matchers.md
+++ b/docs/_releases/v4.1.2/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.1.3/matchers.md
+++ b/docs/_releases/v4.1.3/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.1.4/matchers.md
+++ b/docs/_releases/v4.1.4/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.1.5/matchers.md
+++ b/docs/_releases/v4.1.5/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.1.6/matchers.md
+++ b/docs/_releases/v4.1.6/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.2.0/matchers.md
+++ b/docs/_releases/v4.2.0/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.2.1/matchers.md
+++ b/docs/_releases/v4.2.1/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.2.2/matchers.md
+++ b/docs/_releases/v4.2.2/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.2.3/matchers.md
+++ b/docs/_releases/v4.2.3/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.3.0/matchers.md
+++ b/docs/_releases/v4.3.0/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.0/matchers.md
+++ b/docs/_releases/v4.4.0/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.1/matchers.md
+++ b/docs/_releases/v4.4.1/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.10/matchers.md
+++ b/docs/_releases/v4.4.10/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.2/matchers.md
+++ b/docs/_releases/v4.4.2/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.3/matchers.md
+++ b/docs/_releases/v4.4.3/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.4/matchers.md
+++ b/docs/_releases/v4.4.4/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.5/matchers.md
+++ b/docs/_releases/v4.4.5/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.6/matchers.md
+++ b/docs/_releases/v4.4.6/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.7/matchers.md
+++ b/docs/_releases/v4.4.7/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.8/matchers.md
+++ b/docs/_releases/v4.4.8/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.4.9/matchers.md
+++ b/docs/_releases/v4.4.9/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v4.5.0/matchers.md
+++ b/docs/_releases/v4.5.0/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.0.1/matchers.md
+++ b/docs/_releases/v5.0.1/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.0.10/matchers.md
+++ b/docs/_releases/v5.0.10/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.0.2/matchers.md
+++ b/docs/_releases/v5.0.2/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.0.3/matchers.md
+++ b/docs/_releases/v5.0.3/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.0.4/matchers.md
+++ b/docs/_releases/v5.0.4/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.0.5/matchers.md
+++ b/docs/_releases/v5.0.5/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.0.6/matchers.md
+++ b/docs/_releases/v5.0.6/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.0.7/matchers.md
+++ b/docs/_releases/v5.0.7/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.0.8/matchers.md
+++ b/docs/_releases/v5.0.8/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.0.9/matchers.md
+++ b/docs/_releases/v5.0.9/matchers.md
@@ -222,7 +222,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v5.1.0/matchers.md
+++ b/docs/_releases/v5.1.0/matchers.md
@@ -218,7 +218,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v6.0.0/matchers.md
+++ b/docs/_releases/v6.0.0/matchers.md
@@ -218,7 +218,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v6.0.1/matchers.md
+++ b/docs/_releases/v6.0.1/matchers.md
@@ -218,7 +218,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v6.1.0/matchers.md
+++ b/docs/_releases/v6.1.0/matchers.md
@@ -218,7 +218,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v6.1.1/matchers.md
+++ b/docs/_releases/v6.1.1/matchers.md
@@ -218,7 +218,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v6.1.2/matchers.md
+++ b/docs/_releases/v6.1.2/matchers.md
@@ -218,7 +218,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v6.1.3/matchers.md
+++ b/docs/_releases/v6.1.3/matchers.md
@@ -218,7 +218,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v6.1.4/matchers.md
+++ b/docs/_releases/v6.1.4/matchers.md
@@ -218,7 +218,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v6.1.4/spies.md
+++ b/docs/_releases/v6.1.4/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
 
 
 #### `spy.alwaysReturned(obj);`

--- a/docs/_releases/v6.1.4/spy-call.md
+++ b/docs/_releases/v6.1.4/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v6.1.5/matchers.md
+++ b/docs/_releases/v6.1.5/matchers.md
@@ -218,7 +218,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/_releases/v6.1.5/spies.md
+++ b/docs/_releases/v6.1.5/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
 
 
 #### `spy.alwaysReturned(obj);`

--- a/docs/_releases/v6.1.5/spy-call.md
+++ b/docs/_releases/v6.1.5/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
 
 ### `spyCall.threw();`
 

--- a/docs/api/v1.17.3/spies/index.md
+++ b/docs/api/v1.17.3/spies/index.md
@@ -251,7 +251,7 @@ Returns `true` if the spy was called after `anotherSpy`
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -348,7 +348,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -452,7 +452,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 #### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
 
 
 #### `spyCall.calledWith(arg1, arg2, ...);`
@@ -485,7 +485,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
 
 #### `spyCall.threw();`
 

--- a/docs/release-source/release/matchers.md
+++ b/docs/release-source/release/matchers.md
@@ -218,7 +218,7 @@ Same as `sinon.match.has` but the property must be defined by the value itself. 
 
 #### `sinon.match.hasNested(propertyPath[, expectation])`
 
-Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in (Lodash.get)[https://lodash.com/docs/4.4.2#get].
+Requires the value to define the given `propertyPath`. Dot (`prop.prop`) and bracket (`prop[0]`) notations are supported as in [Lodash.get](https://lodash.com/docs/4.4.2#get).
 
 The propertyPath might be inherited via the prototype chain. If the optional expectation is given, the value at the propertyPath is deeply compared with the expectation. The expectation can be another matcher.
 

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
 
 
 #### `spy.alwaysReturned(obj);`

--- a/docs/release-source/release/spy-call.md
+++ b/docs/release-source/release/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](#matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](#matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
 
 ### `spyCall.threw();`
 


### PR DESCRIPTION
#### Purpose

This PR fixes two link issues in the documentation for upcoming and past releases.

#### Background

Reading the docs was leading to two issues:
* Link syntax has a typo for an external link (`Lodash.get`) in `matchers.md`
* There is a reference to a Anchor (`#matchers`) in several files which does not exists

#### Solution

> Link syntax has a typo for an external link (`Lodash.get`) in `matchers.md`

Rewrite from `(Lodash.get)[https://lodash.com/docs/4.4.2#get]` to `[Lodash.get](https://lodash.com/docs/4.4.2#get)`

> There is a reference to a Anchor (`#matchers`) in several files which does not exists

Rewrite from `#matechers` to `matchers`

#### How to verify
1. https://sinonjs.org/releases/v6.1.5/matchers/
2. https://sinonjs.org/releases/v6.1.5/spy-call/#matchers

#### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
