### PR TITLE
Add Google Analytics

### DIFF
--- a/docs/google04dc5213e8f949a9.html
+++ b/docs/google04dc5213e8f949a9.html
@@ -1,0 +1,1 @@
+google-site-verification: google04dc5213e8f949a9.html


### PR DESCRIPTION
Add analytics to our site to analyze search traffic patterns.

Right now we are a little bit in the dark with regards to how people come to our site, but we do know they sometimes end up at the wrong docs.
Having analytics would enable us to make better decisions for how to improve our docs and also verify that our changes work as intended

Ref #1927 and #1929

With increasing number of infrastructure points and logons we might need some central password store for the Sinon members, like 1Password.
Right now, I added this to my personal google account, as a start. I am not too intimately aware of Google Search Console, but
I am quite certain I can just add the rest of the team as well.

No verification for us - it's a file for Google to verify :-)