### PR TITLE
Add funding to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "mail": "christian@cjohansen.no",
     "url": "http://github.com/sinonjs/sinon/issues"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/sinon"
+  },
   "license": "BSD-3-Clause",
   "scripts": {
     "test-node": "mocha --recursive -R dot \"test/**/*-test.js\"",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "url": "http://github.com/sinonjs/sinon.git"
   },
   "bugs": {
-    "mail": "christian@cjohansen.no",
     "url": "http://github.com/sinonjs/sinon/issues"
   },
   "funding": {


### PR DESCRIPTION
This PR adds a `funding` field to `package.json`.

See https://github.com/npm/rfcs/blob/latest/accepted/0017-add-funding-support.md#prior-art
