### PR TITLE
Restore sinon.createStubInstance() behaviour

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -51,11 +51,18 @@ function Sandbox() {
         return fakeRestorers;
     };
 
-    sandbox.createStubInstance = function createStubInstance(constructor) {
-        if (typeof constructor !== "function") {
-            throw new TypeError("The constructor should be a function.");
-        }
-        return this.stub(Object.create(constructor.prototype));
+    sandbox.createStubInstance = function createStubInstance() {
+        var stubbed = sinonStub.createStubInstance.apply(null, arguments);
+
+        var ownMethods = collectOwnMethods(stubbed);
+
+        forEach(ownMethods, function(method) {
+            push(collection, method);
+        });
+
+        usePromiseLibrary(promiseLib, ownMethods);
+
+        return stubbed;
     };
 
     sandbox.inject = function inject(obj) {

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -657,4 +657,27 @@ describe("issues", function() {
             });
         });
     });
+
+    describe("#2073 - sinon.createStubInstance()", function() {
+        function Foo() {
+            return;
+        }
+        Foo.prototype.testMethod = function() {
+            return 1;
+        };
+
+        it("should override the method", function() {
+            var thing = sinon.createStubInstance(Foo, {
+                testMethod: sinon.stub().returns(2)
+            });
+            assert.equals(thing.testMethod(), 2);
+        });
+
+        it("should support calling without object binding", function() {
+            var createStubInstance = sinon.createStubInstance;
+            refute.exception(function() {
+                createStubInstance(Foo);
+            });
+        });
+    });
 });

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -280,6 +280,71 @@ describe("Sandbox", function() {
                 });
             }
         });
+
+        it("allows providing optional overrides", function() {
+            var Class = function() {
+                return;
+            };
+            Class.prototype.method = function() {
+                return;
+            };
+
+            var stub = this.sandbox.createStubInstance(Class, {
+                method: sinonStub().returns(3)
+            });
+
+            assert.equals(3, stub.method());
+        });
+
+        it("allows providing optional returned values", function() {
+            var Class = function() {
+                return;
+            };
+            Class.prototype.method = function() {
+                return;
+            };
+
+            var stub = this.sandbox.createStubInstance(Class, {
+                method: 3
+            });
+
+            assert.equals(3, stub.method());
+        });
+
+        it("allows providing null as a return value", function() {
+            var Class = function() {
+                return;
+            };
+            Class.prototype.method = function() {
+                return;
+            };
+
+            var stub = this.sandbox.createStubInstance(Class, {
+                method: null
+            });
+
+            assert.equals(null, stub.method());
+        });
+
+        it("throws an exception when trying to override non-existing property", function() {
+            var Class = function() {
+                return;
+            };
+            Class.prototype.method = function() {
+                return;
+            };
+
+            var sandbox = this.sandbox;
+
+            assert.exception(
+                function() {
+                    sandbox.createStubInstance(Class, {
+                        foo: sinonStub().returns(3)
+                    });
+                },
+                { message: "Cannot stub foo. Property does not exist!" }
+            );
+        });
     });
 
     describe(".stub", function() {


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
Fix issue #2073 by reusing `createStubInstance()` behaviour from `stub.js` while maintaining the sandbox `collection`.

#### Background (Problem in detail)  - optional
PR #2022 redirected `sinon.createStubInstance()` to use the Sandbox implementation thereof. This introduced a breaking change due to the sandbox implementation not supporting property overrides.

#### Solution  - optional
This PR extends `sandbox.createStubInstance()` to mimic the behaviour of the original `sinon.createStubInstance()` method.

Instead of duplicating the original `createStubInstance()` behaviour from `stub.js` into `sandbox.js`, it now calls through to the `stub.js` implementation, then adds all the stubs to the sandbox `collection` as usual.

The extra tests for property overrides in `stub-test.js` have also been added to `sandbox-test.js` to ensure the  sandbox implementation now works the same as the original `createStubInstance()`, while maintaining backward compatibility with all existing sandbox tests.

EDIT: Added some specific tests for issue #2073 in `issues-test.js`.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

 #### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
