### PR TITLE
Skip write to 'name' property if not [[writable]]

### DIFF
--- a/lib/sinon/util/core/extend.js
+++ b/lib/sinon/util/core/extend.js
@@ -73,8 +73,8 @@ function extendCommon(target, sources, doCopy) {
     return target;
 }
 
-/** Public: Extend target in place with all (own) properties from sources in-order. Thus, last source will
- *         override properties in previous sources.
+/** Public: Extend target in place with all (own) properties, except 'name' when [[writable]] is false,
+ *         from sources in-order. Thus, last source will override properties in previous sources.
  *
  * @arg {Object} target - The Object to extend
  * @arg {Object[]} sources - Objects to copy properties from.
@@ -85,7 +85,18 @@ module.exports = function extend(target /*, sources */) {
     var sources = slice(arguments, 1);
 
     return extendCommon(target, sources, function copyValue(dest, source, prop) {
-        dest[prop] = source[prop];
+        var destOwnPropertyDescriptor = Object.getOwnPropertyDescriptor(dest, prop);
+        var sourceOwnPropertyDescriptor = Object.getOwnPropertyDescriptor(source, prop);
+
+        // If the property is 'name' but is not [[writable]], skip it
+        if (prop !== "name" || destOwnPropertyDescriptor.writable) {
+            Object.defineProperty(dest, prop, {
+                configurable: sourceOwnPropertyDescriptor.configurable,
+                enumerable: sourceOwnPropertyDescriptor.enumerable,
+                writable: sourceOwnPropertyDescriptor.writable,
+                value: sourceOwnPropertyDescriptor.value
+            });
+        }
     });
 };
 

--- a/lib/sinon/util/core/extend.js
+++ b/lib/sinon/util/core/extend.js
@@ -89,7 +89,7 @@ module.exports = function extend(target /*, sources */) {
         var sourceOwnPropertyDescriptor = Object.getOwnPropertyDescriptor(source, prop);
 
         if (prop === "name" && !destOwnPropertyDescriptor.writable) {
-        	return;
+            return;
         }
 
         Object.defineProperty(dest, prop, {

--- a/lib/sinon/util/core/extend.js
+++ b/lib/sinon/util/core/extend.js
@@ -88,15 +88,16 @@ module.exports = function extend(target /*, sources */) {
         var destOwnPropertyDescriptor = Object.getOwnPropertyDescriptor(dest, prop);
         var sourceOwnPropertyDescriptor = Object.getOwnPropertyDescriptor(source, prop);
 
-        // If the property is 'name' but is not [[writable]], skip it
-        if (prop !== "name" || destOwnPropertyDescriptor.writable) {
-            Object.defineProperty(dest, prop, {
-                configurable: sourceOwnPropertyDescriptor.configurable,
-                enumerable: sourceOwnPropertyDescriptor.enumerable,
-                writable: sourceOwnPropertyDescriptor.writable,
-                value: sourceOwnPropertyDescriptor.value
-            });
+        if (prop === "name" && !destOwnPropertyDescriptor.writable) {
+        	return;
         }
+
+        Object.defineProperty(dest, prop, {
+            configurable: sourceOwnPropertyDescriptor.configurable,
+            enumerable: sourceOwnPropertyDescriptor.enumerable,
+            writable: sourceOwnPropertyDescriptor.writable,
+            value: sourceOwnPropertyDescriptor.value
+        });
     });
 };
 

--- a/test/extend-test.js
+++ b/test/extend-test.js
@@ -77,4 +77,30 @@ describe("extend", function() {
 
         assert.equals(result, expected);
     });
+
+    it("does not attempt to write to 'name' property if it is not [[writable]]", function() {
+        var object1 = { prop1: null };
+
+        Object.defineProperty(object1, "name", {
+            configurable: false,
+            enumerable: true,
+            value: "not-writable",
+            writable: false
+        });
+
+        var object2 = {
+            prop2: "hey",
+            name: "write-attempt"
+        };
+
+        var result = extend(object1, object2);
+
+        var expected = {
+            prop1: null,
+            prop2: "hey",
+            name: "not-writable"
+        };
+
+        assert.equals(result, expected);
+    });
 });

--- a/test/extend-test.js
+++ b/test/extend-test.js
@@ -78,7 +78,7 @@ describe("extend", function() {
         assert.equals(result, expected);
     });
 
-    context("when 'name' property is not writable", function(){
+    context("when 'name' property is not writable", function() {
         it("does not attempt to write to the property", function() {
             var object1 = { prop1: null };
 

--- a/test/extend-test.js
+++ b/test/extend-test.js
@@ -78,29 +78,31 @@ describe("extend", function() {
         assert.equals(result, expected);
     });
 
-    it("does not attempt to write to 'name' property if it is not [[writable]]", function() {
-        var object1 = { prop1: null };
+    context("when 'name' property is not writable", function(){
+        it("does not attempt to write to the property", function() {
+            var object1 = { prop1: null };
 
-        Object.defineProperty(object1, "name", {
-            configurable: false,
-            enumerable: true,
-            value: "not-writable",
-            writable: false
+            Object.defineProperty(object1, "name", {
+                configurable: false,
+                enumerable: true,
+                value: "not-writable",
+                writable: false
+            });
+
+            var object2 = {
+                prop2: "hey",
+                name: "write-attempt"
+            };
+
+            var result = extend(object1, object2);
+
+            var expected = {
+                prop1: null,
+                prop2: "hey",
+                name: "not-writable"
+            };
+
+            assert.equals(result, expected);
         });
-
-        var object2 = {
-            prop2: "hey",
-            name: "write-attempt"
-        };
-
-        var result = extend(object1, object2);
-
-        var expected = {
-            prop1: null,
-            prop2: "hey",
-            name: "not-writable"
-        };
-
-        assert.equals(result, expected);
     });
 });


### PR DESCRIPTION
 #### Purpose
Fix issue #2203 by skipping 'name' property if it is not [[writable]].

#### Solution
This solution works by skipping writing a source property to the target object if the property is 'name' _and_ is not [[writable]] on the 'target'.

 #### How to verify
1. Check out this branch
2. `npm install`
3. `npm test`

 #### Checklist for author
- [x] `npm run lint` passes 
> // unable to run npm script on Windows, linted manually with `eslint --fix`.

- [X] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
