### PR TITLE
Add example where withArgs of a stub is used in an assertion

### DIFF
--- a/docs/release-source/release/examples/stubs-2-different-args.test.js
+++ b/docs/release-source/release/examples/stubs-2-different-args.test.js
@@ -11,6 +11,7 @@ describe("stubbed callback", function() {
 
         assert.isUndefined(callback()); // No return value, no exception
         assert.equals(callback(42), 1); // Returns 1
+        assert.equals(callback.withArgs(42).callCount, 1);// Use withArgs in assertion
         assert.exception(() => {
             callback(1);
         }); // Throws Error("name")


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
There was no example whether it is allowed to use withArgs within an assertion.
It was not clear if this is allowed or if sinon.stub().withArgs can only be used to specify the behavior.

