### PR TITLE
Ci action performance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
           ${{ runner.OS }}-node-
           ${{ runner.OS }}-
     - run: npm ci
+      env:
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 1
     - name: Pre-Test
       run: |
         npm run lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,14 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Cache modules
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.OS }}-node-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
+          ${{ runner.OS }}-
     - run: npm ci
     - name: Pre-Test
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,9 @@ jobs:
       run: |
         npm run lint
 
-        npm run test-headless -- --chrome $(which google-chrome-stable) --allow-chrome-as-root
-        npm run test-webworker -- --chrome $(which google-chrome-stable) --allow-chrome-as-root
+        export SINON_CHROME_BIN=$(which google-chrome-stable)
+        npm run test-headless -- --chrome $SINON_CHROME_BIN --allow-chrome-as-root
+        npm run test-webworker -- --chrome $SINON_CHROME_BIN --allow-chrome-as-root
         npm run test-esm-bundle
       if: matrix.node-version == 10
 


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

Improve build performance by configuring npm dependency caching and skipping the unused Chromium download.

 #### Background (Problem in detail)  - optional

The build is currently downloading all dependencies and an unused Chromium binary on every execution. This PR should save some resources and speed up the build.

 #### How to verify - mandatory

Inspect the GitHub actions log for this branch at https://github.com/sinonjs/sinon/runs/400526914 and find these messages in the logs:

- In Cache modules: `Cache Size: ~14 MB (14936242 B)` and `Cache restored from key: Linux-node-39f0627 ...`
- In npm ci: `**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" environment variable was found.`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
