### PR TITLE
sinon.resetHistory() does not reset history

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -10,6 +10,8 @@ var nise = require("nise");
 var Sandbox = require("./sinon/sandbox");
 var stub = require("./sinon/stub");
 
+var sandbox = new Sandbox();
+
 var apiMethods = {
     createSandbox: createSandbox,
     assert: require("./sinon/assert"),
@@ -17,7 +19,6 @@ var apiMethods = {
     spyCall: require("./sinon/call"),
 
     expectation: require("./sinon/mock-expectation"),
-    createStubInstance: require("./sinon/stub").createStubInstance,
     defaultConfig: require("./sinon/util/core/default-config"),
 
     setFormatter: format.setFormatter,
@@ -49,8 +50,6 @@ var legacySandboxAPI = {
         )
     }
 };
-
-var sandbox = new Sandbox();
 
 var api = extend(sandbox, legacySandboxAPI, apiMethods);
 

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -10,8 +10,6 @@ var nise = require("nise");
 var Sandbox = require("./sinon/sandbox");
 var stub = require("./sinon/stub");
 
-var sandbox = new Sandbox();
-
 var apiMethods = {
     createSandbox: createSandbox,
     assert: require("./sinon/assert"),
@@ -51,6 +49,7 @@ var legacySandboxAPI = {
     }
 };
 
+var sandbox = new Sandbox();
 var api = extend(sandbox, legacySandboxAPI, apiMethods);
 
 module.exports = api;

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -50,6 +50,7 @@ var legacySandboxAPI = {
 };
 
 var sandbox = new Sandbox();
+
 var api = extend(sandbox, legacySandboxAPI, apiMethods);
 
 module.exports = api;

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -601,16 +601,14 @@ describe("issues", function() {
     });
 
     describe("#2016", function() {
-        var sandbox;
-
         function Foo() {
             return;
         }
-
-        Foo.prototype.testMethod = function testMethod() {
+        Foo.prototype.testMethod = function() {
             return;
         };
 
+        var sandbox;
         beforeEach(function() {
             sandbox = sinon.createStubInstance(Foo);
         });
@@ -623,6 +621,7 @@ describe("issues", function() {
             it("should clear 'called' status on stub", function() {
                 sandbox.testMethod();
                 assert.isTrue(sandbox.testMethod.called);
+
                 sandbox.testMethod.resetHistory();
                 assert.isFalse(sandbox.testMethod.called);
             });
@@ -632,6 +631,7 @@ describe("issues", function() {
             it("should clear 'called' status on all stubs", function() {
                 sandbox.testMethod();
                 assert.isTrue(sandbox.testMethod.called);
+
                 sinon.resetHistory();
                 assert.isFalse(sandbox.testMethod.called);
             });

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -599,4 +599,42 @@ describe("issues", function() {
             assert.equals(fake.lastArg, false);
         });
     });
+
+    describe("#2016", function() {
+        var sandbox;
+
+        function Foo() {
+            return;
+        }
+
+        Foo.prototype.testMethod = function testMethod() {
+            return;
+        };
+
+        beforeEach(function() {
+            sandbox = sinon.createStubInstance(Foo);
+        });
+
+        afterEach(function() {
+            sinon.restore();
+        });
+
+        describe("called on individual stub method", function() {
+            it("should clear 'called' status on stub", function() {
+                sandbox.testMethod();
+                assert.isTrue(sandbox.testMethod.called);
+                sandbox.testMethod.resetHistory();
+                assert.isFalse(sandbox.testMethod.called);
+            });
+        });
+
+        describe("called on module", function() {
+            it("should clear 'called' status on all stubs", function() {
+                sandbox.testMethod();
+                assert.isTrue(sandbox.testMethod.called);
+                sinon.resetHistory();
+                assert.isFalse(sandbox.testMethod.called);
+            });
+        });
+    });
 });


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Fix issue: https://github.com/sinonjs/sinon/issues/2016 `sinon.resetHistory()` does not reset history

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
Remove `createStubInstance` from `sinon.js` so same method from `sandbox` will be used.

 #### How to verify - mandatory
No tests added yet.
But followed below code snippet.
```js
const sinon = require('../../my_sinon_fork/sinon/');
const { assert } = require('referee');

describe('resetHistory', function() {
  var num = null;

  beforeEach(function() {
    num = sinon.createStubInstance(Number);
  });

  afterEach(() => {
    // Restore the default sandbox here
    sinon.restore();
  });

  describe('num.toFixed.resetHistory()', function() {
    it('num.toFixed.resetHistory()', function() {
      num.toFixed();
      assert.isTrue(num.toFixed.called);
      num.toFixed.resetHistory();
      assert.isFalse(num.toFixed.called);
    });
  });

  describe('sinon.resetHistory()', function() {
    it('sinon.resetHistory()', function() {
      num.toFixed();
      assert.isTrue(num.toFixed.called);
      sinon.resetHistory();
      assert.isFalse(num.toFixed.called);
    });
  });
});

```
Need to execute as follows.
`mocha test.js`
Got the following output.
```
  resetHistory
    num.toFixed.resetHistory()
      ✓ num.toFixed.resetHistory()
    sinon.resetHistory()
      ✓ sinon.resetHistory()


  2 passing (27ms)
```
 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
