### PR TITLE
Resolve #2305 by fixing broken 'matchers' link

### DIFF
--- a/docs/_releases/latest/spies.md
+++ b/docs/_releases/latest/spies.md
@@ -156,7 +156,7 @@ are also available on `object.method`.
 
 Creates a spy that only records [calls][call] when the received arguments match those passed to `withArgs`. This is useful to be more expressive in your assertions, where you can access the spy with the same [call][call].
 
-Uses deep comparison for objects and arrays. Use `spy.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 <div data-example-id="spies-7-with-args"></div>
 
@@ -235,7 +235,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -340,7 +340,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -426,3 +426,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/latest/spy-call.md
+++ b/docs/_releases/latest/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -157,3 +157,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/latest/stubs.md
+++ b/docs/_releases/latest/stubs.md
@@ -135,7 +135,7 @@ Stubs the method only for the provided arguments.
 
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
-Uses deep comparison for objects and arrays. Use `stub.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `stub.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 <div data-example-id="stubs-2-different-args"></div>
 
@@ -527,3 +527,5 @@ You can restore values by calling the `restore` method:
 
 Holds a reference to the original method/function this stub has
 wrapped. `undefined` for the property accessors.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.4.1/spies.md
+++ b/docs/_releases/v7.4.1/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.4.1/spy-call.md
+++ b/docs/_releases/v7.4.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.4.2/spies.md
+++ b/docs/_releases/v7.4.2/spies.md
@@ -241,7 +241,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -346,7 +346,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -436,3 +436,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.4.2/spy-call.md
+++ b/docs/_releases/v7.4.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v7.5.0/spies.md
+++ b/docs/_releases/v7.5.0/spies.md
@@ -275,7 +275,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -380,7 +380,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -470,3 +470,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v7.5.0/spy-call.md
+++ b/docs/_releases/v7.5.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v8.0.0/spies.md
+++ b/docs/_releases/v8.0.0/spies.md
@@ -199,7 +199,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -304,7 +304,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -388,3 +388,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v8.0.0/spy-call.md
+++ b/docs/_releases/v8.0.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v8.0.1/spies.md
+++ b/docs/_releases/v8.0.1/spies.md
@@ -199,7 +199,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -304,7 +304,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -388,3 +388,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v8.0.1/spy-call.md
+++ b/docs/_releases/v8.0.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v8.0.2/spies.md
+++ b/docs/_releases/v8.0.2/spies.md
@@ -233,7 +233,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -422,3 +422,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v8.0.2/spy-call.md
+++ b/docs/_releases/v8.0.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v8.0.3/spies.md
+++ b/docs/_releases/v8.0.3/spies.md
@@ -233,7 +233,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -422,3 +422,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v8.0.3/spy-call.md
+++ b/docs/_releases/v8.0.3/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v8.0.4/spies.md
+++ b/docs/_releases/v8.0.4/spies.md
@@ -233,7 +233,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -422,3 +422,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v8.0.4/spy-call.md
+++ b/docs/_releases/v8.0.4/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v8.1.0/spies.md
+++ b/docs/_releases/v8.1.0/spies.md
@@ -233,7 +233,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v8.1.0/spy-call.md
+++ b/docs/_releases/v8.1.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v8.1.1/spies.md
+++ b/docs/_releases/v8.1.1/spies.md
@@ -233,7 +233,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v8.1.1/spy-call.md
+++ b/docs/_releases/v8.1.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -143,3 +143,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v9.0.0/spies.md
+++ b/docs/_releases/v9.0.0/spies.md
@@ -233,7 +233,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v9.0.0/spy-call.md
+++ b/docs/_releases/v9.0.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -157,3 +157,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v9.0.1/spies.md
+++ b/docs/_releases/v9.0.1/spies.md
@@ -233,7 +233,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v9.0.1/spy-call.md
+++ b/docs/_releases/v9.0.1/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -157,3 +157,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v9.0.2/spies.md
+++ b/docs/_releases/v9.0.2/spies.md
@@ -233,7 +233,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v9.0.2/spy-call.md
+++ b/docs/_releases/v9.0.2/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -157,3 +157,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v9.0.3/spies.md
+++ b/docs/_releases/v9.0.3/spies.md
@@ -233,7 +233,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -338,7 +338,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -424,3 +424,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v9.0.3/spy-call.md
+++ b/docs/_releases/v9.0.3/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -157,3 +157,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v9.1.0/spies.md
+++ b/docs/_releases/v9.1.0/spies.md
@@ -156,7 +156,7 @@ are also available on `object.method`.
 
 Creates a spy that only records [calls][call] when the received arguments match those passed to `withArgs`. This is useful to be more expressive in your assertions, where you can access the spy with the same [call][call].
 
-Uses deep comparison for objects and arrays. Use `spy.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 <div data-example-id="spies-7-with-args"></div>
 
@@ -235,7 +235,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -340,7 +340,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -426,3 +426,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v9.1.0/spy-call.md
+++ b/docs/_releases/v9.1.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -157,3 +157,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v9.1.0/stubs.md
+++ b/docs/_releases/v9.1.0/stubs.md
@@ -135,7 +135,7 @@ Stubs the method only for the provided arguments.
 
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
-Uses deep comparison for objects and arrays. Use `stub.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `stub.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 <div data-example-id="stubs-2-different-args"></div>
 
@@ -527,3 +527,5 @@ You can restore values by calling the `restore` method:
 
 Holds a reference to the original method/function this stub has
 wrapped. `undefined` for the property accessors.
+
+[matchers]: ../matchers

--- a/docs/_releases/v9.2.0/spies.md
+++ b/docs/_releases/v9.2.0/spies.md
@@ -156,7 +156,7 @@ are also available on `object.method`.
 
 Creates a spy that only records [calls][call] when the received arguments match those passed to `withArgs`. This is useful to be more expressive in your assertions, where you can access the spy with the same [call][call].
 
-Uses deep comparison for objects and arrays. Use `spy.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 <div data-example-id="spies-7-with-args"></div>
 
@@ -235,7 +235,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -340,7 +340,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -426,3 +426,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/_releases/v9.2.0/spy-call.md
+++ b/docs/_releases/v9.2.0/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -157,3 +157,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/_releases/v9.2.0/stubs.md
+++ b/docs/_releases/v9.2.0/stubs.md
@@ -135,7 +135,7 @@ Stubs the method only for the provided arguments.
 
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
-Uses deep comparison for objects and arrays. Use `stub.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `stub.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 <div data-example-id="stubs-2-different-args"></div>
 
@@ -527,3 +527,5 @@ You can restore values by calling the `restore` method:
 
 Holds a reference to the original method/function this stub has
 wrapped. `undefined` for the property accessors.
+
+[matchers]: ../matchers

--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -156,7 +156,7 @@ are also available on `object.method`.
 
 Creates a spy that only records [calls][call] when the received arguments match those passed to `withArgs`. This is useful to be more expressive in your assertions, where you can access the spy with the same [call][call].
 
-Uses deep comparison for objects and arrays. Use `spy.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 <div data-example-id="spies-7-with-args"></div>
 
@@ -235,7 +235,7 @@ occurred between `anotherSpy` and `spy`.
 
 #### `spy.calledOn(obj);`
 
-Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if the spy was called at least once with `obj` as `this`. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 #### `spy.alwaysCalledOn(obj);`
@@ -340,7 +340,7 @@ Returns `true` if spy always threw the provided exception object.
 
 Returns `true` if spy returned the provided value at least once.
 
-Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spy.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 
 #### `spy.alwaysReturned(obj);`
@@ -426,3 +426,4 @@ Returns the passed format string with the following replacements performed:
 </dl>
 
 [call]: ../spy-call
+[matchers]: ../matchers

--- a/docs/release-source/release/spy-call.md
+++ b/docs/release-source/release/spy-call.md
@@ -23,7 +23,7 @@ assertEquals("/stuffs", spyCall.args[0]);
 
 ### `spyCall.calledOn(obj);`
 
-Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers](matchers)).
+Returns `true` if `obj` was `this` for this call. `calledOn` also accepts a matcher `spyCall.calledOn(sinon.match(fn))` (see [matchers][matchers]).
 
 
 ### `spyCall.calledWith(arg1, arg2, ...);`
@@ -56,7 +56,7 @@ This behaves the same as `spyCall.notCalledWith(sinon.match(arg1), sinon.match(a
 
 Returns `true` if spied function returned the provided `value` on this call.
 
-Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `spyCall.returned(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 ### `spyCall.threw();`
 
@@ -157,3 +157,5 @@ Exception thrown, if any.
 ### `spyCall.returnValue`
 
 Return value.
+
+[matchers]: ../matchers

--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -135,7 +135,7 @@ Stubs the method only for the provided arguments.
 
 This is useful to be more expressive in your assertions, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
 
-Uses deep comparison for objects and arrays. Use `stub.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers](matchers)).
+Uses deep comparison for objects and arrays. Use `stub.withArgs(sinon.match.same(obj))` for strict comparison (see [matchers][matchers]).
 
 <div data-example-id="stubs-2-different-args"></div>
 
@@ -527,3 +527,5 @@ You can restore values by calling the `restore` method:
 
 Holds a reference to the original method/function this stub has
 wrapped. `undefined` for the property accessors.
+
+[matchers]: ../matchers


### PR DESCRIPTION
 #### Purpose (TL;DR) 
Resolve #2305 by fixing broken 'matchers' link

 #### Solution 
Fix broken links (3 of them)


 #### How to verify 
1. Check out this branch
2. Open file
3. Observe markdown
4. Hover over links to confirm accuracy

 #### Checklist for author
- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
