### PR TITLE
add documentation about sinon.restoreObject()

### DIFF
--- a/docs/release-source/release/utils.md
+++ b/docs/release-source/release/utils.md
@@ -23,3 +23,21 @@ Creates a new object with the given function as the protoype and stubs all imple
 ```
 
 The given constructor function is not invoked. See also the [stub API](../stubs).
+
+### `sinon.restoreObject(object);`
+
+Restores all methods of an object and returns the restored object.
+
+```javascript
+    const obj = {
+        foo: () => {}
+    }
+    sinon.spy(obj)
+    sinon.restoreObject(obj);
+```
+
+Throws an error if the object contains no restorable methods (spies, stubs, etc).
+
+```javascript
+    sinon.restoreObject({});
+```


### PR DESCRIPTION
 #### Add documentation about `sinon.restoreObject()` related to https://github.com/sinonjs/sinon/issues/2089
 #### How to verify
1. Check out this branch
2. `npm install`
3. Start documentation (https://github.com/sinonjs/sinon/blob/master/docs/CONTRIBUTING.md)
4. Then go to the `utils` section and see `sinon.restoreObject(object);`