### PR TITLE
Remove obsolete `deprecated.printWarning` stubbing from test

### DIFF
--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -5,7 +5,6 @@ var createStub = require("../lib/sinon/stub");
 var createStubInstance = require("../lib/sinon/stub").createStubInstance;
 var createSpy = require("../lib/sinon/spy");
 var match = require("@sinonjs/samsam").createMatcher;
-var deprecated = require("@sinonjs/commons").deprecated;
 var assert = referee.assert;
 var refute = referee.refute;
 var fail = referee.fail;
@@ -22,16 +21,6 @@ function verifyFunctionName(func, expectedName) {
 }
 
 describe("stub", function() {
-    beforeEach(function() {
-        createStub(deprecated, "printWarning");
-    });
-
-    afterEach(function() {
-        if (deprecated.printWarning.restore) {
-            deprecated.printWarning.restore();
-        }
-    });
-
     it("is spy", function() {
         var stub = createStub();
 


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

For some reason IE 11 decided to fail on stubbing out this function, saying it was already stubbed. Weirdly, it was failing on the third test, so it worked fine twice before.

Anywhay, it turns out the stub isn't needed anymore.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run test-cloud`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
