### PR TITLE
fix sinon.assert link in sandbox.assert doc

### DIFF
--- a/docs/_releases/v6.3.5/sandbox.md
+++ b/docs/_releases/v6.3.5/sandbox.md
@@ -124,7 +124,7 @@ sinon.config = {
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 *Since `sinon@2.0.0`*
 


### PR DESCRIPTION
#### Purpose (TL;DR)
the https://sinonjs.org/releases/v6.3.5/sandbox/#sandboxassert section 
`sinon.assert` link leads to 404

#### Background (Problem in detail)

in the https://sinonjs.org/releases/v6.3.5/sandbox/#sandboxassert section,
`sinon.assert` is linked to ./assertions, which translates to 
https://sinonjs.org/releases/v6.3.5/sandbox/assertions which gives a 404, as
`.` in the url is interpreted to be under `/sandbox/`, while the assertions documentation
is on the same hierarchy level

#### How to verify - mandatory
1. visit https://sinonjs.org/releases/v6.3.5/sandbox/#sandboxassert
2. click on the `sinon.assert` link
3. verify it is not a 404, but the right documentation page