### PR TITLE
Update error message on assert when representation of expected and ac…

### DIFF
--- a/lib/sinon/spy-formatters.js
+++ b/lib/sinon/spy-formatters.js
@@ -10,6 +10,7 @@ var jsDiff = require("diff");
 var join = arrayProto.join;
 var map = arrayProto.map;
 var push = arrayProto.push;
+var slice = arrayProto.slice;
 
 function colorSinonMatchText(matcher, calledArg, calledArgMessage) {
     var calledArgumentMessage = calledArgMessage;
@@ -38,6 +39,13 @@ function colorDiffText(diff) {
     return join(objects, "");
 }
 
+function quoteStringValue(value) {
+    if (typeof value === "string") {
+        return JSON.stringify(value);
+    }
+    return value;
+}
+
 module.exports = {
     c: function(spyInstance) {
         return timesInWords(spyInstance.callCount);
@@ -57,13 +65,24 @@ module.exports = {
                 message += "\nCall " + (i + 1) + ":";
             }
             var calledArgs = spyInstance.getCall(i).args;
-            for (var j = 0; j < calledArgs.length || j < args.length; ++j) {
+            var expectedArgs = slice(args);
+
+            for (var j = 0; j < calledArgs.length || j < expectedArgs.length; ++j) {
+                if (calledArgs[j]) {
+                    calledArgs[j] = quoteStringValue(calledArgs[j]);
+                }
+
+                if (expectedArgs[j]) {
+                    expectedArgs[j] = quoteStringValue(expectedArgs[j]);
+                }
+
                 message += "\n";
+
                 var calledArgMessage = j < calledArgs.length ? sinonFormat(calledArgs[j]) : "";
-                if (match.isMatcher(args[j])) {
-                    message += colorSinonMatchText(args[j], calledArgs[j], calledArgMessage);
+                if (match.isMatcher(expectedArgs[j])) {
+                    message += colorSinonMatchText(expectedArgs[j], calledArgs[j], calledArgMessage);
                 } else {
-                    var expectedArgMessage = j < args.length ? sinonFormat(args[j]) : "";
+                    var expectedArgMessage = j < expectedArgs.length ? sinonFormat(expectedArgs[j]) : "";
                     var diff = jsDiff.diffJson(calledArgMessage, expectedArgMessage);
                     message += colorDiffText(diff);
                 }

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1657,7 +1657,7 @@ describe("assert", function() {
                     color.green("1") +
                     " \n" +
                     "3\n" +
-                    "hey"
+                    '"hey"'
             );
         });
 
@@ -1674,13 +1674,13 @@ describe("assert", function() {
                     color.green("1") +
                     " \n" +
                     "3\n" +
-                    "hey\n" +
+                    '"hey"\n' +
                     "Call 2:\n" +
                     "1\n" +
                     "3\n" +
-                    color.red("not") +
+                    color.red('"not"') +
                     " " +
-                    color.green("hey") +
+                    color.green('"hey"') +
                     " "
             );
         });
@@ -1892,7 +1892,7 @@ describe("assert", function() {
                     color.green("4") +
                     " \n" +
                     "3\n" +
-                    "hey"
+                    '"hey"'
             );
         });
 
@@ -1907,13 +1907,13 @@ describe("assert", function() {
                     "1\n" +
                     color.red("3") +
                     " " +
-                    color.green("hey") +
+                    color.green('"hey"') +
                     " \n" +
-                    color.red("hey") +
+                    color.red('"hey"') +
                     "\n" +
                     "Call 2:\n" +
                     "1\n" +
-                    "hey"
+                    '"hey"'
             );
         });
 
@@ -1928,13 +1928,13 @@ describe("assert", function() {
                     "1\n" +
                     color.red("3") +
                     " " +
-                    color.green("hey") +
+                    color.green('"hey"') +
                     " \n" +
-                    color.red("hey") +
+                    color.red('"hey"') +
                     "\n" +
                     "Call 2:\n" +
                     "1\n" +
-                    "hey"
+                    '"hey"'
             );
         });
 
@@ -1943,7 +1943,7 @@ describe("assert", function() {
 
             assert.equals(
                 this.message("calledWithExactly", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
-                "expected doSomething to be called with exact arguments \n1\n3\n" + color.red("hey")
+                "expected doSomething to be called with exact arguments \n1\n3\n" + color.red('"hey"')
             );
         });
 
@@ -1962,7 +1962,7 @@ describe("assert", function() {
                     color.green("1") +
                     " \n" +
                     "3\n" +
-                    "bob"
+                    '"bob"'
             );
 
             this.obj.doSomething();
@@ -1974,9 +1974,22 @@ describe("assert", function() {
                     "\n" +
                     color.red("3") +
                     "\n" +
-                    color.red("bob") +
+                    color.red(JSON.stringify('"bob"')) +
                     "\n" +
                     "Call 2:"
+            );
+        });
+
+        it("assert.calledWith exception message with equal string representations", function() {
+            this.obj.doSomething(1234);
+
+            assert.equals(
+                this.message("calledWith", this.obj.doSomething, "1234"),
+                "expected doSomething to be called with arguments \n" +
+                    color.red(1234) +
+                    " " +
+                    color.green('"1234"') +
+                    " "
             );
         });
 
@@ -1990,7 +2003,7 @@ describe("assert", function() {
                     "Call 1:\n" +
                     "1\n" +
                     "3\n" +
-                    color.red("hey") +
+                    color.red('"hey"') +
                     "\n" +
                     "Call 2:\n" +
                     "1\n" +

--- a/test/proxy-test.js
+++ b/test/proxy-test.js
@@ -161,7 +161,7 @@ describe("proxy", function() {
                     "\n" +
                         color.red("1") +
                         "\n" +
-                        color.red("a") +
+                        color.red('"a"') +
                         "\n" +
                         color.red("true") +
                         "\n" +
@@ -198,7 +198,7 @@ describe("proxy", function() {
                         "\n" +
                         color.red("1") +
                         "\n" +
-                        color.red("a") +
+                        color.red('"a"') +
                         "\n" +
                         color.red("true") +
                         "\nCall 2:" +


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
Fixes issue #2084 by adding quotes to diff values if said values are strings, creating distinct string representations and preventing the expected and actual values from being reduced to a single value.

 #### Background (Problem in detail)  - optional
When the expected and actual values of an assertion do not match but they have the same string representation (for example the number 1234 and the string "1234"), the output does not show the difference, but reduces it to a single value. In this example, this output is produced:

expected spy to be called with arguments
<black>1234</black>
while this output was expected:

expected spy to be called with arguments
<red>1234</red>
<green>1234</green>

 #### Solution  - optional
A solution was proposed in the ticket itself which was also implemented here: adding quotes around a diff value if the value in question is a string. This process is skipped if the value is undefined, not a string, or already wrapped in quotes.

Instead, diffs are now displayed as follows, given the example where the string 1234 was expected but the number 1234 was found instead:

expected spy to be called with arguments
<red>1234</red>
<green>'1234'</green>

 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Run the test included with this PR

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
