### PR TITLE
Fix opencollective on homepage

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,2 +1,6 @@
 # This project uses Prettier defaults, the config file is present in
 # order to trigger editor plugins to allow format on save behaviour
+overrides:
+  - files: "*.html"
+    options:
+      tabWidth: 2

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -24,7 +24,9 @@
             }}" alt="">Star Sinon.JS on Github</a
           >
         </p>
+      </div>
 
+      <div class="container">
         <div class="backed">
           <div class="wrap">
             <p class="centre-line">
@@ -123,15 +125,15 @@
               </a>
             </div>
             <div class="backer">
-              <span>Become a sponsor and get your logo on our README on GitHub with a link to your site.</span>
-              <a
-                class="btn btn-primary"
-                target="blank"
-                href="https://opencollective.com/sinon/"
-                >Become a sponsor</a
-              >
+              <a target="blank" href="https://opencollective.com/sinon/">
+                Become a sponsor and get your logo on our README on GitHub with a link to your site
+              </a>
             </div>
+          </div>
+        </div>
 
+        <div class="backed">
+          <div class="wrap">
             <p class="centre-line">
               <span>Proudly Backed By</span>
             </p>
@@ -229,16 +231,9 @@
             </div>
           </div>
           <div class="backer">
-            <span
-              >Become a backer and support Sinon.JS with a monthly
-              donation.</span
-            >
-            <a
-              class="btn btn-primary"
-              target="blank"
-              href="https://opencollective.com/sinon/"
-              >Become a backer</a
-            >
+            <a target="blank" href="https://opencollective.com/sinon/">
+              Become a backer and support Sinon.JS with a monthly donation.
+            </a>
           </div>
         </div>
       </div>

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -1,46 +1,66 @@
 <!DOCTYPE html>
 <html lang="en">
-{% include head.html %}
-<body>
-  {% include header.html %}
+  {% include head.html %}
+  <body>
+    {% include header.html %}
 
-  <div class="top">
-    <div class="container home-header">
-      <img class="logo grow img-responsive" src="{{ "/assets/images/logo.png" | prepend: site.baseurl }}" alt="">
-      <h1>
-          Standalone test spies, stubs and mocks for JavaScript. <br>
+    <div class="top">
+      <div class="container home-header">
+        <img class="logo grow img-responsive" src="{{ "/assets/images/logo.png"
+        | prepend: site.baseurl }}" alt="">
+        <h1>
+          Standalone test spies, stubs and mocks for JavaScript.
+          <br />
           Works with any unit testing framework.
-      </h1>
+        </h1>
 
+        <p class="btn-top text-center">
+          <a class="btn btn-primary" href="#get-started">Get Started</a>
+          <a
+            class="btn btn-default"
+            target="blank"
+            href="https://github.com/sinonjs/sinon"
+            ><img src="{{ "/assets/images/github.png" | prepend: site.baseurl
+            }}" alt="">Star Sinon.JS on Github</a
+          >
+        </p>
 
-
-      <p class="btn-top text-center">
-        <a class="btn btn-primary" href="#get-started">Get Started</a>
-        <a class="btn btn-default" target="blank" href="https://github.com/sinonjs/sinon"><img src="{{ "/assets/images/github.png" | prepend: site.baseurl }}" alt="">Star Sinon.JS on Github</a>
-      </p>
-
-      <div class="backed">
-        <div class="wrap">
-          <p class="centre-line"><span>Proudly Backed By</span></p>
-          <div class="people">
-            <a href="https://opencollective.com/sinon/"><img src="https://opencollective.com/sinon/backer/0/avatar.svg"></a>
-            <a href="https://opencollective.com/sinon/"><img src="https://opencollective.com/sinon/backer/1/avatar.svg"></a>
+        <div class="backed">
+          <div class="wrap">
+            <p class="centre-line">
+              <span>Proudly Backed By</span>
+            </p>
+            <div class="people">
+              <a href="https://opencollective.com/sinon/"
+                ><img
+                  src="https://opencollective.com/sinon/backer/0/avatar.svg"
+              /></a>
+              <a href="https://opencollective.com/sinon/"
+                ><img
+                  src="https://opencollective.com/sinon/backer/1/avatar.svg"
+              /></a>
+            </div>
           </div>
-        </div>
-        <div class="backer">
-            <span>Become a backer and support Sinon.JS with a monthly donation.</span>
-            <a class="btn btn-primary" target="blank" href="https://opencollective.com/sinon/">Become a backer</a>
+          <div class="backer">
+            <span
+              >Become a backer and support Sinon.JS with a monthly
+              donation.</span
+            >
+            <a
+              class="btn btn-primary"
+              target="blank"
+              href="https://opencollective.com/sinon/"
+              >Become a backer</a
+            >
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="content">
-    <div class="container container-2">
-      {{ content }}
+    <div class="content">
+      <div class="container container-2">{{ content }}</div>
     </div>
-  </div>
 
-  {% include footer.html %}
-</body>
+    {% include footer.html %}
+  </body>
 </html>

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -31,14 +31,96 @@
               <span>Proudly Backed By</span>
             </p>
             <div class="people">
-              <a href="https://opencollective.com/sinon/"
-                ><img
-                  src="https://opencollective.com/sinon/backer/0/avatar.svg"
-              /></a>
-              <a href="https://opencollective.com/sinon/"
-                ><img
-                  src="https://opencollective.com/sinon/backer/1/avatar.svg"
-              /></a>
+              <a href="https://opencollective.com/sinon/backer/0/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/0/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/1/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/1/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/2/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/2/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/3/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/3/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/4/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/4/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/5/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/5/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/6/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/6/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/7/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/7/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/8/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/8/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/9/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/9/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/10/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/10/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/11/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/11/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/12/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/12/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/13/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/13/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/14/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/14/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/15/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/15/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/16/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/16/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/17/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/17/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/18/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/18/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/19/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/19/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/20/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/20/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/21/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/21/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/22/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/22/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/23/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/23/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/24/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/24/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/25/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/25/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/26/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/26/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/27/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/27/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/28/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/28/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/backer/29/website" target="_blank">
+                <img src="https://opencollective.com/sinon/backer/29/avatar.svg">
+              </a>
             </div>
           </div>
           <div class="backer">

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -28,6 +28,111 @@
         <div class="backed">
           <div class="wrap">
             <p class="centre-line">
+              <span>Proudly Sponsored By</span>
+            </p>
+            <div class="people">
+              <a href="https://opencollective.com/sinon/sponsor/0/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/0/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/1/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/1/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/2/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/2/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/3/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/3/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/4/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/4/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/5/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/5/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/6/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/6/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/7/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/7/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/8/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/8/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/9/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/9/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/10/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/10/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/11/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/11/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/12/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/12/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/13/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/13/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/14/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/14/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/15/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/15/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/16/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/16/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/17/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/17/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/18/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/18/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/19/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/19/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/20/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/20/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/21/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/21/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/22/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/22/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/23/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/23/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/24/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/24/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/25/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/25/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/26/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/26/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/27/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/27/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/28/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/28/avatar.svg">
+              </a>
+              <a href="https://opencollective.com/sinon/sponsor/29/website" target="_blank">
+                <img src="https://opencollective.com/sinon/sponsor/29/avatar.svg">
+              </a>
+            </div>
+            <div class="backer">
+              <span>Become a sponsor and get your logo on our README on GitHub with a link to your site.</span>
+              <a
+                class="btn btn-primary"
+                target="blank"
+                href="https://opencollective.com/sinon/"
+                >Become a sponsor</a
+              >
+            </div>
+
+            <p class="centre-line">
               <span>Proudly Backed By</span>
             </p>
             <div class="people">

--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -45,9 +45,6 @@ a {
         position: relative;
         margin-top: 60px;
 
-        &:first-child {
-            margin-top: 0px;
-        }
         &:before {
             content: "";
             width: 34px;
@@ -193,26 +190,22 @@ a {
                 margin-bottom: 20px;
             }
         }
-        .backed {
-            .wrap {
-                margin: 0px !important;
-            }
-            p.centre-line {
-                display: block;
-                width: 100% !important;
-            }
+    }
+    .backed {
+        .wrap {
+            margin-top: 25px !important;
         }
-        .backer {
-            span {
-                margin-right: 0px !important;
-                display: block;
-                line-height: 24px;
-                margin-bottom: 20px;
-            }
-            .btn-primary {
-                text-align: center;
-                margin-right: 0px;
-            }
+        p.centre-line {
+            display: block;
+            width: 100% !important;
+        }
+    }
+    .backer {
+        span {
+            margin-right: 0px !important;
+            display: block;
+            line-height: 24px;
+            margin-bottom: 20px;
         }
     }
 }

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -90,7 +90,7 @@ body {
     }
 }
 .home-header {
-    padding: 50px 0px 20px 0px;
+    padding: 50px 0px;
     text-align: center;
     .btn-top {
         margin-top: 35px;
@@ -136,73 +136,65 @@ body {
         margin: 0 auto;
     }
 
-    // Backed Badge
-    .backed {
-        .wrap {
-            height: 100px;
-            position: relative;
-            margin-top: 50px;
+}
+
+// Backed Badge
+.backed {
+    text-align: center;
+    .wrap {
+        position: relative;
+        margin-top: 50px;
+    }
+    p.centre-line {
+        text-align: center;
+        border-bottom: 1px solid #dcccbe;
+        line-height: 0.1em;
+        width: 40%;
+        display: inline-block;
+        span {
+            background: #fff9f4;
+            font-size: 14px;
+            padding: 5px 20px;
+            color: #4b352a;
         }
-        p.centre-line {
-            text-align: center;
-            border-bottom: 1px solid #dcccbe;
-            line-height: 0.1em;
-            width: 40%;
+    }
+
+    .people {
+        display: block;
+        margin: 25px 0;
+        img {
+            margin: 3px 4px;
+            max-width: 120px;
+            max-height: 40px;
             display: inline-block;
-            span {
-                background: #fff9f4;
-                font-size: 14px;
-                padding: 5px 20px;
-                color: #4b352a;
-            }
         }
-
-        .people {
-            display: block;
-            img {
-                margin-top: 20px;
-                width: 42px;
-                display: inline-block;
-            }
-            span {
-                position: relative;
-                top: 10px;
-                margin-left: 10px;
-                font-size: 13px;
-                color: #656565;
-                a {
-                    color: #000;
-                    &:hover {
-                        color: #469a4c;
-                    }
-                }
-            }
-        }
-
-        .backer {
-            span {
-                font-size: 13px;
-                color: #281d18;
-                margin-right: 25px;
-            }
-            .btn-primary {
-                border: 1px solid #eadcd5;
-                font-size: 14px;
-                color: #281d18;
-                background: none;
-                font-weight: 800;
+        span {
+            position: relative;
+            top: 10px;
+            margin-left: 10px;
+            font-size: 13px;
+            color: #656565;
+            a {
+                color: #000;
                 &:hover {
                     color: #469a4c;
-                    border: 1px solid #469a4c;
                 }
             }
+        }
+    }
+
+    .backer {
+        span {
+            font-size: 13px;
+            color: #281d18;
+            margin-right: 25px;
         }
     }
 }
 
 // Content
 .content {
-    padding: 30px 0px 60px 0px;
+    padding: 60px 0px;
 }
 
 // Pages


### PR DESCRIPTION
This PR fixes the missing backers and sponsors on the homepage

#### TODO

- [x] Fix the weird rendering

![2021-03-27 at 14 13](https://user-images.githubusercontent.com/20321/112723524-e6d18a80-8f06-11eb-8f14-283ef1f57de3.png)

#### How to verify - mandatory

1. Check out this branch
2. `cd docs`
3. `bundle exec jekyll serve`
4. Wait patiently
5. Navigate to http://localhost:4000/
6. Observe that backers and sponsors are displayed
7. Observe that the rendering looks ok

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
