### PR TITLE
Fake docs improvement

### DIFF
--- a/docs/_releases/v10.0.1/fakes.md
+++ b/docs/_releases/v10.0.1/fakes.md
@@ -6,13 +6,57 @@ breadcrumb: fakes
 
 ### Introduction
 
-`fake` is available in Sinon from v5 onwards. It allows creation of a `fake` `Function` with the ability to set a default [behavior](#fakes-with-behavior). Set the [behavior](#fakes-with-behavior) using `Functions` with the same API as those in a [`sinon.stub`][stubs]. The created `fake` `Function`, with or without behavior has the same API as a (`sinon.spy`)[spies].
+`fake` is available in Sinon from v5 onwards. It allows creation of a `fake` `Function` with the ability to set a default [behavior](#fakes-with-behavior). Set the [behavior](#fakes-with-behavior) using `Functions` with the same API as those in a [`sinon.stub`][stubs].
 
 In Sinon, a `fake` is a `Function` that records arguments, return value, the value of `this` and exception thrown (if any) for all of its calls.
 
 A fake is immutable: once created, the behavior will not change.
 
 Unlike [`sinon.spy`][spies] and [`sinon.stub`][stubs] methods, the `sinon.fake` API knows only how to create fakes, and doesn't concern itself with plugging them into the system under test. To plug the fakes into the system under test, you can use the [`sinon.replace*`](../sandbox#sandboxreplaceobject-property-replacement) methods.
+
+### When to use fakes?
+
+Fakes are alternatives to the Stubs and Spies, and they can fully replace all such use cases.
+
+They are intended to be simpler to use, and avoids many bugs by having immutable behaviour.
+
+The created `fake` `Function`, with or without behavior has the same API as a (`sinon.spy`)[spies].
+
+#### Using fakes instead of spies
+
+```js
+var foo = {
+  bar: () => {
+    return 'baz';
+  }
+};
+// wrap existing method without changing its behaviour
+var fake = sinon.replace(foo, 'bar', sinon.fake(foo.bar));
+
+fake();
+// baz
+
+fake.callCount;
+// 1
+```
+
+#### Using fakes instead of stubs
+
+```js
+var foo = {
+  bar: () => {
+    return 'baz';
+  }
+};
+// replace method with a fake one
+var fake = sinon.replace(foo, 'bar', sinon.fake.returns('fake value'));
+
+fake();
+// fake value
+
+fake.callCount;
+// 1
+```
 
 ### Creating a fake
 
@@ -123,7 +167,8 @@ This is useful when complex behavior not covered by the `sinon.fake.*` methods i
 
 ### Instance properties
 
-The instance properties are the same as a [`sinon.spy`][spies].
+The instance properties are the same as a [`sinon.spy`][spies]. The following properties are just a few of them, you can refer to
+[spies][spies] documentation for all of them.
 
 #### `f.callback`
 
@@ -141,7 +186,7 @@ f.callback === cb2;
 // true
 ```
 
-The same convenience has been added to [spy calls](../spy-call):
+The same convenience has been added to [spy calls](../spy-call#spycallcallback):
 
 ```js
 f.getCall(1).callback === cb2;
@@ -167,6 +212,18 @@ f.firstArg === date2;
 // true
 ```
 
+The same convenience has been added to [spy calls](../spy-call#spycallfirstarg):
+
+```js
+f.getCall(0).firstArg === date1;
+// true
+f.getCall(1).firstArg === date2;
+// true
+//
+f.lastCall.firstArg === date2;
+// true
+```
+
 #### `f.lastArg`
 
 This property is a convenient way to get a reference to the last argument passed in the last call to the fake.
@@ -183,7 +240,7 @@ f.lastArg === date2;
 // true
 ```
 
-The same convenience has been added to [spy calls](../spy-call):
+The same convenience has been added to [spy calls](../spy-call#spycalllastarg):
 
 ```js
 f.getCall(0).lastArg === date1;

--- a/docs/_releases/v10.0.1/sandbox.md
+++ b/docs/_releases/v10.0.1/sandbox.md
@@ -183,7 +183,7 @@ _Since `sinon@2.0.0`_
 
 #### `sandbox.replace(object, property, replacement);`
 
-Replaces `property` on `object` with `replacement` argument. Attempts to replace an already replaced value cause an exception.
+Replaces `property` on `object` with `replacement` argument. Attempts to replace an already replaced value cause an exception. Returns the `replacement`.
 
 `replacement` can be any value, including `spies`, `stubs` and `fakes`.
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Tries to improve documentation for the fake API. Resolves #2070 


#### Solution

I went over this [comment](https://github.com/sinonjs/sinon/issues/2070#issuecomment-823090909):

- [x] Make sure the list of static factory methods on sinon.fake is complete

* yes, the list is complete except for usingPromise

- [ ] Convert and/or add some runnable Runkit examples (very easy, but takes a bit of time)

* On it, I wanted open this so that you can check out current status.

- [x] Update the link in Instance properties to point to the same section in Spies.

* Only `firstArg` was missing a reference, added that. Changed others' links so that they are linked to the exact same header.


- [x] State that the listed props are just one of the many from the spies documentation and that you can refer to that for the complete list

- [x] Clarify the wording so that it becomes clear that 1. The Fakes API is an alternative to the Stubs and Spies API that can fully replace all such uses. 2. It is intended to be simpler to use, maintain and has a lot smaller API surface and avoids many bugs by having quazi-immutable Fake instances (the behavior cannot be changed after creation (unlike Stubs), but they do have internal state that changes when used, like the callCount and other stats) 3. A Fake instance has the API of a Spy (

* I've done my best to make it clear. 


#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. cd docs
4. gem install bundler
5. bundle install
6. bundle exec jekyll serve
7. Check the website

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
