### PR TITLE
Run test-cloud in preversion.sh

### DIFF
--- a/scripts/preversion.sh
+++ b/scripts/preversion.sh
@@ -13,6 +13,7 @@ done
 
 npm run lint
 npm test
+npm run test-cloud
 
 echo 'Updating History.md'
 git changelog --no-merges


### PR DESCRIPTION
This PR is a follow up to https://github.com/sinonjs/samsam/issues/42, it aims to prevent maintainers  (me) from publishing to npm when there are tests failing.

Since `preversion.sh` is already running linting and unit tests, we might as well also run the tests in the supported browsers before shipping something to npm.

#### How to verify - mandatory
1. Check out this branch
1. `npm install`
1. `./scripts/preversion.sh`
1. Observe that tests are run in Sauce Labs

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).