### PR TITLE
Support negative indices in getCall

### DIFF
--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -350,6 +350,8 @@ Returns `true` if spy always returned the provided value.
 
 Returns the *nth* [call](#spycall).
 
+If *n* is negative, the *nth* call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
+
 Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 <div data-example-id="spies-8-spy-call"></div>

--- a/lib/sinon/proxy.js
+++ b/lib/sinon/proxy.js
@@ -43,6 +43,7 @@ var proxyApi = {
     getCall: function getCall(index) {
         var i = index;
         if (i < 0) {
+            // Negative indices means counting backwards from the last call
             i += this.callCount;
         }
         if (i < 0 || i >= this.callCount) {

--- a/lib/sinon/proxy.js
+++ b/lib/sinon/proxy.js
@@ -40,7 +40,11 @@ var proxyApi = {
         return emptyFakes;
     },
 
-    getCall: function getCall(i) {
+    getCall: function getCall(index) {
+        var i = index;
+        if (i < 0) {
+            i += this.callCount;
+        }
         if (i < 0 || i >= this.callCount) {
             return null;
         }

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -2086,6 +2086,48 @@ describe("spy", function() {
         });
     });
 
+    describe(".getCall", function() {
+        it("is null for indexes >= length", function() {
+            var spy = createSpy();
+
+            spy();
+
+            assert.isNull(spy.getCall(1));
+            assert.isNull(spy.getCall(2));
+        });
+
+        it("is null for indexes < -length", function() {
+            var spy = createSpy();
+
+            spy();
+
+            assert.isNull(spy.getCall(-2));
+            assert.isNull(spy.getCall(-3));
+        });
+
+        it("is same as last call when passed index -1", function() {
+            var spy = createSpy();
+
+            spy();
+            spy();
+            spy();
+
+            assert.same(spy.getCall(-1).callId, spy.lastCall.callId);
+            assert.same(spy.getCall(-1).spy, spy.lastCall.spy);
+        });
+
+        it("is same as n-1th call when passed index -2", function() {
+            var spy = createSpy();
+
+            spy();
+            spy();
+            spy();
+
+            assert.same(spy.getCall(-2).callId, spy.getCall(1).callId);
+            assert.same(spy.getCall(-2).spy, spy.getCall(1).spy);
+        });
+    });
+
     describe(".lastCall", function() {
         it("is undefined by default", function() {
             var spy = createSpy();


### PR DESCRIPTION
This allows getting calls indexed from the end of the array
e.g. -1 gets the last call, -2 gets the penultimate call etc.

 #### Purpose (TL;DR)
Implements the proposal in #2196

Allows the user to get the -nth call when the total number of calls is arbitrary, without having to wrap around getCalls() function.

In an ideal world, the full set of calls should be known and this function would not be necessary, but for some use cases this can be useful (see #2196 for my use case). I understand this is a bit of a niche case so don't mind if you choose to close instead of merge!

 #### How to verify
1. Check out this branch
2. `npm install`
3. `npm test`
