### PR TITLE
refactor: Move behavior setup from spy to stub

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var arrayProto = require("@sinonjs/commons").prototypes.array;
-var createBehavior = require("./behavior").create;
 var extend = require("./util/core/extend");
 var functionName = require("@sinonjs/commons").functionName;
 var functionToString = require("./util/core/function-to-string");
@@ -436,11 +435,6 @@ var spyApi = {
         fake.matchingArguments = args;
         fake.parent = this;
         push(this.fakes, fake);
-
-        if (original.defaultBehavior && original.defaultBehavior.promiseLibrary) {
-            fake.defaultBehavior = fake.defaultBehavior || createBehavior(fake);
-            fake.defaultBehavior.promiseLibrary = original.defaultBehavior.promiseLibrary;
-        }
 
         fake.withArgs = function() {
             return original.withArgs.apply(original, arguments);

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -196,6 +196,15 @@ var proto = {
 
     onThirdCall: function onThirdCall() {
         return this.onCall(2);
+    },
+
+    withArgs: function withArgs() {
+        var fake = spy.withArgs.apply(this, arguments);
+        if (this.defaultBehavior && this.defaultBehavior.promiseLibrary) {
+            fake.defaultBehavior = fake.defaultBehavior || behavior.create(fake);
+            fake.defaultBehavior.promiseLibrary = this.defaultBehavior.promiseLibrary;
+        }
+        return fake;
     }
 };
 
@@ -204,7 +213,6 @@ forEach(Object.keys(behavior), function(method) {
         hasOwnProperty(behavior, method) &&
         !hasOwnProperty(proto, method) &&
         method !== "create" &&
-        method !== "withArgs" &&
         method !== "invoke"
     ) {
         proto[method] = behavior.createBehavior(method);


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

The behavior setup code is not required for spies. It should be done in `stub.js` where it's actually being used.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`
4. Observe that all tests still pass.

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
