### PR TITLE
Retain stubbed function name and make additional properties non-enumerable

### DIFF
--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -76,7 +76,7 @@ extend(mock, {
         }
 
         var expectation = mockExpectation.create(method);
-        extend.nonEnum(expectation, this.object[method]);
+        expectation.wrappedMethod = this.object[method].wrappedMethod;
         push(this.expectations[method], expectation);
         usePromiseLibrary(this.promiseLibrary, expectation);
 

--- a/lib/sinon/proxy.js
+++ b/lib/sinon/proxy.js
@@ -4,9 +4,8 @@ var slice = require("@sinonjs/commons").prototypes.array.slice;
 var extend = require("./util/core/extend");
 var functionToString = require("./util/core/function-to-string");
 
-function createProxy(func, arity) {
-    var length = arity || func.length;
-    var proxy = wrapFunction(func, length);
+function createProxy(func, originalFunc) {
+    var proxy = wrapFunction(func, originalFunc);
 
     // Inherit function properties:
     extend(proxy, func);
@@ -20,87 +19,86 @@ function createProxy(func, arity) {
     return proxy;
 }
 
-function wrapFunction(func, proxyLength) {
-    // Retain the function length:
+function wrapFunction(func, originalFunc) {
+    var arity = originalFunc.length;
     var p;
-    if (proxyLength) {
-        // Do not change this to use an eval. Projects that depend on sinon block the use of eval.
-        // ref: https://github.com/sinonjs/sinon/issues/710
-        switch (proxyLength) {
-            /*eslint-disable no-unused-vars, max-len*/
-            case 1:
-                p = function proxy(a) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 2:
-                p = function proxy(a, b) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 3:
-                p = function proxy(a, b, c) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 4:
-                p = function proxy(a, b, c, d) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 5:
-                p = function proxy(a, b, c, d, e) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 6:
-                p = function proxy(a, b, c, d, e, f) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 7:
-                p = function proxy(a, b, c, d, e, f, g) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 8:
-                p = function proxy(a, b, c, d, e, f, g, h) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 9:
-                p = function proxy(a, b, c, d, e, f, g, h, i) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 10:
-                p = function proxy(a, b, c, d, e, f, g, h, i, j) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 11:
-                p = function proxy(a, b, c, d, e, f, g, h, i, j, k) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            case 12:
-                p = function proxy(a, b, c, d, e, f, g, h, i, j, k, l) {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            default:
-                p = function proxy() {
-                    return p.invoke(func, this, slice(arguments));
-                };
-                break;
-            /*eslint-enable*/
-        }
-    } else {
-        p = function proxy() {
-            return p.invoke(func, this, slice(arguments));
-        };
+    // Do not change this to use an eval. Projects that depend on sinon block the use of eval.
+    // ref: https://github.com/sinonjs/sinon/issues/710
+    switch (arity) {
+        /*eslint-disable no-unused-vars, max-len*/
+        case 0:
+            p = function proxy() {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 1:
+            p = function proxy(a) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 2:
+            p = function proxy(a, b) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 3:
+            p = function proxy(a, b, c) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 4:
+            p = function proxy(a, b, c, d) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 5:
+            p = function proxy(a, b, c, d, e) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 6:
+            p = function proxy(a, b, c, d, e, f) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 7:
+            p = function proxy(a, b, c, d, e, f, g) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 8:
+            p = function proxy(a, b, c, d, e, f, g, h) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 9:
+            p = function proxy(a, b, c, d, e, f, g, h, i) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 10:
+            p = function proxy(a, b, c, d, e, f, g, h, i, j) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 11:
+            p = function proxy(a, b, c, d, e, f, g, h, i, j, k) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        case 12:
+            p = function proxy(a, b, c, d, e, f, g, h, i, j, k, l) {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        default:
+            p = function proxy() {
+                return p.invoke(func, this, slice(arguments));
+            };
+            break;
+        /*eslint-enable*/
     }
-    var nameDescriptor = Object.getOwnPropertyDescriptor(func, "name");
+    var nameDescriptor = Object.getOwnPropertyDescriptor(originalFunc, "name");
     if (nameDescriptor && nameDescriptor.configurable) {
         // IE 11 functions don't have a name.
         // Safari 9 has names that are not configurable.

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -26,7 +26,7 @@ var bind = Function.prototype.bind;
 var callId = 0;
 var uuid = 0;
 
-function createSpy(func, arity) {
+function createSpy(func) {
     var name;
     var funk = func;
 
@@ -38,7 +38,7 @@ function createSpy(func, arity) {
         name = functionName(funk);
     }
 
-    var proxy = createProxy(funk, arity);
+    var proxy = createProxy(funk, funk);
 
     // Inherit spy API:
     extend.nonEnum(proxy, spy);

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -4,6 +4,7 @@ var arrayProto = require("@sinonjs/commons").prototypes.array;
 var behavior = require("./behavior");
 var behaviors = require("./default-behaviors");
 var createProxy = require("./proxy");
+var functionName = require("@sinonjs/commons").functionName;
 var hasOwnProperty = require("@sinonjs/commons").prototypes.object.hasOwnProperty;
 var isNonExistentOwnProperty = require("./util/core/is-non-existent-own-property");
 var spy = require("./spy");
@@ -22,7 +23,7 @@ var sort = arrayProto.sort;
 
 var uuid = 0;
 
-function createStub(arity) {
+function createStub(originalFunc) {
     var proxy;
 
     function functionStub() {
@@ -38,15 +39,16 @@ function createStub(arity) {
         return getCurrentBehavior(fnStub).invoke(this, arguments);
     }
 
-    proxy = createProxy(functionStub, arity);
+    proxy = createProxy(functionStub, originalFunc || functionStub);
     // Inherit spy API:
-    extend(proxy, spy);
+    extend.nonEnum(proxy, spy);
     // Inherit stub API:
-    extend(proxy, stub);
+    extend.nonEnum(proxy, stub);
 
+    var name = originalFunc ? functionName(originalFunc) : null;
     extend.nonEnum(proxy, {
         instantiateFake: createStub,
-        displayName: "stub",
+        displayName: name || "stub",
         defaultBehavior: null,
         behaviors: [],
         id: "stub#" + uuid++
@@ -79,11 +81,6 @@ function stub(object, property) {
         typeof property !== "undefined" &&
         (typeof actualDescriptor === "undefined" || typeof actualDescriptor.value !== "function") &&
         typeof descriptor === "undefined";
-    var isStubbingExistingMethod =
-        typeof object === "object" &&
-        typeof actualDescriptor !== "undefined" &&
-        typeof actualDescriptor.value === "function";
-    var arity = isStubbingExistingMethod ? object[property].length : 0;
 
     if (isStubbingEntireObject) {
         return stubEntireObject(stub, object);
@@ -93,7 +90,8 @@ function stub(object, property) {
         return createStub();
     }
 
-    var s = createStub(arity);
+    var func = typeof actualDescriptor.value === "function" ? actualDescriptor.value : null;
+    var s = createStub(func);
 
     extend.nonEnum(s, {
         rootObj: object,

--- a/lib/sinon/util/core/wrap-method.js
+++ b/lib/sinon/util/core/wrap-method.js
@@ -109,6 +109,8 @@ module.exports = function wrapMethod(object, property, method) {
     extend.nonEnum(method, {
         displayName: property,
 
+        wrappedMethod: wrappedMethod,
+
         // Set up an Error object for a stack trace which can be used later to find what line of
         // code the original method was created on.
         stackTraceError: new Error("Stack Trace for original"),
@@ -142,8 +144,6 @@ module.exports = function wrapMethod(object, property, method) {
             }
         }
     });
-
-    method.wrappedMethod = wrappedMethod;
 
     method.restore.sinon = true;
 

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2889,8 +2889,6 @@ describe("spy", function() {
 
             // call some spy APIs and verify no enumerable properties are added
             spy.withArgs(1);
-            // eslint-disable-next-line no-unused-vars
-            var val = spy.called;
             spy.calledBefore(createSpy());
             spy.calledAfter(createSpy());
             spy.calledOn(undefined);
@@ -2898,9 +2896,9 @@ describe("spy", function() {
             spy.calledWithNew();
             spy.threw();
             spy.returned("ret");
-            val = spy.thisValues.length;
-            val = spy.exceptions.length;
-            val = spy.returnValues.length;
+            assert.equals(spy.thisValues.length, 1);
+            assert.equals(spy.exceptions.length, 1);
+            assert.equals(spy.returnValues.length, 1);
             assert.equals(Object.keys(spy), ["fooBar"]);
 
             // verify that reset history doesn't change enumerable properties
@@ -2919,13 +2917,10 @@ describe("spy", function() {
             assert.equals(Object.keys(spy), Object.keys(func));
             assert.equals(Object.keys(spy), ["aProp"]);
 
-            // eslint-disable-next-line no-restricted-syntax
-            try {
+            assert.exception(function() {
                 spy();
-            } catch (e) {
-                // empty
-            }
-            spy.threw();
+            });
+            assert(spy.threw());
 
             spy.resetHistory();
             assert.equals(Object.keys(spy), ["aProp"]);

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -11,6 +11,16 @@ var refute = referee.refute;
 var fail = referee.fail;
 var Promise = require("native-promise-only"); // eslint-disable-line no-unused-vars
 
+function verifyFunctionName(func, expectedName) {
+    var descriptor = Object.getOwnPropertyDescriptor(func, "name");
+    if (descriptor && descriptor.configurable) {
+        // IE 11 functions don't have a name.
+        // Safari 9 has names that are not configurable.
+        assert.equals(descriptor.value, expectedName);
+        assert.equals(func.name, expectedName);
+    }
+}
+
 describe("stub", function() {
     beforeEach(function() {
         createStub(deprecated, "printWarning");
@@ -114,6 +124,72 @@ describe("stub", function() {
         stub(1);
 
         refute.isNull(stub.withArgs(1).firstCall);
+    });
+
+    it("retains function name", function() {
+        var object = {
+            test: function test() {
+                return;
+            }
+        };
+
+        var stub = createStub(object, "test");
+
+        assert.equals(stub.displayName, "test");
+        verifyFunctionName(stub, "test");
+    });
+
+    describe("non enumerable properties", function() {
+        it("create and call spy apis", function() {
+            var stub = createStub();
+            assert.equals(Object.keys(stub), []);
+
+            // call spy and verify no enumerable properties are added
+            stub(15);
+            assert.equals(Object.keys(stub), []);
+
+            // it should still work to add properties
+            stub.fooBar = 1;
+            assert.equals(Object.keys(stub), ["fooBar"]);
+
+            // call some spy APIs and verify no enumerable properties are added
+            stub.withArgs(1);
+            stub.calledBefore(createStub());
+            stub.calledAfter(createStub());
+            stub.calledOn(undefined);
+            stub.calledWith(15);
+            stub.calledWithNew();
+            stub.threw();
+            stub.returned("ret");
+            assert.equals(stub.thisValues.length, 1);
+            assert.equals(stub.exceptions.length, 1);
+            assert.equals(stub.returnValues.length, 1);
+            assert.equals(Object.keys(stub), ["fooBar"]);
+
+            // verify that reset history doesn't change enumerable properties
+            stub.resetHistory();
+            assert.equals(Object.keys(stub), ["fooBar"]);
+        });
+
+        it("create stub from function on object", function() {
+            var func = function() {
+                throw new Error("aError");
+            };
+            var object = {
+                test: func
+            };
+            func.aProp = 42;
+            createStub(object, "test");
+
+            assert.equals(object.test.aProp, 42);
+            assert.equals(Object.keys(object.test), Object.keys(func));
+            assert.equals(Object.keys(object.test), ["aProp"]);
+
+            object.test();
+
+            object.test.resetHistory();
+            assert.equals(Object.keys(object.test), ["aProp"]);
+        });
     });
 
     describe(".returns", function() {
@@ -2770,16 +2846,82 @@ describe("stub", function() {
             assert.equals(stub.length, 0);
         });
 
-        it("matches the function length", function() {
-            var api = {
-                // eslint-disable-next-line no-unused-vars
-                someMethod: function(a, b, c) {
+        it("retains function length 0", function() {
+            var object = {
+                test: function() {
                     return;
                 }
             };
-            var stub = createStub(api, "someMethod");
+
+            var stub = createStub(object, "test");
+
+            assert.equals(stub.length, 0);
+        });
+
+        it("retains function length 1", function() {
+            var object = {
+                // eslint-disable-next-line no-unused-vars
+                test: function(a) {
+                    return;
+                }
+            };
+
+            var stub = createStub(object, "test");
+
+            assert.equals(stub.length, 1);
+        });
+
+        it("retains function length 2", function() {
+            var object = {
+                // eslint-disable-next-line no-unused-vars
+                test: function(a, b) {
+                    return;
+                }
+            };
+
+            var stub = createStub(object, "test");
+
+            assert.equals(stub.length, 2);
+        });
+
+        it("retains function length 3", function() {
+            var object = {
+                // eslint-disable-next-line no-unused-vars
+                test: function(a, b, c) {
+                    return;
+                }
+            };
+
+            var stub = createStub(object, "test");
 
             assert.equals(stub.length, 3);
+        });
+
+        it("retains function length 4", function() {
+            var object = {
+                // eslint-disable-next-line no-unused-vars
+                test: function(a, b, c, d) {
+                    return;
+                }
+            };
+
+            var stub = createStub(object, "test");
+
+            assert.equals(stub.length, 4);
+        });
+
+        it("retains function length 12", function() {
+            // eslint-disable-next-line no-unused-vars
+            var func12Args = function(a, b, c, d, e, f, g, h, i, j, k, l) {
+                return;
+            };
+            var object = {
+                test: func12Args
+            };
+
+            var stub = createStub(object, "test");
+
+            assert.equals(stub.length, 12);
         });
     });
 


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

This aligns stubbed functions on objects with the behavior of spies where the function name is retained and the additional properties added by Sinon are made non-enumerable.

 #### Background (Problem in detail)  - optional

Properties on stubs where added in a way so that they where returned by `Object.keys(stub)`. Also, the function name wasn't retained.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
