### PR TITLE
Explain how to restore a wholly stubbed object

### DIFF
--- a/docs/_releases/latest/stubs.md
+++ b/docs/_releases/latest/stubs.md
@@ -86,7 +86,7 @@ A [codemod is available](https://github.com/hurrymaplelad/sinon-codemod) to upgr
 
 #### `var stub = sinon.stub(obj);`
 
-Stubs all the object's methods.
+Stubs all the object's methods. Use the `restore` utility to restore an object stubbed this way.
 
 Note that it's usually better practice to stub individual methods, particularly on objects that you don't understand or control all the methods for (e.g. library dependencies).
 


### PR DESCRIPTION
 #### Purpose (TL;DR)

To help those trying to restore a wholly-stubbed object via `sinon.stub(obj)`.

 #### Background

* Solution and doc change proposed in #1553 
* Whoever is reading this will still need to figure out how to access the utility. It functions as a clue more than a real solution. There are a few reasons I'm not explaining how to use it:
    1. This doesn't feel like the right place to explain how to import a utility.
    1. I'm using `restore` by directly importing the util via `import restore from 'sinon/lib/sinon/util/core/restore.js'`. I wonder if there's a more direct way to access it that would be better to recommend.
    1. [This page](https://sinonjs.org/releases/latest/utils/) makes me unsure whether or not it's something you want to draw attention to at all.

 #### How to verify - mandatory

NA. It's a documentation change.

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
