### PR TITLE
Remove the gofundme campaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,6 @@
 <a href="https://saucelabs.com/u/sinonjs"><img src="https://saucelabs.com/browser-matrix/sinonjs.svg" alt="Sauce Test Status"></a>
 </p>
 
-## Better docs?
-
-Do you wish that Sinon had better documentation?
-
-So do we!
-
-With your support, we can improve the documentation for everyone.
-
-1. [Donate to the campaign for better documentation](https://www.gofundme.com/f/sinon-docs)
-1. Spread the word of the campaign in your companies and on social media
-
-Thank you!
-
 ## Compatibility
 
 For details on compatibility and browser support, please see [`COMPATIBILITY.md`](COMPATIBILITY.md)

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -3,10 +3,6 @@
 {% include head.html %}
 <body>
   {% include header.html %}
-  <div style="text-align: center; background-color: #5F5954; color: #fff; padding: 12px;">
-    Want better documentation for Sinon? Please <a href="https://www.gofundme.com/f/sinon-docs" style="color: #fff; text-decoration: underline;">donate to our campaign for better documentation</a>.
-  </div>
-
   <div class="content">
     <div class="container container-2">
       {% include banner.html %}


### PR DESCRIPTION
 #### Purpose (TL;DR)

Remove the link to the [documentation campaign on GoFundMe](https://www.gofundme.com/f/sinon-docs).

The campaign was not very successful:

*  few funds collected
* I didn't manage to make any new documentation site
* I didn't manage spend any of the donations

I'll close the campaign on GoFundMe and figure out how to redirect the funds into the [Sinon Open Collective](https://opencollective.com/sinon)