### PR TITLE
test(1882): add test case

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,10 +6,14 @@ globals:
   Promise: false
   Set: false
   Symbol: false
+  Proxy: false
 
 plugins:
   - ie11
   - local-rules
+
+parserOptions:
+  ecmaVersion: 6
 
 rules:
   ie11/no-collection-args: error

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,14 +6,10 @@ globals:
   Promise: false
   Set: false
   Symbol: false
-  Proxy: false
 
 plugins:
   - ie11
   - local-rules
-
-parserOptions:
-  ecmaVersion: 6
 
 rules:
   ie11/no-collection-args: error

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -536,12 +536,15 @@ describe("issues", function () {
 
     describe("#1882", function () {
         it("should use constructor name when checking deepEquality", function () {
-            class ClassWithoutProps {}
-            const arg1 = new ClassWithoutProps(); //arg1.constructor.name === ClassWithoutProps
-            const arg2 = new Proxy({}, {}); //arg2.constructor.name === Object
-            const stub = sinon.stub();
+            function ClassWithoutProps() {}
+            function AnotherClassWithoutProps() {}
+            ClassWithoutProps.prototype.constructor = ClassWithoutProps;
+            AnotherClassWithoutProps.prototype.constructor = AnotherClassWithoutProps;
+            var arg1 = new ClassWithoutProps(); //arg1.constructor.name === ClassWithoutProps
+            var arg2 = new AnotherClassWithoutProps(); //arg2.constructor.name === Object
+            var stub = sinon.stub();
             stub.withArgs(arg1).returns(5);
-            const result = stub(arg2);
+            var result = stub(arg2);
             assert.same(result, undefined); //[ERR_ASSERTION]: 5 === undefined
         });
     });

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -533,4 +533,16 @@ describe("issues", function () {
             assert.same(calledWith, false);
         });
     });
+
+    describe("#1882", function () {
+        it("should use constructor name when checking deepEquality", function () {
+            class ClassWithoutProps {}
+            const arg1 = new ClassWithoutProps(); //arg1.constructor.name === ClassWithoutProps
+            const arg2 = new Proxy({}, {}); //arg2.constructor.name === Object
+            const stub = sinon.stub();
+            stub.withArgs(arg1).returns(5);
+            const result = stub(arg2);
+            assert.same(result, undefined); //[ERR_ASSERTION]: 5 === undefined
+        });
+    });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

See: #1882, sinonjs/samsam#37

#### Background (Problem in detail)  - optional

* add test case provided in #1882
* change some eslint config to match test:
** class definitions are not enabled in ecmaVersion 5,
** addint Proxy as global


#### Solution  - optional

This test is passing for me locally

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run test-node`
#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
