### PR TITLE
Upgrade formatio, samsam, nise and referee

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,40 +30,36 @@
       }
     },
     "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha1-hNt+nrVTHfGKjF4L+25EnlXmVLI=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
+      "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
       "requires": {
-        "samsam": "1.3.0"
-      },
-      "dependencies": {
-        "samsam": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-          "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
-        }
+        "@sinonjs/samsam": "2.1.0"
       }
     },
     "@sinonjs/referee": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-2.5.0.tgz",
-      "integrity": "sha512-Sc6fZtudn/rbCpu0UuYVI1gOY4DBhFqdoNpVsnyreF/GYAgOjNc6xd4Y9FnE50XH4aLRu29SZk68H0Mde+x5Jg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-2.5.2.tgz",
+      "integrity": "sha512-H8+E/bTNX4P/XNRSC5f3nQ3/n9pS3D8RxF6Vxcb7TTuyFpns0jtTGX2JAkoj43B3dw/quWjanPNIN2VexetKzw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
+        "@sinonjs/formatio": "^3.0.0",
+        "@sinonjs/samsam": "^2.1.0",
         "array-from": "2.1.1",
         "bane": "^1.x",
         "es6-promise": "^4.2.4",
         "lodash.includes": "^4.3.0",
         "lodash.isarguments": "^3.1.0",
-        "object-assign": "^4.1.1",
-        "samsam": "^1.x"
+        "object-assign": "^4.1.1"
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
-      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
+      "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+      "requires": {
+        "array-from": "^2.1.1"
+      }
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -303,8 +299,7 @@
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-      "dev": true
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
     "array-map": {
       "version": "0.0.0",
@@ -4651,11 +4646,11 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.4.tgz",
-      "integrity": "sha512-pxE0c9PzgrUTyhfv5p+5eMIdfU2bLEsq8VQEuE0kxM4zP7SujSar7rk9wpI2F7RyyCEvLyj5O7Is3RER5F36Fg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.5.tgz",
+      "integrity": "sha512-OHRVvdxKgwZELf2DTgsJEIA4MOq8XWvpSUzoOXyxJ2mY0mMENWC66+70AShLR2z05B1dzrzWlUQJmJERlOUpZw==",
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
+        "@sinonjs/formatio": "3.0.0",
         "just-extend": "^3.0.0",
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
@@ -5841,12 +5836,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
-    },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "saucelabs": {

--- a/package.json
+++ b/package.json
@@ -45,17 +45,17 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^1.0.2",
-    "@sinonjs/formatio": "^2.0.0",
-    "@sinonjs/samsam": "^2.0.0",
+    "@sinonjs/formatio": "^3.0.0",
+    "@sinonjs/samsam": "^2.1.0",
     "diff": "^3.5.0",
     "lodash.get": "^4.4.2",
     "lolex": "^2.7.4",
-    "nise": "^1.4.4",
+    "nise": "^1.4.5",
     "supports-color": "^5.5.0",
     "type-detect": "^4.0.8"
   },
   "devDependencies": {
-    "@sinonjs/referee": "^2.5.0",
+    "@sinonjs/referee": "^2.5.2",
     "browserify": "^15.1.0",
     "dependency-check": "^2.9.1",
     "eslint": "^4.19.1",


### PR DESCRIPTION
This means installing `sinon` will only install one copy of `samsam`, not two

#### Before

```
npm ls samsam @sinonjs/samsam
sinon@6.3.2 /Users/mroderick/code/sinonjs/sinon
├─┬ @sinonjs/formatio@2.0.0
│ └── samsam@1.3.0
├─┬ @sinonjs/referee@2.5.0
│ └── samsam@1.3.0
└── @sinonjs/samsam@2.0.0
```

#### After

```
$ npm ls samsam @sinonjs/samsam
sinon@6.3.2 /Users/mroderick/code/sinonjs/sinon
├─┬ @sinonjs/formatio@3.0.0
│ └── @sinonjs/samsam@2.1.0  deduped
├─┬ @sinonjs/referee@2.5.2
│ └── @sinonjs/samsam@2.1.0  deduped
└── @sinonjs/samsam@2.1.0
```


#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).