### PR TITLE
2026 - Updated to support spying all methods on an object

### DIFF
--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -32,6 +32,40 @@ handles a callback, as in the following simplified example:
 }
 ```
 
+### Using a spy to wrap all object method
+
+`sinon.spy(object)`
+
+Spies all the object's methods.
+
+Note that it's usually better practice to spy individual methods, particularly on objects that you don't understand or control all the methods for (e.g. library dependencies).
+
+spying individual methods tests intent more precisely and is less susceptible to unexpected behavior as the object's code evolves.
+
+ The following is a slightly contrived example:
+
+```javascript
+{
+    sandbox: sinon.createSandbox(),
+
+    setUp: function () {
+        this.sandbox.spy(jQuery);
+    },
+
+    tearDown: function () {
+        this.sandbox.restore(); // Unwraps all spied methods
+    },
+
+    "test should inspect jQuery.getJSON's usage of jQuery.ajax": function () {
+        jQuery.getJSON("/some/resource");
+
+        assert(jQuery.ajax.calledOnce);
+        assertEquals("/some/resource", jQuery.ajax.getCall(0).args[0].url);
+        assertEquals("json", jQuery.ajax.getCall(0).args[0].dataType);
+    }
+}
+```
+
 
 ### Using a spy to wrap an existing method
 

--- a/lib/sinon/spy-entire-object.js
+++ b/lib/sinon/spy-entire-object.js
@@ -1,0 +1,22 @@
+"use strict";
+
+var getPropertyDescriptor = require("./util/core/get-property-descriptor");
+var walk = require("./util/core/walk");
+
+function spyEntireObject(spy, object) {
+    walk(object || {}, function(prop, propOwner) {
+        // we don't want to spy things like toString(), valueOf(), etc. so we only spy if the object
+        // is not Object.prototype
+        if (
+            propOwner !== Object.prototype &&
+            prop !== "constructor" &&
+            typeof getPropertyDescriptor(propOwner, prop).value === "function"
+        ) {
+            spy(object, prop);
+        }
+    });
+
+    return object;
+}
+
+module.exports = spyEntireObject;

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -9,6 +9,7 @@ var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var deepEqual = require("@sinonjs/samsam").deepEqual;
 var isEsModule = require("./util/core/is-es-module");
 var spyCall = require("./call");
+var spyEntireObject = require("./spy-entire-object");
 var wrapMethod = require("./util/core/wrap-method");
 var sinonFormat = require("./util/core/format");
 var valueToString = require("@sinonjs/commons").valueToString;
@@ -34,6 +35,10 @@ function spy(object, property, types) {
 
     if (!property && typeof object === "function") {
         return spy.create(object);
+    }
+
+    if (!property && typeof object === "object") {
+        return spyEntireObject(spy, object);
     }
 
     if (!object && !property) {

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -54,6 +54,25 @@ describe("assert", function() {
         });
     });
 
+    it("supports no properties", function() {
+        var api = {
+            method1: function() {
+                return;
+            },
+            method2: function() {
+                return;
+            }
+        };
+        sinonSpy(api);
+        api.method1();
+        api.method2();
+
+        refute.exception(function() {
+            sinonAssert.calledOnce(api.method1);
+            sinonAssert.calledOnce(api.method2);
+        });
+    });
+
     describe(".fail", function() {
         beforeEach(function() {
             this.exceptionName = sinonAssert.failException;


### PR DESCRIPTION
 #### Purpose
Fix issue #2026 by adding **spyEntireObject** to the supported signature of sinon.spy
added tests and updated docs to reflect the change

 #### How to verify
1. Check out this branch
2. `npm install`
3. npm run test
4. note: **assert-test** / **supports no properties** uses the newly added syntax and no other tests are broken
```
sinonSpy(api);
```

 #### Checklist for author

- [X] `npm run lint` passes
- [X] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
