### PR TITLE
Retain spy function names and fix spy.named(name)

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -152,6 +152,12 @@ function createProxy(func, proxyLength) {
             return p.invoke(func, this, slice(arguments));
         };
     }
+    var nameDescriptor = Object.getOwnPropertyDescriptor(func, "name");
+    if (nameDescriptor && nameDescriptor.configurable) {
+        // IE 11 functions don't have a name.
+        // Safari 9 has names that are not configurable.
+        Object.defineProperty(p, "name", nameDescriptor);
+    }
     extend.nonEnum(p, {
         isSinonProxy: true,
 
@@ -332,6 +338,13 @@ var spyApi = {
 
     named: function named(name) {
         this.displayName = name;
+        var nameDescriptor = Object.getOwnPropertyDescriptor(this, "name");
+        if (nameDescriptor && nameDescriptor.configurable) {
+            // IE 11 functions don't have a name.
+            // Safari 9 has names that are not configurable.
+            nameDescriptor.value = name;
+            Object.defineProperty(this, "name", nameDescriptor);
+        }
         return this;
     },
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -111,7 +111,8 @@ describe("issues", function() {
         // IE 11 does not support the function name property
         if (bob.name) {
             it("should not rename spies", function() {
-                var expectedName = "proxy";
+                var nameDescriptor = Object.getOwnPropertyDescriptor(bob, "name");
+                var expectedName = nameDescriptor && nameDescriptor.configurable ? "bob" : "proxy";
                 var spy = sinon.spy(bob);
 
                 assert.equals(spy.name, expectedName);

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -207,6 +207,16 @@ function spyNeverCalledTests(method) {
     };
 }
 
+function verifyFunctionName(func, expectedName) {
+    var descriptor = Object.getOwnPropertyDescriptor(func, "name");
+    if (descriptor && descriptor.configurable) {
+        // IE 11 functions don't have a name.
+        // Safari 9 has names that are not configurable.
+        assert.equals(descriptor.value, expectedName);
+        assert.equals(func.name, expectedName);
+    }
+}
+
 describe("spy", function() {
     it("does not throw if called without function", function() {
         refute.exception(function() {
@@ -423,10 +433,11 @@ describe("spy", function() {
     });
 
     describe(".named", function() {
-        it("sets displayName", function() {
+        it("sets name and displayName", function() {
             var spy = createSpy();
             var retval = spy.named("beep");
             assert.equals(spy.displayName, "beep");
+            verifyFunctionName(spy, "beep");
             assert.same(spy, retval);
         });
     });
@@ -504,6 +515,17 @@ describe("spy", function() {
             });
 
             assert.exception(spy, err);
+        });
+
+        it("retains function name", function() {
+            function test() {
+                return;
+            }
+
+            var spy = createSpy.create(test);
+
+            assert.equals(spy.displayName, "test");
+            verifyFunctionName(spy, "test");
         });
 
         it("retains function length 0", function() {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

- Let spies have the same `name` as the function they wrap
- Change the `name` property in `spy.named(name)`, not just the `displayName` (used for sinon error messages)

Fixes #250 

#### Background (Problem in detail)

We used to retain the name of spied functions, but this has been lost along the way at some point.

There is https://github.com/sinonjs/sinon/issues/950 which shows in the issue description that the `name` property of a spy reflected the original function name. However, the [test that is verifying this](https://github.com/sinonjs/sinon/pull/1435) was added later and it hard coded the name to `"proxy"`.

I think this dates back to the old times when we used `eval` to generate the spy function.

#### Solution  - optional

This change verifies that a `name` can be configured on the function – unfortunately this is inconsistent across (old but supported) browser versions – and then configures the name using the same property descritor flags as the original value.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`
4. `npm run test-cloud`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).