### PR TITLE
Add a deep equality note to the stub and spy documentation

### DIFF
--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -156,6 +156,8 @@ are also available on `object.method`.
 
 Creates a spy that only records [calls][call] when the received arguments match those passed to `withArgs`. This is useful to be more expressive in your assertions, where you can access the spy with the same [call][call].
 
+Uses deep comparison for objects and arrays. Use `spy.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+
 <div data-example-id="spies-7-with-args"></div>
 
 

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -135,6 +135,8 @@ Stubs the method only for the provided arguments.
 
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
+Uses deep comparison for objects and arrays. Use `stub.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+
 <div data-example-id="stubs-2-different-args"></div>
 
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fixes issue #2286 by making it clearer that sinon uses deep equality by default for withArgs calls and gives a clear alternative for users who wish to use strict equality

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run serve-docs`
4. View docs for stubs and spies

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
