### PR TITLE
Add documentation on how to test methods that return promises, linked…

### DIFF
--- a/docs/_howto/stub-dependency.md
+++ b/docs/_howto/stub-dependency.md
@@ -1,15 +1,17 @@
 ---
 layout: page
-title: How to stub a dependency of a module?
+title: How to stub a dependency of a module
 ---
 
 Sinon is simply a stubbing library, not a module interception library. Stubbing dependencies is highly dependant on your enviroment and the implementation. For Node environments, we usually recommend solutions targetting [link seams](../link-seams-commonjs/) or explicit dependency injection. Though in some simple cases, you can get away with just using Sinon by modifying the module exports of the dependency.
 
 To stub a dependency (imported module) of a module under test you have to import it explicitly in your test and stub the desired method. For the stubbing to work, the stubbed method cannot be [destructured](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment), neither in the module under test nor in the test.
 
-## Example: dependencyModule.js
-```javascript
+## A simple example
 
+### Source file: dependencyModule.js
+
+```javascript
 function getSecretNumber() {
   return 44;
 }
@@ -19,7 +21,7 @@ module.exports = {
 };
 ```
 
-## Example: moduleUnderTest.js
+### Source file: moduleUnderTest.js
 
 ```javascript
 const dependencyModule = require("./dependencyModule");
@@ -33,7 +35,7 @@ module.exports = {
 };
 ```
 
-## Example: test.js
+### Test file: test.js
 
 ```javascript
 const assert = require("assert");
@@ -48,6 +50,131 @@ describe("moduleUnderTest", function() {
       sinon.stub(dependencyModule, "getSecretNumber").returns(3);
       const result = getTheSecret();
       assert.equal(result, "The secret was: 3");
+    });
+  });
+});
+```
+
+## A complex example with asynchronous code
+
+In some cases you might need to stub a dependency that returns a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). To test it you can add the [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) keyword to the test method and call the method being tested with the [await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) keyword.
+
+### Source file: userApi.js
+
+```javascript
+const axios = require("axios");
+
+async function getPageOfUsers(page) {
+  const result = await axios({
+    method: "GET",
+    url: `https://reqres.in/api/users?page=${page}`
+  });
+  return result.data;
+}
+
+module.exports = {
+  getPageOfUsers
+};
+```
+
+### Source file: userUtils.js
+
+```javascript
+const userApi = require("./userApi");
+
+async function getAllUsers() {
+  const users = [];
+
+  let page = 0,
+    usersPage = null;
+
+  do {
+    page += 1;
+    usersPage = await userApi.getPageOfUsers(page);
+
+    users.push(...usersPage.data);
+  } while (usersPage.total_pages > page);
+
+  return users;
+}
+
+module.exports = {
+  getAllUsers
+};
+```
+
+### Test file: UserUtils-test.js
+
+```javascript
+const assert = require("assert");
+const sinon = require("sinon");
+const userUtils = require("./userUtils");
+const userApi = require("./userApi");
+
+function aUser(id) {
+  return {
+    id,
+    email: `someemail@user${id}.com`,
+    first_name: `firstName${id}`,
+    last_name: `lastName${id}`,
+    avatar: `https://www.somepage${id}.com`
+  };
+}
+
+describe("userUtils", function() {
+  let getPageOfUsersStub;
+
+  beforeEach(function() {
+    getPageOfUsersStub = sinon.stub(userApi, "getPageOfUsers");
+  });
+
+  afterEach(function() {
+    getPageOfUsersStub.restore();
+  });
+
+  describe("when a single page of users exists", function() {
+    it("should return users from that page", async function() {
+      // Arrange
+      const pageOfUsers = {
+        page: 1,
+        total_pages: 1,
+        data: [aUser(1), aUser(2), aUser(3)]
+      };
+
+      getPageOfUsersStub.returns(Promise.resolve(pageOfUsers));
+
+      // Act
+      const result = await userUtils.getAllUsers();
+
+      // Assert
+      assert.equal(result.length, 3);
+      assert.equal(getPageOfUsersStub.calledOnce, true);
+    });
+  });
+
+  describe("when multiple pages of users exists", function() {
+    it("should return a combined list of all users", async function() {
+      // Arrange
+      const pageOfUsers1 = {
+        page: 1,
+        total_pages: 2,
+        data: [aUser(1), aUser(2), aUser(3)]
+      };
+      const pageOfUsers2 = {
+        page: 2,
+        total_pages: 2,
+        data: [aUser(4), aUser(5)]
+      };
+
+      getPageOfUsersStub.withArgs(1).returns(Promise.resolve(pageOfUsers1));
+      getPageOfUsersStub.withArgs(2).returns(Promise.resolve(pageOfUsers2));
+
+      // Act
+      const result = await userUtils.getAllUsers();
+
+      // Assert
+      assert.equal(result.length, 5);
+      assert.equal(getPageOfUsersStub.callCount, 2);
     });
   });
 });


### PR DESCRIPTION
Issue https://github.com/sinonjs/sinon/issues/1898 is stale and talks about missing documentation for promises. Is this something we would like?

I can change the code to use dependency injection if we think more developers would use that. If we want that we need to decide constructor or property injection... :)

 #### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->


<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. <your-steps-here>

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
