### PR TITLE
Updated Copyright year in Footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -4,7 +4,7 @@
   <div class="container text-center">
     <a href="http://sinonjs.org/" target="blank"><img class="grow" src="{{ "/assets/images/logo.png" | prepend: site.baseurl }}" alt="Sinon.JS"></a>
     <p><a target="blank" class="join-btn" href="https://stackoverflow.com/questions/tagged/sinon">Join the discussion on Stack Overflow!</a></p>
-    <p>Copyright 2010 - 2018, the Sinon.JS committers.</p>
+    <p>Copyright 2010 - 2019, the Sinon.JS committers.</p>
     <p>Released under the <a href="https://opensource.org/licenses/BSD-3-Clause">BSD license</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
Solved issue #2014 

Earlier it was `2010-2018`. I have changed it to `2010-2019`

### EARLIER

<img width="444" alt="Screenshot 2019-05-07 at 6 15 00 PM" src="https://user-images.githubusercontent.com/20594326/57300645-e3576f00-70f4-11e9-81fb-614df3a32824.png">

### NOW

<img width="433" alt="Screenshot 2019-05-07 at 6 20 28 PM" src="https://user-images.githubusercontent.com/20594326/57300669-efdbc780-70f4-11e9-8fb2-9fff4ead1e8c.png">
