### PR TITLE
Added support for browsers without fn.name - fixes #2134

### DIFF
--- a/lib/sinon/util/core/walk-object.js
+++ b/lib/sinon/util/core/walk-object.js
@@ -1,16 +1,13 @@
 "use strict";
 
-var valueToString = require("@sinonjs/commons").valueToString;
+var functionName = require("@sinonjs/commons").functionName;
 
 var getPropertyDescriptor = require("./get-property-descriptor");
 var walk = require("./walk");
 
-var reFunctionName = /^function\s*([^\s(]+)/;
-
 function walkObject(predicate, object, filter) {
     var called = false;
-    // IE11 doesn't support fn.name
-    var name = predicate.name || (valueToString(predicate).match(reFunctionName) || [null, ""])[1];
+    var name = functionName(predicate);
 
     if (!object) {
         throw new Error("Trying to " + name + " object but received " + String(object));

--- a/lib/sinon/util/core/walk-object.js
+++ b/lib/sinon/util/core/walk-object.js
@@ -1,13 +1,19 @@
 "use strict";
 
+var valueToString = require("@sinonjs/commons").valueToString;
+
 var getPropertyDescriptor = require("./get-property-descriptor");
 var walk = require("./walk");
 
+var reFunctionName = /^function\s*([^\s(]+)/;
+
 function walkObject(predicate, object, filter) {
     var called = false;
+    // IE11 doesn't support fn.name
+    var name = predicate.name || (valueToString(predicate).match(reFunctionName) || [null, ""])[1];
 
     if (!object) {
-        throw new Error("Trying to " + predicate.name + " object but received " + String(object));
+        throw new Error("Trying to " + name + " object but received " + String(object));
     }
 
     walk(object, function(prop, propOwner) {
@@ -31,7 +37,7 @@ function walkObject(predicate, object, filter) {
     });
 
     if (!called) {
-        throw new Error("Expected to " + predicate.name + " methods on object but found none");
+        throw new Error("Expected to " + name + " methods on object but found none");
     }
 
     return object;

--- a/test/util/core/walk-object-test.js
+++ b/test/util/core/walk-object-test.js
@@ -48,14 +48,14 @@ describe("util/core/walk-object", function() {
                 function() {
                     walkObject(anonymousFn, false);
                 },
-                { message: "Trying to  object but received false" }
+                { message: "Trying to undefined object but received false" }
             );
 
             assert.exception(
                 function() {
                     walkObject(anonymousFn, {});
                 },
-                { message: "Expected to  methods on object but found none" }
+                { message: "Expected to undefined methods on object but found none" }
             );
         });
     });

--- a/test/util/core/walk-object-test.js
+++ b/test/util/core/walk-object-test.js
@@ -17,7 +17,11 @@ describe("util/core/walk-object", function() {
         };
 
         before(function() {
-            if (typeof Object.defineProperty !== "function") {
+            if (
+                typeof Object.defineProperty !== "function" ||
+                typeof Object.getOwnPropertyDescriptor !== "function" ||
+                (Object.getOwnPropertyDescriptor(fnWithNoName, "name") || {}).configurable !== true
+            ) {
                 this.skip();
             }
 

--- a/test/util/core/walk-object-test.js
+++ b/test/util/core/walk-object-test.js
@@ -1,0 +1,62 @@
+"use strict";
+
+var referee = require("@sinonjs/referee");
+
+var walkObject = require("../../../lib/sinon/util/core/walk-object");
+
+var assert = referee.assert;
+
+describe("util/core/walk-object", function() {
+    // IE11
+    describe("without function.name support", function() {
+        function fnWithNoName() {
+            return;
+        }
+        var anonymousFn = function() {
+            return;
+        };
+
+        before(function() {
+            if (typeof Object.defineProperty !== "function") {
+                this.skip();
+            }
+
+            var descriptor = { value: undefined };
+
+            Object.defineProperty(anonymousFn, "name", descriptor);
+            Object.defineProperty(fnWithNoName, "name", descriptor);
+        });
+
+        it("should still identify functions in environments", function() {
+            assert.exception(
+                function() {
+                    walkObject(fnWithNoName, false);
+                },
+                { message: "Trying to fnWithNoName object but received false" }
+            );
+
+            assert.exception(
+                function() {
+                    walkObject(fnWithNoName, {});
+                },
+                { message: "Expected to fnWithNoName methods on object but found none" }
+            );
+        });
+
+        it("should work with anonymous functions", function() {
+            assert.exception(
+                function() {
+                    walkObject(anonymousFn, false);
+                },
+                { message: "Trying to  object but received false" }
+            );
+
+            assert.exception(
+                function() {
+                    walkObject(anonymousFn, {});
+                },
+                { message: "Expected to  methods on object but found none" }
+            );
+        });
+    });
+});


### PR DESCRIPTION
IE11 doesn't support `fn.name` so I worked around it by parsing `fn.toString()`.

This fixes #2134.