### PR TITLE
Clarify documentation for spy.calledOnceWithExactly

### DIFF
--- a/docs/_releases/v4.3.0/spies.md
+++ b/docs/_releases/v4.3.0/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.0/spies.md
+++ b/docs/_releases/v4.4.0/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.1/spies.md
+++ b/docs/_releases/v4.4.1/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.10/spies.md
+++ b/docs/_releases/v4.4.10/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.2/spies.md
+++ b/docs/_releases/v4.4.2/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.3/spies.md
+++ b/docs/_releases/v4.4.3/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.4/spies.md
+++ b/docs/_releases/v4.4.4/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.5/spies.md
+++ b/docs/_releases/v4.4.5/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.6/spies.md
+++ b/docs/_releases/v4.4.6/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.7/spies.md
+++ b/docs/_releases/v4.4.7/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.8/spies.md
+++ b/docs/_releases/v4.4.8/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.4.9/spies.md
+++ b/docs/_releases/v4.4.9/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v4.5.0/spies.md
+++ b/docs/_releases/v4.5.0/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.0.1/spies.md
+++ b/docs/_releases/v5.0.1/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.0.10/spies.md
+++ b/docs/_releases/v5.0.10/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.0.2/spies.md
+++ b/docs/_releases/v5.0.2/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.0.3/spies.md
+++ b/docs/_releases/v5.0.3/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.0.4/spies.md
+++ b/docs/_releases/v5.0.4/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.0.5/spies.md
+++ b/docs/_releases/v5.0.5/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.0.6/spies.md
+++ b/docs/_releases/v5.0.6/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.0.7/spies.md
+++ b/docs/_releases/v5.0.7/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.0.8/spies.md
+++ b/docs/_releases/v5.0.8/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.0.9/spies.md
+++ b/docs/_releases/v5.0.9/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v5.1.0/spies.md
+++ b/docs/_releases/v5.1.0/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.0.0/spies.md
+++ b/docs/_releases/v6.0.0/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.0.1/spies.md
+++ b/docs/_releases/v6.0.1/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.1.0/spies.md
+++ b/docs/_releases/v6.1.0/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.1.1/spies.md
+++ b/docs/_releases/v6.1.1/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.1.2/spies.md
+++ b/docs/_releases/v6.1.2/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.1.3/spies.md
+++ b/docs/_releases/v6.1.3/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.1.4/spies.md
+++ b/docs/_releases/v6.1.4/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.1.5/spies.md
+++ b/docs/_releases/v6.1.5/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.1.6/spies.md
+++ b/docs/_releases/v6.1.6/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.2.0/spies.md
+++ b/docs/_releases/v6.2.0/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.3.0/spies.md
+++ b/docs/_releases/v6.3.0/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.3.1/spies.md
+++ b/docs/_releases/v6.3.1/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.3.2/spies.md
+++ b/docs/_releases/v6.3.2/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.3.3/spies.md
+++ b/docs/_releases/v6.3.3/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.3.4/spies.md
+++ b/docs/_releases/v6.3.4/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/_releases/v6.3.5/spies.md
+++ b/docs/_releases/v6.3.5/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -271,7 +271,7 @@ Returns `true` if spy was called at least once with the provided arguments and n
 
 #### `spy.calledOnceWithExactly(arg1, arg2, ...);`
 
-Returns `true` if spy was called exactly once with the provided arguments and no others.
+Returns `true` if spy was called exactly once and with only the provided arguments.
 
 
 #### `spy.alwaysCalledWithExactly(arg1, arg2, ...);`


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix issue #1912 by changing documentation for `spy.calledOnceWithExactly`

#### How to verify - mandatory
1. Check out this branch
2. See that I only modified four words in a markdown file and please understand that I have no idea how to come up with good verification instructions for this kind of a change.

#### Checklist for author
- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
