### PR TITLE
Fix use of non-cached forEach

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -78,7 +78,7 @@ stub.createStubInstance = function (constructor, overrides) {
 
     var stubbedObject = stub(Object.create(constructor.prototype));
 
-    Object.keys(overrides || {}).forEach(function (propertyName) {
+    forEach(Object.keys(overrides || {}), function (propertyName) {
         if (propertyName in stubbedObject) {
             var value = overrides[propertyName];
             if (value.createStubInstance) {

--- a/scripts/preversion.sh
+++ b/scripts/preversion.sh
@@ -11,6 +11,7 @@ do
     fi
 done
 
+npm run lint
 npm test
 
 echo 'Updating History.md'


### PR DESCRIPTION
This fixes a non-cached use of `forEach` introduced in #1864.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
