### PR TITLE
add browser field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "LICENSE",
     "README.md"
   ],
+  "browser": "./lib/sinon.js",
   "main": "./lib/sinon.js",
   "module": "./pkg/sinon-esm.js",
   "cdn": "./pkg/sinon.js",


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

It makes bundlers(webpack, rollup) to pick up the es5 version by default when targeting browsers. It solves issues like https://github.com/sinonjs/sinon/issues/1951


 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. use webpack to bundle tests without compiling sinon
4. run tests in non-es6 ready browsers, e.g. IE11 
5. tests should run successfully
