### PR TITLE
Add link to PluralSight course on Sinon

### DIFF
--- a/docs/_data/external_howtos.yml
+++ b/docs/_data/external_howtos.yml
@@ -21,3 +21,6 @@
 
 - title: Stubbing Node Authentication Middleware with Sinon
   url: http://mherman.org/blog/2018/01/22/stubbing-node-authentication-middleware-with-sinon
+
+- title: SinonJS Fundamentals
+  url: https://www.pluralsight.com/courses/sinonjs-fundamentals


### PR DESCRIPTION
This PR adds a link to the PluralSight course ["SinonJS Fundamentals"](https://www.pluralsight.com/courses/sinonjs-fundamentals).

 #### Checklist for author

~~- [ ] `npm run lint` passes~~
~~- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).~~