### PR TITLE
Fix test failing in IE 11

### DIFF
--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("@sinonjs/referee").assert;
+var functionName = require("@sinonjs/commons").functionName;
 var Sandbox = require("../lib/sinon/sandbox");
 var proxyquire = require("proxyquire");
 
@@ -73,7 +74,8 @@ describe("sinon module", function() {
             it("should be a unary Function named 'createSandbox'", function() {
                 assert.isFunction(sinon.createSandbox);
                 assert.equals(sinon.createSandbox.length, 1);
-                assert.equals(sinon.createSandbox.name, "createSandbox");
+                // Use helper because IE 11 doesn't support the `name` property:
+                assert.equals(functionName(sinon.createSandbox), "createSandbox");
             });
         });
 


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
 
IE 11 does not support the `name` property on functions.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run test-cloud`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
