### PR TITLE
add callsThroughFake(decoratorFunction)

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -243,6 +243,22 @@ sinon.stub(myObj, 'prop').callsFake(function fakeFn() {
 myObj.prop(); // 'bar'
 ```
 
+#### `stub.callsThroughFake(decoratorFunction);`
+Makes the stub call the provided `decoratorFunction` with the result from the call of the original method wrapped into the stub, when none of the conditional stubs are matched.
+
+```javascript
+var myObj = {};
+myObj.prop = function propFn() {
+    return 'foo';
+};
+
+sinon.stub(myObj, 'prop').callsThroughFake(function decoratorFunction(result) {
+    return result + '-bar';
+});
+
+myObj.prop(); // 'foo-bar'
+```
+
 #### `stub.returns(obj);`
 Makes the stub return the provided value.
 

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -160,6 +160,8 @@ var proto = {
             throw args[this.throwArgAt];
         } else if (this.fakeFn) {
             return this.fakeFn.apply(context, args);
+        } else if (this.callsThroughFakeFn) {
+            return this.callsThroughFakeFn.apply(context, args);
         } else if (typeof this.resolveArgAt === "number") {
             ensureArgs("resolvesArg", this, args);
             return (this.promiseLibrary || Promise).resolve(args[this.resolveArgAt]);

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -29,7 +29,15 @@ function throwsException(fake, error, message) {
 
 module.exports = {
     callsFake: function callsFake(fake, fn) {
+        fake.callsThroughFakeFn = undefined;
         fake.fakeFn = fn;
+    },
+
+    callsThroughFake: function callsThroughFake(fake, fn) {
+        fake.callsThroughFakeFn = function () {
+            var result = fake.stub.wrappedMethod.apply(this, arguments);
+            return fn.apply(this, [result]);
+        };
     },
 
     callsArg: function callsArg(fake, index) {
@@ -135,6 +143,7 @@ module.exports = {
         fake.exception = undefined;
         fake.exceptionCreator = undefined;
         fake.fakeFn = undefined;
+        fake.callsThroughFakeFn = undefined;
     },
 
     returnsArg: function returnsArg(fake, index) {
@@ -166,6 +175,7 @@ module.exports = {
         fake.exception = undefined;
         fake.exceptionCreator = undefined;
         fake.fakeFn = undefined;
+        fake.callsThroughFakeFn = undefined;
     },
 
     resolvesArg: function resolvesArg(fake, index) {
@@ -181,6 +191,7 @@ module.exports = {
         fake.exception = undefined;
         fake.exceptionCreator = undefined;
         fake.fakeFn = undefined;
+        fake.callsThroughFakeFn = undefined;
     },
 
     rejects: function rejects(fake, error, message) {
@@ -201,6 +212,7 @@ module.exports = {
         fake.exception = undefined;
         fake.exceptionCreator = undefined;
         fake.fakeFn = undefined;
+        fake.callsThroughFakeFn = undefined;
 
         return fake;
     },
@@ -214,6 +226,7 @@ module.exports = {
         fake.exception = undefined;
         fake.exceptionCreator = undefined;
         fake.fakeFn = undefined;
+        fake.callsThroughFakeFn = undefined;
     },
 
     callThrough: function callThrough(fake) {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1089,6 +1089,40 @@ describe("stub", function () {
         });
     });
 
+    describe(".callsThroughFake", function () {
+        beforeEach(function () {
+            this.method = function (a, b) { return a + b; };
+            this.object = {method: this.method};
+        });
+
+        it("uses provided function as a decorator of the result", function () {
+            var fakeFn = createStub.create().callsFake(
+                function (result) {
+                    return result + 8;
+                });
+
+            this.stub = createStub(this.object, "method");
+
+            this.stub.callsThroughFake(fakeFn);
+            var u = this.object.method(1, 1);
+
+            assert(fakeFn.calledWith(2));
+            assert(u === 10);
+            assert(fakeFn.calledOn(this.object));
+        });
+
+        it("is overwritten by subsequent stub behavior", function () {
+            var fakeFn = createStub.create();
+            this.stub = createStub(this.object, "method");
+
+            this.stub.callsThroughFake(fakeFn).returns(3);
+            var returned = this.object.method(1, 1);
+
+            refute(fakeFn.called);
+            assert(returned === 3);
+        });
+    });
+
     describe(".callsFake", function () {
         beforeEach(function () {
             this.method = function () { throw new Error("Should be stubbed"); };


### PR DESCRIPTION
a method which allows to decorate the result from the
wrapped method. It behaves like callThrough plus
callsFake, i.e. the provided function will be
executed by receiving as an argument
the result from the original wrapped method

#### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Example: Implement feature #1885 by adding the `callsThroughFake` method

<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->
There are times that I have found myself with the need of decorating or modifying the response from a stubbed method (like an extended version of callsFake), while still being able to use all of the sinon methods to assess different test scenarios.

A practical example:
Stripe is a payment system that provides test tokens to make requests and test their API.
Unfortunately, they don't provide all test tokens (e.g. apple pay, google pay), so in order to be able to test those scenarios, we need to decorate such responses with a respective parameter that reflects those type of payments (i.e. tokenization_method). This is one of several scenarios in which I have been on the need of modifying the response from a library. One may argue that for these tests scenarios I could implement a decorator service myself, instead of relying on sinon, but I find quite useful to stub methods with sinon, and then been able to check the times they were called, the arguments, etc.

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

I added the functionality using as reference the `callThrough` and `callsFake` implementation.
Please add comments for my PR. First time I see this codebase.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. run the tests, then try the function by yourself.

```javascript
const Service = {
  aMethod: (a, b) => a + b,
};

const decoratorFunction = result => result + 10;

const stub = sinon.stub(Service, 'aMethod').callsThroughFake(decoratorFunction);
Service.aMethod(1, 2); // 13
```
😄 
#### Checklist for author

- [ ] `npm run lint` passes
- [ ]  documentation is proper
- [ ] test the function
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
