### PR TITLE
Copy over acessor properties to target object #2387

### DIFF
--- a/lib/sinon/util/core/extend.js
+++ b/lib/sinon/util/core/extend.js
@@ -102,13 +102,30 @@ module.exports = function extend(target, ...sources) {
             if (prop === "name" && !destOwnPropertyDescriptor.writable) {
                 return;
             }
-
-            Object.defineProperty(dest, prop, {
+            const descriptors = {
                 configurable: sourceOwnPropertyDescriptor.configurable,
                 enumerable: sourceOwnPropertyDescriptor.enumerable,
-                writable: sourceOwnPropertyDescriptor.writable,
-                value: sourceOwnPropertyDescriptor.value,
-            });
+            };
+            /*
+                if the sorce has an Accessor property copy over the accessor functions (get and set)
+                data properties has writable attribute where as acessor property don't
+                REF: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#properties
+            */
+
+            if (hasOwnProperty(sourceOwnPropertyDescriptor, "writable")) {
+                descriptors.writable = sourceOwnPropertyDescriptor.writable;
+                descriptors.value = sourceOwnPropertyDescriptor.value;
+            } else {
+                if (sourceOwnPropertyDescriptor.get) {
+                    descriptors.get =
+                        sourceOwnPropertyDescriptor.get.bind(dest);
+                }
+                if (sourceOwnPropertyDescriptor.set) {
+                    descriptors.set =
+                        sourceOwnPropertyDescriptor.set.bind(dest);
+                }
+            }
+            Object.defineProperty(dest, prop, descriptors);
         }
     );
 };

--- a/test/extend-test.js
+++ b/test/extend-test.js
@@ -78,6 +78,58 @@ describe("extend", function () {
         assert.equals(result, expected);
     });
 
+    it("copies acessor properties into the target", function () {
+        var target = {
+            hello: "hello",
+        };
+        const obj = {
+            private: 1,
+        };
+        Object.defineProperty(obj, "lexical", {
+            configurable: true,
+            enumerable: true,
+            get: () => this.private,
+            set: (value) => {
+                this.private = value;
+            },
+        });
+        Object.defineProperty(obj, "instance", {
+            configurable: true,
+            enumerable: true,
+            get: () => obj.private,
+            set: (value) => {
+                obj.private = value;
+            },
+        });
+        Object.defineProperty(obj, "bound", {
+            configurable: true,
+            enumerable: true,
+            get: function () {
+                return this.private;
+            },
+            set: function (value) {
+                this.private = value;
+            },
+        });
+        extend(target, obj);
+        assert.equals(target.hello, "hello");
+        assert.equals(target.lexical === undefined, true);
+        assert.equals(target.instance, 1);
+        assert.equals(target.bound, 1);
+        target.lexical = 2;
+        assert.equals(target.lexical, 2);
+        assert.equals(target.instance, 1);
+        assert.equals(target.bound, 1);
+        target.instance = 3;
+        assert.equals(target.lexical, 2);
+        assert.equals(target.instance, 3);
+        assert.equals(target.bound, 1);
+        target.bound = 4;
+        assert.equals(target.lexical, 2);
+        assert.equals(target.instance, 3);
+        assert.equals(target.bound, 4);
+    });
+
     context("when 'name' property is not writable", function () {
         it("does not attempt to write to the property", function () {
             var object1 = { prop1: null };


### PR DESCRIPTION
### Fix for issue #2387 where acessor properties were not copied over to target object
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->
The existing implementation assumed that  all the properties of an object are Data property 
Documentation link : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#properties


<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
