### PR TITLE
Add links for better docs campaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@
 <a href="https://saucelabs.com/u/sinonjs"><img src="https://saucelabs.com/browser-matrix/sinonjs.svg" alt="Sauce Test Status"></a>
 </p>
 
+## Better docs?
+
+Do you wish that Sinon had better documentation?
+
+So do we!
+
+With your support, we can improve the documentation for everyone.
+
+1. [Donate to the campaign for better documentation](https://www.gofundme.com/f/sinon-docs)
+1. Spread the word of the campaign in your companies and on social media
+
+Thank you!
+
 ## Compatibility
 
 For details on compatibility and browser support, please see [`COMPATIBILITY.md`](COMPATIBILITY.md)

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -3,6 +3,9 @@
 {% include head.html %}
 <body>
   {% include header.html %}
+  <div style="text-align: center; background-color: #5F5954; color: #fff; padding: 12px;">
+    Want better documentation for Sinon? Please <a href="https://www.gofundme.com/f/sinon-docs" style="color: #fff; text-decoration: underline;">donate to our campaign for better documentation</a>.
+  </div>
 
   <div class="content">
     <div class="container container-2">

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -3,6 +3,11 @@
 {% include head.html %}
 <body>
   {% include header.html %}
+
+  <div style="text-align: center; background-color: #5F5954; color: #fff; padding: 12px;">
+    Want better documentation for Sinon? Please <a href="https://www.gofundme.com/f/sinon-docs" style="color: #fff; text-decoration: underline;">donate to our campaign for better documentation</a>.
+  </div>
+
   <div class="top">
     <div class="container home-header">
       <img class="logo grow img-responsive" src="{{ "/assets/images/logo.png" | prepend: site.baseurl }}" alt="">
@@ -10,6 +15,8 @@
           Standalone test spies, stubs and mocks for JavaScript. <br>
           Works with any unit testing framework.
       </h1>
+
+
 
       <p class="btn-top text-center">
         <a class="btn btn-primary" href="#get-started">Get Started</a>


### PR DESCRIPTION
This PR adds a couple of links for the [better docs campaign](https://www.gofundme.com/f/sinon-docs)

In the `README.md`, and nn every documentatation page and on the home page

![2020-01-21 at 17 31](https://user-images.githubusercontent.com/20321/72828107-e8088700-3c73-11ea-9b10-33ed87b26a8a.png)