### PR TITLE
Set `fake.lastArg` to last argument regardless of type

### DIFF
--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -37,7 +37,7 @@ function cleanProxy(f) {
 var uuid = 0;
 function wrapFunc(f) {
     var fakeInstance = function() {
-        var lastArg = (arguments.length > 0 && arguments[arguments.length - 1]) || undefined;
+        var lastArg = arguments.length > 0 ? arguments[arguments.length - 1] : undefined;
         var callback = lastArg && typeof lastArg === "function" ? lastArg : undefined;
 
         /* eslint-disable no-use-before-define */

--- a/test/fake-test.js
+++ b/test/fake-test.js
@@ -143,6 +143,18 @@ describe("fake", function() {
             f(46);
             assert.equals(f.lastArg, 46);
 
+            f(false, true, 47, "string");
+            assert.equals(f.lastArg, "string");
+
+            f("string", false, true, 47);
+            assert.equals(f.lastArg, 47);
+
+            f(47, "string", false, true);
+            assert.equals(f.lastArg, true);
+
+            f(true, 47, "string", false);
+            assert.equals(f.lastArg, false);
+
             f();
             refute.defined(f.lastArg);
         });

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -588,4 +588,14 @@ describe("issues", function() {
             assert.equals(stub({}, [], "b"), "b");
         });
     });
+
+    describe("#1986", function() {
+        it("should not set `lastArg` to undefined when last argument is `false`", function() {
+            var fake = sinon.fake();
+
+            fake(99, false);
+
+            assert.equals(fake.lastArg, false);
+        });
+    });
 });


### PR DESCRIPTION
 #### Purpose (TL;DR)
"Falsy" last arguments to `fake` were ignored.

Rely on arguments length instead of value comparison.

resolves #1986 

 #### Solution
Change `lastArg` assignment from this
```js
var lastArg = (arguments.length > 0 && arguments[arguments.length - 1]) || undefined;
```
to only trust arguments list length
```js
var lastArg = arguments.length > 0 ? arguments[arguments.length - 1] : undefined;
```

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`
4. (optional) Use `sinon.fake` and pass `false` as the last argument; assert `lastArg` to equal `false`; it should pass.

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
