### PR TITLE
Upgrade ~browserify~ cached-path-relative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -814,9 +814,9 @@
       }
     },
     "cached-path-relative": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
-      "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
       "dev": true
     },
     "caller-path": {


### PR DESCRIPTION
This also upgrades cached-path-relative, which has a security warning.

See https://nvd.nist.gov/vuln/detail/CVE-2018-16472
