### PR TITLE
Remove old apis

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -2,7 +2,6 @@
 
 var behavior = require("./sinon/behavior");
 var createSandbox = require("./sinon/create-sandbox");
-var deprecated = require("@sinonjs/commons").deprecated;
 var extend = require("./sinon/util/core/extend");
 var fakeTimers = require("./sinon/util/fake-timers");
 var format = require("./sinon/util/core/format");
@@ -40,18 +39,8 @@ var apiMethods = {
     }
 };
 
-var legacySandboxAPI = {
-    sandbox: {
-        create: deprecated.wrap(
-            createSandbox,
-            // eslint-disable-next-line max-len
-            "`sandbox.create()` is deprecated. Use default sandbox at `sinon.sandbox` or create new sandboxes with `sinon.createSandbox()`"
-        )
-    }
-};
-
 var sandbox = new Sandbox();
 
-var api = extend(sandbox, legacySandboxAPI, apiMethods);
+var api = extend(sandbox, apiMethods);
 
 module.exports = api;

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -14,7 +14,6 @@ var apiMethods = {
     assert: require("./sinon/assert"),
     match: require("@sinonjs/samsam").createMatcher,
     restoreObject: require("./sinon/restore-object"),
-    spyCall: require("./sinon/proxy-call"),
 
     expectation: require("./sinon/mock-expectation"),
     defaultConfig: require("./sinon/util/core/default-config"),

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -37,27 +37,6 @@ describe("sinon module", function() {
         });
     });
 
-    describe("deprecated methods", function() {
-        it(".sandbox.create", function() {
-            // use full sinon for this test as it compares sinon instance
-            // proxyquire changes the instance, so `actual instanceof Sandbox` returns `false`
-            // see https://github.com/sinonjs/sinon/pull/1586#issuecomment-354457231
-            sinon = require("../lib/sinon");
-
-            // eslint-disable-next-line max-len
-            var expectedMessage =
-                "`sandbox.create()` is deprecated. Use default sandbox at `sinon.sandbox` or create new sandboxes with `sinon.createSandbox()`";
-            var infoStub = sinon.stub(console, "info");
-            var actual = sinon.sandbox.create();
-
-            sinon.assert.calledWith(infoStub, expectedMessage);
-
-            assert.hasPrototype(actual, Sandbox.prototype);
-
-            infoStub.restore();
-        });
-    });
-
     describe("exports", function() {
         describe("default sandbox", function() {
             it("should be an instance of Sandbox", function() {


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

Remove old `sinon.spyCall` and `sinon.sandbox.create` APIs.

#### Background (Problem in detail)  - optional

- `sinon.sandbox.create` is deprecated for a long time now.
- I don't even know why `spyCall` was exposed. There isn't even a test for it.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
