### PR TITLE
Bring `config.target` into the light

### DIFF
--- a/docs/release-source/release/fake-timers.md
+++ b/docs/release-source/release/fake-timers.md
@@ -60,6 +60,7 @@ You can also pass in a Date object, and its `getTime()` will be used for the sta
 As above, but allows further configuration options, some of which are:
 
 - `config.now` - *Number/Date* - installs lolex with the specified unix epoch (default: 0)
+- `config.target` - *Object* - use `target` instead of the usual global object. This is useful if you use JSDOM along with Node.
 - `config.toFake` - *String[ ]* - an array with explicit function names to fake. By default lolex will automatically fake all methods *except* `process.nextTick`. You could, however, still fake `nextTick` by providing it explicitly
 - `config.shouldAdvanceTime` - *Boolean* - tells lolex to increment mocked time automatically based on the real system time shift (default: false)
 

--- a/lib/sinon/util/fake-timers.js
+++ b/lib/sinon/util/fake-timers.js
@@ -3,12 +3,8 @@
 var extend = require("./core/extend");
 var llx = require("lolex");
 
-function createClock(config, globalCtx) {
-    var llxCtx = llx;
-    if (globalCtx !== null && typeof globalCtx === "object") {
-        llxCtx = llx.withGlobal(globalCtx);
-    }
-    var clock = llxCtx.install(config);
+function createClock(config) {
+    var clock = llx.install(config);
     clock.restore = clock.uninstall;
     return clock;
 }
@@ -21,7 +17,7 @@ function addIfDefined(obj, globalPropName) {
 }
 
 /**
- * @param {number|Date|Object} dateOrConfig The unix epoch value to install with (default 0)
+ * @param {number|Date|Object} dateOrConfig The lolex config or a unix epoch value to install with (default 0)
  * @returns {Object} Returns a lolex clock instance
  */
 exports.useFakeTimers = function(dateOrConfig) {
@@ -44,12 +40,16 @@ exports.useFakeTimers = function(dateOrConfig) {
 
     if (argumentIsObject) {
         var config = extend.nonEnum({}, dateOrConfig);
-        var globalCtx = config.global;
+        if (typeof config.target === "undefined") {
+            config.target = config.global;
+        }
         delete config.global;
-        return createClock(config, globalCtx);
+        return createClock(config);
     }
 
-    throw new TypeError("useFakeTimers expected epoch or config object. See https://github.com/sinonjs/sinon");
+    throw new TypeError(
+        "useFakeTimers expected a config object similar to lolex.install(). See https://github.com/sinonjs/lolex#var-clock--lolexinstallconfig"
+    );
 };
 
 exports.clock = {

--- a/test/util/fake-timers-test.js
+++ b/test/util/fake-timers-test.js
@@ -1183,7 +1183,8 @@ describe("fakeTimers.clock", function() {
         });
 
         it("throws on old useFakeTimers signatures", function() {
-            var expectedError = "useFakeTimers expected epoch or config object. See https://github.com/sinonjs/sinon";
+            var expectedError =
+                "useFakeTimers expected a config object similar to lolex.install(). See https://github.com/sinonjs/lolex#var-clock--lolexinstallconfig";
 
             assert.exception(
                 function() {
@@ -1221,7 +1222,7 @@ describe("fakeTimers.clock", function() {
                 setTimeout: stub,
                 clearTimeout: sinonStub()
             };
-            this.clock = fakeTimers.useFakeTimers({ global: globalCtx });
+            this.clock = fakeTimers.useFakeTimers({ target: globalCtx });
             assert.isUndefined(this.clock.performance);
             assert.same(this.clock._setTimeout, stub); // eslint-disable-line no-underscore-dangle
             this.clock.restore();


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Remove unneeded branch logic and improve docs.

 #### Background (Problem in detail)  - optional
When looking into a user question (#2155) it became obvious that the
it's not obvious at all that the docs for Lolex install config can be
used when trying to configure `useFakeTimers`.

For one, we added a prop, `config.global`, to Sinon's `useFakeTimers` config in #1935 that
was quite superfluous: it supported a use case that was already there using `config.target`!

In this PR, I remove some extra branching logic and also update the docs
to highlight the lolex docs and the `target` prop.

 #### How to verify - mandatory
1. `npm test`
1. `npm run build-docs`