### PR TITLE
Fix mock.withArgs using matchers

### DIFF
--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -37,7 +37,7 @@ function arrayEquals(arr1, arr2, compareLength) {
     }
 
     return every(arr1, function(element, i) {
-        return deepEqual(element, arr2[i]);
+        return deepEqual(arr2[i], element);
     });
 }
 

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -653,6 +653,20 @@ describe("sinonMock", function() {
                     { name: "ExpectationError" }
                 );
             });
+
+            it("should not throw when expectation withArgs using matcher", function() {
+                var obj = {
+                    foobar: function() {
+                        return;
+                    }
+                };
+                var mock = sinonMock(obj);
+                mock.expects("foobar").withArgs(match.string);
+
+                refute.exception(function() {
+                    obj.foobar("arg1");
+                });
+            });
         });
 
         describe(".withExactArgs", function() {


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

Fixes #1960

 #### Background (Problem in detail)  - optional

The `deepEqual` semantics in `@sinonjs/samsam` have changed in v3 to be `(actual, expected)` instead of `(expected, actual)`. There was a call left unchanged since no test case existed for this case.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
