### PR TITLE
Removing undefined variable `descriptor`

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -80,8 +80,7 @@ function stub(object, property) {
     var isStubbingNonFuncProperty =
         isObjectOrFunction &&
         typeof property !== "undefined" &&
-        (typeof actualDescriptor === "undefined" || typeof actualDescriptor.value !== "function") &&
-        typeof descriptor === "undefined";
+        (typeof actualDescriptor === "undefined" || typeof actualDescriptor.value !== "function");
 
     if (isStubbingEntireObject) {
         return walkObject(stub, object);


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
* Fix issue #2271 by removing the unused variable.
* Also installed `dotenv` package to read environment variables and required it to read variable `SINON_CHROME_BIN` in `check-esm-bundle-is-runnable.js` (added `.env` to `.gitignore`)
* Note: `issues-test.js` test #1456 throws an error locally for me, `beforeEach` is seems to not be executed therefore`afterEach`'s `sandbox` is `undefined`.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `stub` should work as intended

 #### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
