### PR TITLE
don't call extends.nonEnum in spy.resetHistory

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -238,7 +238,7 @@ var spyApi = {
 
         extend.nonEnum(proxy, spy);
         delete proxy.create;
-        extend.nonEnum(proxy, funk);
+        extend(proxy, funk);
 
         proxy.resetHistory();
         proxy.prototype = funk.prototype;
@@ -408,7 +408,7 @@ var spyApi = {
                 return matching;
             }
         } else {
-            this.fakes = [];
+            extend.nonEnum(this, { fakes: [] });
         }
 
         var original = this;

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -152,7 +152,26 @@ function createProxy(func, proxyLength) {
             return p.invoke(func, this, slice(arguments));
         };
     }
-    extend.nonEnum(p, { isSinonProxy: true });
+    extend.nonEnum(p, {
+        isSinonProxy: true,
+
+        called: false,
+        notCalled: true,
+        calledOnce: false,
+        calledTwice: false,
+        calledThrice: false,
+        callCount: 0,
+        firstCall: null,
+        secondCall: null,
+        thirdCall: null,
+        lastCall: null,
+        args: [],
+        returnValues: [],
+        thisValues: [],
+        exceptions: [],
+        callIds: [],
+        errorsWithCallStack: []
+    });
     return p;
 }
 
@@ -172,24 +191,22 @@ var spyApi = {
             throw err;
         }
 
-        extend.nonEnum(this, {
-            called: false,
-            notCalled: true,
-            calledOnce: false,
-            calledTwice: false,
-            calledThrice: false,
-            callCount: 0,
-            firstCall: null,
-            secondCall: null,
-            thirdCall: null,
-            lastCall: null,
-            args: [],
-            returnValues: [],
-            thisValues: [],
-            exceptions: [],
-            callIds: [],
-            errorsWithCallStack: []
-        });
+        this.called = false;
+        this.notCalled = true;
+        this.calledOnce = false;
+        this.calledTwice = false;
+        this.calledThrice = false;
+        this.callCount = 0;
+        this.firstCall = null;
+        this.secondCall = null;
+        this.thirdCall = null;
+        this.lastCall = null;
+        this.args = [];
+        this.returnValues = [];
+        this.thisValues = [];
+        this.exceptions = [];
+        this.callIds = [];
+        this.errorsWithCallStack = [];
 
         if (this.fakes) {
             forEach(this.fakes, function(fake) {

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2893,7 +2893,7 @@ describe("spy", function() {
             func.aProp = 42;
             var spy = createSpy.create(func);
 
-            assert.equals(spy.myProp, func.myProp);
+            assert.equals(spy.aProp, 42);
             assert.equals(Object.keys(spy), Object.keys(func));
             assert.equals(Object.keys(spy), ["aProp"]);
 

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2860,7 +2860,7 @@ describe("spy", function() {
             spy(15);
             assert.equals(Object.keys(spy), []);
             spy.fooBar = 1;
-            assert.equals(Object.keys(spy), [ "fooBar" ]);
+            assert.equals(Object.keys(spy), ["fooBar"]);
 
             spy.withArgs(1);
             assert(spy.called);
@@ -2874,10 +2874,10 @@ describe("spy", function() {
             assert.equals(spy.thisValues.length, 1);
             assert.equals(spy.exceptions.length, 1);
             assert.equals(spy.returnValues.length, 1);
-            assert.equals(Object.keys(spy), [ "fooBar" ]);
+            assert.equals(Object.keys(spy), ["fooBar"]);
 
             spy.resetHistory();
-            assert.equals(Object.keys(spy), [ "fooBar" ]);
+            assert.equals(Object.keys(spy), ["fooBar"]);
         });
 
         it("create spy from function", function() {
@@ -2889,16 +2889,18 @@ describe("spy", function() {
 
             assert.equals(spy.myProp, func.myProp);
             assert.equals(Object.keys(spy), Object.keys(func));
-            assert.equals(Object.keys(spy), [ "aProp" ]);
+            assert.equals(Object.keys(spy), ["aProp"]);
 
+            // eslint-disable-next-line no-restricted-syntax
             try {
                 spy();
             } catch (e) {
+                // empty
             }
             assert(spy.threw());
 
             spy.resetHistory();
-            assert.equals(Object.keys(spy), [ "aProp" ]);
+            assert.equals(Object.keys(spy), ["aProp"]);
         });
     });
 });

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2851,4 +2851,54 @@ describe("spy", function() {
             }
         });
     });
+
+    describe("non enumerable properties", function() {
+        it("create and call spy apis", function() {
+            var spy = createSpy();
+            assert.equals(Object.keys(spy), []);
+
+            spy(15);
+            assert.equals(Object.keys(spy), []);
+            spy.fooBar = 1;
+            assert.equals(Object.keys(spy), [ "fooBar" ]);
+
+            spy.withArgs(1);
+            assert(spy.called);
+            assert(spy.calledBefore(createSpy()));
+            assert(!spy.calledAfter(createSpy()));
+            assert(spy.calledOn(undefined));
+            assert(spy.calledWith(15));
+            assert(!spy.calledWithNew());
+            assert(!spy.threw());
+            assert(!spy.returned("ret"));
+            assert.equals(spy.thisValues.length, 1);
+            assert.equals(spy.exceptions.length, 1);
+            assert.equals(spy.returnValues.length, 1);
+            assert.equals(Object.keys(spy), [ "fooBar" ]);
+
+            spy.resetHistory();
+            assert.equals(Object.keys(spy), [ "fooBar" ]);
+        });
+
+        it("create spy from function", function() {
+            var func = function() {
+                throw new Error("aError");
+            };
+            func.aProp = 42;
+            var spy = createSpy.create(func);
+
+            assert.equals(spy.myProp, func.myProp);
+            assert.equals(Object.keys(spy), Object.keys(func));
+            assert.equals(Object.keys(spy), [ "aProp" ]);
+
+            try {
+                spy();
+            } catch (e) {
+            }
+            assert(spy.threw());
+
+            spy.resetHistory();
+            assert.equals(Object.keys(spy), [ "aProp" ]);
+        });
+    });
 });

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2857,25 +2857,31 @@ describe("spy", function() {
             var spy = createSpy();
             assert.equals(Object.keys(spy), []);
 
+            // call spy and verify no enumerable properties are added
             spy(15);
             assert.equals(Object.keys(spy), []);
+
+            // it should still work to add properties
             spy.fooBar = 1;
             assert.equals(Object.keys(spy), ["fooBar"]);
 
+            // call some spy APIs and verify no enumerable properties are added
             spy.withArgs(1);
-            assert(spy.called);
-            assert(spy.calledBefore(createSpy()));
-            assert(!spy.calledAfter(createSpy()));
-            assert(spy.calledOn(undefined));
-            assert(spy.calledWith(15));
-            assert(!spy.calledWithNew());
-            assert(!spy.threw());
-            assert(!spy.returned("ret"));
-            assert.equals(spy.thisValues.length, 1);
-            assert.equals(spy.exceptions.length, 1);
-            assert.equals(spy.returnValues.length, 1);
+            // eslint-disable-next-line no-unused-vars
+            var val = spy.called;
+            spy.calledBefore(createSpy());
+            spy.calledAfter(createSpy());
+            spy.calledOn(undefined);
+            spy.calledWith(15);
+            spy.calledWithNew();
+            spy.threw();
+            spy.returned("ret");
+            val = spy.thisValues.length;
+            val = spy.exceptions.length;
+            val = spy.returnValues.length;
             assert.equals(Object.keys(spy), ["fooBar"]);
 
+            // verify that reset history doesn't change enumerable properties
             spy.resetHistory();
             assert.equals(Object.keys(spy), ["fooBar"]);
         });
@@ -2897,7 +2903,7 @@ describe("spy", function() {
             } catch (e) {
                 // empty
             }
-            assert(spy.threw());
+            spy.threw();
 
             spy.resetHistory();
             assert.equals(Object.keys(spy), ["aProp"]);


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

Fixes #1983 by not calling `extends.nonEnum()` in `spy.resetHistory()`

It seems that `extends.nonEnum()` is significant slower then just setting properties. By ensuring that the properties on the proxy exist as non enumerable during creation it's not needed to use `extends.nonEnum()` during updating them.

Refs: #1975

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

Not sure what to write here as there is no functional change...

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
