### PR TITLE
Fix Circle CI headless builds breaking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,15 +20,6 @@ jobs:
           command: |
             npm config set strict-ssl false
             npm install
-
-            # install latest chrome unstable version
-            if node --version | grep -q '^v10'; then
-              wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-              echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list
-              apt-get -qq update
-              apt-get -qq install -y --no-install-recommends google-chrome-stable
-              apt-get -qq install -y --no-install-recommends google-chrome-unstable
-            fi
       - run:
           name: Pre-Test
           # ESLint only supports Node >=4
@@ -36,8 +27,8 @@ jobs:
             if node --version | grep -q '^v10'; then
               npm run lint
 
-              npm run test-headless -- --chrome $(which google-chrome-stable) --allow-chrome-as-root
-              npm run test-webworker -- --chrome $(which google-chrome-stable) --allow-chrome-as-root
+              npm run test-headless  -- --chrome "$SINON_CHROME_BIN" --allow-chrome-as-root
+              npm run test-webworker -- --chrome "$SINON_CHROME_BIN" --allow-chrome-as-root
               npm run test-esm-bundle
 
               if [ -z "$CIRCLE_PULL_REQUESTS" ]; then
@@ -65,10 +56,9 @@ jobs:
   node-10:
     <<: *common-build
     docker:
-      - image: node:10
+      - image: circleci/node:10.15.1-browsers
     environment:
-        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
-        SINON_CHROME_BIN: /usr/bin/google-chrome-unstable
+        SINON_CHROME_BIN: /usr/bin/google-chrome-stable
 
 
 workflows:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,13 +17,13 @@ services:
     volumes:
       # This mounts the local directory - saving `npm install`
       - ./:/home/node/app
-    command: >
-      sh -c "
-      $$SINON_CHROME_BIN --version
 
-      npm run test-headless -- --chrome $$SINON_CHROME_BIN --allow-chrome-as-root
+    # There are differences between Circle CI and Docker `command`,
+    # forcing us to do this little workaround
+    command: >
+      sh -c " $$SINON_CHROME_BIN --version
+      && npm run test-headless -- --chrome $$SINON_CHROME_BIN --allow-chrome-as-root
       && npm run test-webworker -- --chrome $$SINON_CHROME_BIN --allow-chrome-as-root
       && npm run test-esm-bundle
       && npm run test-node
-
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# Docker Compose setup file
+# Purpose: testbed for changes to Circle CI setup
+# Usage: `docker-compose up`
+version: "3"
+services:
+  node:
+    image: "circleci/node:10.15.1-browsers"
+    user: "root"
+    working_dir: /home/node/app
+
+    # use the one built-in to the image to avoid potential issues like
+    # https://github.com/GoogleChrome/puppeteer/issues/3774
+    # This variable is used by all scripts - including the `test-esm-bundle`
+    environment:
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
+      SINON_CHROME_BIN: /usr/bin/google-chrome-stable
+    volumes:
+      # This mounts the local directory - saving `npm install`
+      - ./:/home/node/app
+    command: >
+      sh -c "
+      $$SINON_CHROME_BIN --version
+
+      npm run test-headless -- --chrome $$SINON_CHROME_BIN --allow-chrome-as-root
+      && npm run test-webworker -- --chrome $$SINON_CHROME_BIN --allow-chrome-as-root
+      && npm run test-esm-bundle
+      && npm run test-node
+
+      "

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test-webworker": "mochify --https-server 8080 test/webworker/webworker-support-assessment.js",
     "test-esm": "mocha -r esm test/es2015/module-support-assessment-test.mjs",
     "test-esm-bundle": "node test/es2015/check-esm-bundle-is-runnable.js",
+    "test-docker-image": "docker-compose up",
     "test": "run-s test-node test-headless test-webworker test-esm",
     "check-dependencies": "dependency-check package.json --unused --no-dev --ignore-module coveralls --ignore-module esm",
     "build": "run-p build-esm build-bundle",


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
All builds on the `node:10` image running the headless Puppeteer tests have been [failing](https://circleci.com/gh/sinonjs/sinon/1248) for the last two weeks (last good build is [1223](https://circleci.com/gh/sinonjs/sinon/1223).

This PR fixes that build by sticking to a known good version of `circleci/node:10-browsers`, which has a vetted version of Chrome (v72).

 #### Background (Problem in detail) 
As https://github.com/sinonjs/sinon/pull/1995#issuecomment-472358296 details, the biggest problem with the failures was that we were left blind with just an `[object Object]` as the only output from the `test-headless` run.

So to get any further I needed to be able to
1. reproduce the issue
1. get some diagnostic input of value

 #### Solution  - optional
First I needed to be able to reproduce this locally to get a quicker feedback loop and not overload Circle CI. That story is [documented in a branch of its own](https://github.com/fatso83/sinon/commits/docker-experiments) and basically gave me a reproducible setup for local debugging. I could now do `docker-compose up` to run the tests. Now for the debugging output.

I dug into the documentation of Puppeteer and found it accepted an options object, which among other things had a field `dumpio`. By manually editing `node_modules/mochify/lib/chromium.js` to add the `dumpio:true` option, I could finally see some useful output! (I guess this should could exposed as a user option in `mochify`, @mantoni?)

At some point during the run, Chrome just gave up and exited with the following error:
```
    node_1 | [0320/100336.123457:FATAL:gpu_data_manager_impl_private.cc(892)] The display compositor is frequently crashing. Goodbye.
```

Googling that error I found GoogleChrome/puppeteer#894, which showed a lot of people having that issue, along with some proposed fixes (basically setting a version).

This has happened in other versions of Chrome as well, so by always downloading the latest version we are likely to break the build again. This is why I propose to explicitly use vetted image versions in this PR.

 #### How to verify - mandatory
1. Check out this branch
2. `npm run test-docker-image`

 #### Checklist for author
- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
