### PR TITLE
Replace @sinonjs/formatio with util.inspect

### DIFF
--- a/lib/sinon/util/core/format.js
+++ b/lib/sinon/util/core/format.js
@@ -1,12 +1,6 @@
 "use strict";
 
-var formatio = require("@sinonjs/formatio");
-
-var formatter = formatio.configure({
-    quoteStrings: false,
-    limitChildrenCount: 250
-});
-
+var inspect = require("util").inspect;
 var customFormatter;
 
 function format() {
@@ -14,7 +8,7 @@ function format() {
         return customFormatter.apply(null, arguments);
     }
 
-    return formatter.ascii.apply(formatter, arguments);
+    return inspect.apply(inspect, arguments);
 }
 
 format.setFormatter = function(aCustomFormatter) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -495,15 +495,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
-      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
-      "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^5.0.2"
-      }
-    },
     "@sinonjs/referee": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-6.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "dependencies": {
     "@sinonjs/commons": "^1.8.1",
     "@sinonjs/fake-timers": "^6.0.1",
-    "@sinonjs/formatio": "^5.0.1",
     "@sinonjs/samsam": "^5.3.0",
     "diff": "^4.0.2",
     "nise": "^4.0.4",

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -822,7 +822,7 @@ describe("sinonMock", function() {
                         expectation.verify();
                     },
                     {
-                        message: "Expected myMeth([...]) once (never called)"
+                        message: "Expected myMeth('[...]') once (never called)"
                     }
                 );
             });
@@ -884,8 +884,8 @@ describe("sinonMock", function() {
                 },
                 {
                     message:
-                        "Expected method([...]) thrice (never called)\n" +
-                        "Expected method(42[, ...]) once (never called)"
+                        "Expected method('[...]') thrice (never called)\n" +
+                        "Expected method(42, '[...]') once (never called)"
                 }
             );
         });
@@ -960,7 +960,7 @@ describe("sinonMock", function() {
                 {
                     message:
                         "Unexpected call: method()\n" +
-                        "    Expectation met: method(1[, ...]) once\n" +
+                        "    Expectation met: method(1, '[...]') once\n" +
                         "    Expected method(42) thrice (never called)"
                 }
             );
@@ -982,7 +982,7 @@ describe("sinonMock", function() {
                     mock.verify();
                 },
                 {
-                    message: "Expected method(42) thrice (never called)\nExpectation met: method(1[, ...]) once"
+                    message: "Expected method(42) thrice (never called)\nExpectation met: method(1, '[...]') once"
                 }
             );
         });
@@ -996,7 +996,7 @@ describe("sinonMock", function() {
                     mock.verify();
                 },
                 {
-                    message: "Expected method([...]) at least once (never called)"
+                    message: "Expected method('[...]') at least once (never called)"
                 }
             );
         });
@@ -1014,7 +1014,7 @@ describe("sinonMock", function() {
                     object.method();
                 },
                 {
-                    message: "Unexpected call: method()\n    Expectation met: method([...]) at most twice"
+                    message: "Unexpected call: method()\n    Expectation met: method('[...]') at most twice"
                 }
             );
         });
@@ -1037,8 +1037,8 @@ describe("sinonMock", function() {
                 {
                     message:
                         "Unexpected call: method(2)\n" +
-                        "    Expectation met: method([...]) at least once\n" +
-                        "    Expectation met: method(2[, ...]) once"
+                        "    Expectation met: method('[...]') at least once\n" +
+                        "    Expectation met: method(2, '[...]') once"
                 }
             );
         });
@@ -1054,7 +1054,7 @@ describe("sinonMock", function() {
                     mock.verify();
                 },
                 {
-                    message: "Expected method([...]) at least once and at most twice (never called)"
+                    message: "Expected method('[...]') at least once and at most twice (never called)"
                 }
             );
         });

--- a/test/proxy-call-test.js
+++ b/test/proxy-call-test.js
@@ -1079,7 +1079,7 @@ describe("sinonSpy.call", function() {
                     .getCall(0)
                     .toString()
                     .replace(/ at.*/g, ""),
-                "doIt(42, Hey)"
+                "doIt(42, 'Hey')"
             );
         });
 
@@ -1092,7 +1092,7 @@ describe("sinonSpy.call", function() {
                     .getCall(0)
                     .toString()
                     .replace(/ at.*/g, ""),
-                "doIt(42, Hey) => 42"
+                "doIt(42, 'Hey') => 42"
             );
         });
 
@@ -1105,7 +1105,7 @@ describe("sinonSpy.call", function() {
                     .getCall(0)
                     .toString()
                     .replace(/ at.*/g, ""),
-                "doIt(42, Hey) => (empty string)"
+                "doIt(42, 'Hey') => ''"
             );
         });
 

--- a/test/proxy-test.js
+++ b/test/proxy-test.js
@@ -88,8 +88,8 @@ describe("proxy", function() {
                 verify(-1, "faux(-1)");
                 verify(-1.1, "faux(-1.1)");
                 verify(Infinity, "faux(Infinity)");
-                verify(["a"], 'faux(["a"])');
-                verify({ a: "a" }, 'faux({ a: "a" })');
+                verify(["a"], "faux([ 'a' ])");
+                verify({ a: "a" }, "faux({ a: 'a' })");
             });
 
             it("multiline", function() {
@@ -102,7 +102,7 @@ describe("proxy", function() {
 
                 assert.equals(
                     faux.printf("%C").replace(/ at.*/g, ""),
-                    "\n    faux(" + str + ")\n\n    faux(" + str + ")\n\n    faux(" + str + ")"
+                    "\n    faux('faux\\ntest')\n    faux('faux\\ntest')\n    faux('faux\\ntest')"
                 );
 
                 faux.resetHistory();
@@ -113,7 +113,7 @@ describe("proxy", function() {
 
                 assert.equals(
                     faux.printf("%C").replace(/ at.*/g, ""),
-                    "\n    faux(test)\n    faux(" + str + ")\n\n    faux(" + str + ")"
+                    "\n    faux('test')\n    faux('faux\\ntest')\n    faux('faux\\ntest')"
                 );
             });
         });
@@ -139,9 +139,9 @@ describe("proxy", function() {
 
             assert.equals(
                 faux.printf("%*", 1.4567, "a", true, {}, [], undefined, null),
-                "1.4567, a, true, {  }, [], undefined, null"
+                "1.4567, 'a', true, {}, [], undefined, null"
             );
-            assert.equals(faux.printf("%*", "a", "b", "c"), "a, b, c");
+            assert.equals(faux.printf("%*", "a", "b", "c"), "'a', 'b', 'c'");
         });
 
         describe("arguments", function() {
@@ -161,7 +161,7 @@ describe("proxy", function() {
                     "\n" +
                         color.red("1") +
                         "\n" +
-                        color.red('"a"') +
+                        color.red("'\"a\"'") +
                         "\n" +
                         color.red("true") +
                         "\n" +
@@ -169,7 +169,7 @@ describe("proxy", function() {
                         "\n" +
                         color.red("[]") +
                         "\n" +
-                        color.red("{  }") +
+                        color.red("{}") +
                         "\n" +
                         color.red("null") +
                         "\n" +
@@ -198,7 +198,7 @@ describe("proxy", function() {
                         "\n" +
                         color.red("1") +
                         "\n" +
-                        color.red('"a"') +
+                        color.red("'\"a\"'") +
                         "\n" +
                         color.red("true") +
                         "\nCall 2:" +
@@ -207,7 +207,7 @@ describe("proxy", function() {
                         "\n" +
                         color.red("[]") +
                         "\n" +
-                        color.red("{  }") +
+                        color.red("{}") +
                         "\nCall 3:" +
                         "\n" +
                         color.red("null") +

--- a/test/util/core/format-test.js
+++ b/test/util/core/format-test.js
@@ -6,22 +6,6 @@ var format = require("../../../lib/sinon/util/core/format");
 var assert = referee.assert;
 
 describe("util/core/format", function() {
-    it("formats with formatio by default", function() {
-        assert.equals(format({ id: 42 }), "{ id: 42 }");
-    });
-
-    // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip("should configure formatio to use maximum 250 entries", function() {
-        // not sure how we can verify this integration with the current setup
-        // where sinon.js calls formatio as part of its loading
-        // extracting sinon.format into a separate module would make this a lot
-        // easier
-    });
-
-    it("formats strings without quotes", function() {
-        assert.equals(format("Hey"), "Hey");
-    });
-
     describe("format.setFormatter", function() {
         it("sets custom formatter", function() {
             format.setFormatter(function() {


### PR DESCRIPTION
Replace `@sinonjs/formatio` with Node's `util.inspect`.

 #### Background

As part of a larger effort, we are retiring `@sinonjs/formatio`. When it was created Node was
quite immature and there were no other community projects for solid object formatting.

Ten years later, Node is mature and has great support for formatting all sorts of values.

Removing the use of `@sinonjs/formatio` in favour of Node's `util.inspect` removes an entire
project's worth of maintenance burden from the organisation.

In practial terms, it means that some output from `sinon` will look slightly different. This won't
cause a new major release as this output is only intended to be read by humans and not be part of
an API promise.

See:

* https://github.com/sinonjs/referee/pull/183
* https://github.com/sinonjs/referee-sinon/pull/98
* https://github.com/sinonjs/samsam/pull/182
* https://github.com/sinonjs/nise/pull/139

 #### How to verify - mandatory

1. Check out this branch
2. `npm ci`
3. Observe that tests pass
4. `npm ls @sinonjs/formatio`
5. Observe that the dependency has been removed

 #### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
