### PR TITLE
Restore fully spied objects in the sandbox

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -210,7 +210,7 @@ function Sandbox() {
         var descriptor = getPropertyDescriptor(object, property);
 
         if (typeof descriptor === "undefined") {
-            throw new TypeError("Cannot replace non-existent own property " + valueToString(property));
+            throw new TypeError("Cannot replace non-existent property " + valueToString(property));
         }
 
         if (typeof replacement === "undefined") {
@@ -243,7 +243,7 @@ function Sandbox() {
         var descriptor = getPropertyDescriptor(object, property);
 
         if (typeof descriptor === "undefined") {
-            throw new TypeError("Cannot replace non-existent own property " + valueToString(property));
+            throw new TypeError("Cannot replace non-existent property " + valueToString(property));
         }
 
         if (typeof replacement !== "function") {
@@ -271,7 +271,7 @@ function Sandbox() {
         var descriptor = getPropertyDescriptor(object, property);
 
         if (typeof descriptor === "undefined") {
-            throw new TypeError("Cannot replace non-existent own property " + valueToString(property));
+            throw new TypeError("Cannot replace non-existent property " + valueToString(property));
         }
 
         if (typeof replacement !== "function") {

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -22,6 +22,7 @@ var filter = arrayProto.filter;
 var forEach = arrayProto.filter;
 var push = arrayProto.push;
 var reverse = arrayProto.reverse;
+var slice = arrayProto.slice;
 
 function applyOnEach(fakes, method) {
     var matchingFakes = filter(fakes, function(fake) {
@@ -298,28 +299,23 @@ function Sandbox() {
         return replacement;
     };
 
-    sandbox.spy = function spy() {
-        var s = sinonSpy.apply(sinonSpy, arguments);
+    function commonSpyChecksAndSetup(args, sinonSpyOrStubFn) {
+        var object = args[0];
+        var property = args[1];
 
-        push(collection, s);
-
-        return s;
-    };
-
-    sandbox.stub = function stub(object, property) {
         if (isEsModule(object)) {
-            throw new TypeError("ES Modules cannot be stubbed");
+            throw new TypeError("ES Modules cannot be stubbed or be spied on");
         }
 
         if (isNonExistentOwnProperty(object, property)) {
-            throw new TypeError("Cannot stub non-existent own property " + valueToString(property));
+            throw new TypeError("Cannot stub or spy on non-existent own property " + valueToString(property));
         }
 
-        var stubbed = sinonStub.apply(null, arguments);
-        var isStubbingEntireObject = typeof property === "undefined" && typeof object === "object";
+        var spy = sinonSpyOrStubFn.apply(sinonSpyOrStubFn, args);
+        var isSpyingOnEntireObject = typeof property === "undefined" && typeof object === "object";
 
-        if (isStubbingEntireObject) {
-            var ownMethods = collectOwnMethods(stubbed);
+        if (isSpyingOnEntireObject) {
+            var ownMethods = collectOwnMethods(spy);
 
             forEach(ownMethods, function(method) {
                 push(collection, method);
@@ -327,11 +323,19 @@ function Sandbox() {
 
             usePromiseLibrary(promiseLib, ownMethods);
         } else {
-            push(collection, stubbed);
-            usePromiseLibrary(promiseLib, stubbed);
+            push(collection, spy);
+            usePromiseLibrary(promiseLib, spy);
         }
 
-        return stubbed;
+        return spy;
+    }
+
+    sandbox.spy = function spy() {
+        return commonSpyChecksAndSetup(slice(arguments), sinonSpy);
+    };
+
+    sandbox.stub = function stub() {
+        return commonSpyChecksAndSetup(slice(arguments), sinonStub);
     };
 
     // eslint-disable-next-line no-unused-vars

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -20,7 +20,6 @@ var filter = arrayProto.filter;
 var forEach = arrayProto.filter;
 var push = arrayProto.push;
 var reverse = arrayProto.reverse;
-var slice = arrayProto.slice;
 
 function applyOnEach(fakes, method) {
     var matchingFakes = filter(fakes, function(fake) {
@@ -297,11 +296,10 @@ function Sandbox() {
         return replacement;
     };
 
-    function commonSpyChecksAndSetup(args, sinonSpyOrStubFn) {
+    function commonPostInitSetup(args, spy) {
         var object = args[0];
         var property = args[1];
 
-        var spy = sinonSpyOrStubFn.apply(sinonSpyOrStubFn, args);
         var isSpyingOnEntireObject = typeof property === "undefined" && typeof object === "object";
 
         if (isSpyingOnEntireObject) {
@@ -321,11 +319,13 @@ function Sandbox() {
     }
 
     sandbox.spy = function spy() {
-        return commonSpyChecksAndSetup(slice(arguments), sinonSpy);
+        var createdSpy = sinonSpy.apply(sinonSpy, arguments);
+        return commonPostInitSetup(arguments, createdSpy);
     };
 
     sandbox.stub = function stub() {
-        return commonSpyChecksAndSetup(slice(arguments), sinonStub);
+        var createdStub = sinonStub.apply(sinonStub, arguments);
+        return commonPostInitSetup(arguments, createdStub);
     };
 
     // eslint-disable-next-line no-unused-vars

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -3,9 +3,7 @@
 var arrayProto = require("@sinonjs/commons").prototypes.array;
 var collectOwnMethods = require("./collect-own-methods");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
-var isEsModule = require("./util/core/is-es-module");
 var isPropertyConfigurable = require("./util/core/is-property-configurable");
-var isNonExistentOwnProperty = require("./util/core/is-non-existent-own-property");
 var match = require("@sinonjs/samsam").createMatcher;
 var sinonAssert = require("./assert");
 var sinonClock = require("./util/fake-timers");
@@ -302,14 +300,6 @@ function Sandbox() {
     function commonSpyChecksAndSetup(args, sinonSpyOrStubFn) {
         var object = args[0];
         var property = args[1];
-
-        if (isEsModule(object)) {
-            throw new TypeError("ES Modules cannot be stubbed or be spied on");
-        }
-
-        if (isNonExistentOwnProperty(object, property)) {
-            throw new TypeError("Cannot stub or spy on non-existent own property " + valueToString(property));
-        }
 
         var spy = sinonSpyOrStubFn.apply(sinonSpyOrStubFn, args);
         var isSpyingOnEntireObject = typeof property === "undefined" && typeof object === "object";

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -562,7 +562,7 @@ describe("Sandbox", function() {
                     function() {
                         sandbox.stub(object, Symbol());
                     },
-                    { message: "Cannot stub or spy on non-existent own property Symbol()" },
+                    { message: "Cannot stub non-existent own property Symbol()" },
                     TypeError
                 );
 

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -814,7 +814,7 @@ describe("Sandbox", function() {
                     sandbox.replace({}, "i-dont-exist");
                 },
                 {
-                    message: "Cannot replace non-existent own property i-dont-exist",
+                    message: "Cannot replace non-existent property i-dont-exist",
                     name: "TypeError"
                 }
             );
@@ -1014,7 +1014,7 @@ describe("Sandbox", function() {
                     sandbox.replaceGetter({}, "i-dont-exist");
                 },
                 {
-                    message: "Cannot replace non-existent own property i-dont-exist",
+                    message: "Cannot replace non-existent property i-dont-exist",
                     name: "TypeError"
                 }
             );
@@ -1161,7 +1161,7 @@ describe("Sandbox", function() {
                     sandbox.replaceSetter({}, "i-dont-exist");
                 },
                 {
-                    message: "Cannot replace non-existent own property i-dont-exist",
+                    message: "Cannot replace non-existent property i-dont-exist",
                     name: "TypeError"
                 }
             );

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -562,7 +562,7 @@ describe("Sandbox", function() {
                     function() {
                         sandbox.stub(object, Symbol());
                     },
-                    { message: "Cannot stub non-existent own property Symbol()" },
+                    { message: "Cannot stub or spy on non-existent own property Symbol()" },
                     TypeError
                 );
 
@@ -1754,6 +1754,35 @@ describe("Sandbox", function() {
                     message: "sandbox.restore() does not take any parameters. Perhaps you meant stub.restore()"
                 }
             );
+        });
+
+        // https://github.com/sinonjs/sinon/issues/2192
+        it("restores all fields of a spied object", function() {
+            var sandbox = new Sandbox();
+            var o = {
+                foo: function() {
+                    return 42;
+                }
+            };
+
+            sandbox.spy(o);
+            sandbox.restore();
+
+            assert.isUndefined(o.foo.callCount);
+        });
+
+        it("restores all fields of a stubbed object", function() {
+            var sandbox = new Sandbox();
+            var o = {
+                foo: function() {
+                    return 42;
+                }
+            };
+
+            sandbox.stub(o);
+            sandbox.restore();
+
+            assert.isUndefined(o.foo.callCount);
         });
     });
 


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
- Align the behaviour of spies with that of stubs to fix #2192 

Additionally, this PR also fixes a misleading error message.

 #### Background (Problem in detail)  - optional
See #2192. It is currently not possible to use the sandbox restore functionality on objects that have been spied on like this `sinon.spy(obj)`.

 #### Solution  
The only thing I want to point out as strange is the fixes to the error message. I found it somewhat strange that we allow fakes to replace stuff on the prototype, even though we have had a discussion about this earlier regarding spies and stubs where @mroderick came to the opposite conclusion: do not allow stubbing on fields up the prototype chain (hence the error messages). This makes using fakes a different beast from using spies and stubs, which I think is a bit unfortunate.

 #### How to verify - mandatory
1. Notice the additional test
2. See `npm test` pass

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
