### PR TITLE
Adds guard for empty properties in deepEqual when a matcher is provided

### DIFF
--- a/lib/sinon/util/core/deep-equal.js
+++ b/lib/sinon/util/core/deep-equal.js
@@ -38,11 +38,12 @@ var deepEqual = module.exports = function deepEqual(a, b, matcher) {
     }
 
     if (matcher) {
-        var allKeysMatch = every(Object.keys(a), function (key) {
+        var keys = Object.keys(a);
+        var allKeysMatch = every(keys, function (key) {
             return matcher(a[key], b[key]);
         });
 
-        return allKeysMatch;
+        return keys.length > 0 && allKeysMatch;
     }
 
     return false;

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -520,4 +520,17 @@ describe("issues", function () {
             stub.restore();
         });
     });
+
+    describe("#1900 - calledWith returns false positive", function () {
+        it("should return false when call args don't match", function () {
+            var stub = sinon.stub();
+            var dateOne = new Date("2018-07-01");
+            var dateTwo = new Date("2018-07-31");
+
+            stub(dateOne);
+
+            var calledWith = stub.calledWith(dateTwo);
+            assert.same(calledWith, false);
+        });
+    });
 });


### PR DESCRIPTION
Fix issue #1900 by guarding against empty properties in `deepEqual` when a matcher is provided.

My big assumption here is that the behaviour of `Array.every` when passed an empty array is not expected. I've tried to keep the pattern of only exiting the `deepEqual` function early when we find equality. If we end up at the bottom of the function and we have a matcher (due to being called via `calledWith`) then we should not assume we are an object with properties. Guarding against this by checking the length of `Object.keys` fixes this bug and does not break any other tests so I assume it is the correct solution.

Happy to hear alternative suggestions though as I am not too familiar with the code base.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
