### PR TITLE
Refactor fake

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 coverage/
+out/
 pkg/
 tmp/
 docs/_site/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+out/
 pkg
 tmp/
 node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 coverage/
+out/
 pkg/
 tmp/
 .sass-cache

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -9,6 +9,38 @@ var promiseLib = Promise;
 
 module.exports = fake;
 
+/**
+ * Returns a `fake` that records all calls, arguments and return values.
+ *
+ * When an `f` argument is supplied, this implementation will be used.
+ *
+ * @example
+ * // create an empty fake
+ * var f1 = sinon.fake();
+ *
+ * f1();
+ *
+ * f1.calledOnce()
+ * // true
+ *
+ * @example
+ * function greet(greeting) {
+ *   console.log(`Hello ${greeting}`);
+ * }
+ *
+ * // create a fake with implementation
+ * var f2 = sinon.fake(greet);
+ *
+ * // Hello world
+ * f2("world");
+ *
+ * f2.calledWith("world");
+ * // true
+ *
+ * @param {Function|undefined} f
+ * @returns {Function}
+ * @namespace
+ */
 function fake(f) {
     if (arguments.length > 0 && typeof f !== "function") {
         throw new TypeError("Expected f argument to be a Function");
@@ -17,7 +49,22 @@ function fake(f) {
     return wrapFunc(f);
 }
 
+/**
+ * Creates a `fake` that returns the provided `value`, as well as recording all
+ * calls, arguments and returnvalues.
+ *
+ * @example
+ * var f1 = sinon.fake.returns(42);
+ *
+ * f1();
+ * // 42
+ *
+ * @memberof fake
+ * @param {*} value
+ * @returns {Function}
+ */
 fake.returns = function returns(value) {
+    // eslint-disable-next-line jsdoc/require-jsdoc
     function f() {
         return value;
     }
@@ -25,7 +72,29 @@ fake.returns = function returns(value) {
     return wrapFunc(f);
 };
 
+/**
+ * Creates a `fake` that throws an Error.
+ * If the `value` argument does not have Error in its prototype chain, it will
+ * be used for creating a new error.
+ *
+ * @example
+ * var f1 = sinon.fake.throws("hello");
+ *
+ * f1();
+ * // Uncaught Error: hello
+ *
+ * @example
+ * var f2 = sinon.fake.throws(new TypeError("Invalid argument"));
+ *
+ * f2();
+ * // Uncaught TypeError: Invalid argument
+ *
+ * @memberof fake
+ * @param {*|Error} value
+ * @returns {Function}
+ */
 fake.throws = function throws(value) {
+    // eslint-disable-next-line jsdoc/require-jsdoc
     function f() {
         throw getError(value);
     }
@@ -33,7 +102,22 @@ fake.throws = function throws(value) {
     return wrapFunc(f);
 };
 
+/**
+ * Creates a `fake` that returns a promise that resolves to the passed `value`
+ * argument.
+ *
+ * @example
+ * var f1 = sinon.fake.resolves("apple pie");
+ *
+ * await f1();
+ * // "apple pie"
+ *
+ * @memberof fake
+ * @param {*} value
+ * @returns {Function}
+ */
 fake.resolves = function resolves(value) {
+    // eslint-disable-next-line jsdoc/require-jsdoc
     function f() {
         return promiseLib.resolve(value);
     }
@@ -41,7 +125,27 @@ fake.resolves = function resolves(value) {
     return wrapFunc(f);
 };
 
+/**
+ * Creates a `fake` that returns a promise that rejects to the passed `value`
+ * argument. When `value` does not have Error in its prototype chain, it will be
+ * wrapped in an Error.
+ *
+ * @example
+ * var f1 = sinon.fake.rejects(":(");
+ *
+ * try {
+ *   await ft();
+ * } catch (error) {
+ *   console.log(error);
+ *   // ":("
+ * }
+ *
+ * @memberof fake
+ * @param {*} value
+ * @returns {Function}
+ */
 fake.rejects = function rejects(value) {
+    // eslint-disable-next-line jsdoc/require-jsdoc
     function f() {
         return promiseLib.reject(getError(value));
     }
@@ -49,14 +153,43 @@ fake.rejects = function rejects(value) {
     return wrapFunc(f);
 };
 
+/**
+ * Causes `fake` to use a custom Promise implementation, instead of the native
+ * Promise implementation.
+ *
+ * @example
+ * const bluebird = require("bluebird");
+ * sinon.fake.usingPromise(bluebird);
+ *
+ * @memberof fake
+ * @param {*} promiseLibrary
+ * @returns {Function}
+ */
 fake.usingPromise = function usingPromise(promiseLibrary) {
     promiseLib = promiseLibrary;
     return fake;
 };
 
+/**
+ * Returns a `fake` that calls the callback with the defined arguments.
+ *
+ * @example
+ * function callback() {
+ *   console.log(arguments.join("*"));
+ * }
+ *
+ * const f1 = sinon.fake.yields("apple", "pie");
+ *
+ * f1(callback);
+ * // "apple*pie"
+ *
+ * @memberof fake
+ * @returns {Function}
+ */
 fake.yields = function yields() {
     var values = slice(arguments);
 
+    // eslint-disable-next-line jsdoc/require-jsdoc
     function f() {
         var callback = arguments[arguments.length - 1];
         if (typeof callback !== "function") {
@@ -69,9 +202,30 @@ fake.yields = function yields() {
     return wrapFunc(f);
 };
 
+/**
+ * Returns a `fake` that calls the callback **asynchronously** with the
+ * defined arguments.
+ *
+ * @example
+ * function callback() {
+ *   console.log(arguments.join("*"));
+ * }
+ *
+ * const f1 = sinon.fake.yields("apple", "pie");
+ *
+ * f1(callback);
+ *
+ * setTimeout(() => {
+ *   // "apple*pie"
+ * });
+ *
+ * @memberof fake
+ * @returns {Function}
+ */
 fake.yieldsAsync = function yieldsAsync() {
     var values = slice(arguments);
 
+    // eslint-disable-next-line jsdoc/require-jsdoc
     function f() {
         var callback = arguments[arguments.length - 1];
         if (typeof callback !== "function") {
@@ -86,6 +240,13 @@ fake.yieldsAsync = function yieldsAsync() {
 };
 
 var uuid = 0;
+/**
+ * Creates a proxy (sinon concept) from the passed function.
+ *
+ * @private
+ * @param  {Function} f
+ * @returns {Function}
+ */
 function wrapFunc(f) {
     var proxy;
     var fakeInstance = function () {
@@ -113,6 +274,14 @@ function wrapFunc(f) {
     return proxy;
 }
 
+/**
+ * Returns an Error instance from the passed value, if the value is not
+ * already an Error instance.
+ *
+ * @private
+ * @param  {*} value [description]
+ * @returns {Error}       [description]
+ */
 function getError(value) {
     return value instanceof Error ? value : new Error(value);
 }

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -40,79 +40,75 @@ function wrapFunc(f) {
 
 var promiseLib = Promise;
 
-function fakeClass() {
-    function fake(f) {
-        if (arguments.length > 0 && typeof f !== "function") {
-            throw new TypeError("Expected f argument to be a Function");
-        }
-
-        return wrapFunc(f);
+function fake(f) {
+    if (arguments.length > 0 && typeof f !== "function") {
+        throw new TypeError("Expected f argument to be a Function");
     }
 
-    fake.returns = function returns(value) {
-        function f() {
-            return value;
-        }
-
-        return wrapFunc(f);
-    };
-
-    fake.throws = function throws(value) {
-        function f() {
-            throw getError(value);
-        }
-
-        return wrapFunc(f);
-    };
-
-    fake.resolves = function resolves(value) {
-        function f() {
-            return promiseLib.resolve(value);
-        }
-
-        return wrapFunc(f);
-    };
-
-    fake.rejects = function rejects(value) {
-        function f() {
-            return promiseLib.reject(getError(value));
-        }
-
-        return wrapFunc(f);
-    };
-
-    fake.usingPromise = function usingPromise(promiseLibrary) {
-        promiseLib = promiseLibrary;
-        return fake;
-    };
-
-    function yieldInternal(async, values) {
-        function f() {
-            var callback = arguments[arguments.length - 1];
-            if (typeof callback !== "function") {
-                throw new TypeError("Expected last argument to be a function");
-            }
-            if (async) {
-                nextTick(function () {
-                    callback.apply(null, values);
-                });
-            } else {
-                callback.apply(null, values);
-            }
-        }
-
-        return wrapFunc(f);
-    }
-
-    fake.yields = function yields() {
-        return yieldInternal(false, slice(arguments));
-    };
-
-    fake.yieldsAsync = function yieldsAsync() {
-        return yieldInternal(true, slice(arguments));
-    };
-
-    return fake;
+    return wrapFunc(f);
 }
 
-module.exports = fakeClass();
+fake.returns = function returns(value) {
+    function f() {
+        return value;
+    }
+
+    return wrapFunc(f);
+};
+
+fake.throws = function throws(value) {
+    function f() {
+        throw getError(value);
+    }
+
+    return wrapFunc(f);
+};
+
+fake.resolves = function resolves(value) {
+    function f() {
+        return promiseLib.resolve(value);
+    }
+
+    return wrapFunc(f);
+};
+
+fake.rejects = function rejects(value) {
+    function f() {
+        return promiseLib.reject(getError(value));
+    }
+
+    return wrapFunc(f);
+};
+
+fake.usingPromise = function usingPromise(promiseLibrary) {
+    promiseLib = promiseLibrary;
+    return fake;
+};
+
+function yieldInternal(async, values) {
+    function f() {
+        var callback = arguments[arguments.length - 1];
+        if (typeof callback !== "function") {
+            throw new TypeError("Expected last argument to be a function");
+        }
+        if (async) {
+            nextTick(function () {
+                callback.apply(null, values);
+            });
+        } else {
+            callback.apply(null, values);
+        }
+    }
+
+    return wrapFunc(f);
+}
+
+fake.yields = function yields() {
+    return yieldInternal(false, slice(arguments));
+};
+
+fake.yieldsAsync = function yieldsAsync() {
+    return yieldInternal(true, slice(arguments));
+};
+
+module.exports = fake;

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -55,11 +55,34 @@ fake.usingPromise = function usingPromise(promiseLibrary) {
 };
 
 fake.yields = function yields() {
-    return yieldInternal(false, slice(arguments));
+    var values = slice(arguments);
+
+    function f() {
+        var callback = arguments[arguments.length - 1];
+        if (typeof callback !== "function") {
+            throw new TypeError("Expected last argument to be a function");
+        }
+
+        callback.apply(null, values);
+    }
+
+    return wrapFunc(f);
 };
 
 fake.yieldsAsync = function yieldsAsync() {
-    return yieldInternal(true, slice(arguments));
+    var values = slice(arguments);
+
+    function f() {
+        var callback = arguments[arguments.length - 1];
+        if (typeof callback !== "function") {
+            throw new TypeError("Expected last argument to be a function");
+        }
+        nextTick(function () {
+            callback.apply(null, values);
+        });
+    }
+
+    return wrapFunc(f);
 };
 
 var uuid = 0;
@@ -92,22 +115,4 @@ function wrapFunc(f) {
 
 function getError(value) {
     return value instanceof Error ? value : new Error(value);
-}
-
-function yieldInternal(async, values) {
-    function f() {
-        var callback = arguments[arguments.length - 1];
-        if (typeof callback !== "function") {
-            throw new TypeError("Expected last argument to be a function");
-        }
-        if (async) {
-            nextTick(function () {
-                callback.apply(null, values);
-            });
-        } else {
-            callback.apply(null, values);
-        }
-    }
-
-    return wrapFunc(f);
 }

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -5,42 +5,9 @@ var createProxy = require("./proxy");
 var nextTick = require("./util/core/next-tick");
 
 var slice = arrayProto.slice;
+var promiseLib = Promise;
 
 module.exports = fake;
-
-function getError(value) {
-    return value instanceof Error ? value : new Error(value);
-}
-
-var uuid = 0;
-function wrapFunc(f) {
-    var proxy;
-    var fakeInstance = function () {
-        var firstArg, lastArg;
-
-        if (arguments.length > 0) {
-            firstArg = arguments[0];
-            lastArg = arguments[arguments.length - 1];
-        }
-
-        var callback =
-            lastArg && typeof lastArg === "function" ? lastArg : undefined;
-
-        proxy.firstArg = firstArg;
-        proxy.lastArg = lastArg;
-        proxy.callback = callback;
-
-        return f && f.apply(this, arguments);
-    };
-    proxy = createProxy(fakeInstance, f || fakeInstance);
-
-    proxy.displayName = "fake";
-    proxy.id = `fake#${uuid++}`;
-
-    return proxy;
-}
-
-var promiseLib = Promise;
 
 function fake(f) {
     if (arguments.length > 0 && typeof f !== "function") {
@@ -87,6 +54,46 @@ fake.usingPromise = function usingPromise(promiseLibrary) {
     return fake;
 };
 
+fake.yields = function yields() {
+    return yieldInternal(false, slice(arguments));
+};
+
+fake.yieldsAsync = function yieldsAsync() {
+    return yieldInternal(true, slice(arguments));
+};
+
+var uuid = 0;
+function wrapFunc(f) {
+    var proxy;
+    var fakeInstance = function () {
+        var firstArg, lastArg;
+
+        if (arguments.length > 0) {
+            firstArg = arguments[0];
+            lastArg = arguments[arguments.length - 1];
+        }
+
+        var callback =
+            lastArg && typeof lastArg === "function" ? lastArg : undefined;
+
+        proxy.firstArg = firstArg;
+        proxy.lastArg = lastArg;
+        proxy.callback = callback;
+
+        return f && f.apply(this, arguments);
+    };
+    proxy = createProxy(fakeInstance, f || fakeInstance);
+
+    proxy.displayName = "fake";
+    proxy.id = `fake#${uuid++}`;
+
+    return proxy;
+}
+
+function getError(value) {
+    return value instanceof Error ? value : new Error(value);
+}
+
 function yieldInternal(async, values) {
     function f() {
         var callback = arguments[arguments.length - 1];
@@ -104,13 +111,3 @@ function yieldInternal(async, values) {
 
     return wrapFunc(f);
 }
-
-fake.yields = function yields() {
-    return yieldInternal(false, slice(arguments));
-};
-
-fake.yieldsAsync = function yieldsAsync() {
-    return yieldInternal(true, slice(arguments));
-};
-
-

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -6,6 +6,8 @@ var nextTick = require("./util/core/next-tick");
 
 var slice = arrayProto.slice;
 
+module.exports = fake;
+
 function getError(value) {
     return value instanceof Error ? value : new Error(value);
 }
@@ -111,4 +113,4 @@ fake.yieldsAsync = function yieldsAsync() {
     return yieldInternal(true, slice(arguments));
 };
 
-module.exports = fake;
+

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -51,7 +51,7 @@ function fake(f) {
 
 /**
  * Creates a `fake` that returns the provided `value`, as well as recording all
- * calls, arguments and returnvalues.
+ * calls, arguments and return values.
  *
  * @example
  * var f1 = sinon.fake.returns(42);

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -38,12 +38,9 @@ function wrapFunc(f) {
     return proxy;
 }
 
-function fakeClass() {
-    var promiseLib = null;
-    if (typeof Promise === "function") {
-        promiseLib = Promise;
-    }
+var promiseLib = Promise;
 
+function fakeClass() {
     function fake(f) {
         if (arguments.length > 0 && typeof f !== "function") {
             throw new TypeError("Expected f argument to be a Function");


### PR DESCRIPTION
This PR has some refactorings and JSDoc for `fake`.

#### Purpose

Have JSDoc so we can generate API docs in the future

#### Discussion

* Is there a way to document members of _functions_, as opposed to _namespaces_?
* How do we document the returned function `f` from most of these methods?

This is not complete, but I think it is a good start. Suggestions for improvements welcome.

#### How to verify - mandatory

1. Check out this branch
2. `npm install jsdoc`
3. `jsdoc lib/sinon/fake.js`
4. `open out/index.html`
5. Navigate to the docs for `fake`
6. Observe that all methods are documented

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
