### PR TITLE
feat: further es module detection

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,8 @@ docs/release-source/release/examples
 
 # has "invalid" ESM syntax
 rollup.config.js
+
+# generated code
+test/typescript-modules/foo.js
+test/typescript-modules/foo-impl.js
+test/typescript-modules/ts-index.js

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -7,6 +7,7 @@ var functionName = require("@sinonjs/commons").functionName;
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var deepEqual = require("@sinonjs/samsam").deepEqual;
 var isEsModule = require("./util/core/is-es-module");
+var checkNotEsProperty = require("./util/core/is-es-property");
 var proxyCallUtil = require("./proxy-call-util");
 var walkObject = require("./util/core/walk-object");
 var wrapMethod = require("./util/core/wrap-method");
@@ -137,6 +138,8 @@ function spy(object, property, types) {
     if (isEsModule(object)) {
         throw new TypeError("ES Modules cannot be spied");
     }
+
+    checkNotEsProperty(object, property);
 
     if (!property && typeof object === "function") {
         return createSpy(object);

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -11,6 +11,7 @@ var spy = require("./spy");
 var extend = require("./util/core/extend");
 var getPropertyDescriptor = require("./util/core/get-property-descriptor");
 var isEsModule = require("./util/core/is-es-module");
+var checkNotEsProperty = require("./util/core/is-es-property");
 var wrapMethod = require("./util/core/wrap-method");
 var throwOnFalsyObject = require("./throw-on-falsy-object");
 var valueToString = require("@sinonjs/commons").valueToString;
@@ -66,6 +67,8 @@ function stub(object, property) {
     if (isEsModule(object)) {
         throw new TypeError("ES Modules cannot be stubbed");
     }
+
+    checkNotEsProperty(object, property);
 
     throwOnFalsyObject.apply(null, arguments);
 

--- a/lib/sinon/util/core/is-es-property.js
+++ b/lib/sinon/util/core/is-es-property.js
@@ -1,0 +1,41 @@
+"use strict";
+
+var deprecated = require("@sinonjs/commons").deprecated;
+
+/**
+ * Verify an object's property is not an ECMAScript Module property
+ *
+ * As the exports from a module is immutable we cannot alter the exports
+ * using spies or stubs. Let the consumer know this to avoid bug reports
+ * on weird error messages.
+ *
+ * @param {Object} object The object to examine
+ * @param {string} property The property to examine
+ */
+module.exports = function(object, property) {
+    // eslint-disable-next-line no-underscore-dangle
+    if (!object || !object.__esModule) {
+        return;
+    }
+
+    var own = Object.getOwnPropertyDescriptor(object, property);
+    if (!own.get || own.set) {
+        return;
+    }
+
+    var msg =
+        'Property "' +
+        property +
+        '" cannot be overriden, it appears to be a ES Module read-only property. ' +
+        "These can be generated with re-exports in Typescript.";
+
+    switch (process.env.SINON_ES_MODULE_DETECTION) {
+        case "error":
+            throw new TypeError(msg);
+        case "ignore":
+            break;
+        case "warn":
+        default:
+            deprecated.printWarning(msg);
+    }
+};

--- a/test/typescript-modules/Makefile
+++ b/test/typescript-modules/Makefile
@@ -1,0 +1,5 @@
+all: tsc
+
+tsc:
+	npx typescript@4.1 --module commonjs --target es2015 ts-index.ts
+

--- a/test/typescript-modules/foo-impl.js
+++ b/test/typescript-modules/foo-impl.js
@@ -1,0 +1,5 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.foo = void 0;
+function foo() { return 'REAL'; }
+exports.foo = foo;

--- a/test/typescript-modules/foo-impl.ts
+++ b/test/typescript-modules/foo-impl.ts
@@ -1,0 +1,2 @@
+export function foo() { return 'REAL'; }
+

--- a/test/typescript-modules/foo.js
+++ b/test/typescript-modules/foo.js
@@ -1,0 +1,5 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.foo = void 0;
+var foo_impl_1 = require("./foo-impl");
+Object.defineProperty(exports, "foo", { enumerable: true, get: function () { return foo_impl_1.foo; } });

--- a/test/typescript-modules/foo.ts
+++ b/test/typescript-modules/foo.ts
@@ -1,0 +1,1 @@
+export { foo } from './foo-impl';

--- a/test/typescript-modules/module-support-assessment-test.js
+++ b/test/typescript-modules/module-support-assessment-test.js
@@ -11,7 +11,7 @@ var referee = require("@sinonjs/referee");
 var sinon = require("../../lib/sinon");
 
 var assert = referee.assert;
-var equals = referee.equals;
+var equals = assert.equals;
 
 var envBackup = process.env.SINON_ES_MODULE_DETECTION;
 describe("stubbing typescript", function() {

--- a/test/typescript-modules/module-support-assessment-test.js
+++ b/test/typescript-modules/module-support-assessment-test.js
@@ -6,6 +6,7 @@
  */
 var aModule = require("./ts-index");
 var fooModule = require("./foo");
+var fooImplModule = require("./foo-impl");
 
 var referee = require("@sinonjs/referee");
 var sinon = require("../../lib/sinon");
@@ -17,6 +18,7 @@ var envBackup = process.env.SINON_ES_MODULE_DETECTION;
 describe("stubbing typescript", function() {
     afterEach(function() {
         process.env.SINON_ES_MODULE_DETECTION = envBackup;
+        sinon.restore();
     });
 
     it("silently fails to stub", function() {
@@ -34,5 +36,10 @@ describe("stubbing typescript", function() {
         assert.exception(function() {
             sinon.stub(fooModule, "foo");
         }, /ES Module read-only property/);
+    });
+
+    it("stubs the impl correctly", function() {
+        sinon.stub(fooImplModule, "foo").returns("impl");
+        equals(aModule.main(), "impl");
     });
 });

--- a/test/typescript-modules/module-support-assessment-test.js
+++ b/test/typescript-modules/module-support-assessment-test.js
@@ -1,0 +1,38 @@
+"use strict";
+
+/**
+ * About these tests:
+ * These tests concern Typescript "commonjs" "es" Modules.
+ */
+var aModule = require("./ts-index");
+var fooModule = require("./foo");
+
+var referee = require("@sinonjs/referee");
+var sinon = require("../../lib/sinon");
+
+var assert = referee.assert;
+var equals = referee.equals;
+
+var envBackup = process.env.SINON_ES_MODULE_DETECTION;
+describe("stubbing typescript", function() {
+    afterEach(function() {
+        process.env.SINON_ES_MODULE_DETECTION = envBackup;
+    });
+
+    it("silently fails to stub", function() {
+        process.env.SINON_ES_MODULE_DETECTION = "ignore";
+        var stub = sinon.stub(fooModule, "foo");
+        if (stub) {
+            stub.returns("good");
+        }
+        // mocking has failed
+        equals(aModule.main(), "REAL");
+    });
+
+    it("throws for illegal stubs", function() {
+        process.env.SINON_ES_MODULE_DETECTION = "error";
+        assert.exception(function() {
+            sinon.stub(fooModule, "foo");
+        }, /ES Module read-only property/);
+    });
+});

--- a/test/typescript-modules/ts-index.js
+++ b/test/typescript-modules/ts-index.js
@@ -1,0 +1,8 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.main = void 0;
+const foo_1 = require("./foo");
+function main() {
+    return foo_1.foo();
+}
+exports.main = main;

--- a/test/typescript-modules/ts-index.ts
+++ b/test/typescript-modules/ts-index.ts
@@ -1,0 +1,6 @@
+import { foo } from './foo';
+
+export function main() {
+  return foo();
+}
+


### PR DESCRIPTION
Typescript 3.9 and above generate a different type of ES Module,
which we don't currently provide an error for; the mocks just
silently fail. Detect this type of module, and explicitly throw
an explanation here, instead of failing silently.

 #### Purpose (TL;DR)

Throw an error for new types of ES Modules. We already try and do this, but it doesn't pick up typescript's ES modules.


#### Background (Problem in detail) 

Here's the typescript team breaking us. https://github.com/microsoft/TypeScript/issues/38568


 #### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Run tests against a broken project, and get a nice error.

 #### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
