### PR TITLE
Enable esm named exports

### DIFF
--- a/build.cjs
+++ b/build.cjs
@@ -18,6 +18,11 @@ try {
     // We seem to have it already
 }
 
+/**
+ * @param entryPoint
+ * @param config
+ * @param done
+ */
 function makeBundle(entryPoint, config, done) {
     browserify(entryPoint, config).bundle(function (err, buffer) {
         if (err) {
@@ -39,7 +44,8 @@ makeBundle(
     },
     function (bundle) {
         var script = preamble + bundle;
-        fs.writeFileSync("pkg/sinon.js", script);
+        fs.writeFileSync("pkg/sinon.cjs", script);
+        fs.writeFileSync("pkg/sinon.js", script); // WebWorker can only load js files
     }
 );
 
@@ -53,7 +59,7 @@ makeBundle(
     },
     function (bundle) {
         var script = preamble + bundle;
-        fs.writeFileSync("pkg/sinon-no-sourcemaps.js", script);
+        fs.writeFileSync("pkg/sinon-no-sourcemaps.cjs", script);
     }
 );
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test-runnable-examples": "docs/release-source/release/examples/run-test.sh",
     "test": "npm run test-node && npm run test-headless && npm run test-webworker && npm run test-esm",
     "check-dependencies": "dependency-check package.json --no-dev --ignore-module esm",
-    "build": "node ./build.js",
+    "build": "node ./build.cjs",
     "build-docs": "cd docs; bundle exec jekyll build",
     "serve-docs": "cd docs; bundle exec jekyll serve --incremental --verbose",
     "lint": "eslint '**/*.{js,mjs}'",
@@ -115,6 +115,11 @@
   "browser": "./lib/sinon.js",
   "main": "./lib/sinon.js",
   "module": "./pkg/sinon-esm.js",
+  "exports": {
+    "require": "./pkg/sinon.cjs",
+    "import": "./pkg/sinon-esm.js"
+  },
+  "type": "module",
   "cdn": "./pkg/sinon.js",
   "jsdelivr": "./pkg/sinon.js",
   "esm": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build": "node ./build.cjs",
     "build-docs": "cd docs; bundle exec jekyll build",
     "serve-docs": "cd docs; bundle exec jekyll serve --incremental --verbose",
-    "lint": "eslint '**/*.{js,mjs}'",
+    "lint": "eslint '**/*.{js,cjs,mjs}'",
     "pretest-webworker": "npm run build",
     "prebuild": "rimraf pkg && npm run check-dependencies",
     "postbuild": "npm run test-esm-bundle",

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
#### Adds support for esm named exports

Fixes issue #2361

I tried to keep this as backwards compatible as possible, but some minor (undocumented) changes were made which may break people importing from the `pkg` directory directly.
Specifically we can't do `require('sinon/pkg/sinon.js')` or `require('sinon/pkg/sinon-no-sourcemaps.js')` anymore, as these were changed into `cjs` files.
An additional `pkg/sinon.js` file is produced, identical to `pkg/sinon.cjs`, to keep the WebWorker functional. `importScripts` seems to fail on `cjs` files.

#### How to verify

1. Check out this branch
2. `npm ci`
3. `npm test`
4. `import { stub } from "sinon"` from an esm javascript file on node >= 12 should work

Edit: this is more of a band-aid, since the preferred solution would be an esm rewrite and using rollup to produce a cjs and esm build.
