### PR TITLE
Force upgrade @sinonjs/commons

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "docs/**/*.md": "markdownlint"
   },
   "dependencies": {
-    "@sinonjs/commons": "^1.4.0",
+    "@sinonjs/commons": "^1.7.0",
     "@sinonjs/formatio": "^4.0.1",
     "@sinonjs/samsam": "^4.0.1",
     "diff": "^4.0.1",


### PR DESCRIPTION
Fixes https://github.com/sinonjs/sinon/issues/2180

#### Background

I guess `@sinonjs/commons` should have had a major version bump somewhere along the way, when the  API changed.


#### Solution 

* Force `@sinonjs/commons` to latest

#### How to verify - mandatory

1. Observe tests pass
