### PR TITLE
Inject fake functionality and createStubInstance

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -71,6 +71,26 @@ function Sandbox() {
             return sandbox.mock.apply(null, arguments);
         };
 
+        obj.createStubInstance = function() {
+            return sandbox.createStubInstance.apply(sandbox, arguments);
+        };
+
+        obj.fake = function() {
+            return sandbox.fake.apply(null, arguments);
+        };
+
+        obj.replace = function() {
+            return sandbox.replace.apply(null, arguments);
+        };
+
+        obj.replaceSetter = function() {
+            return sandbox.replaceSetter.apply(null, arguments);
+        };
+
+        obj.replaceGetter = function() {
+            return sandbox.replaceGetter.apply(null, arguments);
+        };
+
         if (sandbox.clock) {
             obj.clock = sandbox.clock;
         }

--- a/lib/sinon/util/core/default-config.js
+++ b/lib/sinon/util/core/default-config.js
@@ -1,7 +1,6 @@
 "use strict";
 
 module.exports = {
-    injectIntoThis: true,
     injectInto: null,
     properties: ["spy", "stub", "mock", "clock", "server", "requests"],
     useFakeTimers: true,

--- a/lib/sinon/util/core/default-config.js
+++ b/lib/sinon/util/core/default-config.js
@@ -2,7 +2,19 @@
 
 module.exports = {
     injectInto: null,
-    properties: ["spy", "stub", "mock", "clock", "server", "requests"],
+    properties: [
+        "spy",
+        "stub",
+        "mock",
+        "clock",
+        "server",
+        "requests",
+        "fake",
+        "replace",
+        "replaceSetter",
+        "replaceGetter",
+        "createStubInstance"
+    ],
     useFakeTimers: true,
     useFakeServer: true
 };

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1551,12 +1551,42 @@ describe("Sandbox", function() {
             this.sandbox.restore();
         });
 
-        it("injects spy, stub, mock", function() {
+        it("injects spy, stub, mock, fake, replace, replaceSetter, createStubInstance", function() {
             this.sandbox.inject(this.obj);
 
             assert.isFunction(this.obj.spy);
             assert.isFunction(this.obj.stub);
             assert.isFunction(this.obj.mock);
+            assert.isFunction(this.obj.createStubInstance);
+            assert.isFunction(this.obj.fake);
+            assert.isFunction(this.obj.replace);
+            assert.isFunction(this.obj.replaceSetter);
+            assert.isFunction(this.obj.replaceGetter);
+        });
+
+        it("should inject callable functions", function() {
+            /* eslint-disable no-empty-function, accessor-pairs */
+            this.sandbox.inject(this.obj);
+
+            var myObj = { a: function() {} };
+            function MyClass() {}
+            Object.defineProperty(myObj, "b", {
+                get: function() {
+                    return 42;
+                },
+                configurable: true
+            });
+            Object.defineProperty(myObj, "c", { set: function() {}, configurable: true });
+
+            refute.exception(
+                function() {
+                    this.obj.createStubInstance(MyClass);
+                    var fake = this.obj.fake();
+                    this.obj.replace(myObj, "a", fake);
+                    this.obj.replaceGetter(myObj, "b", fake);
+                    this.obj.replaceSetter(myObj, "c", fake);
+                }.bind(this)
+            );
         });
 
         it("does not define clock, server and requests objects", function() {

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1671,7 +1671,6 @@ describe("Sandbox", function() {
         it("yields stub, mock as arguments", function() {
             var sandbox = createSandbox(
                 sinonConfig({
-                    injectIntoThis: false,
                     properties: ["stub", "mock"]
                 })
             );
@@ -1686,7 +1685,6 @@ describe("Sandbox", function() {
         it("yields spy, stub, mock as arguments", function() {
             var sandbox = createSandbox(
                 sinonConfig({
-                    injectIntoThis: false,
                     properties: ["spy", "stub", "mock"]
                 })
             );
@@ -1701,7 +1699,6 @@ describe("Sandbox", function() {
         it("does not yield server when not faking xhr", function() {
             var sandbox = createSandbox(
                 sinonConfig({
-                    injectIntoThis: false,
                     properties: ["server", "stub", "mock"],
                     useFakeServer: false
                 })
@@ -1740,7 +1737,6 @@ describe("Sandbox", function() {
                 it("yields server when faking xhr", function() {
                     var sandbox = createSandbox(
                         sinonConfig({
-                            injectIntoThis: false,
                             properties: ["server", "stub", "mock"]
                         })
                     );
@@ -1756,7 +1752,6 @@ describe("Sandbox", function() {
                 it("uses serverWithClock when faking xhr", function() {
                     var sandbox = createSandbox(
                         sinonConfig({
-                            injectIntoThis: false,
                             properties: ["server"],
                             useFakeServer: fakeServerWithClock
                         })
@@ -1784,7 +1779,6 @@ describe("Sandbox", function() {
                 it("yields clock when faking timers", function() {
                     var sandbox = createSandbox(
                         sinonConfig({
-                            injectIntoThis: false,
                             properties: ["server", "clock"]
                         })
                     );
@@ -1846,7 +1840,6 @@ describe("Sandbox", function() {
         it("fakes specified timers", function() {
             var sandbox = createSandbox(
                 sinonConfig({
-                    injectIntoThis: false,
                     properties: ["clock"],
                     useFakeTimers: { toFake: ["Date", "setTimeout"] }
                 })

--- a/test/util/core/get-config-test.js
+++ b/test/util/core/get-config-test.js
@@ -12,7 +12,6 @@ describe("core/util/getConfig", function() {
             var config = getConfig();
 
             refute.same(config, defaultConfig);
-            assert.equals(config.injectIntoThis, defaultConfig.injectIntoThis);
             assert.equals(config.injectInto, defaultConfig.injectInto);
             assert.equals(config.properties, defaultConfig.properties);
             assert.equals(config.useFakeTimers, defaultConfig.useFakeTimers);
@@ -26,7 +25,6 @@ describe("core/util/getConfig", function() {
             });
 
             refute.same(config, defaultConfig);
-            assert.equals(config.injectIntoThis, defaultConfig.injectIntoThis);
             assert.equals(config.injectInto, defaultConfig.injectInto);
             assert.equals(config.properties, ["stub", "mock"]);
             assert.equals(config.useFakeTimers, defaultConfig.useFakeTimers);


### PR DESCRIPTION
#### Purpose
Fix sinonjs/sinon-test#102 by exposing the newer props on object we are
injecting the sandbox functionality into.

Also removes the unused `injectIntoThis` prop from the config.

 #### How to verify - mandatory
1. Check out the `master` branch
1. `npm install sinon-test`
1. Run the mocha test case under this block. It should fail.
1. Check out this branch
1. Re-run the test case. It should now work.

```javascript
import * as sinon from "sinon";

const sinonTest = require("sinon-test");
const test = sinonTest(sinon);

describe("sandbox", function() {

    class MyClass {

    }

    it("test 1", test(function() {
        this.createStubInstance(MyClass);
    }));

});
```

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).