### PR TITLE
Upgrade nise to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2133,7 +2133,7 @@
     "eslint-plugin-ie11": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-ie11/-/eslint-plugin-ie11-1.0.0.tgz",
-      "integrity": "sha512-PPv2Cbq5roUmoIZJfPWbEEILHvi2Yfp/cRVzaVKL/YJiYGGLJ0/Qrq1HKd2OZKb3RQQOXweCd/hh261bljEe8A==",
+      "integrity": "sha1-iZDl2achLMEvYh6JyGoy1tN/38U=",
       "dev": true,
       "requires": {
         "requireindex": "~1.1.0"
@@ -4861,7 +4861,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -5317,9 +5317,9 @@
       "dev": true
     },
     "nise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.0.tgz",
-      "integrity": "sha512-EObFx5tioBMePHpU/gGczaY2YDqL255iwjmZwswu2CiwEW8xIGrr3E2xij+efIppS1nLQo9NyXSIUySGHUOhHQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
+      "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
       "requires": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/formatio": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@sinonjs/samsam": "^4.0.1",
     "diff": "^4.0.1",
     "lolex": "^5.1.2",
-    "nise": "^3.0.0",
+    "nise": "^3.0.1",
     "supports-color": "^7.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This version has fixed an issue reported as

`TypeError: GlobalTextEncoder is not a constructor`

See https://github.com/sinonjs/nise/issues/123
