### PR TITLE
.matching function implemented

### DIFF
--- a/docs/_releases/v3.1.0/spies.md
+++ b/docs/_releases/v3.1.0/spies.md
@@ -202,6 +202,23 @@ Creates a spy that only records [calls][call] when the received arguments match 
 }
 ```
 
+#### `spy.matching((arg1[, arg2, ...]) => boolean);`
+
+Creates a spy that only records [calls][call] when the received arguments are resolved as matching by function passed to `matching`. This is useful to differentiate calls by a dynamic logic, where you can access the spy with the same [call][call].
+
+```javascript
+"should call method once with each argument": function () {
+    var object = { method: function () {} };
+    var spy = sinon.spy(object, "method");
+
+    object.method(42);
+    object.method(1);
+
+    assert(spy.matching((number) => number > 5).calledOnce);
+    assert(spy.matching((number) => number < 5).calledOnce);
+}
+```
+
 
 #### `spy.callCount`
 

--- a/docs/_releases/v6.1.1/stubs.md
+++ b/docs/_releases/v6.1.1/stubs.md
@@ -116,6 +116,24 @@ This is useful to be more expressive in your assertions, where you can access th
 }
 ```
 
+#### `stub.matching((arg1[, arg2, ...]) => boolean);`
+
+Stubs the method only for arguments matching a function.
+
+This is useful to be more expressive in your assertions in a dynamic way, where you can access the spy with the same call. It is also useful to create a stub that can act differently in response to different arguments.
+
+```javascript
+"test should stub method differently based on arguments": function () {
+    var callback = sinon.stub();
+    callback.matching((num) => num > 5).returns(1);
+    callback.matching((num) => num <= 5).throws("name");
+
+    callback(); // No return value, no exception
+    callback(42); // Returns 1
+    callback(1); // Throws Error("name")
+}
+```
+
 #### `stub.onCall(n);` *Added in v1.8*
 
 Defines the behavior of the stub on the *nth* call. Useful for testing sequential interactions.

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -21,8 +21,15 @@ var filter = Array.prototype.filter;
 
 var uuid = 0;
 
+function MatchingWrapper(matcher) {
+    this.matcher = matcher;
+}
+
 function matches(fake, args, strict) {
     var margs = fake.matchingArguments;
+    if (margs[0] instanceof MatchingWrapper) {
+        return margs[0].matcher(...args);
+    }
     if (
         margs.length <= args.length &&
         deepEqual(slice(args, 0, margs.length), margs)
@@ -67,6 +74,10 @@ var spyApi = {
         proxyCallUtil.createCallProperties(fake);
 
         return fake;
+    },
+
+    matching(matcher) {
+        return this.withArgs(new MatchingWrapper(matcher));
     },
 
     // Override proxy default implementation

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -474,6 +474,29 @@ describe("spy", function () {
         assertSpy(spy2);
     });
 
+    describe(".matching", function () {
+        it("should filter matching function calls", function () {
+            var object = {
+                f1: function () {
+                    return "real";
+                },
+            };
+            var spy1 = createSpy(object, "f1");
+            var matchingSpy = spy1.matching((...args) => args.length >= 3);
+
+            object.f1(1);
+            object.f1(1, 2);
+            object.f1(1, 2, 3);
+            object.f1(1, 2, 3, 4);
+            object.f1(1, 2, 3, 4, 5);
+            object.f1(1, 2, 3, 4, 5, 6);
+            object.f1(1, 2, 3, 4, 5, 6, 7);
+
+            assert.equals(spy1.callCount, 7);
+            assert.equals(matchingSpy.callCount, 5);
+        });
+    });
+
     describe(".named", function () {
         it("sets name and displayName", function () {
             var spy = createSpy();


### PR DESCRIPTION
#### Purpose (TL;DR)
To be able distinguish calls in cases, where exact arguments are not known. For example functions where the first argument is dynamic object with a constant part - we cannot use withArgs() behaviour in such case, because of its deep comparsion.

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. run test(s) introduced in this PR

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
