### PR TITLE
Update function name in error comment

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -112,7 +112,7 @@ var spyApi = {
     resetHistory: function () {
         if (this.invoking) {
             var err = new Error("Cannot reset Sinon function while invoking it. " +
-                                "Move the call to .reset outside of the callback.");
+                                "Move the call to .resetHistory outside of the callback.");
             err.name = "InvalidResetException";
             throw err;
         }


### PR DESCRIPTION
#### Purpose
* `.resetHistory` function would throw an error referencing the old `.reset` function.
* Fixes #1837

#### Background
* `.reset` was deprecated in [5.0.0](https://github.com/sinonjs/sinon/blob/master/docs/guides/migrating-to-5.0.md#spyreset-is-removed-use-spyresethistory)