### PR TITLE
dependency-check: remove --unused flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test-esm-bundle": "node test/es2015/check-esm-bundle-is-runnable.js",
     "test-docker-image": "docker-compose up",
     "test": "run-s test-node test-headless test-webworker test-esm",
-    "check-dependencies": "dependency-check package.json --unused --no-dev --ignore-module esm",
+    "check-dependencies": "dependency-check package.json --no-dev --ignore-module esm",
     "build": "run-p build-esm build-bundle",
     "build-bundle": "node ./build.js",
     "build-esm": "rollup -c",


### PR DESCRIPTION
This PR removes `--unused` flag from the `dependency-check` task.

#### Background (Problem in detail)  - optional

`--unused` is implicit (default) from `dependency-check@4.0.0`, which we're using
since e2d0d9ae6ed134021b52537d20e30b1023c1caa7

See:
* https://github.com/dependency-check-team/dependency-check/releases/tag/v4.0.0

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run check-dependencies`
1. Observe that it doesn't complain about missing or unused dependencies and that the exit code is zero (`$?`)

