### PR TITLE
refactor: Internalize spy.create

### DIFF
--- a/lib/sinon/proxy.js
+++ b/lib/sinon/proxy.js
@@ -1,0 +1,133 @@
+"use strict";
+
+var slice = require("@sinonjs/commons").prototypes.array.slice;
+var extend = require("./util/core/extend");
+var functionToString = require("./util/core/function-to-string");
+
+function createProxy(func, arity) {
+    var length = arity || func.length;
+    var proxy = wrapFunction(func, length);
+
+    // Inherit function properties:
+    extend(proxy, func);
+
+    proxy.prototype = func.prototype;
+
+    extend.nonEnum(proxy, {
+        toString: functionToString
+    });
+
+    return proxy;
+}
+
+function wrapFunction(func, proxyLength) {
+    // Retain the function length:
+    var p;
+    if (proxyLength) {
+        // Do not change this to use an eval. Projects that depend on sinon block the use of eval.
+        // ref: https://github.com/sinonjs/sinon/issues/710
+        switch (proxyLength) {
+            /*eslint-disable no-unused-vars, max-len*/
+            case 1:
+                p = function proxy(a) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 2:
+                p = function proxy(a, b) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 3:
+                p = function proxy(a, b, c) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 4:
+                p = function proxy(a, b, c, d) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 5:
+                p = function proxy(a, b, c, d, e) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 6:
+                p = function proxy(a, b, c, d, e, f) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 7:
+                p = function proxy(a, b, c, d, e, f, g) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 8:
+                p = function proxy(a, b, c, d, e, f, g, h) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 9:
+                p = function proxy(a, b, c, d, e, f, g, h, i) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 10:
+                p = function proxy(a, b, c, d, e, f, g, h, i, j) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 11:
+                p = function proxy(a, b, c, d, e, f, g, h, i, j, k) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            case 12:
+                p = function proxy(a, b, c, d, e, f, g, h, i, j, k, l) {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            default:
+                p = function proxy() {
+                    return p.invoke(func, this, slice(arguments));
+                };
+                break;
+            /*eslint-enable*/
+        }
+    } else {
+        p = function proxy() {
+            return p.invoke(func, this, slice(arguments));
+        };
+    }
+    var nameDescriptor = Object.getOwnPropertyDescriptor(func, "name");
+    if (nameDescriptor && nameDescriptor.configurable) {
+        // IE 11 functions don't have a name.
+        // Safari 9 has names that are not configurable.
+        Object.defineProperty(p, "name", nameDescriptor);
+    }
+    extend.nonEnum(p, {
+        isSinonProxy: true,
+
+        called: false,
+        notCalled: true,
+        calledOnce: false,
+        calledTwice: false,
+        calledThrice: false,
+        callCount: 0,
+        firstCall: null,
+        secondCall: null,
+        thirdCall: null,
+        lastCall: null,
+        lastArg: null,
+        args: [],
+        returnValues: [],
+        thisValues: [],
+        exceptions: [],
+        callIds: [],
+        errorsWithCallStack: []
+    });
+    return p;
+}
+
+module.exports = createProxy;

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -1,9 +1,9 @@
 "use strict";
 
 var arrayProto = require("@sinonjs/commons").prototypes.array;
+var createProxy = require("./proxy");
 var extend = require("./util/core/extend");
 var functionName = require("@sinonjs/commons").functionName;
-var functionToString = require("./util/core/function-to-string");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var deepEqual = require("@sinonjs/samsam").deepEqual;
 var isEsModule = require("./util/core/is-es-module");
@@ -24,6 +24,32 @@ var ErrorConstructor = Error.prototype.constructor;
 var bind = Function.prototype.bind;
 
 var callId = 0;
+var uuid = 0;
+
+function createSpy(func, arity) {
+    var name;
+    var funk = func;
+
+    if (typeof funk !== "function") {
+        funk = function() {
+            return;
+        };
+    } else {
+        name = functionName(funk);
+    }
+
+    var proxy = createProxy(funk, arity);
+
+    // Inherit spy API:
+    extend.nonEnum(proxy, spy);
+    extend.nonEnum(proxy, {
+        displayName: name || "spy",
+        instantiateFake: createSpy,
+        id: "spy#" + uuid++
+    });
+    proxy.resetHistory();
+    return proxy;
+}
 
 function spy(object, property, types) {
     var descriptor, methodDesc;
@@ -33,7 +59,7 @@ function spy(object, property, types) {
     }
 
     if (!property && typeof object === "function") {
-        return spy.create(object);
+        return createSpy(object);
     }
 
     if (!property && typeof object === "object") {
@@ -41,20 +67,20 @@ function spy(object, property, types) {
     }
 
     if (!object && !property) {
-        return spy.create(function() {
+        return createSpy(function() {
             return;
         });
     }
 
     if (!types) {
-        return wrapMethod(object, property, spy.create(object[property]));
+        return wrapMethod(object, property, createSpy(object[property]));
     }
 
     descriptor = {};
     methodDesc = getPropertyDescriptor(object, property);
 
     forEach(types, function(type) {
-        descriptor[type] = spy.create(methodDesc[type]);
+        descriptor[type] = createSpy(methodDesc[type]);
     });
 
     return wrapMethod(object, property, descriptor);
@@ -75,118 +101,6 @@ function createCallProperties() {
     this.thirdCall = this.getCall(2);
     this.lastCall = this.getCall(this.callCount - 1);
 }
-
-function createProxy(func, proxyLength) {
-    // Retain the function length:
-    var p;
-    if (proxyLength) {
-        // Do not change this to use an eval. Projects that depend on sinon block the use of eval.
-        // ref: https://github.com/sinonjs/sinon/issues/710
-        switch (proxyLength) {
-            /*eslint-disable no-unused-vars, max-len*/
-            case 1:
-                p = function proxy(a) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 2:
-                p = function proxy(a, b) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 3:
-                p = function proxy(a, b, c) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 4:
-                p = function proxy(a, b, c, d) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 5:
-                p = function proxy(a, b, c, d, e) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 6:
-                p = function proxy(a, b, c, d, e, f) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 7:
-                p = function proxy(a, b, c, d, e, f, g) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 8:
-                p = function proxy(a, b, c, d, e, f, g, h) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 9:
-                p = function proxy(a, b, c, d, e, f, g, h, i) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 10:
-                p = function proxy(a, b, c, d, e, f, g, h, i, j) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 11:
-                p = function proxy(a, b, c, d, e, f, g, h, i, j, k) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 12:
-                p = function proxy(a, b, c, d, e, f, g, h, i, j, k, l) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            default:
-                p = function proxy() {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            /*eslint-enable*/
-        }
-    } else {
-        p = function proxy() {
-            return p.invoke(func, this, slice(arguments));
-        };
-    }
-    var nameDescriptor = Object.getOwnPropertyDescriptor(func, "name");
-    if (nameDescriptor && nameDescriptor.configurable) {
-        // IE 11 functions don't have a name.
-        // Safari 9 has names that are not configurable.
-        Object.defineProperty(p, "name", nameDescriptor);
-    }
-    extend.nonEnum(p, {
-        isSinonProxy: true,
-
-        called: false,
-        notCalled: true,
-        calledOnce: false,
-        calledTwice: false,
-        calledThrice: false,
-        callCount: 0,
-        firstCall: null,
-        secondCall: null,
-        thirdCall: null,
-        lastCall: null,
-        lastArg: null,
-        args: [],
-        returnValues: [],
-        thisValues: [],
-        exceptions: [],
-        callIds: [],
-        errorsWithCallStack: []
-    });
-    return p;
-}
-
-var uuid = 0;
 
 // Public API
 var spyApi = {
@@ -231,38 +145,6 @@ var spyApi = {
         }
 
         return this;
-    },
-
-    create: function create(func, spyLength) {
-        var name;
-        var funk = func;
-
-        if (typeof funk !== "function") {
-            funk = function() {
-                return;
-            };
-        } else {
-            name = functionName(funk);
-        }
-
-        var length = spyLength || funk.length;
-        var proxy = createProxy(funk, length);
-
-        extend.nonEnum(proxy, spy);
-        delete proxy.create;
-        extend(proxy, funk);
-
-        proxy.resetHistory();
-        proxy.prototype = funk.prototype;
-
-        extend.nonEnum(proxy, {
-            displayName: name || "spy",
-            toString: functionToString,
-            instantiateFake: spy.create,
-            id: "spy#" + uuid++
-        });
-
-        return proxy;
     },
 
     invoke: function invoke(func, thisValue, args) {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -3,11 +3,11 @@
 var arrayProto = require("@sinonjs/commons").prototypes.array;
 var behavior = require("./behavior");
 var behaviors = require("./default-behaviors");
+var createProxy = require("./proxy");
 var hasOwnProperty = require("@sinonjs/commons").prototypes.object.hasOwnProperty;
 var isNonExistentOwnProperty = require("./util/core/is-non-existent-own-property");
 var spy = require("./spy");
 var extend = require("./util/core/extend");
-var functionToString = require("./util/core/function-to-string");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var isEsModule = require("./util/core/is-es-module");
 var wrapMethod = require("./util/core/wrap-method");
@@ -130,23 +130,19 @@ var proto = {
             return getCurrentBehavior(fnStub).invoke(this, arguments);
         };
 
-        var orig = functionStub;
-        functionStub = spy.create(functionStub, stubLength);
-
-        extend.nonEnum(functionStub, {
-            id: "stub#" + uuid++,
-            func: orig
-        });
-
+        functionStub = createProxy(functionStub, stubLength);
+        // Inherit spy API:
+        extend(functionStub, spy);
+        // Inherit stub API:
         extend(functionStub, stub);
+        functionStub.resetHistory();
 
         extend.nonEnum(functionStub, {
             instantiateFake: stub.create,
             displayName: "stub",
-            toString: functionToString,
-
             defaultBehavior: null,
-            behaviors: []
+            behaviors: [],
+            id: "stub#" + uuid++
         });
 
         return functionStub;

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -119,7 +119,7 @@ describe("sinonSpy.call", function() {
         beforeEach(spyCallSetUp);
 
         it("gets call object", function() {
-            var spy = sinonSpy.create();
+            var spy = sinonSpy();
             spy();
             var firstCall = spy.getCall(0);
 

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -10,7 +10,7 @@ function spyCalledTests(method) {
     return function() {
         // eslint-disable-next-line mocha/no-top-level-hooks
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("returns false if spy was not called", function() {
@@ -100,7 +100,7 @@ function spyAlwaysCalledTests(method) {
     return function() {
         // eslint-disable-next-line mocha/no-top-level-hooks, mocha/no-sibling-hooks
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         // eslint-disable-next-line mocha/no-identical-title
@@ -161,7 +161,7 @@ function spyNeverCalledTests(method) {
     return function() {
         // eslint-disable-next-line mocha/no-top-level-hooks, mocha/no-sibling-hooks
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("returns true if spy was not called", function() {
@@ -220,12 +220,12 @@ function verifyFunctionName(func, expectedName) {
 describe("spy", function() {
     it("does not throw if called without function", function() {
         refute.exception(function() {
-            createSpy.create();
+            createSpy();
         });
     });
 
     it("does not throw when calling anonymous spy", function() {
-        var spy = createSpy.create();
+        var spy = createSpy();
 
         refute.exception(spy);
 
@@ -236,7 +236,7 @@ describe("spy", function() {
         var func = function() {
             return;
         };
-        var spy = createSpy.create(func);
+        var spy = createSpy(func);
 
         assert.isFunction(spy);
         refute.same(func, spy);
@@ -247,13 +247,13 @@ describe("spy", function() {
             return;
         };
         func.myProp = 42;
-        var spy = createSpy.create(func);
+        var spy = createSpy(func);
 
         assert.equals(spy.myProp, func.myProp);
     });
 
     it("does not define create method", function() {
-        var spy = createSpy.create();
+        var spy = createSpy();
 
         assert.isUndefined(spy.create);
     });
@@ -263,13 +263,13 @@ describe("spy", function() {
             return;
         };
         var object = (func.create = {});
-        var spy = createSpy.create(func);
+        var spy = createSpy(func);
 
         assert.same(spy.create, object);
     });
 
     it("sets up logging arrays", function() {
-        var spy = createSpy.create();
+        var spy = createSpy();
 
         assert.isArray(spy.args);
         assert.isArray(spy.returnValues);
@@ -446,7 +446,7 @@ describe("spy", function() {
         it("calls underlying function", function() {
             var called = false;
 
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 called = true;
             });
 
@@ -460,7 +460,7 @@ describe("spy", function() {
                 return;
             }
 
-            var SpyClass = createSpy.create(TestClass);
+            var SpyClass = createSpy(TestClass);
 
             var instance = new SpyClass();
 
@@ -475,7 +475,7 @@ describe("spy", function() {
             };
 
             var args = [1, {}, [], ""];
-            var spy = createSpy.create(func);
+            var spy = createSpy(func);
             spy(args[0], args[1], args[2], args[3]);
 
             assert.equals(actualArgs, args);
@@ -489,7 +489,7 @@ describe("spy", function() {
             };
 
             var object = {};
-            var spy = createSpy.create(func);
+            var spy = createSpy(func);
             spy.call(object);
 
             assert.same(actualThis, object);
@@ -502,7 +502,7 @@ describe("spy", function() {
                 return object;
             };
 
-            var spy = createSpy.create(func);
+            var spy = createSpy(func);
             var actualReturn = spy();
 
             assert.same(actualReturn, object);
@@ -510,7 +510,7 @@ describe("spy", function() {
 
         it("throws if function throws", function() {
             var err = new Error();
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 throw err;
             });
 
@@ -522,14 +522,14 @@ describe("spy", function() {
                 return;
             }
 
-            var spy = createSpy.create(test);
+            var spy = createSpy(test);
 
             assert.equals(spy.displayName, "test");
             verifyFunctionName(spy, "test");
         });
 
         it("retains function length 0", function() {
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 return;
             });
 
@@ -538,7 +538,7 @@ describe("spy", function() {
 
         it("retains function length 1", function() {
             // eslint-disable-next-line no-unused-vars
-            var spy = createSpy.create(function(a) {
+            var spy = createSpy(function(a) {
                 return;
             });
 
@@ -547,7 +547,7 @@ describe("spy", function() {
 
         it("retains function length 2", function() {
             // eslint-disable-next-line no-unused-vars
-            var spy = createSpy.create(function(a, b) {
+            var spy = createSpy(function(a, b) {
                 return;
             });
 
@@ -556,7 +556,7 @@ describe("spy", function() {
 
         it("retains function length 3", function() {
             // eslint-disable-next-line no-unused-vars
-            var spy = createSpy.create(function(a, b, c) {
+            var spy = createSpy(function(a, b, c) {
                 return;
             });
 
@@ -565,7 +565,7 @@ describe("spy", function() {
 
         it("retains function length 4", function() {
             // eslint-disable-next-line no-unused-vars
-            var spy = createSpy.create(function(a, b, c, d) {
+            var spy = createSpy(function(a, b, c, d) {
                 return;
             });
 
@@ -577,7 +577,7 @@ describe("spy", function() {
             var func12Args = function(a, b, c, d, e, f, g, h, i, j, k, l) {
                 return;
             };
-            var spy = createSpy.create(func12Args);
+            var spy = createSpy(func12Args);
 
             assert.equals(spy.length, 12);
         });
@@ -585,7 +585,7 @@ describe("spy", function() {
 
     describe(".called", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("is false prior to calling the spy", function() {
@@ -608,7 +608,7 @@ describe("spy", function() {
 
     describe(".notCalled", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("is true prior to calling the spy", function() {
@@ -624,7 +624,7 @@ describe("spy", function() {
 
     describe(".calledOnce", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("is false prior to calling the spy", function() {
@@ -647,7 +647,7 @@ describe("spy", function() {
 
     describe(".calledTwice", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("is false prior to calling the spy", function() {
@@ -678,7 +678,7 @@ describe("spy", function() {
 
     describe(".calledThrice", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("is false prior to calling the spy", function() {
@@ -712,7 +712,7 @@ describe("spy", function() {
 
     describe(".callCount", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("reports 0 calls", function() {
@@ -744,7 +744,7 @@ describe("spy", function() {
 
     describe(".calledOn", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("is false if spy wasn't called", function() {
@@ -815,7 +815,7 @@ describe("spy", function() {
 
     describe(".alwaysCalledOn", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("is false prior to calling the spy", function() {
@@ -862,7 +862,7 @@ describe("spy", function() {
 
     describe(".calledWithNew", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("is false if spy wasn't called", function() {
@@ -946,7 +946,7 @@ describe("spy", function() {
 
     describe(".alwaysCalledWithNew", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("is false if spy wasn't called", function() {
@@ -976,7 +976,7 @@ describe("spy", function() {
 
     describe(".thisValues", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("contains one object", function() {
@@ -1006,7 +1006,7 @@ describe("spy", function() {
 
     describe(".calledWithMatchSpecial", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("checks substring match", function() {
@@ -1036,7 +1036,7 @@ describe("spy", function() {
 
     describe(".alwaysCalledWithMatchSpecial", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("checks true", function() {
@@ -1086,7 +1086,7 @@ describe("spy", function() {
 
     describe(".neverCalledWithMatchSpecial", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("checks substring match", function() {
@@ -1118,7 +1118,7 @@ describe("spy", function() {
 
     describe(".args", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("contains real arrays", function() {
@@ -1151,7 +1151,7 @@ describe("spy", function() {
 
     describe(".calledWithExactly", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("returns false for partial match", function() {
@@ -1233,7 +1233,7 @@ describe("spy", function() {
 
     describe(".calledOnceWith", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("returns true for not exact match", function() {
@@ -1265,7 +1265,7 @@ describe("spy", function() {
 
     describe(".calledOnceWithExactly", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("returns true for exact match", function() {
@@ -1297,7 +1297,7 @@ describe("spy", function() {
 
     describe(".alwaysCalledWithExactly", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
         });
 
         it("returns false for partial match", function() {
@@ -1359,13 +1359,13 @@ describe("spy", function() {
 
     describe(".threw", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
 
-            this.spyWithTypeError = createSpy.create(function() {
+            this.spyWithTypeError = createSpy(function() {
                 throw new TypeError();
             });
 
-            this.spyWithStringError = createSpy.create(function() {
+            this.spyWithStringError = createSpy(function() {
                 // eslint-disable-next-line no-throw-literal
                 throw "error";
             });
@@ -1374,7 +1374,7 @@ describe("spy", function() {
         it("returns exception thrown by function", function() {
             var err = new Error();
 
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 throw err;
             });
 
@@ -1428,9 +1428,9 @@ describe("spy", function() {
 
     describe(".alwaysThrew", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
 
-            this.spyWithTypeError = createSpy.create(function() {
+            this.spyWithTypeError = createSpy(function() {
                 throw new TypeError();
             });
         });
@@ -1438,7 +1438,7 @@ describe("spy", function() {
         it("returns true when spy threw", function() {
             var err = new Error();
 
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 throw err;
             });
 
@@ -1513,10 +1513,10 @@ describe("spy", function() {
 
     describe(".exceptions", function() {
         beforeEach(function() {
-            this.spy = createSpy.create();
+            this.spy = createSpy();
             var error = (this.error = {});
 
-            this.spyWithTypeError = createSpy.create(function() {
+            this.spyWithTypeError = createSpy(function() {
                 throw error;
             });
         });
@@ -1538,7 +1538,7 @@ describe("spy", function() {
             var calls = 0;
             var err = this.error;
 
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 calls += 1;
 
                 if (calls % 2 === 0) {
@@ -1567,14 +1567,14 @@ describe("spy", function() {
 
     describe(".returned", function() {
         it("returns true when no argument", function() {
-            var spy = createSpy.create();
+            var spy = createSpy();
             spy();
 
             assert(spy.returned());
         });
 
         it("returns true for undefined when no explicit return", function() {
-            var spy = createSpy.create();
+            var spy = createSpy();
             spy();
 
             assert(spy.returned(undefined));
@@ -1589,7 +1589,7 @@ describe("spy", function() {
                     return;
                 }
             ];
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 return values[spy.callCount];
             });
 
@@ -1610,7 +1610,7 @@ describe("spy", function() {
                     return;
                 }
             ];
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 return values[spy.callCount];
             });
 
@@ -1624,7 +1624,7 @@ describe("spy", function() {
 
         it("returns true when value is returned several times", function() {
             var object = { id: 42 };
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 return object;
             });
 
@@ -1637,7 +1637,7 @@ describe("spy", function() {
 
         it("compares values deeply", function() {
             var object = { deep: { id: 42 } };
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 return object;
             });
 
@@ -1648,7 +1648,7 @@ describe("spy", function() {
 
         it("compares values strictly using match.same", function() {
             var object = { id: 42 };
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 return object;
             });
 
@@ -1661,7 +1661,7 @@ describe("spy", function() {
 
     describe(".returnValues", function() {
         it("contains undefined when function does not return explicitly", function() {
-            var spy = createSpy.create();
+            var spy = createSpy();
             spy();
 
             assert.equals(spy.returnValues.length, 1);
@@ -1671,7 +1671,7 @@ describe("spy", function() {
         it("contains return value", function() {
             var object = { id: 42 };
 
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 return object;
             });
 
@@ -1681,7 +1681,7 @@ describe("spy", function() {
         });
 
         it("contains undefined when function throws", function() {
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 throw new Error();
             });
 
@@ -1692,7 +1692,7 @@ describe("spy", function() {
         });
 
         it("contains the created object for spied constructors", function() {
-            var Spy = createSpy.create(function() {
+            var Spy = createSpy(function() {
                 return;
             });
 
@@ -1702,7 +1702,7 @@ describe("spy", function() {
         });
 
         it("contains the return value for spied constructors that explicitly return objects", function() {
-            var Spy = createSpy.create(function() {
+            var Spy = createSpy(function() {
                 return { isExplicitlyCreatedValue: true };
             });
 
@@ -1713,7 +1713,7 @@ describe("spy", function() {
         });
 
         it("contains the created object for spied constructors that explicitly return primitive values", function() {
-            var Spy = createSpy.create(function() {
+            var Spy = createSpy(function() {
                 return 10;
             });
 
@@ -1727,7 +1727,7 @@ describe("spy", function() {
             var calls = 0;
 
             /*eslint consistent-return: "off"*/
-            var spy = createSpy.create(function() {
+            var spy = createSpy(function() {
                 calls += 1;
 
                 if (calls % 2 === 0) {
@@ -2913,7 +2913,7 @@ describe("spy", function() {
                 throw new Error("aError");
             };
             func.aProp = 42;
-            var spy = createSpy.create(func);
+            var spy = createSpy(func);
 
             assert.equals(spy.aProp, 42);
             assert.equals(Object.keys(spy), Object.keys(func));

--- a/test/util/fake-timers-test.js
+++ b/test/util/fake-timers-test.js
@@ -310,7 +310,7 @@ describe("fakeTimers.clock", function() {
         });
 
         it("triggers in the order scheduled", function() {
-            var spies = [sinonSpy.create(), sinonSpy.create()];
+            var spies = [sinonSpy(), sinonSpy()];
             this.clock.setTimeout(spies[0], 13);
             this.clock.setTimeout(spies[1], 11);
 
@@ -320,7 +320,7 @@ describe("fakeTimers.clock", function() {
         });
 
         it("creates updated Date while ticking", function() {
-            var spy = sinonSpy.create();
+            var spy = sinonSpy();
 
             this.clock.setInterval(function() {
                 spy(new Date().getTime());
@@ -342,7 +342,7 @@ describe("fakeTimers.clock", function() {
         });
 
         it("fires timer in intervals of 13", function() {
-            var spy = sinonSpy.create();
+            var spy = sinonSpy();
             this.clock.setInterval(spy, 13);
 
             this.clock.tick(500);
@@ -353,8 +353,8 @@ describe("fakeTimers.clock", function() {
         it("fires timers in correct order", function() {
             this.timeout(5000);
 
-            var spy13 = sinonSpy.create();
-            var spy10 = sinonSpy.create();
+            var spy13 = sinonSpy();
+            var spy10 = sinonSpy();
 
             this.clock.setInterval(function() {
                 spy13(new Date().getTime());
@@ -377,7 +377,7 @@ describe("fakeTimers.clock", function() {
         });
 
         it("triggers timeouts and intervals in the order scheduled", function() {
-            var spies = [sinonSpy.create(), sinonSpy.create()];
+            var spies = [sinonSpy(), sinonSpy()];
             this.clock.setInterval(spies[0], 10);
             this.clock.setTimeout(spies[1], 50);
 
@@ -403,7 +403,7 @@ describe("fakeTimers.clock", function() {
         });
 
         it("passes 6 seconds", function() {
-            var spy = sinonSpy.create();
+            var spy = sinonSpy();
             this.clock.setInterval(spy, 4000);
 
             this.clock.tick("08");
@@ -412,7 +412,7 @@ describe("fakeTimers.clock", function() {
         });
 
         it("passes 1 minute", function() {
-            var spy = sinonSpy.create();
+            var spy = sinonSpy();
             this.clock.setInterval(spy, 6000);
 
             this.clock.tick("01:00");
@@ -423,7 +423,7 @@ describe("fakeTimers.clock", function() {
         it("passes 2 hours, 34 minutes and 12 seconds", function() {
             this.timeout(50000);
 
-            var spy = sinonSpy.create();
+            var spy = sinonSpy();
             this.clock.setInterval(spy, 10000);
 
             this.clock.tick("02:34:10");
@@ -432,7 +432,7 @@ describe("fakeTimers.clock", function() {
         });
 
         it("throws for invalid format", function() {
-            var spy = sinonSpy.create();
+            var spy = sinonSpy();
             this.clock.setInterval(spy, 10000);
             var test = this;
 
@@ -444,7 +444,7 @@ describe("fakeTimers.clock", function() {
         });
 
         it("throws for invalid minutes", function() {
-            var spy = sinonSpy.create();
+            var spy = sinonSpy();
             this.clock.setInterval(spy, 10000);
             var test = this;
 
@@ -456,7 +456,7 @@ describe("fakeTimers.clock", function() {
         });
 
         it("throws for negative minutes", function() {
-            var spy = sinonSpy.create();
+            var spy = sinonSpy();
             this.clock.setInterval(spy, 10000);
             var test = this;
 
@@ -586,7 +586,7 @@ describe("fakeTimers.clock", function() {
         it("does not schedule recurring timeout when cleared", function() {
             var clock = this.clock;
             var id;
-            var stub = sinonSpy.create(function() {
+            var stub = sinonSpy(function() {
                 if (stub.callCount === 3) {
                     clock.clearInterval(id);
                 }


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

The `spy.create` function was inherited by every spy and is then deleted from each spy instance upon creation. The call order of the different functions initializing spies and stubs is/was rather confusing.

This is the first step of an attempt to clean up the internal setup logic of spies, stubs and fakes.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`
4. Observe that all tests are green.

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
