### PR TITLE
Add context to wrapped function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
               wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
               echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list
               apt-get -qq update
-              apt-get -qq install -y --no-install-recommends google-chrome-unstable
+              apt-get -qq install -y --no-install-recommends google-chrome-stable
             fi
       - run:
           name: Pre-Test
@@ -35,8 +35,8 @@ jobs:
             if node --version | grep -q '^v10'; then
               npm run lint
 
-              npm run test-headless -- --chrome $(which google-chrome-unstable) --allow-chrome-as-root
-              npm run test-webworker -- --chrome $(which google-chrome-unstable) --allow-chrome-as-root
+              npm run test-headless -- --chrome $(which google-chrome-stable) --allow-chrome-as-root
+              npm run test-webworker -- --chrome $(which google-chrome-stable) --allow-chrome-as-root
               npm run test-esm-bundle
 
               if [ -z "$CIRCLE_PULL_REQUESTS" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
               echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list
               apt-get -qq update
               apt-get -qq install -y --no-install-recommends google-chrome-stable
+              apt-get -qq install -y --no-install-recommends google-chrome-unstable
             fi
       - run:
           name: Pre-Test
@@ -35,7 +36,7 @@ jobs:
             if node --version | grep -q '^v10'; then
               npm run lint
 
-              npm run test-headless -- --chrome $(which google-chrome-stable) --allow-chrome-as-root
+              npm run test-headless -- --chrome $(which google-chrome-unstable) --allow-chrome-as-root
               npm run test-webworker -- --chrome $(which google-chrome-stable) --allow-chrome-as-root
               npm run test-esm-bundle
 

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -45,7 +45,7 @@ function wrapFunc(f) {
         p.callback = callback;
         /* eslint-enable no-use-before-define */
 
-        return f && f.apply(f, arguments);
+        return f && f.apply(this, arguments);
     };
     var p = cleanProxy(spy(fakeInstance));
 

--- a/test/fake-test.js
+++ b/test/fake-test.js
@@ -51,6 +51,17 @@ describe("fake", function () {
 
     describe("when passed a Function", function () {
         verifyProxy(fake, function () {});
+
+        it("should keep the `this` context of the wrapped function", function () {
+            function method() { return this.foo; }
+            var o = { foo: 42 };
+            var fakeMethod = fake(method);
+
+            var result = fakeMethod.call(o);
+
+            assert.equals(fakeMethod.callCount, 1);
+            assert.equals(result, 42);
+        });
     });
 
     describe("when passed no value", function () {


### PR DESCRIPTION
# Summary
- Fix #1850 by keeping this context 
- Added a regression test to verify it.

# How to verify
1. Check out this branch
2. `npm install`
3. `npm test` - see the test added in the first commit pass


- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).