### PR TITLE
Update cached reference to forEach function in sandbox

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -17,7 +17,7 @@ var fakeXhr = require("nise").fakeXhr;
 var usePromiseLibrary = require("./util/core/use-promise-library");
 
 var filter = arrayProto.filter;
-var forEach = arrayProto.filter;
+var forEach = arrayProto.forEach;
 var push = arrayProto.push;
 var reverse = arrayProto.reverse;
 


### PR DESCRIPTION
It appears that the cached function for `forEach` is incorrectly mapped to `arrayProto.filter` in the sinon sandbox.

 #### Purpose (TL;DR) - mandatory
The cached reference of the `forEach` function is currently mapped to `filter`. The following PR replaces the cached reference with the correct function reference.

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run build`
4. `npm run test`

 #### Checklist for author

- [ ] `npm run lint` passes (I wasn't able to test this as I don't have a proper environment setup)
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
