### PR TITLE
Fix Typo in migration 6 and updated migration docs for migration from…

### DIFF
--- a/docs/guides/migrating-to-6.0.md
+++ b/docs/guides/migrating-to-6.0.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Migrating to v6.0 - Sinon.JS
-breadcrumb: migrating to 5.0
+breadcrumb: migrating to 6.0
 ---
 
 There should be no reason for any code changes with the new Sinon 6. Usually, `MAJOR` releases should come with breaking changes, but there are no known breaking changes in `sinon@6` at the time of this writing. We chose to release a new major version as a [pragmatic solution to some noise related to releasing Sinon 5.1](https://github.com/sinonjs/sinon/pull/1829#issue-193284761), which featured some breaking changes related to ESM (which since has been resolved).

--- a/docs/guides/migrating-to-7.0.md
+++ b/docs/guides/migrating-to-7.0.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: Migrating to v7.0 - Sinon.JS
+breadcrumb: migrating to 7.0
+---
+
+For upgrading to new Sinon 7 there are no known major breaking Changes except **negative ticks** are not allowed in `Sinon@7` due to update to lolex 3. So you cannot use negative values in sinon.useFakeTimers().tick();
+
+
+If you experience any issues moving from Sinon 6 to Sinon 7, [please let us know!](https://github.com/sinonjs/sinon/issues/new?template=Bug_report.md).
+

--- a/docs/guides/migrating-to-7.0.md
+++ b/docs/guides/migrating-to-7.0.md
@@ -4,7 +4,7 @@ title: Migrating to v7.0 - Sinon.JS
 breadcrumb: migrating to 7.0
 ---
 
-For upgrading to new Sinon 7 there are no known major breaking Changes except **negative ticks** are not allowed in `Sinon@7` due to update to lolex 3. So you cannot use negative values in sinon.useFakeTimers().tick();
+For upgrading to new Sinon 7 there is no known major breaking Change except **negative ticks** are not allowed in `Sinon@7` due to update to lolex 3. So you cannot use negative values in sinon.useFakeTimers().tick();
 
 
 If you experience any issues moving from Sinon 6 to Sinon 7, [please let us know!](https://github.com/sinonjs/sinon/issues/new?template=Bug_report.md).

--- a/docs/guides/migrating-to-7.0.md
+++ b/docs/guides/migrating-to-7.0.md
@@ -4,7 +4,7 @@ title: Migrating to v7.0 - Sinon.JS
 breadcrumb: migrating to 7.0
 ---
 
-For upgrading to new Sinon 7 there is no known major breaking Change except **negative ticks** are not allowed in `Sinon@7` due to update to lolex 3. So you cannot use negative values in sinon.useFakeTimers().tick();
+For users upgrading to Sinon 7 the only known breaking API change is that **negative ticks** are not allowed in `Sinon@7` due to updating to lolex 3 internally. This means you cannot use negative values in sinon.useFakeTimers().tick();
 
 
 If you experience any issues moving from Sinon 6 to Sinon 7, [please let us know!](https://github.com/sinonjs/sinon/issues/new?template=Bug_report.md).


### PR DESCRIPTION
 #### Purpose (TL;DR) -  Created Migration guide for migration from version 6 to version 7
<!--
>
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->


<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3.  check the migrating-to-7.0.md file for migration steps

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
