### PR TITLE
Make sandboxes each use their own assert object

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -15,203 +15,210 @@ var forEach = arrayProto.forEach;
 var join = arrayProto.join;
 var splice = arrayProto.splice;
 
-var assert;
+function createAssertObject() {
+    var assert;
 
-function verifyIsStub() {
-    var args = arraySlice(arguments);
+    function verifyIsStub() {
+        var args = arraySlice(arguments);
 
-    forEach(args, function(method) {
-        if (!method) {
-            assert.fail("fake is not a spy");
-        }
-
-        if (method.proxy && method.proxy.isSinonProxy) {
-            verifyIsStub(method.proxy);
-        } else {
-            if (typeof method !== "function") {
-                assert.fail(method + " is not a function");
+        forEach(args, function(method) {
+            if (!method) {
+                assert.fail("fake is not a spy");
             }
 
-            if (typeof method.getCall !== "function") {
-                assert.fail(method + " is not stubbed");
-            }
-        }
-    });
-}
-
-function verifyIsValidAssertion(assertionMethod, assertionArgs) {
-    switch (assertionMethod) {
-        case "notCalled":
-        case "called":
-        case "calledOnce":
-        case "calledTwice":
-        case "calledThrice":
-            if (assertionArgs.length !== 0) {
-                assert.fail(
-                    assertionMethod +
-                        " takes 1 argument but was called with " +
-                        (assertionArgs.length + 1) +
-                        " arguments"
-                );
-            }
-            break;
-        default:
-            break;
-    }
-}
-
-function failAssertion(object, msg) {
-    var obj = object || globalObject;
-    var failMethod = obj.fail || assert.fail;
-    failMethod.call(obj, msg);
-}
-
-function mirrorPropAsAssertion(name, method, message) {
-    var msg = message;
-    var meth = method;
-    if (arguments.length === 2) {
-        msg = method;
-        meth = name;
-    }
-
-    assert[name] = function(fake) {
-        verifyIsStub(fake);
-
-        var args = arraySlice(arguments, 1);
-        var failed = false;
-
-        verifyIsValidAssertion(name, args);
-
-        if (typeof meth === "function") {
-            failed = !meth(fake);
-        } else {
-            failed = typeof fake[meth] === "function" ? !fake[meth].apply(fake, args) : !fake[meth];
-        }
-
-        if (failed) {
-            failAssertion(this, (fake.printf || fake.proxy.printf).apply(fake, concat([msg], args)));
-        } else {
-            assert.pass(name);
-        }
-    };
-}
-
-function exposedName(prefix, prop) {
-    return !prefix || /^fail/.test(prop) ? prop : prefix + stringSlice(prop, 0, 1).toUpperCase() + stringSlice(prop, 1);
-}
-
-assert = {
-    failException: "AssertError",
-
-    fail: function fail(message) {
-        var error = new Error(message);
-        error.name = this.failException || assert.failException;
-
-        throw error;
-    },
-
-    pass: function pass() {
-        return;
-    },
-
-    callOrder: function assertCallOrder() {
-        verifyIsStub.apply(null, arguments);
-        var expected = "";
-        var actual = "";
-
-        if (!calledInOrder(arguments)) {
-            try {
-                expected = join(arguments, ", ");
-                var calls = arraySlice(arguments);
-                var i = calls.length;
-                while (i) {
-                    if (!calls[--i].called) {
-                        splice(calls, i, 1);
-                    }
+            if (method.proxy && method.proxy.isSinonProxy) {
+                verifyIsStub(method.proxy);
+            } else {
+                if (typeof method !== "function") {
+                    assert.fail(method + " is not a function");
                 }
-                actual = join(orderByFirstCall(calls), ", ");
-            } catch (e) {
-                // If this fails, we'll just fall back to the blank string
-            }
 
-            failAssertion(this, "expected " + expected + " to be called in order but were called as " + actual);
-        } else {
-            assert.pass("callOrder");
-        }
-    },
-
-    callCount: function assertCallCount(method, count) {
-        verifyIsStub(method);
-
-        if (method.callCount !== count) {
-            var msg = "expected %n to be called " + timesInWords(count) + " but was called %c%C";
-            failAssertion(this, method.printf(msg));
-        } else {
-            assert.pass("callCount");
-        }
-    },
-
-    expose: function expose(target, options) {
-        if (!target) {
-            throw new TypeError("target is null or undefined");
-        }
-
-        var o = options || {};
-        var prefix = (typeof o.prefix === "undefined" && "assert") || o.prefix;
-        var includeFail = typeof o.includeFail === "undefined" || Boolean(o.includeFail);
-        var instance = this;
-
-        forEach(Object.keys(instance), function(method) {
-            if (method !== "expose" && (includeFail || !/^(fail)/.test(method))) {
-                target[exposedName(prefix, method)] = instance[method];
+                if (typeof method.getCall !== "function") {
+                    assert.fail(method + " is not stubbed");
+                }
             }
         });
+    }
 
-        return target;
-    },
-
-    match: function match(actual, expectation) {
-        var matcher = createMatcher(expectation);
-        if (matcher.test(actual)) {
-            assert.pass("match");
-        } else {
-            var formatted = [
-                "expected value to match",
-                "    expected = " + format(expectation),
-                "    actual = " + format(actual)
-            ];
-
-            failAssertion(this, join(formatted, "\n"));
+    function verifyIsValidAssertion(assertionMethod, assertionArgs) {
+        switch (assertionMethod) {
+            case "notCalled":
+            case "called":
+            case "calledOnce":
+            case "calledTwice":
+            case "calledThrice":
+                if (assertionArgs.length !== 0) {
+                    assert.fail(
+                        assertionMethod +
+                            " takes 1 argument but was called with " +
+                            (assertionArgs.length + 1) +
+                            " arguments"
+                    );
+                }
+                break;
+            default:
+                break;
         }
     }
-};
 
-mirrorPropAsAssertion("called", "expected %n to have been called at least once but was never called");
-mirrorPropAsAssertion(
-    "notCalled",
-    function(spy) {
-        return !spy.called;
-    },
-    "expected %n to not have been called but was called %c%C"
-);
-mirrorPropAsAssertion("calledOnce", "expected %n to be called once but was called %c%C");
-mirrorPropAsAssertion("calledTwice", "expected %n to be called twice but was called %c%C");
-mirrorPropAsAssertion("calledThrice", "expected %n to be called thrice but was called %c%C");
-mirrorPropAsAssertion("calledOn", "expected %n to be called with %1 as this but was called with %t");
-mirrorPropAsAssertion("alwaysCalledOn", "expected %n to always be called with %1 as this but was called with %t");
-mirrorPropAsAssertion("calledWithNew", "expected %n to be called with new");
-mirrorPropAsAssertion("alwaysCalledWithNew", "expected %n to always be called with new");
-mirrorPropAsAssertion("calledWith", "expected %n to be called with arguments %D");
-mirrorPropAsAssertion("calledWithMatch", "expected %n to be called with match %D");
-mirrorPropAsAssertion("alwaysCalledWith", "expected %n to always be called with arguments %D");
-mirrorPropAsAssertion("alwaysCalledWithMatch", "expected %n to always be called with match %D");
-mirrorPropAsAssertion("calledWithExactly", "expected %n to be called with exact arguments %D");
-mirrorPropAsAssertion("calledOnceWithExactly", "expected %n to be called once and with exact arguments %D");
-mirrorPropAsAssertion("calledOnceWithMatch", "expected %n to be called once and with match %D");
-mirrorPropAsAssertion("alwaysCalledWithExactly", "expected %n to always be called with exact arguments %D");
-mirrorPropAsAssertion("neverCalledWith", "expected %n to never be called with arguments %*%C");
-mirrorPropAsAssertion("neverCalledWithMatch", "expected %n to never be called with match %*%C");
-mirrorPropAsAssertion("threw", "%n did not throw exception%C");
-mirrorPropAsAssertion("alwaysThrew", "%n did not always throw exception%C");
+    function failAssertion(object, msg) {
+        var obj = object || globalObject;
+        var failMethod = obj.fail || assert.fail;
+        failMethod.call(obj, msg);
+    }
 
-module.exports = assert;
+    function mirrorPropAsAssertion(name, method, message) {
+        var msg = message;
+        var meth = method;
+        if (arguments.length === 2) {
+            msg = method;
+            meth = name;
+        }
+
+        assert[name] = function(fake) {
+            verifyIsStub(fake);
+
+            var args = arraySlice(arguments, 1);
+            var failed = false;
+
+            verifyIsValidAssertion(name, args);
+
+            if (typeof meth === "function") {
+                failed = !meth(fake);
+            } else {
+                failed = typeof fake[meth] === "function" ? !fake[meth].apply(fake, args) : !fake[meth];
+            }
+
+            if (failed) {
+                failAssertion(this, (fake.printf || fake.proxy.printf).apply(fake, concat([msg], args)));
+            } else {
+                assert.pass(name);
+            }
+        };
+    }
+
+    function exposedName(prefix, prop) {
+        return !prefix || /^fail/.test(prop)
+            ? prop
+            : prefix + stringSlice(prop, 0, 1).toUpperCase() + stringSlice(prop, 1);
+    }
+
+    assert = {
+        failException: "AssertError",
+
+        fail: function fail(message) {
+            var error = new Error(message);
+            error.name = this.failException || assert.failException;
+
+            throw error;
+        },
+
+        pass: function pass() {
+            return;
+        },
+
+        callOrder: function assertCallOrder() {
+            verifyIsStub.apply(null, arguments);
+            var expected = "";
+            var actual = "";
+
+            if (!calledInOrder(arguments)) {
+                try {
+                    expected = join(arguments, ", ");
+                    var calls = arraySlice(arguments);
+                    var i = calls.length;
+                    while (i) {
+                        if (!calls[--i].called) {
+                            splice(calls, i, 1);
+                        }
+                    }
+                    actual = join(orderByFirstCall(calls), ", ");
+                } catch (e) {
+                    // If this fails, we'll just fall back to the blank string
+                }
+
+                failAssertion(this, "expected " + expected + " to be called in order but were called as " + actual);
+            } else {
+                assert.pass("callOrder");
+            }
+        },
+
+        callCount: function assertCallCount(method, count) {
+            verifyIsStub(method);
+
+            if (method.callCount !== count) {
+                var msg = "expected %n to be called " + timesInWords(count) + " but was called %c%C";
+                failAssertion(this, method.printf(msg));
+            } else {
+                assert.pass("callCount");
+            }
+        },
+
+        expose: function expose(target, options) {
+            if (!target) {
+                throw new TypeError("target is null or undefined");
+            }
+
+            var o = options || {};
+            var prefix = (typeof o.prefix === "undefined" && "assert") || o.prefix;
+            var includeFail = typeof o.includeFail === "undefined" || Boolean(o.includeFail);
+            var instance = this;
+
+            forEach(Object.keys(instance), function(method) {
+                if (method !== "expose" && (includeFail || !/^(fail)/.test(method))) {
+                    target[exposedName(prefix, method)] = instance[method];
+                }
+            });
+
+            return target;
+        },
+
+        match: function match(actual, expectation) {
+            var matcher = createMatcher(expectation);
+            if (matcher.test(actual)) {
+                assert.pass("match");
+            } else {
+                var formatted = [
+                    "expected value to match",
+                    "    expected = " + format(expectation),
+                    "    actual = " + format(actual)
+                ];
+
+                failAssertion(this, join(formatted, "\n"));
+            }
+        }
+    };
+
+    mirrorPropAsAssertion("called", "expected %n to have been called at least once but was never called");
+    mirrorPropAsAssertion(
+        "notCalled",
+        function(spy) {
+            return !spy.called;
+        },
+        "expected %n to not have been called but was called %c%C"
+    );
+    mirrorPropAsAssertion("calledOnce", "expected %n to be called once but was called %c%C");
+    mirrorPropAsAssertion("calledTwice", "expected %n to be called twice but was called %c%C");
+    mirrorPropAsAssertion("calledThrice", "expected %n to be called thrice but was called %c%C");
+    mirrorPropAsAssertion("calledOn", "expected %n to be called with %1 as this but was called with %t");
+    mirrorPropAsAssertion("alwaysCalledOn", "expected %n to always be called with %1 as this but was called with %t");
+    mirrorPropAsAssertion("calledWithNew", "expected %n to be called with new");
+    mirrorPropAsAssertion("alwaysCalledWithNew", "expected %n to always be called with new");
+    mirrorPropAsAssertion("calledWith", "expected %n to be called with arguments %D");
+    mirrorPropAsAssertion("calledWithMatch", "expected %n to be called with match %D");
+    mirrorPropAsAssertion("alwaysCalledWith", "expected %n to always be called with arguments %D");
+    mirrorPropAsAssertion("alwaysCalledWithMatch", "expected %n to always be called with match %D");
+    mirrorPropAsAssertion("calledWithExactly", "expected %n to be called with exact arguments %D");
+    mirrorPropAsAssertion("calledOnceWithExactly", "expected %n to be called once and with exact arguments %D");
+    mirrorPropAsAssertion("calledOnceWithMatch", "expected %n to be called once and with match %D");
+    mirrorPropAsAssertion("alwaysCalledWithExactly", "expected %n to always be called with exact arguments %D");
+    mirrorPropAsAssertion("neverCalledWith", "expected %n to never be called with arguments %*%C");
+    mirrorPropAsAssertion("neverCalledWithMatch", "expected %n to never be called with match %*%C");
+    mirrorPropAsAssertion("threw", "%n did not throw exception%C");
+    mirrorPropAsAssertion("alwaysThrew", "%n did not always throw exception%C");
+
+    return assert;
+}
+
+module.exports = createAssertObject();
+module.exports.createAssertObject = createAssertObject;

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -37,6 +37,8 @@ function Sandbox() {
     var fakeRestorers = [];
     var promiseLib;
 
+    sandbox.assert = sinonAssert.createAssertObject();
+
     sandbox.serverPrototype = fakeServer;
 
     // this is for testing only
@@ -410,7 +412,6 @@ function Sandbox() {
     };
 }
 
-Sandbox.prototype.assert = sinonAssert;
 Sandbox.prototype.match = match;
 
 module.exports = Sandbox;

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -15,7 +15,6 @@ var sinonFake = require("../lib/sinon/fake");
 var sinonSpy = require("../lib/sinon/spy");
 var sinonStub = require("../lib/sinon/stub");
 var sinonConfig = require("../lib/sinon/util/core/get-config");
-var sinonAssert = require("../lib/sinon/assert");
 var sinonClock = require("../lib/sinon/util/fake-timers");
 
 var supportsAjax = typeof XMLHttpRequest !== "undefined" || typeof ActiveXObject !== "undefined";
@@ -45,12 +44,6 @@ describe("Sandbox", function() {
         var sandbox = new Sandbox();
 
         assert.same(sandbox.match, match);
-    });
-
-    it("exposes assert", function() {
-        var sandbox = new Sandbox();
-
-        assert.same(sandbox.assert, sinonAssert);
     });
 
     it("can be reset without failing when pre-configured to use a fake server", function() {
@@ -2075,6 +2068,26 @@ describe("Sandbox", function() {
             object.prop = "bla";
 
             assert.equals(object.prop, "bla");
+        });
+    });
+
+    describe(".assert", function() {
+        it("allows rebinding of .fail on a per-sandbox level", function() {
+            var sandboxA = createSandbox();
+            var sandboxB = createSandbox();
+
+            sandboxA.assert.failException = "CustomErrorA";
+            sandboxB.assert.failException = "CustomErrorB";
+
+            assert.exception(
+                function() {
+                    sandboxA.assert.fail("Some message");
+                },
+                { name: "CustomErrorA" }
+            );
+
+            sandboxA.restore();
+            sandboxB.restore();
         });
     });
 });


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Fix issue #2298 by having assertion objects be created by each sandbox instead of using the global one


<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

Intuitively you would think that sandboxes use isolated assertion objects. But this was not the case. If you overrode the `failException` or `pass`/`fail` functions, they would apply to all sandboxes and all assertions. This particularly was an issue with concurrent testing, such as with AVA.

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

We no longer create and export a single `assert` object, instead there is a `createAssertionObject` function that is used inside the sandboxes' constructor.

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

PS: on github the diff shows very poorly. In actuality only ~3 lines changed and a test case was added, but a buch of lines were indented one step.