### PR TITLE
Fix yields vs callsFake precedence + extra tests

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -91,6 +91,7 @@ var defaultBehaviors = {
         fake.callbackContext = undefined;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
+        fake.fakeFn = undefined;
     },
 
     yieldsRight: function (fake) {
@@ -99,6 +100,7 @@ var defaultBehaviors = {
         fake.callbackContext = undefined;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
+        fake.fakeFn = undefined;
     },
 
     yieldsOn: function (fake, context) {
@@ -107,6 +109,7 @@ var defaultBehaviors = {
         fake.callbackContext = context;
         fake.callArgProp = undefined;
         fake.callbackAsync = false;
+        fake.fakeFn = undefined;
     },
 
     yieldsTo: function (fake, prop) {
@@ -115,6 +118,7 @@ var defaultBehaviors = {
         fake.callbackContext = undefined;
         fake.callArgProp = prop;
         fake.callbackAsync = false;
+        fake.fakeFn = undefined;
     },
 
     yieldsToOn: function (fake, prop, context) {
@@ -123,6 +127,7 @@ var defaultBehaviors = {
         fake.callbackContext = context;
         fake.callArgProp = prop;
         fake.callbackAsync = false;
+        fake.fakeFn = undefined;
     },
 
     throws: throwsException,


### PR DESCRIPTION
#### Purpose (TL;DR)

Fix issue https://github.com/sinonjs/sinon/issues/2339, by assuring the `fakeFn` is cleaned when calling `yields`.
Add tests to the applicable stubs functions to be sure `callsFake()` precedence is clear with current code base as well.

 #### Background (Problem in detail)

I investigated some history around when `callsFake()` was introduced in https://github.com/sinonjs/sinon/pull/1207. It's curious that in one of the first [examples](https://github.com/sinonjs/sinon/pull/823#issuecomment-136228403) it was mentioned the precedence `callsFake` <-> `yields`:

> stub().callsFake(->).yields(2) // only calls callback, doesn't call fake

However, when it was implemented only `returns` and `resolves` were modified to take it into account. I'm wondering if I missed some piece while reading.

It is also curious how the precedence is in some cases defined by [default-behavior definition](https://github.com/sinonjs/sinon/blob/17c1b1ce1f9e6a4971fbd8e3cfdf7719a012ce61/lib/sinon/default-behaviors.js#L174) (removing `fake.fakeFn`) and in other cases by `if` precedence in the [`invoke` function](https://github.com/sinonjs/sinon/blob/17c1b1ce1f9e6a4971fbd8e3cfdf7719a012ce61/lib/sinon/behavior.js#L170-L183).

 #### Solution

I used similar approach as done in `returns` and `resolves` for `yields`.
I added tests to the rest of applicable stubs to avoid future breaking changes if the `if` in the `behavior.invoke` function is modified, altering the `callsFake` precedence.

**Alternative:** I thought that at some point the current _(buggy)_ behavior could be useful for some corner case where you want to use `callsFake` as a replacement for `returns` so that the fake function would only return, instead of yielding too. I leave that decision to maintainers. I find more common, or at least in my case, to define a generic case using `callsFake` which will run in the majority of test cases and then in some cases you specify a unique behavior using `yields`.

In any case, this PR could serve as a fix or as an improvement for test cases in relation `callsFake` precedence.

#### How to verify
Run:
```js
const sinon = require('sinon');

const stub = sinon.stub().callsFake((cb) => cb('fake'));
stub.yields('return');

stub(console.log);
```
You should see:
```
return
```

Tests can also be run using: `npm install && npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
