### PR TITLE
add missing 'of'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ You can run the linter locally:
 $ npm run lint
 ```
 
-You can fix a lot lint and style violations automatically:
+You can fix a lot of lint and style violations automatically:
 
 ```
 $ npm run lint -- --fix


### PR DESCRIPTION
 #### Purpose (TL;DR) - mandatory
Fix a typo, missing the word 'of'

 #### Solution 
Add a missing 'of'

 #### How to verify - mandatory
1. Read the edit

 #### Checklist for author

- [ ] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
