### PR TITLE
Minor formatting improvements to legacy sandbox documentation

### DIFF
--- a/docs/_releases/latest/sandbox.md
+++ b/docs/_releases/latest/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v2.1.0/sandbox.md
+++ b/docs/_releases/v2.1.0/sandbox.md
@@ -74,7 +74,9 @@ sinon.defaultConfig = {
   <dd>If <code>true</code>, the sandbox will have a <code>clock</code> property. Can also be an <code>Array</code> of timer properties to fake.</dd>
 
   <dt><code>useFakeServer</code></dt>
-  <dd>If <code>true</code>, <code>server</code> and <code>requests</code> properties are added to the sandbox. Can also be an object to use for fake server. The default one is <code>sinon.fakeServer</code>, but if you're using jQuery 1.3.x or some other library that does not set the XHR's <code>onreadystatechange</code> handler, you might want to do:</dd>
+  <dd>If <code>true</code>, <code>server</code> and <code>requests</code> properties are added to the sandbox. Can also be an object to use for fake server. The default one is <code>sinon.fakeServer</code>, but if you're using jQuery 1.3.x or some other library that does not set the XHR's <code>onreadystatechange</code> handler, you might want to do:
+  </dd>
+</dl>
 
 ```javascript
 sinon.config = {

--- a/docs/_releases/v2.2.0/sandbox.md
+++ b/docs/_releases/v2.2.0/sandbox.md
@@ -62,23 +62,23 @@ sinon.defaultConfig = {
 }
 ```
 
-##### injectInto
+##### `injectInto`
 
 The sandbox's methods can be injected into another object for convenience. The
 `injectInto` configuration option can name an object to add properties to.
 
-##### properties
+##### `properties`
 
 What properties to inject. Note that simply naming "server" here is not
 sufficient to have a `server` property show up in the target object, you also
 have to set `useFakeServer` to `true`.
 
-##### useFakeTimers
+##### `useFakeTimers`
 
 If `true`, the sandbox will have a `clock` property. Can also be an `Array` of
 timer properties to fake.
 
-##### useFakeServer
+##### `useFakeServer`
 
 If `true`, `server` and `requests` properties are added to the sandbox. Can
 also be an object to use for fake server. The default one is `sinon.fakeServer`,

--- a/docs/_releases/v2.3.0/sandbox.md
+++ b/docs/_releases/v2.3.0/sandbox.md
@@ -62,23 +62,23 @@ sinon.defaultConfig = {
 }
 ```
 
-##### injectInto
+##### `injectInto`
 
 The sandbox's methods can be injected into another object for convenience. The
 `injectInto` configuration option can name an object to add properties to.
 
-##### properties
+##### `properties`
 
 What properties to inject. Note that simply naming "server" here is not
 sufficient to have a `server` property show up in the target object, you also
 have to set `useFakeServer` to `true`.
 
-##### useFakeTimers
+##### `useFakeTimers`
 
 If `true`, the sandbox will have a `clock` property. Can also be an `Array` of
 timer properties to fake.
 
-##### useFakeServer
+##### `useFakeServer`
 
 If `true`, `server` and `requests` properties are added to the sandbox. Can
 also be an object to use for fake server. The default one is `sinon.fakeServer`,

--- a/docs/_releases/v2.3.3/sandbox.md
+++ b/docs/_releases/v2.3.3/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v2.3.4/sandbox.md
+++ b/docs/_releases/v2.3.4/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v2.3.5/sandbox.md
+++ b/docs/_releases/v2.3.5/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v2.3.6/sandbox.md
+++ b/docs/_releases/v2.3.6/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v2.3.7/sandbox.md
+++ b/docs/_releases/v2.3.7/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v2.3.8/sandbox.md
+++ b/docs/_releases/v2.3.8/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v2.4.0/sandbox.md
+++ b/docs/_releases/v2.4.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v2.4.1/sandbox.md
+++ b/docs/_releases/v2.4.1/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v3.0.0/sandbox.md
+++ b/docs/_releases/v3.0.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v3.1.0/sandbox.md
+++ b/docs/_releases/v3.1.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v3.2.0/sandbox.md
+++ b/docs/_releases/v3.2.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.sandbox.create(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.sandbox.create({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v3.2.1/sandbox.md
+++ b/docs/_releases/v3.2.1/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v3.3.0/sandbox.md
+++ b/docs/_releases/v3.3.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.0.0/sandbox.md
+++ b/docs/_releases/v4.0.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.0.1/sandbox.md
+++ b/docs/_releases/v4.0.1/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.0.2/sandbox.md
+++ b/docs/_releases/v4.0.2/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.1.0/sandbox.md
+++ b/docs/_releases/v4.1.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.1.1/sandbox.md
+++ b/docs/_releases/v4.1.1/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.1.2/sandbox.md
+++ b/docs/_releases/v4.1.2/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.1.3/sandbox.md
+++ b/docs/_releases/v4.1.3/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.1.4/sandbox.md
+++ b/docs/_releases/v4.1.4/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.1.5/sandbox.md
+++ b/docs/_releases/v4.1.5/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.1.6/sandbox.md
+++ b/docs/_releases/v4.1.6/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.2.0/sandbox.md
+++ b/docs/_releases/v4.2.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.2.1/sandbox.md
+++ b/docs/_releases/v4.2.1/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.2.2/sandbox.md
+++ b/docs/_releases/v4.2.2/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.2.3/sandbox.md
+++ b/docs/_releases/v4.2.3/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.3.0/sandbox.md
+++ b/docs/_releases/v4.3.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.0/sandbox.md
+++ b/docs/_releases/v4.4.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.1/sandbox.md
+++ b/docs/_releases/v4.4.1/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.10/sandbox.md
+++ b/docs/_releases/v4.4.10/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.2/sandbox.md
+++ b/docs/_releases/v4.4.2/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.3/sandbox.md
+++ b/docs/_releases/v4.4.3/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.4/sandbox.md
+++ b/docs/_releases/v4.4.4/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.5/sandbox.md
+++ b/docs/_releases/v4.4.5/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.6/sandbox.md
+++ b/docs/_releases/v4.4.6/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.7/sandbox.md
+++ b/docs/_releases/v4.4.7/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.8/sandbox.md
+++ b/docs/_releases/v4.4.8/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.4.9/sandbox.md
+++ b/docs/_releases/v4.4.9/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v4.5.0/sandbox.md
+++ b/docs/_releases/v4.5.0/sandbox.md
@@ -86,7 +86,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.0.1/sandbox.md
+++ b/docs/_releases/v5.0.1/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.0.10/sandbox.md
+++ b/docs/_releases/v5.0.10/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.0.2/sandbox.md
+++ b/docs/_releases/v5.0.2/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.0.3/sandbox.md
+++ b/docs/_releases/v5.0.3/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.0.4/sandbox.md
+++ b/docs/_releases/v5.0.4/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.0.5/sandbox.md
+++ b/docs/_releases/v5.0.5/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.0.6/sandbox.md
+++ b/docs/_releases/v5.0.6/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.0.7/sandbox.md
+++ b/docs/_releases/v5.0.7/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.0.8/sandbox.md
+++ b/docs/_releases/v5.0.8/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.0.9/sandbox.md
+++ b/docs/_releases/v5.0.9/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v5.1.0/sandbox.md
+++ b/docs/_releases/v5.1.0/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.0.0/sandbox.md
+++ b/docs/_releases/v6.0.0/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.0.1/sandbox.md
+++ b/docs/_releases/v6.0.1/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.1.0/sandbox.md
+++ b/docs/_releases/v6.1.0/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.1.1/sandbox.md
+++ b/docs/_releases/v6.1.1/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.1.2/sandbox.md
+++ b/docs/_releases/v6.1.2/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.1.3/sandbox.md
+++ b/docs/_releases/v6.1.3/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.1.4/sandbox.md
+++ b/docs/_releases/v6.1.4/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.1.5/sandbox.md
+++ b/docs/_releases/v6.1.5/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.1.6/sandbox.md
+++ b/docs/_releases/v6.1.6/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.2.0/sandbox.md
+++ b/docs/_releases/v6.2.0/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.3.0/sandbox.md
+++ b/docs/_releases/v6.3.0/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.3.1/sandbox.md
+++ b/docs/_releases/v6.3.1/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.3.2/sandbox.md
+++ b/docs/_releases/v6.3.2/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.3.3/sandbox.md
+++ b/docs/_releases/v6.3.3/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.3.4/sandbox.md
+++ b/docs/_releases/v6.3.4/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v6.3.5/sandbox.md
+++ b/docs/_releases/v6.3.5/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.0.0/sandbox.md
+++ b/docs/_releases/v7.0.0/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.1.0/sandbox.md
+++ b/docs/_releases/v7.1.0/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.1.1/sandbox.md
+++ b/docs/_releases/v7.1.1/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.2.0/sandbox.md
+++ b/docs/_releases/v7.2.0/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.2.1/sandbox.md
+++ b/docs/_releases/v7.2.1/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.2.2/sandbox.md
+++ b/docs/_releases/v7.2.2/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.2.3/sandbox.md
+++ b/docs/_releases/v7.2.3/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.2.4/sandbox.md
+++ b/docs/_releases/v7.2.4/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.2.5/sandbox.md
+++ b/docs/_releases/v7.2.5/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.2.6/sandbox.md
+++ b/docs/_releases/v7.2.6/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.2.7/sandbox.md
+++ b/docs/_releases/v7.2.7/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.3.0/sandbox.md
+++ b/docs/_releases/v7.3.0/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.3.1/sandbox.md
+++ b/docs/_releases/v7.3.1/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.3.2/sandbox.md
+++ b/docs/_releases/v7.3.2/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.4.1/sandbox.md
+++ b/docs/_releases/v7.4.1/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.4.2/sandbox.md
+++ b/docs/_releases/v7.4.2/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v7.5.0/sandbox.md
+++ b/docs/_releases/v7.5.0/sandbox.md
@@ -102,7 +102,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v8.0.0/sandbox.md
+++ b/docs/_releases/v8.0.0/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v8.0.1/sandbox.md
+++ b/docs/_releases/v8.0.1/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v8.0.2/sandbox.md
+++ b/docs/_releases/v8.0.2/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v8.0.3/sandbox.md
+++ b/docs/_releases/v8.0.3/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v8.0.4/sandbox.md
+++ b/docs/_releases/v8.0.4/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v8.1.0/sandbox.md
+++ b/docs/_releases/v8.1.0/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v8.1.1/sandbox.md
+++ b/docs/_releases/v8.1.1/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v9.0.0/sandbox.md
+++ b/docs/_releases/v9.0.0/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v9.0.1/sandbox.md
+++ b/docs/_releases/v9.0.1/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v9.0.2/sandbox.md
+++ b/docs/_releases/v9.0.2/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/_releases/v9.0.3/sandbox.md
+++ b/docs/_releases/v9.0.3/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -108,12 +108,12 @@ var sandbox = sinon.createSandbox({
 });
 ```
 
-##### injectInto
+##### `injectInto`
 
 The sandbox's methods can be injected into another object for convenience. The
 `injectInto` configuration option can name an object to add properties to.
 
-##### properties
+##### `properties`
 
 What properties to inject. Note that only naming "server" here is not
 sufficient to have a `server` property show up in the target object, you also
@@ -132,13 +132,13 @@ returned by the function `inject`, namely:
 }
 ```
 
-##### useFakeTimers
+##### `useFakeTimers`
 
 If set to `true`, the sandbox will have a `clock` property. You can optionally pass
 in a configuration object that follows the [specification for fake timers](../fake-timers),
 such as `{ toFake: ["setTimeout", "setInterval"] }`.
 
-##### useFakeServer
+##### `useFakeServer`
 
 If `true`, `server` and `requests` properties are added to the sandbox. Can
 also be an object to use for fake server. The default one is `sinon.fakeServer`,

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -103,7 +103,7 @@ var sandbox = sinon.createSandbox(sinon.defaultConfig);
 
 // (OR) Add the extra properties that differ from the sinon defaults.
 var sandbox = sinon.createSandbox({
-    useFakeTimers: true
+    useFakeTimers: true,
     useFakeServer: true
 });
 ```


### PR DESCRIPTION
 #### Purpose 
The documentation of sandboxes in versions [2.1.0](https://sinonjs.org/releases/v2.1.0/sandbox/), [2.2.0](https://sinonjs.org/releases/v2.2.0/sandbox/), [2.3.0](https://sinonjs.org/releases/v2.3.0/sandbox/) have some minor formatting issues.

#### Screenshot of v2.1.0 sandbox documentation
<img width="754" alt="Screen Shot 2020-09-26 at 10 35 08 AM" src="https://user-images.githubusercontent.com/9907304/94346810-02a1b580-ffe4-11ea-92b2-bfe744a92254.png">


 #### Background 

* 2.2.0 and 2.3.0 are missing code formatting for the configuration options
* 2.1.0 is missing a closing `</dl>` tag causing the page to display raw markdown

 #### How to verify - mandatory

Visit the sandbox documentation pages for [2.1.0](https://sinonjs.org/releases/v2.1.0/sandbox/), [2.2.0](https://sinonjs.org/releases/v2.2.0/sandbox/), [2.3.0](https://sinonjs.org/releases/v2.3.0/sandbox/). View the section following the sentence: `The default configuration looks like:` and confirm the incorrectly formatted text.

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
- [x] [Happy Hacktoberfest!](https://hacktoberfest.digitalocean.com/)