### PR TITLE
Fix broken link to matchers in spies and spy-call docs

### DIFF
--- a/docs/_releases/latest/spies.md
+++ b/docs/_releases/latest/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/latest/spy-call.md
+++ b/docs/_releases/latest/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.4/spies.md
+++ b/docs/_releases/v6.1.4/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.4/spy-call.md
+++ b/docs/_releases/v6.1.4/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.4/spy-call.md
+++ b/docs/_releases/v6.1.4/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v6.1.5/spies.md
+++ b/docs/_releases/v6.1.5/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.5/spy-call.md
+++ b/docs/_releases/v6.1.5/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.5/spy-call.md
+++ b/docs/_releases/v6.1.5/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v6.1.6/spies.md
+++ b/docs/_releases/v6.1.6/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.6/spy-call.md
+++ b/docs/_releases/v6.1.6/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.1.6/spy-call.md
+++ b/docs/_releases/v6.1.6/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v6.2.0/spies.md
+++ b/docs/_releases/v6.2.0/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.2.0/spy-call.md
+++ b/docs/_releases/v6.2.0/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.2.0/spy-call.md
+++ b/docs/_releases/v6.2.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v6.3.0/spies.md
+++ b/docs/_releases/v6.3.0/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.0/spy-call.md
+++ b/docs/_releases/v6.3.0/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.0/spy-call.md
+++ b/docs/_releases/v6.3.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v6.3.1/spies.md
+++ b/docs/_releases/v6.3.1/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.1/spy-call.md
+++ b/docs/_releases/v6.3.1/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.1/spy-call.md
+++ b/docs/_releases/v6.3.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v6.3.2/spies.md
+++ b/docs/_releases/v6.3.2/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.2/spy-call.md
+++ b/docs/_releases/v6.3.2/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.2/spy-call.md
+++ b/docs/_releases/v6.3.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v6.3.3/spies.md
+++ b/docs/_releases/v6.3.3/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.3/spy-call.md
+++ b/docs/_releases/v6.3.3/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.3/spy-call.md
+++ b/docs/_releases/v6.3.3/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v6.3.4/spies.md
+++ b/docs/_releases/v6.3.4/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.4/spy-call.md
+++ b/docs/_releases/v6.3.4/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.4/spy-call.md
+++ b/docs/_releases/v6.3.4/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v6.3.5/spies.md
+++ b/docs/_releases/v6.3.5/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.5/spy-call.md
+++ b/docs/_releases/v6.3.5/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v6.3.5/spy-call.md
+++ b/docs/_releases/v6.3.5/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.0.0/spies.md
+++ b/docs/_releases/v7.0.0/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.0.0/spy-call.md
+++ b/docs/_releases/v7.0.0/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.0.0/spy-call.md
+++ b/docs/_releases/v7.0.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.1.0/spies.md
+++ b/docs/_releases/v7.1.0/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.1.0/spy-call.md
+++ b/docs/_releases/v7.1.0/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.1.0/spy-call.md
+++ b/docs/_releases/v7.1.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.1.1/spies.md
+++ b/docs/_releases/v7.1.1/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.1.1/spy-call.md
+++ b/docs/_releases/v7.1.1/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.1.1/spy-call.md
+++ b/docs/_releases/v7.1.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.2.0/spies.md
+++ b/docs/_releases/v7.2.0/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.0/spy-call.md
+++ b/docs/_releases/v7.2.0/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.0/spy-call.md
+++ b/docs/_releases/v7.2.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.2.1/spies.md
+++ b/docs/_releases/v7.2.1/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.1/spy-call.md
+++ b/docs/_releases/v7.2.1/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.1/spy-call.md
+++ b/docs/_releases/v7.2.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.2.2/spies.md
+++ b/docs/_releases/v7.2.2/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.2/spy-call.md
+++ b/docs/_releases/v7.2.2/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.2/spy-call.md
+++ b/docs/_releases/v7.2.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.2.3/spies.md
+++ b/docs/_releases/v7.2.3/spies.md
@@ -277,7 +277,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -382,7 +382,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -472,3 +472,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.3/spy-call.md
+++ b/docs/_releases/v7.2.3/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.3/spy-call.md
+++ b/docs/_releases/v7.2.3/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.2.4/spies.md
+++ b/docs/_releases/v7.2.4/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.4/spy-call.md
+++ b/docs/_releases/v7.2.4/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.4/spy-call.md
+++ b/docs/_releases/v7.2.4/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.2.5/spies.md
+++ b/docs/_releases/v7.2.5/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.5/spy-call.md
+++ b/docs/_releases/v7.2.5/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.5/spy-call.md
+++ b/docs/_releases/v7.2.5/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.2.6/spies.md
+++ b/docs/_releases/v7.2.6/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.6/spy-call.md
+++ b/docs/_releases/v7.2.6/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.6/spy-call.md
+++ b/docs/_releases/v7.2.6/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.2.7/spies.md
+++ b/docs/_releases/v7.2.7/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.7/spy-call.md
+++ b/docs/_releases/v7.2.7/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.2.7/spy-call.md
+++ b/docs/_releases/v7.2.7/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.3.0/spies.md
+++ b/docs/_releases/v7.3.0/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.3.0/spy-call.md
+++ b/docs/_releases/v7.3.0/spy-call.md
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.3.0/spy-call.md
+++ b/docs/_releases/v7.3.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 

--- a/docs/_releases/v7.3.1/spies.md
+++ b/docs/_releases/v7.3.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.3.1/spy-call.md
+++ b/docs/_releases/v7.3.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.3.2/spies.md
+++ b/docs/_releases/v7.3.2/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.3.2/spy-call.md
+++ b/docs/_releases/v7.3.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

- fixes relative links for `/matchers` in `/spies` and `/spy-call` documentation pages
- affected versions: `v6.1.4` to `latest`

##### Screenshots of Repro:

![image](https://user-images.githubusercontent.com/1915925/59231800-02439800-8bb0-11e9-9fc3-f1c65279c9cb.png)

![image](https://user-images.githubusercontent.com/1915925/59231823-18515880-8bb0-11e9-8379-81ad182b3f12.png)

![image](https://user-images.githubusercontent.com/1915925/59231882-37e88100-8bb0-11e9-9c41-8348d964767d.png)

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

 #### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. Follow the steps to [serve the documentation site](https://github.com/sinonjs/sinon/blob/master/docs/CONTRIBUTING.md#running-the-documentation-site-locally)
4. Go to http://localhost:4000/releases/v7.3.2/spies/
5. Find `(see matchers)` on the page; click the link; verify it leads to the matchers page
6. Go to http://localhost:4000/releases/v7.3.2/spy-call/
7. Find `(see matchers)` on the page; click the link; verify it leads to the matchers page

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
