### PR TITLE
improve-stubs-doc.md

### DIFF
--- a/docs/release-source/release/examples/stubs-1-pubsub.stub
+++ b/docs/release-source/release/examples/stubs-1-pubsub.stub
@@ -1,0 +1,25 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var PubSub = require("pubsub-js");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("PubSub", function() {
+    it("should call all subscribers, even if there are exceptions", function(){
+        var message = "an example message";
+        var stub = sinon.stub().throws();
+        var spy1 = sinon.spy();
+        var spy2 = sinon.spy();
+
+        PubSub.subscribe(message, stub);
+        PubSub.subscribe(message, spy1);
+        PubSub.subscribe(message, spy2);
+
+        PubSub.publishSync(message, undefined);
+
+        assert.exception(stub);
+        assert(spy1.called);
+        assert(spy2.called);
+        assert(stub.calledBefore(spy1));
+    });
+});

--- a/docs/release-source/release/examples/stubs-10-use-promise-library.stub
+++ b/docs/release-source/release/examples/stubs-10-use-promise-library.stub
@@ -1,0 +1,19 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+var bluebird = require("bluebird");
+
+var myObj = {
+    saveSomething: sinon.stub().usingPromise(bluebird.Promise).resolves("baz")
+};
+
+describe("stub", function() {
+    it("should resolve using specific Promise library", function() {
+        myObj
+            .saveSomething()
+            .tap(function(actual) {
+                assert.equals(actual, "baz");
+            });
+    });
+});

--- a/docs/release-source/release/examples/stubs-12-yield-to.stub
+++ b/docs/release-source/release/examples/stubs-12-yield-to.stub
@@ -1,0 +1,23 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stub", function() {
+    it("should call specified callback", function() {
+        var actual;
+        var callback = sinon.stub();
+        callback({
+            "success": function () {
+                actual = "Success!";
+            },
+            "failure": function () {
+                actual = "Oh noes!";
+            }
+        });
+
+        callback.yieldTo("failure");
+        
+        assert.equals(actual, "Oh noes!");
+    });
+});

--- a/docs/release-source/release/examples/stubs-14-add-behavior.stub
+++ b/docs/release-source/release/examples/stubs-14-add-behavior.stub
@@ -1,0 +1,14 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stub", function() {
+    it("should add a custom behavior", function() {
+        sinon.addBehavior('returnsNum', function(fake, n) { fake.returns(n) });
+
+        var stub = sinon.stub().returnsNum(42);
+
+        assert.equals(stub(), 42);
+    });
+});

--- a/docs/release-source/release/examples/stubs-15-replace-getter.stub
+++ b/docs/release-source/release/examples/stubs-15-replace-getter.stub
@@ -1,0 +1,18 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stub", function() {
+    it("should replace getter", function() {
+        var myObj = {
+            prop: 'foo'
+        };
+
+        sinon.stub(myObj, 'prop').get(function getterFn() {
+            return 'bar';
+        });
+
+        assert.equals(myObj.prop, 'bar');
+    });
+});

--- a/docs/release-source/release/examples/stubs-16-define-new-setter.stub
+++ b/docs/release-source/release/examples/stubs-16-define-new-setter.stub
@@ -1,0 +1,22 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stub", function() {
+    it("should define new setter", function() {
+        var myObj = {
+            example: 'oldValue',
+            prop: 'foo'
+        };
+
+        sinon.stub(myObj, 'prop').set(function setterFn(val) {
+            myObj.example = val;
+        });
+
+        myObj.prop = 'baz';
+
+        assert.equals(myObj.example, 'baz');
+    });
+});
+

--- a/docs/release-source/release/examples/stubs-17-define-new-value.stub
+++ b/docs/release-source/release/examples/stubs-17-define-new-value.stub
@@ -1,0 +1,16 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stub", function() {
+    it("should define new value", function() {
+        var myObj = {
+            example: 'oldValue',
+        };
+
+        sinon.stub(myObj, 'example').value('newValue');
+
+        assert.equals(myObj.example, 'newValue');
+    });
+});

--- a/docs/release-source/release/examples/stubs-18-restore-values.stub
+++ b/docs/release-source/release/examples/stubs-18-restore-values.stub
@@ -1,0 +1,17 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stub", function() {
+    it("should restore values", function() {
+        var myObj = {
+            example: 'oldValue',
+        };
+
+        var stub = sinon.stub(myObj, 'example').value('newValue');
+        stub.restore();
+
+        assert.equals(myObj.example, 'oldValue');
+    });
+});

--- a/docs/release-source/release/examples/stubs-2-different-args.stub
+++ b/docs/release-source/release/examples/stubs-2-different-args.stub
@@ -1,0 +1,16 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stubbed callback", function() {
+    it("should behave differently based on arguments", function() {
+        var callback = sinon.stub();
+        callback.withArgs(42).returns(1);
+        callback.withArgs(1).throws("name");
+
+        assert.equals(callback(), undefined); // No return value, no exception
+        assert.equals(callback(42), 1); // Returns 1
+        assert.exception(function() { callback(1) }); // Throws Error("name")
+    });
+});

--- a/docs/release-source/release/examples/stubs-3-sequential-interactions.stub
+++ b/docs/release-source/release/examples/stubs-3-sequential-interactions.stub
@@ -1,0 +1,17 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stub", function() {
+    it("should behave differently on consecutive calls", function() {
+        var callback = sinon.stub();
+        callback.onCall(0).returns(1);
+        callback.onCall(1).returns(2);
+        callback.returns(3);
+
+        assert.equals(callback(), 1) // Returns 1
+        assert.equals(callback(), 2) // Returns 2
+        assert.equals(callback(), 3) // All following calls return 3
+    });
+});

--- a/docs/release-source/release/examples/stubs-4-sequential-with-args.stub
+++ b/docs/release-source/release/examples/stubs-4-sequential-with-args.stub
@@ -1,0 +1,21 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stub", function() {
+    it("should behave differently on consecutive calls with certain argument", function() {
+        var callback = sinon.stub();
+        callback.withArgs(42)
+            .onFirstCall().returns(1)
+            .onSecondCall().returns(2);
+        callback.returns(0);
+
+        assert.equals(callback(1), 0);
+        assert.equals(callback(42), 1);
+        assert.equals(callback(1), 0);
+        assert.equals(callback(42), 2);
+        assert.equals(callback(1), 0);
+        assert.equals(callback(42), 0);
+    });
+});

--- a/docs/release-source/release/examples/stubs-5-reset-behaviour.stub
+++ b/docs/release-source/release/examples/stubs-5-reset-behaviour.stub
@@ -1,0 +1,18 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stub", function() {
+    it("should reset behaviour", function() {
+        var stub = sinon.stub();
+
+        stub.returns(54)
+
+        assert.equals(stub(), 54);
+
+        stub.resetBehavior();
+
+        assert.equals(stub(), undefined);
+    });
+});

--- a/docs/release-source/release/examples/stubs-6-reset-history.stub
+++ b/docs/release-source/release/examples/stubs-6-reset-history.stub
@@ -1,0 +1,20 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+describe("stub", function() {
+    it("should reset history", function() {
+        var stub = sinon.stub();
+
+        assert.isFalse(stub.called);
+
+        stub();
+
+        assert.isTrue(stub.called);
+
+        stub.resetHistory();
+
+        assert.isFalse(stub.called);
+    });
+});

--- a/docs/release-source/release/examples/stubs-7-call-fake.stub
+++ b/docs/release-source/release/examples/stubs-7-call-fake.stub
@@ -1,0 +1,19 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+var myObj = {};
+myObj.prop = function propFn() {
+    return "foo";
+};
+
+describe("stub", function() {
+    it("should call fake", function() {
+        sinon.stub(myObj, "prop").callsFake(function fakeFn() {
+            return "bar";
+        });
+
+        assert.equals(myObj.prop(), "bar");
+    });
+});

--- a/docs/release-source/release/examples/stubs-8-call-through.stub
+++ b/docs/release-source/release/examples/stubs-8-call-through.stub
@@ -1,0 +1,22 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+var obj = {};
+obj.sum = function sum(a, b) {
+    return a + b;
+};
+
+describe("stub", function() {
+    it("should call through", function() {
+        sinon.stub(obj, 'sum').withArgs(2, 2).callsFake(function foo() {
+            return 'bar';
+        });
+
+        obj.sum.callThrough();
+
+        assert.equals(obj.sum(2, 2), "bar");
+        assert.equals(obj.sum(1, 2), 3);
+    });
+});

--- a/docs/release-source/release/examples/stubs-9-call-through-with-new.stub
+++ b/docs/release-source/release/examples/stubs-9-call-through-with-new.stub
@@ -1,0 +1,22 @@
+require("@fatso83/mini-mocha").install();
+var sinon = require("sinon");
+var referee = require("@sinonjs/referee");
+var assert = referee.assert;
+
+var obj = {};
+obj.Sum = function MyConstructor(a, b) {
+    this.result = a + b;
+};
+
+describe("stub", function() {
+    it("should call through with new operator", function() {
+        sinon
+            .stub(obj, 'Sum')
+            .callThroughWithNew()
+            .withArgs(1, 2)
+            .returns({ result: 9000 });
+
+        assert.equals(new obj.Sum(2, 2).result, 4);
+        assert.equals(new obj.Sum(1, 2).result, 9000);
+    });
+});

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -2,6 +2,23 @@
 layout: page
 title: Stubs - Sinon.JS
 breadcrumb: stubs
+examples:
+- stubs-1-pubsub
+- stubs-2-different-args
+- stubs-3-sequential-interactions
+- stubs-4-sequential-with-args
+- stubs-5-reset-behaviour
+- stubs-6-reset-history
+- stubs-7-call-fake
+- stubs-8-call-through
+- stubs-9-call-through-with-new
+- stubs-10-use-promise-library
+- stubs-12-yield-to
+- stubs-14-add-behavior
+- stubs-15-replace-getter
+- stubs-16-define-new-setter
+- stubs-17-define-new-value
+- stubs-18-restore-values
 ---
 
 ### What are stubs?
@@ -24,24 +41,8 @@ Use a stub when you want to:
 
 The following example is yet another test from [PubSubJS][pubsubjs] which shows how to create an anonymous stub that throws an exception when called.
 
-```javascript
-"test should call all subscribers, even if there are exceptions" : function(){
-    var message = 'an example message';
-    var stub = sinon.stub().throws();
-    var spy1 = sinon.spy();
-    var spy2 = sinon.spy();
+<div data-example-id="stubs-1-pubsub"></div>
 
-    PubSub.subscribe(message, stub);
-    PubSub.subscribe(message, spy1);
-    PubSub.subscribe(message, spy2);
-
-    PubSub.publishSync(message, undefined);
-
-    assert(spy1.called);
-    assert(spy2.called);
-    assert(stub.calledBefore(spy1));
-}
-```
 
 Note how the stub also implements the spy interface. The test verifies that all
 callbacks were called, and also that the exception throwing stub was called
@@ -134,55 +135,22 @@ Stubs the method only for the provided arguments.
 
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
-```javascript
-"test should stub method differently based on arguments": function () {
-    var callback = sinon.stub();
-    callback.withArgs(42).returns(1);
-    callback.withArgs(1).throws("name");
+<div data-example-id="stubs-2-different-args"></div>
 
-    callback(); // No return value, no exception
-    callback(42); // Returns 1
-    callback(1); // Throws Error("name")
-}
-```
 
 #### `stub.onCall(n);` *Added in v1.8*
 
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.
 
-```javascript
-"test should stub method differently on consecutive calls": function () {
-    var callback = sinon.stub();
-    callback.onCall(0).returns(1);
-    callback.onCall(1).returns(2);
-    callback.returns(3);
+<div data-example-id="stubs-3-sequential-interactions"></div>
 
-    callback(); // Returns 1
-    callback(); // Returns 2
-    callback(); // All following calls return 3
-}
-```
 
 There are methods `onFirstCall`, `onSecondCall`,`onThirdCall` to make stub definitions read more naturally.
 
 `onCall` can be combined with all of the behavior defining methods in this section.  In particular, it can be used together with `withArgs`.
 
-```javascript
-"test should stub method differently on consecutive calls with certain argument": function () {
-    var callback = sinon.stub();
-    callback.withArgs(42)
-        .onFirstCall().returns(1)
-        .onSecondCall().returns(2);
-    callback.returns(0);
+<div data-example-id="stubs-4-sequential-with-args"></div>
 
-    callback(1); // Returns 0
-    callback(42); // Returns 1
-    callback(1); // Returns 0
-    callback(42); // Returns 2
-    callback(1); // Returns 0
-    callback(42); // Returns 0
-}
-```
 
 Note how the behavior of the stub for argument `42` falls back to the default behavior once no more calls have been defined.
 
@@ -214,17 +182,8 @@ As a convenience, you can apply `stub.reset()` to all stubs using `sinon.reset()
 
 Resets the stub's behaviour to the default behaviour
 
-```javascript
-var stub = sinon.stub();
+<div data-example-id="stubs-5-reset-behaviour"></div>
 
-stub.returns(54)
-
-stub(); // 54
-
-stub.resetBehavior();
-
-stub(); // undefined
-```
 
 *Since `sinon@5.0.0`*
 
@@ -237,19 +196,7 @@ You can reset behaviour of all stubs using `sinon.resetBehavior()`
 
 Resets the stub's history
 
-```javascript
-var stub = sinon.stub();
-
-stub.called // false
-
-stub();
-
-stub.called // true
-
-stub.resetHistory();
-
-stub.called // false
-```
+<div data-example-id="stubs-6-reset-history"></div>
 
 
 *Since `sinon@5.0.0`*
@@ -260,18 +207,8 @@ You can reset history of all stubs using `sinon.resetHistory()`
 #### `stub.callsFake(fakeFunction);`
 Makes the stub call the provided `fakeFunction` when invoked.
 
-```javascript
-var myObj = {};
-myObj.prop = function propFn() {
-    return 'foo';
-};
+<div data-example-id="stubs-7-call-fake"></div>
 
-sinon.stub(myObj, 'prop').callsFake(function fakeFn() {
-    return 'bar';
-});
-
-myObj.prop(); // 'bar'
-```
 
 #### `stub.returns(obj);`
 Makes the stub return the provided value.
@@ -386,48 +323,14 @@ a `TypeError` will be thrown.
 
 Causes the original method wrapped into the stub to be called when none of the conditional stubs are matched.
 
-```javascript
-var stub = sinon.stub();
-
-var obj = {};
-
-obj.sum = function sum(a, b) {
-    return a + b;
-};
-
-stub(obj, 'sum');
-
-obj.sum.withArgs(2, 2).callsFake(function foo() {
-    return 'bar';
-});
-
-obj.sum.callThrough();
-
-obj.sum(2, 2); // 'bar'
-obj.sum(1, 2); // 3
-```
+<div data-example-id="stubs-8-call-through"></div>
 
 
 #### `stub.callThroughWithNew();`
 
 Causes the original method wrapped into the stub to be called using the `new` operator when none of the conditional stubs are matched.
 
-```javascript
-var obj = {};
-
-obj.Sum = function MyConstructor(a, b) {
-    this.result = a + b;
-};
-
-sinon
-    .stub(obj, 'Sum')
-    .callThroughWithNew()
-    .withArgs(1, 2)
-    .returns({ result: 9000 });
-
-(new obj.Sum(2, 2)).result;  // 4
-(new obj.Sum(1, 2)).result;  // 9000
-```
+<div data-example-id="stubs-9-call-through-with-new"></div>
 
 
 #### `stub.callsArgOn(index, context);`
@@ -450,16 +353,8 @@ Causes the stub to return promises using a specific Promise library instead of
 the global one when using `stub.rejects` or `stub.resolves`. Returns the stub
 to allow chaining.
 
-```javascript
-var myObj = {
-    saveSomething: sinon.stub().usingPromise(bluebird.Promise).resolves("baz");
-}
+<div data-example-id="stubs-10-use-promise-library"></div>
 
-myObj.saveSomething()
-    .tap(function(actual) {
-        console.log(actual); // baz
-    });
-```
 
 *Since `sinon@2.0.0`*
 
@@ -488,11 +383,6 @@ Causes the spy to invoke a callback passed as a property of an object to the spy
 
 Like `yields`, `yieldsTo` grabs the first matching argument, finds the callback and calls it with the (optional) arguments.
 
-
-#### `stub.yieldsToOn(property, context, [arg1, arg2, ...])`
-
-Like above but with an additional parameter to pass the `this` context.
-
 ```javascript
 "test should fake successful ajax request": function () {
     sinon.stub(jQuery, "ajax").yieldsTo("success", [1, 2, 3]);
@@ -504,6 +394,11 @@ Like above but with an additional parameter to pass the `this` context.
     });
 }
 ```
+
+
+#### `stub.yieldsToOn(property, context, [arg1, arg2, ...])`
+
+Like above but with an additional parameter to pass the `this` context.
 
 
 #### `stub.yield([arg1, arg2, ...])`
@@ -523,21 +418,7 @@ Invokes callbacks passed as a property of an object to the stub.
 
 Like `yield`, `yieldTo` grabs the first matching argument, finds the callback and calls it with the (optional) arguments.
 
-```javascript
-"calling callbacks": function () {
-    var callback = sinon.stub();
-    callback({
-        "success": function () {
-            console.log("Success!");
-        },
-        "failure": function () {
-            console.log("Oh noes!");
-        }
-    });
-
-    callback.yieldTo("failure"); // Logs "Oh noes!"
-}
-```
+<div data-example-id="stubs-12-yield-to"></div>
 
 
 #### `stub.callArg(argNum)`
@@ -612,75 +493,31 @@ Async version of [stub.yieldsToOn(property, context, [arg1, arg2, ...])](#stubyi
 
 Add a custom behavior. The name will be available as a function on stubs, and the chaining mechanism will be set up for you (e.g. no need to return anything from your function, its return value will be ignored). The `fn` will be passed the fake instance as its first argument, and then the user's arguments.
 
-```javascript
-const sinon = require('sinon');
+<div data-example-id="stubs-14-add-behavior"></div>
 
-sinon.addBehavior('returnsNum', (fake, n) => fake.returns(n));
-
-var stub = sinon.stub().returnsNum(42);
-
-assert.equals(stub(), 42);
-```
 
 #### `stub.get(getterFn)`
 
 Replaces a new getter for this stub.
 
-```javascript
-var myObj = {
-    prop: 'foo'
-};
+<div data-example-id="stubs-15-replace-getter"></div>
 
-sinon.stub(myObj, 'prop').get(function getterFn() {
-    return 'bar';
-});
-
-myObj.prop; // 'bar'
-```
 
 #### `stub.set(setterFn)`
 
 Defines a new setter for this stub.
 
-```javascript
-var myObj = {
-    example: 'oldValue',
-    prop: 'foo'
-};
+<div data-example-id="stubs-16-define-new-setter"></div>
 
-sinon.stub(myObj, 'prop').set(function setterFn(val) {
-    myObj.example = val;
-});
-
-myObj.prop = 'baz';
-
-myObj.example; // 'baz'
-```
 
 #### `stub.value(newVal)`
 
 Defines a new value for this stub.
 
-```javascript
-var myObj = {
-    example: 'oldValue',
-};
+<div data-example-id="stubs-17-define-new-value"></div>
 
-sinon.stub(myObj, 'example').value('newValue');
-
-myObj.example; // 'newValue'
-```
 
 You can restore values by calling the `restore` method:
 
-```javascript
-var myObj = {
-    example: 'oldValue',
-};
-
-var stub = sinon.stub(myObj, 'example').value('newValue');
-stub.restore()
-
-myObj.example; // 'oldValue'
-```
+<div data-example-id="stubs-18-restore-values"></div>
 


### PR DESCRIPTION
https://github.com/sinonjs/sinon/issues/2062

 #### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Improvement to stubs doc

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
- Focus more on the basics of stubbing an object's function (stub pre-programmed to throw exception/return value)
- Less discussion on spies
- Provide very simple code to test as an example, instead of external library's (PubSub) code
- Show why restoration of a stub is necessary

 #### How to verify - mandatory
N.A. because no code change

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
