### PR TITLE
Chore/add missing backticks

### DIFF
--- a/docs/_releases/latest/stubs.md
+++ b/docs/_releases/latest/stubs.md
@@ -405,7 +405,7 @@ obj.sum.callThrough();
 
 obj.sum(2, 2); // 'bar'
 obj.sum(1, 2); // 3
-
+```
 
 #### `stub.callThroughWithNew();`
 


### PR DESCRIPTION
- In latest documentation for stub, Backticks for stub.callThrough() example were missing and resulted in format inconsistency

 #### Purpose (TL;DR) - mandatory

Fix Markdown formatting issue with docs on stub, between `stub.callThrough()` and `stub.callThroughWithNew()` caused by missing code block backticks.


<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

 #### How to verify - mandatory
1. Visual inspection of Markdown page and Sinon documentation page [(URL)](https://sinonjs.org/releases/latest/stubs/)
<img width="798" alt="Screen Shot 2019-11-26 at 9 08 27 am" src="https://user-images.githubusercontent.com/31234156/69582828-84742b80-102d-11ea-8546-e471eccea8e5.png">

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).