### PR TITLE
Fix 2226: restore props defined on prototype chain by deleting

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -258,7 +258,7 @@ var defaultBehaviors = {
         Object.defineProperty(rootStub.rootObj, rootStub.propName, {
             value: newVal,
             enumerable: true,
-            configurable: isPropertyConfigurable(rootStub.rootObj, rootStub.propName)
+            configurable: rootStub.shadowsPropOnPrototype || isPropertyConfigurable(rootStub.rootObj, rootStub.propName)
         });
 
         return fake;

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -189,10 +189,9 @@ function Sandbox() {
 
     function getFakeRestorer(object, property) {
         var descriptor = getPropertyDescriptor(object, property);
-        var shadowsPrototypeProp = typeof Object.getOwnPropertyDescriptor(object, property) === "undefined";
 
         function restorer() {
-            if (!shadowsPrototypeProp) {
+            if (descriptor.isOwn) {
                 Object.defineProperty(object, property, descriptor);
             } else {
                 delete object[property];

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -189,9 +189,14 @@ function Sandbox() {
 
     function getFakeRestorer(object, property) {
         var descriptor = getPropertyDescriptor(object, property);
+        var shadowsPrototypeProp = typeof Object.getOwnPropertyDescriptor(object, property) === "undefined";
 
         function restorer() {
-            Object.defineProperty(object, property, descriptor);
+            if (!shadowsPrototypeProp) {
+                Object.defineProperty(object, property, descriptor);
+            } else {
+                delete object[property];
+            }
         }
         restorer.object = object;
         restorer.property = property;

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -6,7 +6,7 @@ var behaviors = require("./default-behaviors");
 var createProxy = require("./proxy");
 var functionName = require("@sinonjs/commons").functionName;
 var hasOwnProperty = require("@sinonjs/commons").prototypes.object.hasOwnProperty;
-var isNonExistentOwnProperty = require("./util/core/is-non-existent-own-property");
+var isNonExistentProperty = require("./util/core/is-non-existent-property");
 var spy = require("./spy");
 var extend = require("./util/core/extend");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
@@ -69,8 +69,8 @@ function stub(object, property) {
 
     throwOnFalsyObject.apply(null, arguments);
 
-    if (isNonExistentOwnProperty(object, property)) {
-        throw new TypeError("Cannot stub non-existent own property " + valueToString(property));
+    if (isNonExistentProperty(object, property)) {
+        throw new TypeError("Cannot stub non-existent property " + valueToString(property));
     }
 
     var actualDescriptor = getPropertyDescriptor(object, property);

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -94,14 +94,12 @@ function stub(object, property) {
     var func = typeof actualDescriptor.value === "function" ? actualDescriptor.value : null;
     var s = createStub(func);
 
-    var propIsOwn = Boolean(actualDescriptor.isOwn);
-
     extend.nonEnum(s, {
         rootObj: object,
         propName: property,
-        shadowsPropOnPrototype: !propIsOwn,
+        shadowsPropOnPrototype: !actualDescriptor.isOwn,
         restore: function restore() {
-            if (actualDescriptor !== undefined && propIsOwn) {
+            if (actualDescriptor !== undefined && actualDescriptor.isOwn) {
                 Object.defineProperty(object, property, actualDescriptor);
                 return;
             }

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -94,11 +94,14 @@ function stub(object, property) {
     var func = typeof actualDescriptor.value === "function" ? actualDescriptor.value : null;
     var s = createStub(func);
 
+    var propIsOwn = Boolean(actualDescriptor.isOwn);
+
     extend.nonEnum(s, {
         rootObj: object,
         propName: property,
+        shadowsPropOnPrototype: !propIsOwn,
         restore: function restore() {
-            if (actualDescriptor !== undefined) {
+            if (actualDescriptor !== undefined && propIsOwn) {
                 Object.defineProperty(object, property, actualDescriptor);
                 return;
             }

--- a/lib/sinon/util/core/get-property-descriptor.js
+++ b/lib/sinon/util/core/get-property-descriptor.js
@@ -3,9 +3,15 @@
 module.exports = function getPropertyDescriptor(object, property) {
     var proto = object;
     var descriptor;
+    var isOwn = object && Object.getOwnPropertyDescriptor(object, property);
 
     while (proto && !(descriptor = Object.getOwnPropertyDescriptor(proto, property))) {
         proto = Object.getPrototypeOf(proto);
     }
+
+    if (descriptor) {
+        descriptor.isOwn = isOwn;
+    }
+
     return descriptor;
 };

--- a/lib/sinon/util/core/get-property-descriptor.js
+++ b/lib/sinon/util/core/get-property-descriptor.js
@@ -3,7 +3,7 @@
 module.exports = function getPropertyDescriptor(object, property) {
     var proto = object;
     var descriptor;
-    var isOwn = object && Object.getOwnPropertyDescriptor(object, property);
+    var isOwn = Boolean(object && Object.getOwnPropertyDescriptor(object, property));
 
     while (proto && !(descriptor = Object.getOwnPropertyDescriptor(proto, property))) {
         proto = Object.getPrototypeOf(proto);

--- a/lib/sinon/util/core/is-non-existent-own-property.js
+++ b/lib/sinon/util/core/is-non-existent-own-property.js
@@ -1,7 +1,0 @@
-"use strict";
-
-function isNonExistentOwnProperty(object, property) {
-    return object && typeof property !== "undefined" && !(property in object);
-}
-
-module.exports = isNonExistentOwnProperty;

--- a/lib/sinon/util/core/is-non-existent-property.js
+++ b/lib/sinon/util/core/is-non-existent-property.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/**
+ * @param {*} object
+ * @param {String} property
+ * @returns whether a prop exists in the prototype chain
+ */
+function isNonExistentProperty(object, property) {
+    return object && typeof property !== "undefined" && !(property in object);
+}
+
+module.exports = isNonExistentProperty;

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -580,9 +580,11 @@ describe("issues", function() {
             function ClassWithoutProps() {
                 return;
             }
+
             function AnotherClassWithoutProps() {
                 return;
             }
+
             ClassWithoutProps.prototype.constructor = ClassWithoutProps;
             AnotherClassWithoutProps.prototype.constructor = AnotherClassWithoutProps;
             var arg1 = new ClassWithoutProps(); //arg1.constructor.name === ClassWithoutProps
@@ -640,6 +642,7 @@ describe("issues", function() {
         function Foo() {
             return;
         }
+
         // eslint-disable-next-line mocha/no-setup-in-describe
         Foo.prototype.testMethod = function() {
             return;
@@ -679,6 +682,7 @@ describe("issues", function() {
         function Foo() {
             return;
         }
+
         // eslint-disable-next-line mocha/no-setup-in-describe
         Foo.prototype.testMethod = function() {
             return 1;
@@ -707,6 +711,48 @@ describe("issues", function() {
             assert.equals(fake.lastArg, 3);
             sandbox.reset();
             refute.equals(fake.lastArg, 3);
+        });
+    });
+
+    describe("#2226 - props on prototype are not restored correctly", function() {
+        function createObjectWithPropFromPrototype() {
+            var proto = {};
+            var obj = {};
+
+            Object.setPrototypeOf(obj, proto);
+            Object.defineProperty(proto, "test", { writable: true, value: 1 });
+            return obj;
+        }
+
+        it("should restore fakes shadowing prototype props correctly", function() {
+            var obj = createObjectWithPropFromPrototype();
+
+            var originalPropertyDescriptor = Object.getOwnPropertyDescriptor(obj, "test");
+
+            sinon.replace(obj, "test", 2);
+            var replacedPropertyDescriptor = Object.getOwnPropertyDescriptor(obj, "test");
+
+            sinon.restore();
+            var restoredPropertyDescriptor = Object.getOwnPropertyDescriptor(obj, "test");
+
+            assert.isUndefined(originalPropertyDescriptor);
+            refute.isUndefined(replacedPropertyDescriptor);
+            assert.isUndefined(restoredPropertyDescriptor);
+        });
+
+        it("should restore stubs shadowing prototype props correctly", function() {
+            var obj = createObjectWithPropFromPrototype();
+            var originalPropertyDescriptor = Object.getOwnPropertyDescriptor(obj, "test");
+
+            sinon.stub(obj, "test").value(2);
+            var replacedPropertyDescriptor = Object.getOwnPropertyDescriptor(obj, "test");
+
+            sinon.restore();
+            var restoredPropertyDescriptor = Object.getOwnPropertyDescriptor(obj, "test");
+
+            assert.isUndefined(originalPropertyDescriptor);
+            refute.isUndefined(replacedPropertyDescriptor);
+            assert.isUndefined(restoredPropertyDescriptor);
         });
     });
 });

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -562,7 +562,7 @@ describe("Sandbox", function() {
                     function() {
                         sandbox.stub(object, Symbol());
                     },
-                    { message: "Cannot stub non-existent own property Symbol()" },
+                    { message: "Cannot stub non-existent property Symbol()" },
                     TypeError
                 );
 


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
Issue #2226 shows that we somehow handle props defined on the prototype chain in the wrong manner. This has mostly gone unnoticed, until someone tried stubbing a prop defined on a prototype that had `configurable: false`. Doing a `restore()` will fail in this case.

 #### Background (Problem in detail)  - optional
Up until now, we have simply defined a new property on the object, regardless of where the prop actually "lives". This is fine and does not cause an issue in itself. The problem is that when we restore, we try to restore/recreate the property descriptor onto the object, _regardless of that object is the original source of that descriptor_.

Truth be told, it is not that the "source" does not match: the basic problem here is that we try to redefine a property that we have said is non-configurable, but that is just a symptom of the underlying problem, which is that we do not take the source into consideration at creation/restore phases.

The fix here is quite simple, as can be seen:
1. Create a marker on (an extended version of) the property descriptor that tells us if the object comes from the prototype chain or if it is owned by the object itself.
2. Use this fact when creating the prop descriptor: we need to have `configurable:true` to be able to redefine and/or delete this prop from the object later on
3. Use this fact when restoring. If this prop never "belonged" to us, we can safely just delete it.

##### Details that need to be fixed for clarity (separate issue)
I will try to create a different issue for this, but there are several things I found out while researching this that needs fixing.

_Why do we not always set `configurable: true`?_
Looking at the git log I found #1456 and #1462 which basically changed `true` to use `false` if that attribute was already set to `false`. Why does that make a difference? Well, as long as the prop is writable `Object.defineProperty` will only throw if `configurable` is `false` **AND** any of the other fields change their value. So we can do `Object.defineProperty(obj, prop, {value:42})` on a non-configurable prop, as the other fields will be left alone.

_Why do we tread `enumerable` differently than `configurable`?_
Given the above, reasoning, why do we always set `enumerable` to true? Should it now be subjected to the same handling as `configurable`? _Yes it should have been treated in the same manner_ and in fact, trying to do `stub.value(42)` on a prop that is neither configurable nor enumerable will throw in Sinon today. As should be apparent from the above section, this does not need to happen! We only need to keep properties the same, if they exist, otherwise, use sensible (permissive) default values.

Given that, I think we need to create a separate issue to cover that. A basic fix is to make our own `defineProps` that does this:

```javascript
var getObjectDescriptor = require('./get-object-descriptor');
var defaultPropValues = Object.freeze({configurable: true, enumerable: true, writable: true});

// reuse existing values, if they exist
function defineProperty(obj, prop, newAttributes){
    var originalDescriptor = getObjectDescriptor(obj, prop);
    var descriptor = Object.assign({}, defaultPropValues, originalDescriptor || {}, newAttributes);
    Object.defineProperty(object, prop, descriptor);
}
```

The reason we need to merge in defaultProps is that all of the listed ones are `false` by default when using `Object.defineProperty` while we usually want them to be `true` (like they are in normal assignment operations).
 
 #### How to verify - mandatory
The original issue had a small code listing that would blow up when run. It works now:

```javascript
$ node test.js
0
1
0

$ cat test.js
const sinon = require("./lib/sinon");
const mongoose = require("mongoose");

console.log(mongoose.connection.readyState);

sinon.stub(mongoose.connection, "readyState").value(1);

console.log(mongoose.connection.readyState);

sinon.restore();

console.log(mongoose.connection.readyState);
```

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
