### PR TITLE
Add GitHub Sponsors entry in FUNDING.YML

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: sinonjs
 open_collective: sinon


### PR DESCRIPTION
Now that `sinonjs` organisation has been approved for GitHub Sponsors,
we can add an entry to `FUNDING.yml`, which should allow us to receive
sponsorships routed via GitHub.

See https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository

I have not been able to figure out how `babel/babel` have been able to produce the banner below, without having a `FUNDING.yml`. Maybe they have inside help at GitHub.

![2020-08-14 at 12 55](https://user-images.githubusercontent.com/20321/90242527-81280680-de2d-11ea-9246-8589fd8c4dca.png)

I'm hoping this PR will result in a similar banner for this repository.

#### How to verify

Other than merging this to the primary branch, I don't know how we can verify this. I don't think it'll have a negative effect, even if the desired outcome doesn't happen.