### PR TITLE
Fix `spy.toString` when getters on a spy's `thisValue` throw

### DIFF
--- a/lib/sinon/util/core/function-to-string.js
+++ b/lib/sinon/util/core/function-to-string.js
@@ -8,9 +8,14 @@ module.exports = function toString() {
         while (i--) {
             thisValue = this.getCall(i).thisValue;
 
+            // eslint-disable-next-line guard-for-in
             for (prop in thisValue) {
-                if (thisValue[prop] === this) {
-                    return prop;
+                try {
+                    if (thisValue[prop] === this) {
+                        return prop;
+                    }
+                } catch (e) {
+                    // no-op - accessing props can throw an error, nothing to do here
                 }
             }
         }

--- a/test/util/core/function-to-string-test.js
+++ b/test/util/core/function-to-string-test.js
@@ -35,4 +35,32 @@ describe("util/core/functionToString", function() {
 
         assert.equals(functionToString.call(obj.doStuff), "doStuff");
     });
+
+    // https://github.com/sinonjs/sinon/issues/2215
+    it("ignores errors thrown by property accessors on thisValue", function() {
+        var obj = {};
+
+        Object.defineProperty(obj, "foo", {
+            enumerable: true,
+            get: function() {
+                throw new Error();
+            }
+        });
+
+        // this will cause `fn` to be after `foo` when enumerated
+        obj.fn = function() {
+            return "foo";
+        };
+
+        // validate that the keys are in the expected order that will cause the bug
+        var keys = Object.keys(obj);
+        assert.equals(keys[0], "foo");
+        assert.equals(keys[1], "fn");
+
+        var spy = createSpy(obj, "fn");
+
+        obj.fn();
+
+        assert.equals(spy.toString(), "fn");
+    });
 });


### PR DESCRIPTION
 #### Purpose (TL;DR)
Fix #2215 by ignoring errors thrown from property getters - since the algo is just looking for `thisValue[prop] === this`, errors are irrelevant.

 #### Background (Problem in detail)

This was uncovered when trying to spy on the `Notification` constructor in #2215, but this could happen with any object. The tests for this PR include such an example.

 #### Solution

Ignore the error. There is nothing to do.

 #### How to verify
1. Check out this branch
2. `npm install`
3. run the test without the changes, then run the test with the changes

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
