### PR TITLE
unnecessary things!

### DIFF
--- a/docs/_releases/latest/mocks.md
+++ b/docs/_releases/latest/mocks.md
@@ -166,7 +166,7 @@ An `expectation` instance only holds onto a single set of arguments specified wi
 
 #### `expectation.on(obj);`
 
-Expect the method to be called with `obj` as `this`."}
+Expect the method to be called with `obj` as `this`.
 
 
 #### `expectation.verify();`


### PR DESCRIPTION
maybe a typo or documentation-auto-generation bug

 #### Purpose (TL;DR) - mandatory
fixing documentation