### PR TITLE
Add empty .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,2 @@
+# This project uses Prettier defaults, the config file is present in
+# order to trigger editor plugins to allow format on save behaviour


### PR DESCRIPTION
#### Purpose

It allows editor plugins to activate format-on-save behaviour

#### Background (Problem in detail)  - optional

We updated `prettier` in #2324, this PR makes those changes more convenient to use

#### Solution

Add an empty `.prettierrc`

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. [Configure your editor with a plugin for `prettier`](https://prettier.io/docs/en/editors.html)
4. Change a file, so that it would need formatting
5. Save the file
6. Observe that the file is formatted on save