### PR TITLE
Add usingPromise() method on fakes to fix issue #2293

### DIFF
--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -37,70 +37,87 @@ function wrapFunc(f) {
     return proxy;
 }
 
-function fake(f) {
-    if (arguments.length > 0 && typeof f !== "function") {
-        throw new TypeError("Expected f argument to be a Function");
-    }
+function fakeClass() {
+    var promiseLib;
 
-    return wrapFunc(f);
-}
-
-fake.returns = function returns(value) {
-    function f() {
-        return value;
-    }
-
-    return wrapFunc(f);
-};
-
-fake.throws = function throws(value) {
-    function f() {
-        throw getError(value);
-    }
-
-    return wrapFunc(f);
-};
-
-fake.resolves = function resolves(value) {
-    function f() {
-        return Promise.resolve(value);
-    }
-
-    return wrapFunc(f);
-};
-
-fake.rejects = function rejects(value) {
-    function f() {
-        return Promise.reject(getError(value));
-    }
-
-    return wrapFunc(f);
-};
-
-function yieldInternal(async, values) {
-    function f() {
-        var callback = arguments[arguments.length - 1];
-        if (typeof callback !== "function") {
-            throw new TypeError("Expected last argument to be a function");
+    function fake(f) {
+        if (arguments.length > 0 && typeof f !== "function") {
+            throw new TypeError("Expected f argument to be a Function");
         }
-        if (async) {
-            nextTick(function() {
+
+        return wrapFunc(f);
+    }
+
+    fake.returns = function returns(value) {
+        function f() {
+            return value;
+        }
+
+        return wrapFunc(f);
+    };
+
+    fake.throws = function throws(value) {
+        function f() {
+            throw getError(value);
+        }
+
+        return wrapFunc(f);
+    };
+
+    fake.resolves = function resolves(value) {
+        function f() {
+            if (promiseLib) {
+                return promiseLib.resolve(value);
+            }
+            return Promise.resolve(value);
+        }
+
+        return wrapFunc(f);
+    };
+
+    fake.rejects = function rejects(value) {
+        function f() {
+            if (promiseLib) {
+                return promiseLib.reject(value);
+            }
+            return Promise.reject(getError(value));
+        }
+
+        return wrapFunc(f);
+    };
+
+    fake.usingPromise = function usingPromise(promiseLibrary) {
+        promiseLib = promiseLibrary;
+        return fake;
+    };
+
+    function yieldInternal(async, values) {
+        function f() {
+            var callback = arguments[arguments.length - 1];
+            if (typeof callback !== "function") {
+                throw new TypeError("Expected last argument to be a function");
+            }
+            if (async) {
+                nextTick(function() {
+                    callback.apply(null, values);
+                });
+            } else {
                 callback.apply(null, values);
-            });
-        } else {
-            callback.apply(null, values);
+            }
         }
+
+        return wrapFunc(f);
     }
 
-    return wrapFunc(f);
+    fake.yields = function yields() {
+        return yieldInternal(false, slice(arguments));
+    };
+
+    fake.yieldsAsync = function yieldsAsync() {
+        return yieldInternal(true, slice(arguments));
+    };
+
+    return fake;
 }
 
-fake.yields = function yields() {
-    return yieldInternal(false, slice(arguments));
-};
-
-fake.yieldsAsync = function yieldsAsync() {
-    return yieldInternal(true, slice(arguments));
-};
-
-module.exports = fake;
+module.exports = fakeClass();

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -38,7 +38,7 @@ function wrapFunc(f) {
 }
 
 function fakeClass() {
-    var promiseLib;
+    var promiseLib = Promise;
 
     function fake(f) {
         if (arguments.length > 0 && typeof f !== "function") {
@@ -66,10 +66,7 @@ function fakeClass() {
 
     fake.resolves = function resolves(value) {
         function f() {
-            if (promiseLib) {
-                return promiseLib.resolve(value);
-            }
-            return Promise.resolve(value);
+            return promiseLib.resolve(value);
         }
 
         return wrapFunc(f);
@@ -77,10 +74,7 @@ function fakeClass() {
 
     fake.rejects = function rejects(value) {
         function f() {
-            if (promiseLib) {
-                return promiseLib.reject(value);
-            }
-            return Promise.reject(getError(value));
+            return promiseLib.reject(getError(value));
         }
 
         return wrapFunc(f);

--- a/test/fake-test.js
+++ b/test/fake-test.js
@@ -474,4 +474,47 @@ describe("fake", function() {
             assert.same(myFake.printf, proxy.printf);
         });
     });
+
+    describe(".usingPromise", function() {
+        before(requirePromiseSupport);
+
+        it("should exist and be a function", function() {
+            assert(fake.usingPromise);
+            assert.isFunction(fake.usingPromise);
+        });
+
+        it("should set the promise used by resolve", function() {
+            var promise = {
+                resolve: function(value) {
+                    return Promise.resolve(value);
+                }
+            };
+            var object = {};
+
+            var myFake = fake.usingPromise(promise).resolves(object);
+
+            return myFake().then(function(actual) {
+                assert.same(actual, object, "Same object resolved");
+            });
+        });
+
+        it("should set the promise used by reject", function() {
+            var promise = {
+                reject: function(err) {
+                    return Promise.reject(err);
+                }
+            };
+            var reason = new Error();
+
+            var myFake = fake.usingPromise(promise).rejects(reason);
+
+            return myFake()
+                .then(function() {
+                    referee.fail("this should not resolve");
+                })
+                .catch(function(actual) {
+                    assert.same(actual, reason, "Same object resolved");
+                });
+        });
+    });
 });


### PR DESCRIPTION
 #### Add usingPromise() method on fakes

Fix issue #2293. Added implementation of usingPromise() to be able to override global Promise library.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3.  sinon.fake().usingPromise(bluebird).resolves(42);

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
