### PR TITLE
Fix formatting issue in stubs documentation

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -405,6 +405,7 @@ obj.sum.callThrough();
 
 obj.sum(2, 2); // 'bar'
 obj.sum(1, 2); // 3
+```
 
 
 #### `stub.callThroughWithNew();`


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
Fixes a formatting issue in the stubs documentation

 #### How to verify - mandatory
Check out the diff

 #### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
