### PR TITLE
docs(sandbox): add example for default sandbox

### DIFF
--- a/docs/_releases/latest/sandbox.md
+++ b/docs/_releases/latest/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.0.1/sandbox.md
+++ b/docs/_releases/v5.0.1/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.0.10/sandbox.md
+++ b/docs/_releases/v5.0.10/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.0.2/sandbox.md
+++ b/docs/_releases/v5.0.2/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.0.3/sandbox.md
+++ b/docs/_releases/v5.0.3/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.0.4/sandbox.md
+++ b/docs/_releases/v5.0.4/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.0.5/sandbox.md
+++ b/docs/_releases/v5.0.5/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.0.6/sandbox.md
+++ b/docs/_releases/v5.0.6/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.0.7/sandbox.md
+++ b/docs/_releases/v5.0.7/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.0.8/sandbox.md
+++ b/docs/_releases/v5.0.8/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.0.9/sandbox.md
+++ b/docs/_releases/v5.0.9/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v5.1.0/sandbox.md
+++ b/docs/_releases/v5.1.0/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.0.0/sandbox.md
+++ b/docs/_releases/v6.0.0/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.0.1/sandbox.md
+++ b/docs/_releases/v6.0.1/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.1.0/sandbox.md
+++ b/docs/_releases/v6.1.0/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.1.1/sandbox.md
+++ b/docs/_releases/v6.1.1/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.1.2/sandbox.md
+++ b/docs/_releases/v6.1.2/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.1.3/sandbox.md
+++ b/docs/_releases/v6.1.3/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.1.4/sandbox.md
+++ b/docs/_releases/v6.1.4/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.1.5/sandbox.md
+++ b/docs/_releases/v6.1.5/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.1.6/sandbox.md
+++ b/docs/_releases/v6.1.6/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.2.0/sandbox.md
+++ b/docs/_releases/v6.2.0/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.3.0/sandbox.md
+++ b/docs/_releases/v6.3.0/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.3.1/sandbox.md
+++ b/docs/_releases/v6.3.1/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.3.2/sandbox.md
+++ b/docs/_releases/v6.3.2/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.3.3/sandbox.md
+++ b/docs/_releases/v6.3.3/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.3.4/sandbox.md
+++ b/docs/_releases/v6.3.4/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v6.3.5/sandbox.md
+++ b/docs/_releases/v6.3.5/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v7.0.0/sandbox.md
+++ b/docs/_releases/v7.0.0/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v7.1.0/sandbox.md
+++ b/docs/_releases/v7.1.0/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v7.1.1/sandbox.md
+++ b/docs/_releases/v7.1.1/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v7.2.0/sandbox.md
+++ b/docs/_releases/v7.2.0/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v7.2.1/sandbox.md
+++ b/docs/_releases/v7.2.1/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v7.2.2/sandbox.md
+++ b/docs/_releases/v7.2.2/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/_releases/v7.2.3/sandbox.md
+++ b/docs/_releases/v7.2.3/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -41,6 +41,21 @@ describe('myAPI.hello method', function () {
 
 Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
 
+```javascript
+const myObject = {
+    'hello': 'world'
+};
+
+sinon.stub(myObject, 'hello').value('Sinon');
+
+console.log(myObject.hello);
+// Sinon
+
+sinon.restore();
+console.log(myObject.hello);
+// world
+```
+
 #### `var sandbox = sinon.createSandbox();`
 
 Creates a new sandbox object with spies, stubs, and mocks.


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
This finishes #1874 to document the example for all releases

 #### How to verify - mandatory
1. Check out this branch
2. Run the docs server
3. Inspect the Sandbox API page

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
