### PR TITLE
Issue #1936: Make the spy functions non enumerable so that printing it is more concise

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -217,9 +217,9 @@ var spyApi = {
         var length = spyLength || funk.length;
         var proxy = createProxy(funk, length);
 
-        extend(proxy, spy);
+        extend.nonEnum(proxy, spy);
         delete proxy.create;
-        extend(proxy, funk);
+        extend.nonEnum(proxy, funk);
 
         proxy.resetHistory();
         proxy.prototype = funk.prototype;

--- a/lib/sinon/util/core/extend.js
+++ b/lib/sinon/util/core/extend.js
@@ -51,16 +51,7 @@ var hasDontEnumBug = (function() {
     return join(result, "") !== "0123456789";
 })();
 
-/* Public: Extend target in place with all (own) properties from sources in-order. Thus, last source will
- *         override properties in previous sources.
- *
- * target - The Object to extend
- * sources - Objects to copy properties from.
- *
- * Returns the extended target
- */
-module.exports = function extend(target /*, sources */) {
-    var sources = slice(arguments, 1);
+function extendCommon(target, sources, doCopy) {
     var source, i, prop;
 
     for (i = 0; i < sources.length; i++) {
@@ -68,7 +59,7 @@ module.exports = function extend(target /*, sources */) {
 
         for (prop in source) {
             if (hasOwnProperty(source, prop)) {
-                target[prop] = source[prop];
+                doCopy(target, source, prop);
             }
         }
 
@@ -80,4 +71,41 @@ module.exports = function extend(target /*, sources */) {
     }
 
     return target;
+}
+
+/** Public: Extend target in place with all (own) properties from sources in-order. Thus, last source will
+ *         override properties in previous sources.
+ *
+ * @arg {Object} target - The Object to extend
+ * @arg {Object[]} sources - Objects to copy properties from.
+ *
+ * @returns {Object} the extended target
+ */
+module.exports = function extend(target /*, sources */) {
+    var sources = slice(arguments, 1);
+
+    return extendCommon(target, sources, function copyValue(dest, source, prop) {
+        dest[prop] = source[prop];
+    });
+};
+
+/** Public: Extend target in place with all (own) properties from sources in-order. Thus, last source will
+ *         override properties in previous sources. Define the properties as non enumerable.
+ *
+ * @arg {Object} target - The Object to extend
+ * @arg {Object[]} sources - Objects to copy properties from.
+ *
+ * @returns {Object} the extended target
+ */
+module.exports.nonEnum = function extendNonEnum(target /*, sources */) {
+    var sources = slice(arguments, 1);
+
+    return extendCommon(target, sources, function copyProperty(dest, source, prop) {
+        Object.defineProperty(dest, prop, {
+            value: source[prop],
+            enumerable: false,
+            configurable: true,
+            writable: true
+        });
+    });
 };


### PR DESCRIPTION
 #### Purpose
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Improve issue #1936: Make the spy functions non enumerable so that printing it is more concise

 #### Background
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->
When printing a spy (which is often done by assertion libraries), the output takes a long chunk of space and make debugging really difficult. This PR removes the internal functions from this output, making the list smaller and more useful.

 #### Solution
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

This PR expands the `extend` function to support extending using `Object.defineProperty` with `enumerable: false`. As `configurable` and `writable` are set to `true`, the rest of the codebase will still work as intended. Note that as indicated by @ehmicky in the original issue, the node REPL is not affected.

 #### How to verify

<img width="1503" alt="screen shot 2018-10-28 at 18 38 51" src="https://user-images.githubusercontent.com/7120871/47620632-1258ac80-dae4-11e8-8e8c-2873170271f9.png">
