### PR TITLE
Remove coverage from GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,3 @@ jobs:
 
     - name: npm test
       run: npm run test-node
-
-    - name: generate coverage
-      run: npm run test-coverage -- --chrome $(which google-chrome-stable) --allow-chrome-as-root
-      if: matrix.node-version == 10
-    - name: coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.github_token }}
-      if: matrix.node-version == 10


### PR DESCRIPTION
This PR removes coverage calculation from GitHub Actions.-

#### Purpose (TL;DR) - mandatory
In order to not have tests fail (thanks coveralls)

 #### Background (Problem in detail)  - optional

Since e31c41433d65bef1c64b8962f6df83240ce03517 we are calculating
coverage using Codecov via CircleCI


#### Solution  - optional

Only calculate coverage once

 #### How to verify - mandatory

1. Observe that the GitHub Actions pass

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
