### PR TITLE
Consolidate CI workflows on GH Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,47 +38,8 @@ jobs:
             - node_modules
       - *persist-step
 
-  integration-tests:
-    docker:
-      - image: circleci/node:10.15.1-browsers
-    environment:
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
-    steps:
-      - *attach-step
-      - run:
-          name: Integration tests
-          command: |
-            # test-coverage runs test-headless in Chrome
-            npm run test-coverage  -- --chrome "$SINON_CHROME_BIN" --allow-chrome-as-root
-
-            if [ -z "$CIRCLE_PULL_REQUESTS" ]; then
-              npm run test-cloud
-            fi
-      - run:
-          name: Upload coverage report
-          command: bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
-
-  saucelabs:
-    docker:
-      - image: circleci/node:12
-    steps:
-      - *attach-step
-      - run:
-          name: Test in browsers (Sauce Labs)
-          command: npm run test-cloud
-
 workflows:
   version: 2
   sinon-workflow:
     jobs:
       - install-dependencies
-      - integration-tests:
-          requires:
-            - install-dependencies
-      - saucelabs:
-          context: SAUCE_LABS
-          requires:
-            - integration-tests
-          filters:
-            branches:
-              only: master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
@@ -31,7 +31,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
@@ -54,7 +54,7 @@ jobs:
   browser-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
@@ -87,7 +87,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
@@ -118,7 +118,7 @@ jobs:
         node-version: [12, 14, 16]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,15 +5,11 @@ on: [push]
 jobs:
   prettier:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16]
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "16"
       - name: Cache modules
         uses: actions/cache@v2
         with:
@@ -34,15 +30,11 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16]
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "16"
       - name: Cache modules
         uses: actions/cache@v2
         with:
@@ -61,17 +53,11 @@ jobs:
 
   browser-test:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16]
-
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "16"
       - name: Cache npm
         uses: actions/cache@v2
         with:
@@ -100,17 +86,11 @@ jobs:
   saucelabs-test:
     if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16]
-
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "16"
       - name: Cache npm
         uses: actions/cache@v2
         with:
@@ -140,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache modules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,9 +87,48 @@ jobs:
       - name: Integration
         run: |
           export SINON_CHROME_BIN=$(which google-chrome-stable)
+
+          # test-coverage runs test-headless in Chrome
+          npm run test-coverage  -- --chrome "$SINON_CHROME_BIN" --allow-chrome-as-root
+
           npm run test-headless -- --chrome $SINON_CHROME_BIN --allow-chrome-as-root
           npm run test-webworker -- --chrome $SINON_CHROME_BIN --allow-chrome-as-root
           npm run test-esm-bundle
+      - name: Upload coverage report
+        run: bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
+
+  saucelabs-test:
+    if: ${{ github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache npm
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: |
+          npm ci
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 1
+      - name: Saucelabs test
+        env:
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+        run: |
+          npm run test-cloud
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR consolidates the CI setup on GitHub Actions.

We've added the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` as repository secrets, which are only available to contributors and not in forks.

We've tested the SauceLabs integration by changing the condition to this branch, i.e. `if: ${{ github.ref == 'refs/heads/consolideate-ci-setup' }}`, which showed that it is now working.

#### After merging

Once the branch has been merged, we need to remove the project in CircleCI and remove the configuration file here. Otherwise, CircleCI will block the branch from merging. Additionally, in the "Integrations" settings for the repository, CircleCI can be removed