### PR TITLE
Fix issue #1964

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -170,7 +170,8 @@ var proto = {
         } else if (this.reject) {
             return (this.promiseLibrary || Promise).reject(this.returnValue);
         } else if (this.callsThrough) {
-            return this.stub.wrappedMethod.apply(context, args);
+            var wrappedMethod = this.effectiveWrappedMethod();
+            return wrappedMethod.apply(context, args);
         } else if (typeof this.returnValue !== "undefined") {
             return this.returnValue;
         } else if (typeof this.callArgAt === "number") {
@@ -178,6 +179,15 @@ var proto = {
         }
 
         return this.returnValue;
+    },
+
+    effectiveWrappedMethod: function effectiveWrappedMethod() {
+        for (var stubb = this.stub; stubb; stubb = stubb.parent) {
+            if (stubb.wrappedMethod) {
+                return stubb.wrappedMethod;
+            }
+        }
+        return undefined;
     },
 
     onCall: function onCall(index) {

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -187,7 +187,7 @@ var proto = {
                 return stubb.wrappedMethod;
             }
         }
-        return undefined;
+        throw new Error("Unable to find wrapped method");
     },
 
     onCall: function onCall(index) {

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -599,4 +599,24 @@ describe("issues", function() {
             assert.equals(fake.lastArg, false);
         });
     });
+
+    describe("#1964", function() {
+        it("should allow callThrough on a withArgs fake", function() {
+            var calledThrough = false;
+            var obj = {
+                method: function() {
+                    calledThrough = true;
+                }
+            };
+
+            var baseStub = sinon.stub(obj, "method");
+            baseStub.throws("Should always hit the withArgs fake");
+            var argsStub = baseStub.withArgs("foo").callThrough();
+
+            obj.method("foo");
+
+            sinon.assert.calledOnce(argsStub);
+            assert.isTrue(calledThrough);
+        });
+    });
 });


### PR DESCRIPTION
 #### Purpose

Fix #1964 by adding a helper method to walk the stub parent links to find the `wrappedMethod` value for the `callsThrough` behavior.

 #### Background

If you try to use the `callsThrough` behavior on a `withArgs` stub, calling the stub with the matching args will fail, because the behavior fails to locate the original wrapped method to call through to.

This is effectively a followup to #1442 / #1549.

 #### Solution  - optional

A simple helper method walks up `stub.parent` links until it finds a `stub` that has a `wrappedMethod` member.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`, or just `npm run test-node`, or just `npm run test-node --grep 1964` to run the issue-specific test case

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
  - N/A -- no standard library functions used
