### PR TITLE
Fix stubbing function objects

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -36,10 +36,11 @@ function stub(object, property) {
     }
 
     var actualDescriptor = getPropertyDescriptor(object, property);
-    var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
+    var isObject = typeof object === "object" || typeof object === "function";
+    var isStubbingEntireObject = typeof property === "undefined" && isObject;
     var isCreatingNewStub = !object && typeof property === "undefined";
     var isStubbingNonFuncProperty =
-        (typeof object === "object" || typeof object === "function") &&
+        isObject &&
         typeof property !== "undefined" &&
         (typeof actualDescriptor === "undefined" || typeof actualDescriptor.value !== "function") &&
         typeof descriptor === "undefined";

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1267,11 +1267,9 @@ describe("stub", function() {
             assert.equals(obj[0](), "stubbed value");
         });
 
-        it("does not stub function object", function() {
+        it("does not stub string", function() {
             assert.exception(function() {
-                createStub(function() {
-                    return;
-                });
+                createStub("test");
             });
         });
     });
@@ -1315,6 +1313,32 @@ describe("stub", function() {
             var object = {};
 
             assert.same(createStub(object), object);
+        });
+
+        it("returns function", function() {
+            var func = function() {
+                return;
+            };
+
+            assert.same(createStub(func), func);
+        });
+
+        it("stubs methods of function", function() {
+            var func = function() {
+                return;
+            };
+            func.func1 = function() {
+                return;
+            };
+            // eslint-disable-next-line no-proto
+            func.__proto__.func2 = function() {
+                return;
+            };
+
+            createStub(func);
+
+            assert.isFunction(func.func1.restore);
+            assert.isFunction(func.func2.restore);
         });
 
         it("only stubs functions", function() {


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

Currently `sinon.stub(function () {})` throws `TypeError: Attempted to wrap undefined property undefined as function`. Sinon should either throw a meaningful error explaining why a `function` is not a valid argument, or treat functions like any other object. I can't think of a reason why we shouldn't support this.

Fixes #1967

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).