### PR TITLE
Run tests in Sauce Labs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,15 @@ jobs:
           name: Upload coverage report
           command: bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
 
+  saucelabs:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - *attach-step
+      - run:
+          name: Test in browsers (Sauce Labs)
+          command: npm run test-cloud
+
 workflows:
   version: 2
   sinon-workflow:
@@ -121,3 +130,10 @@ workflows:
             - node-8
             - node-10
             - node-12
+      - saucelabs:
+          context: SAUCE_LABS
+          requires:
+            - integration-tests
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
This PR re-adds running tests in Sauce Labs, which was accidentally removed earlier.

That will fix the "unknown" status in Sauce Labs tests:

![2020-02-03 at 12 08](https://user-images.githubusercontent.com/20321/73652108-f85e3000-467d-11ea-916d-2beb8bd5a992.png)

