### PR TITLE
Documentation for stubbing modules

### DIFF
--- a/docs/_howto/stub-dependency.md
+++ b/docs/_howto/stub-dependency.md
@@ -1,0 +1,54 @@
+---
+layout: page
+title: How to stub a dependency of a module?
+---
+
+Sinon is simply a stubbing library, not a module interception library. Stubbing dependencies is highly dependant on your enviroment and the implementation. For Node environments, we usually recommend solutions targetting [link seams](./link-seams-commonjs) or explicit dependency injection. Though in some simple cases, you can get away with just using Sinon by modifying the module exports of the dependency.
+
+To stub a dependency (imported module) of a module under test you have to import it explicitly in your test and stub the desired method. For the stubbing to work, the stubbed method cannot be [destructured](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment), neither in the module under test nor in the test.
+
+## Example: dependencyModule.js
+```javascript
+
+function getSecretNumber() {
+  return 44;
+}
+
+module.exports = {
+  getSecretNumber
+};
+```
+
+## Example: moduleUnderTest.js
+
+```javascript
+const dependencyModule = require("./dependencyModule");
+
+function getTheSecret() {
+  return `The secret was: ${dependencyModule.getSecretNumber()}`;
+}
+
+module.exports = {
+  getTheSecret
+};
+```
+
+## Example: test.js
+
+```javascript
+const assert = require("assert");
+const sinon = require("sinon");
+
+const dependencyModule = require("./dependencyModule");
+const { getTheSecret } = require("./moduleUnderTest");
+
+describe("moduleUnderTest", function() {
+  describe("when the secret is 3", function() {
+    it("should be returned with a string prefix", function() {
+      sinon.stub(dependencyModule, "getSecretNumber").returns(3);
+      const result = getTheSecret();
+      assert.equal(result, "The secret was: 3");
+    });
+  });
+});
+```

--- a/docs/_releases/latest/stubs.md
+++ b/docs/_releases/latest/stubs.md
@@ -76,6 +76,8 @@ Replaces `object.method` with a stub function. An exception is thrown if the pro
 
 The original function can be restored by calling `object.method.restore();` (or `stub.restore();`).
 
+Stubs can be used to replace a module's dependencies, ensuring it is tested in isolation. [For simple cases](../../_howto/stub-dependency.md) you might not need additional helper libraries, but for more complex cases you might need to [target the module loading mechanisms](../../link-seams-commonjs.md).
+
 #### ~~`var stub = sinon.stub(object, "method", func);`~~
 
 This has been removed from `v3.0.0`. Instead you should use


### PR DESCRIPTION
It is not obvious from the documentation how you stub external dependencies (modules that are imported from the modules under test).
I feel we should add something to help users with this common use case.
What do you think?

 #### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->


<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. <your-steps-here>

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
