### PR TITLE
Upgrade nise, @sinonjs/formatiom, @sinonjs/samsam and @sinonjs/referee

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -193,53 +193,28 @@
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+      "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
       "requires": {
         "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
-      },
-      "dependencies": {
-        "@sinonjs/samsam": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-          "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
-          "requires": {
-            "@sinonjs/commons": "^1.3.0",
-            "array-from": "^2.1.1",
-            "lodash": "^4.17.15"
-          }
-        }
+        "@sinonjs/samsam": "^4.2.0"
       }
     },
     "@sinonjs/referee": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-3.2.0.tgz",
-      "integrity": "sha512-t+sDpTvUmqgYWkPwTuO4gEivScbEKbF6eqFB9Cv70PqcyJla3w7Mj0JQyXn18uCDR2bIZglD4NNGeWGg8YfaGw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-4.0.0.tgz",
+      "integrity": "sha512-gCQf6mbLyHLbrRk1T8VvBRFg6W/0ebFa5KlPxdsH5bUHxvwLwuwPp5Y26X7TkLUdqVw5bQjXXvpFf8/eyznojQ==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.4.0",
-        "@sinonjs/formatio": "^3.1.0",
-        "@sinonjs/samsam": "^3.0.0",
+        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/samsam": "^4.2.0",
         "array-from": "2.1.1",
         "bane": "^1.x",
         "lodash.includes": "^4.3.0",
         "lodash.isarguments": "^3.1.0",
         "object-assign": "^4.1.1"
-      },
-      "dependencies": {
-        "@sinonjs/samsam": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-          "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.3.0",
-            "array-from": "^2.1.1",
-            "lodash": "^4.17.15"
-          }
-        }
       }
     },
     "@sinonjs/samsam": {
@@ -4553,7 +4528,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.differencewith": {
       "version": "4.5.0",
@@ -5341,12 +5317,12 @@
       "dev": true
     },
     "nise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-2.0.1.tgz",
-      "integrity": "sha512-1amGISL/J8xOBVZvlJf+4gof9uTvLLoQiHvja9TQZDF7REgGpktC+vcSYvGdzrwO/POyhUVgkSET9kMonnu1SA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.0.tgz",
+      "integrity": "sha512-EObFx5tioBMePHpU/gGczaY2YDqL255iwjmZwswu2CiwEW8xIGrr3E2xij+efIppS1nLQo9NyXSIUySGHUOhHQ==",
       "requires": {
         "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/formatio": "^4.0.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "lolex": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -57,16 +57,16 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^1.4.0",
-    "@sinonjs/formatio": "^3.2.1",
+    "@sinonjs/formatio": "^4.0.1",
     "@sinonjs/samsam": "^4.0.1",
     "diff": "^4.0.1",
     "lolex": "^5.1.2",
-    "nise": "^2.0.1",
+    "nise": "^3.0.0",
     "supports-color": "^7.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
-    "@sinonjs/referee": "^3.2.0",
+    "@sinonjs/referee": "^4.0.0",
     "babel-plugin-istanbul": "^5.2.0",
     "babelify": "^10.0.0",
     "browserify": "^16.5.0",

--- a/test/fake-test.js
+++ b/test/fake-test.js
@@ -103,7 +103,7 @@ describe("fake", function() {
             assert.equals(f.callback, callback2);
 
             f(1, 2, 3);
-            assert.equals(f.callback, undefined);
+            assert.isUndefined(f.callback);
         });
     });
 

--- a/test/proxy-call-test.js
+++ b/test/proxy-call-test.js
@@ -549,7 +549,7 @@ describe("sinonSpy.call", function() {
             assert.equals(spy.getCall(1).callback, callback2);
 
             spy(1, 2, 3);
-            assert.equals(spy.getCall(2).callback, undefined);
+            assert.isUndefined(spy.getCall(2).callback);
         });
     });
 
@@ -567,7 +567,7 @@ describe("sinonSpy.call", function() {
             assert.equals(spy.getCall(2).lastArg, 46);
 
             spy();
-            assert.equals(spy.getCall(3).lastArg, undefined);
+            assert.isUndefined(spy.getCall(3).lastArg);
         });
     });
 

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -212,9 +212,9 @@ describe("Sandbox", function() {
             assert.equals(3, stub.method3());
 
             this.sandbox.reset();
-            assert.equals(undefined, stub.method1());
-            assert.equals(undefined, stub.method2());
-            assert.equals(undefined, stub.method3());
+            assert.isUndefined(stub.method1());
+            assert.isUndefined(stub.method2());
+            assert.isUndefined(stub.method3());
         });
 
         it("doesn't stub fake methods", function() {

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -362,7 +362,7 @@ describe("spy", function() {
             assert.equals(spy.getCall(3).args[0], 1);
             assert.equals(spy.getCall(3).args[1], 2);
             assert.isUndefined(spy.getCall(3).args[2]);
-            ["args", "callCount", "callId"].forEach(function(propName) {
+            ["args", "callId"].forEach(function(propName) {
                 assert.equals(spy.withArgs(1).getCall(0)[propName], spy.getCall(1)[propName]);
                 assert.equals(spy.withArgs(1).getCall(1)[propName], spy.getCall(2)[propName]);
                 assert.equals(spy.withArgs(1).getCall(2)[propName], spy.getCall(3)[propName]);


### PR DESCRIPTION
This PR upgrades components in order to get on the latest `@sinonjs/samsam`, which doesn't load all of `lodash`, and to only load one version of `@sinonjs/samsam`

Fixes https://github.com/sinonjs/sinon/issues/2177

#### Before

![2019-12-21 at 17 09](https://user-images.githubusercontent.com/20321/71310457-a9817180-2414-11ea-9bdc-70e41d863151.png)

#### After

![2019-12-21 at 17 11](https://user-images.githubusercontent.com/20321/71310478-e3527800-2414-11ea-84bc-9aa364e4f077.png)
