### PR TITLE
Document spying on accessors

### DIFF
--- a/docs/_releases/latest/spies.md
+++ b/docs/_releases/latest/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v1.17.6/spies.md
+++ b/docs/_releases/v1.17.6/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v1.17.7/spies.md
+++ b/docs/_releases/v1.17.7/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.0.0/spies.md
+++ b/docs/_releases/v2.0.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.1.0/spies.md
+++ b/docs/_releases/v2.1.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.2.0/spies.md
+++ b/docs/_releases/v2.2.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.3.0/spies.md
+++ b/docs/_releases/v2.3.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.3.1/spies.md
+++ b/docs/_releases/v2.3.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.3.2/spies.md
+++ b/docs/_releases/v2.3.2/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.3.3/spies.md
+++ b/docs/_releases/v2.3.3/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.3.4/spies.md
+++ b/docs/_releases/v2.3.4/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.3.5/spies.md
+++ b/docs/_releases/v2.3.5/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.3.6/spies.md
+++ b/docs/_releases/v2.3.6/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.3.7/spies.md
+++ b/docs/_releases/v2.3.7/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.3.8/spies.md
+++ b/docs/_releases/v2.3.8/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.4.0/spies.md
+++ b/docs/_releases/v2.4.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v2.4.1/spies.md
+++ b/docs/_releases/v2.4.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v3.0.0/spies.md
+++ b/docs/_releases/v3.0.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v3.1.0/spies.md
+++ b/docs/_releases/v3.1.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v3.2.0/spies.md
+++ b/docs/_releases/v3.2.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v3.2.1/spies.md
+++ b/docs/_releases/v3.2.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v3.3.0/spies.md
+++ b/docs/_releases/v3.3.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.0.0/spies.md
+++ b/docs/_releases/v4.0.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.0.1/spies.md
+++ b/docs/_releases/v4.0.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.0.2/spies.md
+++ b/docs/_releases/v4.0.2/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.1.0/spies.md
+++ b/docs/_releases/v4.1.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.1.1/spies.md
+++ b/docs/_releases/v4.1.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.1.2/spies.md
+++ b/docs/_releases/v4.1.2/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.1.3/spies.md
+++ b/docs/_releases/v4.1.3/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.1.4/spies.md
+++ b/docs/_releases/v4.1.4/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.1.5/spies.md
+++ b/docs/_releases/v4.1.5/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.1.6/spies.md
+++ b/docs/_releases/v4.1.6/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.2.0/spies.md
+++ b/docs/_releases/v4.2.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.2.1/spies.md
+++ b/docs/_releases/v4.2.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.2.2/spies.md
+++ b/docs/_releases/v4.2.2/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.2.3/spies.md
+++ b/docs/_releases/v4.2.3/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.3.0/spies.md
+++ b/docs/_releases/v4.3.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.0/spies.md
+++ b/docs/_releases/v4.4.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.1/spies.md
+++ b/docs/_releases/v4.4.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.10/spies.md
+++ b/docs/_releases/v4.4.10/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.2/spies.md
+++ b/docs/_releases/v4.4.2/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.3/spies.md
+++ b/docs/_releases/v4.4.3/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.4/spies.md
+++ b/docs/_releases/v4.4.4/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.5/spies.md
+++ b/docs/_releases/v4.4.5/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.6/spies.md
+++ b/docs/_releases/v4.4.6/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.7/spies.md
+++ b/docs/_releases/v4.4.7/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.8/spies.md
+++ b/docs/_releases/v4.4.8/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.4.9/spies.md
+++ b/docs/_releases/v4.4.9/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v4.5.0/spies.md
+++ b/docs/_releases/v4.5.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.0.1/spies.md
+++ b/docs/_releases/v5.0.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.0.10/spies.md
+++ b/docs/_releases/v5.0.10/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.0.2/spies.md
+++ b/docs/_releases/v5.0.2/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.0.3/spies.md
+++ b/docs/_releases/v5.0.3/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.0.4/spies.md
+++ b/docs/_releases/v5.0.4/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.0.5/spies.md
+++ b/docs/_releases/v5.0.5/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.0.6/spies.md
+++ b/docs/_releases/v5.0.6/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.0.7/spies.md
+++ b/docs/_releases/v5.0.7/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.0.8/spies.md
+++ b/docs/_releases/v5.0.8/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.0.9/spies.md
+++ b/docs/_releases/v5.0.9/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v5.1.0/spies.md
+++ b/docs/_releases/v5.1.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.0.0/spies.md
+++ b/docs/_releases/v6.0.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.0.1/spies.md
+++ b/docs/_releases/v6.0.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.1.0/spies.md
+++ b/docs/_releases/v6.1.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.1.1/spies.md
+++ b/docs/_releases/v6.1.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.1.2/spies.md
+++ b/docs/_releases/v6.1.2/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.1.3/spies.md
+++ b/docs/_releases/v6.1.3/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.1.4/spies.md
+++ b/docs/_releases/v6.1.4/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.1.5/spies.md
+++ b/docs/_releases/v6.1.5/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.1.6/spies.md
+++ b/docs/_releases/v6.1.6/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.2.0/spies.md
+++ b/docs/_releases/v6.2.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.3.0/spies.md
+++ b/docs/_releases/v6.3.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.3.1/spies.md
+++ b/docs/_releases/v6.3.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.3.2/spies.md
+++ b/docs/_releases/v6.3.2/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.3.3/spies.md
+++ b/docs/_releases/v6.3.3/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.3.4/spies.md
+++ b/docs/_releases/v6.3.4/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v6.3.5/spies.md
+++ b/docs/_releases/v6.3.5/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v7.0.0/spies.md
+++ b/docs/_releases/v7.0.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v7.1.0/spies.md
+++ b/docs/_releases/v7.1.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v7.1.1/spies.md
+++ b/docs/_releases/v7.1.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v7.2.0/spies.md
+++ b/docs/_releases/v7.2.0/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v7.2.1/spies.md
+++ b/docs/_releases/v7.2.1/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v7.2.2/spies.md
+++ b/docs/_releases/v7.2.2/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 

--- a/docs/_releases/v7.2.3/spies.md
+++ b/docs/_releases/v7.2.3/spies.md
@@ -60,6 +60,32 @@ all [calls][call]. The following is a slightly contrived example:
 }
 ```
 
+### Using a spy to wrap property getter and setter
+
+`sinon.spy(object, "property", ["get", "set"])` creates spies that wrap the
+getters and setters for `object.property`. The spies will behave exactly like
+the original getters and setters, but you will have access to data about all
+[calls][call]. Example:
+
+
+```javascript
+var object = {
+  get test() {
+    return this.property;
+  },
+  set test(value) {
+    this.property = value * 2;
+  }
+};
+
+var spy = sinon.spy(object, "test", ["get", "set"]);
+
+object.test = 42;
+assert(spy.set.calledOnce);
+
+assert.equals(object.test, 84);
+assert(spy.get.calledOnce);
+```
 
 ### Creating spies: `sinon.spy()` Method Signatures
 
@@ -79,6 +105,16 @@ all [calls][call]. The following is a slightly contrived example:
     all cases. The original method can be restored by calling
     <code>object.method.restore()</code>. The returned spy is the function
     object which replaced the original method. <code>spy === object.method</code>.
+  </dd>
+  <dt><code>var spy = sinon.spy(object, "property", types);</code></dt>
+  <dd>
+    Creates a spy for <code>object.property</code> descriptor and replaces the
+    original accessor methods (`get`, `set`) listed in the <code>types</code>
+    array with a spy. The spies act exactly like the original accessors in all
+    cases. The original accessors can be restored by calling
+    <code>spy.restore()</code>. The returned spy is the object which replaced
+    the original property descriptor. <code>spy.get ===
+    Object.getOwnPropertyDescriptor(object, 'property').get</code>.
   </dd>
 </dl>
 


### PR DESCRIPTION
Closes #1606

 #### Purpose (TL;DR) - mandatory

Adds documentation for an undocumented feature.

<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->


<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

 #### How to verify - mandatory
1. Check out this branch
2. Open `docs/_releases/latest/spies.md`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
