### PR TITLE
Update `stub.wrappedMethod` docs.

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -524,4 +524,4 @@ You can restore values by calling the `restore` method:
 #### `stub.wrappedMethod`
 
 Holds a reference to the original method/function this stub has
-wrapped.
+wrapped. `undefined` for the property accessors.


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Mention inconsistent/lack of `.wrappedMethod` value for property accessors.


 #### Background (Problem in detail)  - optional

Current documentation, suggests that `.wrappedMethod` property is available for all stubs. However, as stated at https://github.com/sinonjs/sinon/pull/2197/files#diff-888b5036773bbf553212fad0a7977303R3500-R3511 it's not available for property accessors. 

To me getters and setters are functions like any other, so stubs for them are stubs like any other. It took me 5hrs of debugging my own code to figure out why I can use it in `stub(obj, 'funName').callsFake( fakeFn );` but not in `stub(obj, 'funName').get( fakeFn );`

I hope, documenting this inconsistency could save some time for other users :)


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run serve-docs`
4. Open stubs documentation.

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
