### PR TITLE
Adjust documentation so language is more inclusive

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Please try to [write great commit messages](http://chris.beams.io/posts/git-comm
 
 There are numerous benefits to great commit messages
 
-* They allow Sinon.JS users to easily understand the consequences of updating to a newer version
+* They allow Sinon.JS users to understand the consequences of updating to a newer version
 * They help contributors understand what is going on with the codebase, allowing features and fixes to be developed faster
 * They save maintainers time when compiling the changelog for a new release
 
@@ -116,7 +116,7 @@ Note that in dev mode tests run only in Node. Before creating your PR please ens
 
 Build requires Node. Under the hood [Browserify](http://browserify.org/) is used.
 
-To build simply run
+To build run
 
     $ node build.js
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Then we would need to change the documentation for `v1.17.1`, `v1.17.2` and `v1.
 
 ## Running the documentation site locally
 
-For casual improvements to the documentation, this shouldn't really be necessary, as all the content documents are just plain markdown files.
+For casual improvements to the documentation, this shouldn't really be necessary, as all the content documents are plain markdown files.
 
 However, if you're going to contribute changes that alter the overall structure or design of the site, then this section is for you.
 

--- a/docs/_howto/stub-dependency.md
+++ b/docs/_howto/stub-dependency.md
@@ -3,11 +3,11 @@ layout: page
 title: How to stub a dependency of a module
 ---
 
-Sinon is simply a stubbing library, not a module interception library. Stubbing dependencies is highly dependant on your enviroment and the implementation. For Node environments, we usually recommend solutions targetting [link seams](../link-seams-commonjs/) or explicit dependency injection. Though in some simple cases, you can get away with just using Sinon by modifying the module exports of the dependency.
+Sinon is a stubbing library, not a module interception library. Stubbing dependencies is highly dependant on your enviroment and the implementation. For Node environments, we usually recommend solutions targetting [link seams](../link-seams-commonjs/) or explicit dependency injection. Though in some more basic cases, you can get away with only using Sinon by modifying the module exports of the dependency.
 
 To stub a dependency (imported module) of a module under test you have to import it explicitly in your test and stub the desired method. For the stubbing to work, the stubbed method cannot be [destructured](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment), neither in the module under test nor in the test.
 
-## A simple example
+## An example
 
 ### Source file: dependencyModule.js
 

--- a/docs/_includes/docs/contribute.md
+++ b/docs/_includes/docs/contribute.md
@@ -4,4 +4,4 @@ Please ask questions on [Stack Overflow](https://stackoverflow.com/questions/tag
 
 ### Contribute
 
-We really appreciate suggestions to improve the documentation so Sinon.JS can be easy to work with. Get in touch!
+We really appreciate suggestions to improve the documentation so Sinon.JS can be easier to work with. Get in touch!

--- a/docs/_releases/latest/assertions.md
+++ b/docs/_releases/latest/assertions.md
@@ -31,7 +31,7 @@ Every assertion fails by calling this method.
 
 By default it throws an error of type `sinon.assert.failException`.
 
-If the test framework looks for assertion errors by checking for a specific exception, you can simply override the kind of exception thrown. If that does not fit with your testing framework of choice, override the `fail` method to do the right thing.
+If the test framework looks for assertion errors by checking for a specific exception, you can override the kind of exception thrown. If that does not fit with your testing framework of choice, override the `fail` method to do the right thing.
 
 
 #### `sinon.assert.failException;`

--- a/docs/_releases/latest/fake-xhr-and-server.md
+++ b/docs/_releases/latest/fake-xhr-and-server.md
@@ -341,7 +341,7 @@ Supports a pattern common to Ruby on Rails applications. For custom HTTP method 
 
 Used internally to determine the HTTP method used with the provided request.
 
-By default this method simply returns `request.method`. When `server.fakeHTTPMethods` is true, the method will return the value of the `_method` parameter if the method is "POST".
+By default this method returns `request.method`. When `server.fakeHTTPMethods` is true, the method will return the value of the `_method` parameter if the method is "POST".
 
 This method can be overridden to provide custom behavior.
 

--- a/docs/_releases/latest/fakes.md
+++ b/docs/_releases/latest/fakes.md
@@ -106,7 +106,7 @@ This is useful when complex behavior not covered by the `sinon.fake.*` methods i
 
 #### `f.callback`
 
-This property is a convenience to easily get a reference to the last callback passed in the last to the fake.
+This property is a convenience to get a reference to the last callback passed in the last to the fake.
 
 ```js
 var f = sinon.fake();
@@ -174,7 +174,7 @@ console.log('apple pie');
 // 42
 ```
 
-When you want to restore the replaced properties, simply call the `sinon.restore` method.
+When you want to restore the replaced properties, call the `sinon.restore` method.
 
 ```js
 // restores all replaced properties set by sinon methods (replace, spy, stub)

--- a/docs/_releases/latest/json-p.md
+++ b/docs/_releases/latest/json-p.md
@@ -8,11 +8,11 @@ breadcrumb: JSON-P
 
 JSON-P doesn't use `XHR` requests, which is what the fake server is concerned with. A JSON-P request creates a script element and inserts it into the document.
 
-There is no sufficiently unobtrusive way to fake this automatically. The best option is to simply stub jQuery in this case:
+There is no sufficiently unobtrusive way to fake this automatically. The best option is to stub jQuery in this case:
 
 ```javascript
 sinon.stub(jQuery, "ajax");
 sinon.assert.calledOnce(jQuery.ajax);
 ```
 
-We could potentially have had the fake server detect `jQuery` and fake any calls to `jQuery.ajax` when JSON-P is used, but that felt like a compromise in the focus of the Sinon project compared to simply documenting the above practice.
+We could potentially have had the fake server detect `jQuery` and fake any calls to `jQuery.ajax` when JSON-P is used, but that felt like a compromise in the focus of the Sinon project compared to only documenting the above practice.

--- a/docs/_releases/latest/mocks.md
+++ b/docs/_releases/latest/mocks.md
@@ -106,7 +106,7 @@ jQuery.ajax.verify();
 
 #### `var expectation = sinon.expectation.create([methodName]);`
 
-Creates an expectation without a mock object, basically an anonymous mock function.
+Creates an expectation without a mock object, which is essentially an anonymous mock function.
 
 Method name is optional and is used in exception messages to make them more readable.
 

--- a/docs/_releases/latest/sandbox.md
+++ b/docs/_releases/latest/sandbox.md
@@ -39,7 +39,7 @@ describe('myAPI.hello method', function () {
 
 #### Default sandbox
 
-Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
+Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to only use that one.
 
 ```javascript
 const myObject = {
@@ -114,7 +114,7 @@ The sandbox's methods can be injected into another object for convenience. The
 
 ##### properties
 
-What properties to inject. Note that simply naming "server" here is not
+What properties to inject. Note that only naming "server" here is not
 sufficient to have a `server` property show up in the target object, you also
 have to set `useFakeServer` to `true`.
 
@@ -217,7 +217,7 @@ Works exactly like `sinon.spy`
 
 #### `sandbox.createStubInstance();`
 
-Works almost exactly like `sinon.createStubInstance`, only also adds the returned stubs to the internal collection of fakes for easy restoring through `sandbox.restore()`.
+Works almost exactly like `sinon.createStubInstance`, only also adds the returned stubs to the internal collection of fakes for restoring through `sandbox.restore()`.
 
 #### `sandbox.stub();`
 

--- a/docs/_releases/latest/stubs.md
+++ b/docs/_releases/latest/stubs.md
@@ -543,7 +543,7 @@ Like `yield`, `yieldTo` grabs the first matching argument, finds the callback an
 
 Like `yield`, but with an explicit argument number specifying which callback to call.
 
-Useful if a function is called with more than one callback, and simply calling the first callback is not desired.
+Useful if a function is called with more than one callback, and calling the first callback is not desired.
 
 ```javascript
 "calling the last callback": function () {

--- a/docs/guides/migrating-to-2.0.md
+++ b/docs/guides/migrating-to-2.0.md
@@ -75,7 +75,7 @@ The following utility functions are being marked as deprecated and are planned f
 
 ## `sandbox.useFakeXMLHttpRequest` no longer returns a "server"
 
-In Sinon 1.x, the sandbox' `useFakeXMLHttpRequest` was the same as its `useFakeServer`. In 2.x, it maps directly to `sinon.useFakeXMLHttpRequest` (but with sandboxing). If you use `sandbox.useFakeXMLHttpRequest`, just replace it with `sandbox.useFakeServer`, and your tests should behave as they always did.
+In Sinon 1.x, the sandbox' `useFakeXMLHttpRequest` was the same as its `useFakeServer`. In 2.x, it maps directly to `sinon.useFakeXMLHttpRequest` (but with sandboxing). If you use `sandbox.useFakeXMLHttpRequest`, replace it with `sandbox.useFakeServer`, and your tests should behave as they always did.
 
 ## `sinon.behavior` is gone
 

--- a/docs/guides/migrating-to-5.0.md
+++ b/docs/guides/migrating-to-5.0.md
@@ -14,7 +14,7 @@ In a previous version we deprecated and aliased `spy.reset` in favour of using `
 
 ## `sinon` is now a (default) sandbox
 
-Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
+Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to only use that one.
 
 The old sandbox API is still available, so you don't **have** to do anything.
 

--- a/docs/release-source/release/assertions.md
+++ b/docs/release-source/release/assertions.md
@@ -31,7 +31,7 @@ Every assertion fails by calling this method.
 
 By default it throws an error of type `sinon.assert.failException`.
 
-If the test framework looks for assertion errors by checking for a specific exception, you can simply override the kind of exception thrown. If that does not fit with your testing framework of choice, override the `fail` method to do the right thing.
+If the test framework looks for assertion errors by checking for a specific exception, you can override the kind of exception thrown. If that does not fit with your testing framework of choice, override the `fail` method to do the right thing.
 
 
 #### `sinon.assert.failException;`

--- a/docs/release-source/release/fake-xhr-and-server.md
+++ b/docs/release-source/release/fake-xhr-and-server.md
@@ -341,7 +341,7 @@ Supports a pattern common to Ruby on Rails applications. For custom HTTP method 
 
 Used internally to determine the HTTP method used with the provided request.
 
-By default this method simply returns `request.method`. When `server.fakeHTTPMethods` is true, the method will return the value of the `_method` parameter if the method is "POST".
+By default this method returns `request.method`. When `server.fakeHTTPMethods` is true, the method will return the value of the `_method` parameter if the method is "POST".
 
 This method can be overridden to provide custom behavior.
 

--- a/docs/release-source/release/fakes.md
+++ b/docs/release-source/release/fakes.md
@@ -128,7 +128,7 @@ The instance properties are the same as a [`sinon.spy`][spies].
 
 #### `f.callback`
 
-This property is a convenience to easily get a reference to the last callback passed in the last to the fake.
+This property is a convenience to get a reference to the last callback passed in the last to the fake.
 
 ```js
 var f = sinon.fake();
@@ -196,7 +196,7 @@ console.log('apple pie');
 // 42
 ```
 
-When you want to restore the replaced properties, simply call the `sinon.restore` method.
+When you want to restore the replaced properties, call the `sinon.restore` method.
 
 ```js
 // restores all replaced properties set by sinon methods (replace, spy, stub)

--- a/docs/release-source/release/json-p.md
+++ b/docs/release-source/release/json-p.md
@@ -8,11 +8,11 @@ breadcrumb: JSON-P
 
 JSON-P doesn't use `XHR` requests, which is what the fake server is concerned with. A JSON-P request creates a script element and inserts it into the document.
 
-There is no sufficiently unobtrusive way to fake this automatically. The best option is to simply stub jQuery in this case:
+There is no sufficiently unobtrusive way to fake this automatically. The best option is to stub jQuery in this case:
 
 ```javascript
 sinon.stub(jQuery, "ajax");
 sinon.assert.calledOnce(jQuery.ajax);
 ```
 
-We could potentially have had the fake server detect `jQuery` and fake any calls to `jQuery.ajax` when JSON-P is used, but that felt like a compromise in the focus of the Sinon project compared to simply documenting the above practice.
+We could potentially have had the fake server detect `jQuery` and fake any calls to `jQuery.ajax` when JSON-P is used, but that felt like a compromise in the focus of the Sinon project compared to only documenting the above practice.

--- a/docs/release-source/release/mocks.md
+++ b/docs/release-source/release/mocks.md
@@ -106,7 +106,7 @@ jQuery.ajax.verify();
 
 #### `var expectation = sinon.expectation.create([methodName]);`
 
-Creates an expectation without a mock object, basically an anonymous mock function.
+Creates an expectation without a mock object, which is essentially an anonymous mock function.
 
 Method name is optional and is used in exception messages to make them more readable.
 

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -39,7 +39,7 @@ describe('myAPI.hello method', function () {
 
 #### Default sandbox
 
-Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.
+Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to only use that one.
 
 ```javascript
 const myObject = {
@@ -115,7 +115,7 @@ The sandbox's methods can be injected into another object for convenience. The
 
 ##### properties
 
-What properties to inject. Note that simply naming "server" here is not
+What properties to inject. Note that only naming "server" here is not
 sufficient to have a `server` property show up in the target object, you also
 have to set `useFakeServer` to `true`.
 
@@ -247,7 +247,7 @@ Works exactly like `sinon.spy`
 
 #### `sandbox.createStubInstance();`
 
-Works almost exactly like `sinon.createStubInstance`, only also adds the returned stubs to the internal collection of fakes for easy restoring through `sandbox.restore()`.
+Works almost exactly like `sinon.createStubInstance`, only also adds the returned stubs to the internal collection of fakes for restoring through `sandbox.restore()`.
 
 #### `sandbox.stub();`
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -544,7 +544,7 @@ Like `yield`, `yieldTo` grabs the first matching argument, finds the callback an
 
 Like `yield`, but with an explicit argument number specifying which callback to call.
 
-Useful if a function is called with more than one callback, and simply calling the first callback is not desired.
+Useful if a function is called with more than one callback, and calling the first callback is not desired.
 
 ```javascript
 "calling the last callback": function () {


### PR DESCRIPTION
Closes #2139

 #### Purpose 
This PR attempts to remove or replace as many instances of condescending language (ie. simply, easy, just, of course, etc) as possible in the documentation. While most of the changes are removing the word, some involved altering the text.

 #### Background
As discussed in the issue, I focused on the latest release. If you would be interested in having the others updated as well, please let me know and I can tackle that in another PR. 

 #### Solution
Feel free to revert or ask me to fix any parts that you believe should stay the way they are. If even a fraction of these changes can be merged then it will be a huge step towards making the documentation more inclusive!

I tried to separate chunks via commits to help the review process and give more context. Not all of the commit messages are great though, so hoping that gets squashed 😆 

I want to also add that I decided to keep the instances of `easy` and `easily` in the [Goals section of the repository's README](https://github.com/sinonjs/sinon#goals) on purpose because goals represent aspirations and not realities 😊 

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
