### PR TITLE
disable built-ins in Browserify

### DIFF
--- a/build.js
+++ b/build.js
@@ -34,7 +34,9 @@ makeBundle(
         // Add inline source maps to the default bundle
         debug: true,
         // Create a UMD wrapper and install the "sinon" global:
-        standalone: "sinon"
+        standalone: "sinon",
+        // Avoid installing node shims like process
+        builtins: false
     },
     function(bundle) {
         var script = preamble + bundle;

--- a/build.js
+++ b/build.js
@@ -36,6 +36,7 @@ makeBundle(
         // Create a UMD wrapper and install the "sinon" global:
         standalone: "sinon",
         // Avoid installing node shims like process
+        detectGlobals: false,
         builtins: false
     },
     function(bundle) {


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
In favor of @mantoni's comment in https://github.com/sinonjs/commons/pull/37#issuecomment-538656062

> I want to raise awareness for the fact that browserify installs shims for things like process if they're used in the codebase. Maybe we can configure it to not do that. Libraries or apps using Sinon might use typeof process === "object" as Node environment detection.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run build`

 #### Checklist for author

- [x] `npm run lint` passes
