### PR TITLE
test(#1887)

### DIFF
--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -550,7 +550,7 @@ describe("issues", function () {
     });
 
     describe("#1887", function () {
-        it("should match exact arguments", function () {
+        it("should not break stub behavior using multiple `match.any`", function () {
             var stub = sinon.stub();
 
             stub.withArgs(sinon.match.any, sinon.match.any, sinon.match("a")).returns("a");

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -548,4 +548,16 @@ describe("issues", function () {
             assert.same(result, undefined); //[ERR_ASSERTION]: 5 === undefined
         });
     });
+
+    describe("#1887", function () {
+        it("should match exact arguments", function () {
+            var stub = sinon.stub();
+
+            stub.withArgs(sinon.match.any, sinon.match.any, sinon.match("a")).returns("a");
+            stub.withArgs(sinon.match.any, sinon.match.any, sinon.match("b")).returns("b");
+
+            assert.equals(stub({}, [], "a"), "a");
+            assert.equals(stub({}, [], "b"), "b");
+        });
+    });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This adds the test case described in #1887 


#### Background

As of the issue the test fails for `6.1.3` and above.

#### Solution

Testing this with version `6.3.5` (node `6.9.5`), the test passes

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run test-node`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
