### PR TITLE
Issue #1852: Add a way to pass a global context to lolex when calling useFakeTimers

### DIFF
--- a/lib/sinon/util/fake-timers.js
+++ b/lib/sinon/util/fake-timers.js
@@ -3,8 +3,12 @@
 var extend = require("./core/extend");
 var llx = require("lolex");
 
-function createClock(config) {
-    var clock = llx.install(config);
+function createClock(config, globalCtx) {
+    var llxCtx = llx;
+    if (globalCtx !== null && typeof globalCtx === "object") {
+        llxCtx = llx.withGlobal(globalCtx);
+    }
+    var clock = llxCtx.install(config);
     clock.restore = clock.uninstall;
     return clock;
 }
@@ -32,7 +36,10 @@ exports.useFakeTimers = function(dateOrConfig) {
     }
 
     if (argumentIsObject) {
-        return createClock(extend({}, dateOrConfig));
+        var config = extend({}, dateOrConfig);
+        var globalCtx = config.global;
+        delete config.global;
+        return createClock(config, globalCtx);
     }
 
     throw new TypeError("useFakeTimers expected epoch or config object. See https://github.com/sinonjs/sinon");

--- a/test/util/fake-timers-test.js
+++ b/test/util/fake-timers-test.js
@@ -1183,5 +1183,18 @@ describe("fakeTimers.clock", function() {
                 { name: "TypeError", message: expectedError }
             );
         });
+
+        it("supports a way to pass the global context", function() {
+            var stub = sinonStub.create();
+            var globalCtx = {
+                Date: sinonStub.create(),
+                setTimeout: stub,
+                clearTimeout: sinonStub.create()
+            };
+            this.clock = fakeTimers.useFakeTimers({ global: globalCtx });
+            refute.defined(this.clock.performance);
+            assert.same(this.clock._setTimeout, stub); // eslint-disable-line no-underscore-dangle
+            this.clock.restore();
+        });
     });
 });


### PR DESCRIPTION
 #### Purpose (TL;DR)
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Partial fix of issue #1852: Add a way to pass a global context to lolex when calling useFakeTimers

 #### Background
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->
As discussed in #1852, some environments make `sinon.useFakeTimers` crash, because of `lolex`, when some properties are missing in the `global` object. The issue has been improved by triggering a more explicit error in `lolex`, however this PR adds a way to provide the global context directly and forward it to `lolex`.

#### Solution 
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
This PR adds an extra property when using `sinon.useFakeTimers` with an object argument: by giving the `global` property, `lolex.withGlobal(global)` will be called and used to install the clock instead of using the default implementation.

 #### How to verify
Checkout [this repositoy](https://github.com/LouisBrunner/sinon-issue-1852) for an example of an environment that triggers this bug.