### PR TITLE
Merge stub and spy APIs only once

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -40,8 +40,6 @@ function createStub(originalFunc) {
     }
 
     proxy = createProxy(functionStub, originalFunc || functionStub);
-    // Inherit spy API:
-    extend.nonEnum(proxy, spy);
     // Inherit stub API:
     extend.nonEnum(proxy, stub);
 
@@ -147,7 +145,7 @@ function getCurrentBehavior(stubInstance) {
 }
 /*eslint-enable no-use-before-define*/
 
-var proto = {
+var stubApi = {
     resetBehavior: function() {
         this.defaultBehavior = null;
         this.behaviors = [];
@@ -203,19 +201,21 @@ var proto = {
 forEach(Object.keys(behavior), function(method) {
     if (
         hasOwnProperty(behavior, method) &&
-        !hasOwnProperty(proto, method) &&
+        !hasOwnProperty(stubApi, method) &&
         method !== "create" &&
         method !== "invoke"
     ) {
-        proto[method] = behavior.createBehavior(method);
+        stubApi[method] = behavior.createBehavior(method);
     }
 });
 
 forEach(Object.keys(behaviors), function(method) {
-    if (hasOwnProperty(behaviors, method) && !hasOwnProperty(proto, method)) {
+    if (hasOwnProperty(behaviors, method) && !hasOwnProperty(stubApi, method)) {
         behavior.addBehavior(stub, method, behaviors[method]);
     }
 });
 
-extend(stub, proto);
+// Inherit spy API:
+extend(stub, spy);
+extend(stub, stubApi);
 module.exports = stub;


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory

This is an attempt to fix the performance issue described in #2202 that has been introduced by #2130.

Some properties from spy are overridden by the stub implementation. My guess is that re-declaring non-enumerable properties on an object is inefficient in some V8 versions. Doing this just once for the `stubApi` might be faster than doing it on every invocation. @Flarna Can you confirm this with your project?

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
