### PR TITLE
Fix Broken Link to Assertions Page on the Sandbox page

### DIFF
--- a/docs/_releases/latest/sandbox.md
+++ b/docs/_releases/latest/sandbox.md
@@ -139,7 +139,7 @@ sinon.config = {
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 *Since `sinon@2.0.0`*
 

--- a/docs/_releases/v7.3.2/sandbox.md
+++ b/docs/_releases/v7.3.2/sandbox.md
@@ -139,7 +139,7 @@ sinon.config = {
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 *Since `sinon@2.0.0`*
 


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

Fix [Issue 2013](https://github.com/sinonjs/sinon/issues/2013) by changing the relative link to the assertions page.

 #### Solution

The issue was the relative link to assertions in sandbox.md was `./assertions` but should have been `../assertions`. I made this change in `_releases/latest/sandbox.md` and `_releases/v7.3.2/sandbox.md`

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Follow [the steps to locally deploy the documentation site](https://github.com/sinonjs/sinon/blob/master/docs/CONTRIBUTING.md#running-the-documentation-site-locally)
4. Go to http://localhost:4000/releases/v7.3.2/sandbox/
5. Do a `Ctrl+F` to search for sinon.assert (There should only be one instance)
6. Click the link and verify it leads to the assertions page

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
