### PR TITLE
Add Carbon Ads

### DIFF
--- a/docs/_includes/carbonads.html
+++ b/docs/_includes/carbonads.html
@@ -1,0 +1,1 @@
+<script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CE7D453M&placement=sinonjsorg" id="_carbonads_js"></script>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -8,6 +8,19 @@ layout: default
     </header>
 
     <div class="post-content">
+
+        {% comment %}
+        We add Carbon Ads on most posts.
+        The formatting gets a bit weird on the release.md page, so we need a
+        way of turning the ads off.
+
+        P.S. 'skip_ad == false' didn't work out for some reason (?)
+        {% endcomment %}
+
+        {% if page.skip_ad != true %}
+            <div>{% include carbonads.html %}</div>
+        {% endif %}
+
         {{ content }}
     </div>
 

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -257,3 +257,96 @@ body {
     }
   }
 }
+
+
+
+
+// CARBON ADS
+#carbonads {
+  display: flex;
+  float: right;
+  margin: 0 0 20px 20px;
+  max-width: 130px;
+  border-radius: 4px;
+  background-color: hsl(0, 0%, 98%);
+  box-shadow: 0 0 1px hsla(0, 0%, 0%, .15);
+  font-size: 11px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu,
+    Cantarell, "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+#carbonads a {
+  color: #111;
+ text-decoration: none;
+}
+
+#carbonads a:hover {
+  color: #111;
+}
+
+.carbon-img {
+  display: block;
+  margin-bottom: 8px;
+  max-width: 130px;
+  line-height: 1;
+}
+
+.carbon-img img {
+  display: block;
+  margin: 0 auto;
+  max-width: 130px;
+  width: 130px;
+  height: auto;
+}
+
+.carbon-text {
+  display: block;
+  padding: 0 10px 8px;
+  text-align: left;
+  line-height: 1.35;
+}
+
+.carbon-poweredby {
+  display: block;
+  padding: 10px;
+  background: repeating-linear-gradient(-45deg, transparent, transparent 5px, hsla(0, 0%, 0%, .025) 5px, hsla(0, 0%, 0%, .025) 10px) hsla(203, 11%, 95%, .4);
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  font-weight: 600;
+  font-size: 8px;
+  line-height: 0;
+}
+
+
+@media only screen and (min-width: 320px) and (max-width: 759px) {
+  #carbonads {
+    position: relative;
+    float: none;
+    margin: 20px auto;
+    max-width: 330px;
+  }
+
+  .carbon-wrap {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .carbon-img {
+    margin: 0;
+  }
+
+  .carbon-text {
+    padding: 10px 10px 0 10px;
+    font-size: 12px;
+  }
+
+  .carbon-poweredby {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    border-radius: 0;
+    border-top-left-radius: 3px;
+    text-align: center;
+  }
+}
+

--- a/docs/release-source/release.md
+++ b/docs/release-source/release.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: API documentation - Sinon.JS
+skip_ad: true
 release_id: master
 ---
 


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
This adds Carbon Ads on most posts on the Sinon page. They are relatively unannoying, and in the cases where the formatting got wacky, it's possible to set `page.skip_ad = true`.

 #### Background (Problem in detail)  - optional
This ad supplier is used in several open source projects (like Laravel and Lodash) and doesn't do any tracking. This will hopefully generate some 💵 for development without annoying anyone. Let's find out.

I have only added `skip_ad = true` to the `release-source/release.md` file, not all the historic ones, as I hope to address this with a separate pull request to remove a lot of the releases, which will make such updates more manageable.

 #### How to verify - mandatory
1. Check out this branch
1. `npm run serve-docs`
1. Comment out `release-source` from the _config.yml file of entries to exclude.
1. Open `localhost:4000/release-source/release/`
