### PR TITLE
Add a calledOnceWithMatch assertion

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -207,6 +207,7 @@ mirrorPropAsAssertion("alwaysCalledWith", "expected %n to always be called with 
 mirrorPropAsAssertion("alwaysCalledWithMatch", "expected %n to always be called with match %D");
 mirrorPropAsAssertion("calledWithExactly", "expected %n to be called with exact arguments %D");
 mirrorPropAsAssertion("calledOnceWithExactly", "expected %n to be called once and with exact arguments %D");
+mirrorPropAsAssertion("calledOnceWithMatch", "expected %n to be called once and with match %D");
 mirrorPropAsAssertion("alwaysCalledWithExactly", "expected %n to always be called with exact arguments %D");
 mirrorPropAsAssertion("neverCalledWith", "expected %n to never be called with arguments %*%C");
 mirrorPropAsAssertion("neverCalledWithMatch", "expected %n to never be called with match %*%C");

--- a/lib/sinon/proxy.js
+++ b/lib/sinon/proxy.js
@@ -176,6 +176,7 @@ delegateToCalls(proxyApi, "alwaysCalledWith", false, "calledWith");
 delegateToCalls(proxyApi, "alwaysCalledWithMatch", false, "calledWithMatch");
 delegateToCalls(proxyApi, "calledWithExactly", true);
 delegateToCalls(proxyApi, "calledOnceWithExactly", true, "calledWithExactly", false, undefined, 1);
+delegateToCalls(proxyApi, "calledOnceWithMatch", true, "calledWithMatch", false, undefined, 1);
 delegateToCalls(proxyApi, "alwaysCalledWithExactly", false, "calledWithExactly");
 delegateToCalls(proxyApi, "neverCalledWith", false, "notCalledWith", false, function() {
     return true;

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -941,6 +941,105 @@ describe("assert", function() {
             });
         });
 
+        describe(".calledOnceWithMatch", function() {
+            // eslint-disable-next-line mocha/no-setup-in-describe
+            requiresValidFake("calledOnceWithMatch");
+
+            it("fails when method fails", function() {
+                var object = {};
+                sinonStub(this.stub, "calledOnceWithMatch").returns(false);
+                var stub = this.stub;
+
+                assert.exception(function() {
+                    sinonAssert.calledOnceWithMatch(stub, object, 1);
+                });
+
+                assert(this.stub.calledOnceWithMatch.calledOnceWithMatch(object, 1));
+                assert(sinonAssert.fail.called);
+            });
+
+            it("passes when method doesn't fail", function() {
+                var object = {};
+                sinonStub(this.stub, "calledOnceWithMatch").returns(true);
+                var stub = this.stub;
+
+                refute.exception(function() {
+                    sinonAssert.calledOnceWithMatch(stub, object, 1);
+                });
+
+                assert(this.stub.calledOnceWithMatch.calledOnceWithMatch(object, 1));
+                assert.isFalse(sinonAssert.fail.called);
+            });
+
+            it("calls pass callback", function() {
+                this.stub("yeah");
+                sinonAssert.calledOnceWithMatch(this.stub, "yeah");
+
+                assert(sinonAssert.pass.calledOnce);
+                assert(sinonAssert.pass.calledWith("calledOnceWithMatch"));
+            });
+
+            it("fails when method does not exist", function() {
+                assert.exception(function() {
+                    sinonAssert.calledOnceWithMatch();
+                });
+
+                assert(sinonAssert.fail.called);
+            });
+
+            it("fails when method is not stub", function() {
+                assert.exception(function() {
+                    sinonAssert.calledOnceWithMatch(function() {
+                        return;
+                    });
+                });
+
+                assert(sinonAssert.fail.called);
+            });
+
+            it("fails when method was not called", function() {
+                var stub = this.stub;
+
+                assert.exception(function() {
+                    sinonAssert.calledOnceWithMatch(stub);
+                });
+
+                assert(sinonAssert.fail.called);
+            });
+
+            it("fails when called with more than one argument", function() {
+                var stub = this.stub;
+                stub();
+
+                assert.exception(function() {
+                    sinonAssert.calledOnceWithMatch(stub, 1);
+                });
+            });
+
+            it("passes when method was called", function() {
+                var stub = this.stub;
+                stub();
+
+                refute.exception(function() {
+                    sinonAssert.calledOnceWithMatch(stub);
+                });
+
+                assert.isFalse(sinonAssert.fail.called);
+            });
+
+            it("fails when method was called more than once", function() {
+                var stub = this.stub;
+                stub();
+                stub();
+
+                assert.exception(function() {
+                    sinonAssert.calledOnceWithMatch(stub);
+                });
+
+                assert(sinonAssert.fail.called);
+            });
+        });
+
         describe(".neverCalledWith", function() {
             it("fails when method fails", function() {
                 var object = {};

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -1314,6 +1314,44 @@ describe("spy", function() {
         });
     });
 
+    describe(".calledOnceWithMatch", function() {
+        beforeEach(function() {
+            this.spy = createSpy();
+        });
+
+        it("returns true for exact match", function() {
+            this.spy(1, 2, 3);
+
+            assert.isTrue(this.spy.calledOnceWithMatch(1, 2, 3));
+        });
+
+        it("returns true for partial match", function() {
+            this.spy(1, 2, 3);
+
+            assert.isTrue(this.spy.calledOnceWithMatch(1, 2));
+        });
+
+        it("returns false for exact parameters but called more then once", function() {
+            this.spy(1, 2, 3);
+            this.spy(1, 2, 3);
+
+            assert.isFalse(this.spy.calledOnceWithMatch(1, 2, 3));
+        });
+
+        it("return false for one mismatched call", function() {
+            this.spy(1, 2);
+
+            assert.isFalse(this.spy.calledOnceWithMatch(1, 2, 3));
+        });
+
+        it("return false for one mismatched call with some other", function() {
+            this.spy(1, 2, 3);
+            this.spy(1, 2);
+
+            assert.isFalse(this.spy.calledOnceWithMatch(1, 2, 3));
+        });
+    });
+
     describe(".alwaysCalledWithExactly", function() {
         beforeEach(function() {
             this.spy = createSpy();


### PR DESCRIPTION
 #### Purpose

This adds an assertion which combines `calledOnce` and `calledWithMatch` into `calledOnceWithMatch`.

 #### Background (Problem in detail)

This is a common pattern in tests that I write:
```javascript
  sinon.assert.calledOnce(stub);
  sinon.assert.calledWithMatch(stub, arg1, arg2);
```

It would be great to only need write:
```javascript
  sinon.assert.calledOnceWithMatch(stub, arg1, arg2);
```

It seems like uneven coverage to combine `calledOnce + calledWithExactly` whilst not covering this.

However, I can see that there is a potential for temptation to add too much sugar - no-one wants a combinatorial explosion! Many libraries solve this with something like `sinon.assert.calledOnce(stub).withMatch(arg1, arg2)` but that's not a discussion for this PR!

#### Testing

I was looking through the test files and wasn't entirely sure what coverage would be appropriate here - I'm happy to essentially duplicate the `calledOnceWithMatch` testing if that is sufficient coverage and validation, but it feels incomplete.

Please let me know what you think.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

 #### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
