### PR TITLE
Added missing documentation for sinon.assert.calledOnceWithExactly

### DIFF
--- a/docs/_releases/v7.5.0/assertions.md
+++ b/docs/_releases/v7.5.0/assertions.md
@@ -114,6 +114,13 @@ Passes if `spy` was called with the provided arguments and no others.
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);`.
 
 
+#### `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments and no others.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWithExactly(spy.getCall(1), arg1, arg2, ...);`.
+
+
 #### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments and no others.

--- a/docs/_releases/v8.0.0/assertions.md
+++ b/docs/_releases/v8.0.0/assertions.md
@@ -114,6 +114,13 @@ Passes if `spy` was called with the provided arguments and no others.
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);`.
 
 
+#### `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments and no others.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWithExactly(spy.getCall(1), arg1, arg2, ...);`.
+
+
 #### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments and no others.

--- a/docs/_releases/v8.0.1/assertions.md
+++ b/docs/_releases/v8.0.1/assertions.md
@@ -114,6 +114,13 @@ Passes if `spy` was called with the provided arguments and no others.
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);`.
 
 
+#### `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments and no others.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWithExactly(spy.getCall(1), arg1, arg2, ...);`.
+
+
 #### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments and no others.

--- a/docs/_releases/v8.0.2/assertions.md
+++ b/docs/_releases/v8.0.2/assertions.md
@@ -114,6 +114,13 @@ Passes if `spy` was called with the provided arguments and no others.
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);`.
 
 
+#### `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments and no others.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWithExactly(spy.getCall(1), arg1, arg2, ...);`.
+
+
 #### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments and no others.

--- a/docs/_releases/v8.0.3/assertions.md
+++ b/docs/_releases/v8.0.3/assertions.md
@@ -114,6 +114,13 @@ Passes if `spy` was called with the provided arguments and no others.
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);`.
 
 
+#### `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments and no others.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWithExactly(spy.getCall(1), arg1, arg2, ...);`.
+
+
 #### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments and no others.

--- a/docs/_releases/v8.0.4/assertions.md
+++ b/docs/_releases/v8.0.4/assertions.md
@@ -114,6 +114,13 @@ Passes if `spy` was called with the provided arguments and no others.
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);`.
 
 
+#### `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments and no others.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWithExactly(spy.getCall(1), arg1, arg2, ...);`.
+
+
 #### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments and no others.

--- a/docs/_releases/v8.1.0/assertions.md
+++ b/docs/_releases/v8.1.0/assertions.md
@@ -114,6 +114,13 @@ Passes if `spy` was called with the provided arguments and no others.
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);`.
 
 
+#### `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments and no others.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWithExactly(spy.getCall(1), arg1, arg2, ...);`.
+
+
 #### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments and no others.

--- a/docs/_releases/v8.1.1/assertions.md
+++ b/docs/_releases/v8.1.1/assertions.md
@@ -114,6 +114,13 @@ Passes if `spy` was called with the provided arguments and no others.
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);`.
 
 
+#### `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments and no others.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWithExactly(spy.getCall(1), arg1, arg2, ...);`.
+
+
 #### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments and no others.

--- a/docs/_releases/v9.0.0/assertions.md
+++ b/docs/_releases/v9.0.0/assertions.md
@@ -114,6 +114,13 @@ Passes if `spy` was called with the provided arguments and no others.
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);`.
 
 
+#### `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments and no others.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWithExactly(spy.getCall(1), arg1, arg2, ...);`.
+
+
 #### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments and no others.

--- a/docs/release-source/release/assertions.md
+++ b/docs/release-source/release/assertions.md
@@ -114,6 +114,13 @@ Passes if `spy` was called with the provided arguments and no others.
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWithExactly(spy.getCall(1), arg1, arg2, ...);`.
 
 
+#### `sinon.assert.calledOnceWithExactly(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments and no others.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWithExactly(spy.getCall(1), arg1, arg2, ...);`.
+
+
 #### `sinon.assert.alwaysCalledWithExactly(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments and no others.


### PR DESCRIPTION
Added for all versions >=7.5.0 (when it [was introduced](https://github.com/sinonjs/sinon/pull/2080#issuecomment-534948093)).

(Also see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42569)