### PR TITLE
add callThroughWithNew method

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -405,6 +405,27 @@ obj.sum.callThrough();
 
 obj.sum(2, 2); // 'bar'
 obj.sum(1, 2); // 3
+
+
+#### `stub.callThroughWithNew();`
+
+Causes the original method wrapped into the stub to be called using the `new` operator when none of the conditional stubs are matched.
+
+```javascript
+var obj = {};
+
+obj.Sum = function MyConstructor(a, b) {
+    this.result = a + b;
+};
+
+sinon
+    .stub(obj, 'Sum')
+    .callThroughWithNew()
+    .withArgs(1, 2)
+    .returns({ result: 9000 });
+
+(new obj.Sum(2, 2)).result;  // 4
+(new obj.Sum(1, 2)).result;  // 9000
 ```
 
 

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -8,7 +8,6 @@ var valueToString = require("@sinonjs/commons").valueToString;
 var exportAsyncBehaviors = require("./util/core/export-async-behaviors");
 
 var concat = arrayProto.concat;
-var flat = arrayProto.flat;
 var join = arrayProto.join;
 var reverse = arrayProto.reverse;
 var slice = arrayProto.slice;
@@ -176,8 +175,12 @@ var proto = {
 
             return wrappedMethod.apply(context, args);
         } else if (this.callsThroughWithNew) {
+            // Get the original method (assumed to be a constructor in this case)
             var WrappedClass = this.effectiveWrappedMethod();
-            var F = WrappedClass.bind.apply(WrappedClass, concat([null], flat(args)));
+            // Turn the arguments object into a normal array
+            var argsArray = slice(args);
+            // Call the constructor
+            var F = WrappedClass.bind.apply(WrappedClass, concat([null], argsArray));
             return new F();
         } else if (typeof this.returnValue !== "undefined") {
             return this.returnValue;

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -135,6 +135,7 @@ var proto = {
         );
     },
 
+    /*eslint complexity: ["error", 20]*/
     invoke: function invoke(context, args) {
         /*
          * callCallback (conditionally) calls ensureArgs
@@ -171,7 +172,11 @@ var proto = {
             return (this.promiseLibrary || Promise).reject(this.returnValue);
         } else if (this.callsThrough) {
             var wrappedMethod = this.effectiveWrappedMethod();
+
             return wrappedMethod.apply(context, args);
+        } else if (this.callsThroughWithNew) {
+            var WrappedClass = this.effectiveWrappedMethod();
+            return new WrappedClass(args);
         } else if (typeof this.returnValue !== "undefined") {
             return this.returnValue;
         } else if (typeof this.callArgAt === "number") {

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -8,6 +8,7 @@ var valueToString = require("@sinonjs/commons").valueToString;
 var exportAsyncBehaviors = require("./util/core/export-async-behaviors");
 
 var concat = arrayProto.concat;
+var flat = arrayProto.flat;
 var join = arrayProto.join;
 var reverse = arrayProto.reverse;
 var slice = arrayProto.slice;
@@ -176,7 +177,8 @@ var proto = {
             return wrappedMethod.apply(context, args);
         } else if (this.callsThroughWithNew) {
             var WrappedClass = this.effectiveWrappedMethod();
-            return new WrappedClass(args);
+            var F = WrappedClass.bind.apply(WrappedClass, concat([null], flat(args)));
+            return new F();
         } else if (typeof this.returnValue !== "undefined") {
             return this.returnValue;
         } else if (typeof this.callArgAt === "number") {

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -221,6 +221,10 @@ var defaultBehaviors = {
         fake.callsThrough = true;
     },
 
+    callThroughWithNew: function callThroughWithNew(fake) {
+        fake.callsThroughWithNew = true;
+    },
+
     get: function get(fake, getterFunction) {
         var rootStub = fake.stub || fake;
 

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   "esm": {
     "cjs": {
       "mutableNamespace": false,
-      "cache":true
+      "cache": true
     },
     "mode": "auto"
   }

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -3136,6 +3136,73 @@ describe("stub", function() {
         });
     });
 
+    describe(".callThroughWithNew", function() {
+        it("does not call original function with new when arguments match conditional stub", function() {
+            // We need a function here because we can't wrap properties that are already stubs
+            var callCount = 0;
+            var OriginalClass = function SomeClass() {
+                this.foo = "bar";
+                callCount++;
+            };
+
+            var myObj = {
+                MyClass: OriginalClass
+            };
+
+            var propStub = createStub(myObj, "MyClass");
+            propStub.withArgs("foo").returns({ foo: "bar" });
+            propStub.callThroughWithNew(propStub);
+
+            var result = new myObj.MyClass("foo");
+
+            assert.equals(result.foo, "bar");
+            assert.equals(callCount, 0);
+        });
+
+        it("calls original function with new when arguments do not match conditional stub", function() {
+            var callCount = 0;
+            function OriginalClass() {
+                this.foo = "baz";
+                callCount++;
+            }
+
+            var myObj = {
+                MyClass: OriginalClass
+            };
+
+            var propStub = createStub(myObj, "MyClass");
+            propStub.withArgs("foo").returns({ foo: "bar" });
+            propStub.callThroughWithNew(propStub);
+
+            var result = new myObj.MyClass("not foo");
+            assert.equals(result.foo, "baz");
+            assert.equals(callCount, 1);
+        });
+
+        it("calls original function with new with same arguments when call does not match conditional stub", function() {
+            // We need a function here because we can't wrap properties that are already stubs
+            var callArgs = [];
+
+            function OriginalClass() {
+                callArgs = arguments;
+                this.foo = "baz";
+            }
+
+            var myObj = {
+                MyClass: OriginalClass
+            };
+
+            var propStub = createStub(myObj, "MyClass");
+            propStub.withArgs("foo").returns({ foo: "bar" });
+            propStub.callThroughWithNew(propStub);
+
+            var result = new myObj.MyClass("not foo");
+            assert.equals(callArgs[0].length, 1);
+            assert.equals(callArgs[0][0], "not foo");
+            assert.equals(result.foo, "baz");
+        });
+    });
+
     describe(".get", function() {
         it("allows users to stub getter functions for properties", function() {
             var myObj = {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -3176,9 +3176,9 @@ describe("stub", function() {
             propStub.withArgs("foo").returns({ foo: "bar" });
             propStub.callThroughWithNew(propStub);
 
-            var result = new myObj.MyClass("not foo", "definitely not foo");
+            var result = new myObj.MyClass("not foo", ["definitely", "not", "foo"]);
             assert.equals(callArgs[0], "not foo");
-            assert.equals(callArgs[1], "definitely not foo");
+            assert.equals(callArgs[1], ["definitely", "not", "foo"]);
             assert.equals(result.foo, "baz");
         });
     });

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -3159,26 +3159,6 @@ describe("stub", function() {
             assert.equals(callCount, 0);
         });
 
-        it("calls original function with new when arguments do not match conditional stub", function() {
-            var callCount = 0;
-            function OriginalClass() {
-                this.foo = "baz";
-                callCount++;
-            }
-
-            var myObj = {
-                MyClass: OriginalClass
-            };
-
-            var propStub = createStub(myObj, "MyClass");
-            propStub.withArgs("foo").returns({ foo: "bar" });
-            propStub.callThroughWithNew(propStub);
-
-            var result = new myObj.MyClass("not foo");
-            assert.equals(result.foo, "baz");
-            assert.equals(callCount, 1);
-        });
-
         it("calls original function with new with same arguments when call does not match conditional stub", function() {
             // We need a function here because we can't wrap properties that are already stubs
             var callArgs = [];
@@ -3196,9 +3176,9 @@ describe("stub", function() {
             propStub.withArgs("foo").returns({ foo: "bar" });
             propStub.callThroughWithNew(propStub);
 
-            var result = new myObj.MyClass("not foo");
-            assert.equals(callArgs[0].length, 1);
-            assert.equals(callArgs[0][0], "not foo");
+            var result = new myObj.MyClass("not foo", "definitely not foo");
+            assert.equals(callArgs[0], "not foo");
+            assert.equals(callArgs[1], "definitely not foo");
             assert.equals(result.foo, "baz");
         });
     });


### PR DESCRIPTION
This mimics `callThrough`'s behavior but uses the `new` operator as
would be appropriate for classes.

The added `else if` clause to fake.invoke increases that function's
complexity to 20 which is an eslint error by default.  Added an
exception to increase the maximum allowed complexity.

Let me know if this looks like a welcome candidate and I'll add docs.