### PR TITLE
#1957 Fix passing null as an override

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -82,7 +82,7 @@ stub.createStubInstance = function(constructor, overrides) {
     forEach(Object.keys(overrides || {}), function(propertyName) {
         if (propertyName in stubbedObject) {
             var value = overrides[propertyName];
-            if (value.createStubInstance) {
+            if (value && value.createStubInstance) {
                 stubbedObject[propertyName] = value;
             } else {
                 stubbedObject[propertyName].returns(value);

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -2989,6 +2989,21 @@ describe("stub", function() {
             assert.equals(3, stub.method());
         });
 
+        it("allows providing null as a return value", function() {
+            var Class = function() {
+                return;
+            };
+            Class.prototype.method = function() {
+                return;
+            };
+
+            var stub = createStubInstance(Class, {
+                method: null
+            });
+
+            assert.equals(null, stub.method());
+        });
+
         it("throws an exception when trying to override non-existing property", function() {
             var Class = function() {
                 return;


### PR DESCRIPTION
 #### Purpose (TL;DR)
Fix passing null as an override when invoking `sinon.createStubInstance(Class, <overrides>)`

Fixes #1957 

 #### How to verify
Unit test added and can be verified with `npm test`

 #### Checklist for author

- [x] `npm run lint` passes
- [ ] ~~References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).~~ N/A
