### PR TITLE
Make calledWith() assertions idempotent

### DIFF
--- a/lib/sinon/spy-formatters.js
+++ b/lib/sinon/spy-formatters.js
@@ -72,29 +72,29 @@ module.exports = {
                 j < calledArgs.length || j < expectedArgs.length;
                 ++j
             ) {
-                if (calledArgs[j]) {
-                    calledArgs[j] = quoteStringValue(calledArgs[j]);
+                var calledArg = calledArgs[j];
+                var expectedArg = expectedArgs[j];
+                if (calledArg) {
+                    calledArg = quoteStringValue(calledArg);
                 }
 
-                if (expectedArgs[j]) {
-                    expectedArgs[j] = quoteStringValue(expectedArgs[j]);
+                if (expectedArg) {
+                    expectedArg = quoteStringValue(expectedArg);
                 }
 
                 message += "\n";
 
                 var calledArgMessage =
-                    j < calledArgs.length ? sinonFormat(calledArgs[j]) : "";
-                if (match.isMatcher(expectedArgs[j])) {
+                    j < calledArgs.length ? sinonFormat(calledArg) : "";
+                if (match.isMatcher(expectedArg)) {
                     message += colorSinonMatchText(
-                        expectedArgs[j],
-                        calledArgs[j],
+                        expectedArg,
+                        calledArg,
                         calledArgMessage
                     );
                 } else {
                     var expectedArgMessage =
-                        j < expectedArgs.length
-                            ? sinonFormat(expectedArgs[j])
-                            : "";
+                        j < expectedArgs.length ? sinonFormat(expectedArg) : "";
                     var diff = jsDiff.diffJson(
                         calledArgMessage,
                         expectedArgMessage

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -2172,7 +2172,7 @@ describe("assert", function () {
                     "expected doSomething to be called once and with exact arguments \n" +
                     "Call 1:\n"
                 }${color.red("4")}\n${color.red("3")}\n${color.red(
-                    inspect(JSON.stringify('"bob"'))
+                    inspect('"bob"')
                 )}\nCall 2:`
             );
         });

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -2188,6 +2188,18 @@ describe("assert", function () {
             );
         });
 
+        it("assert.calledWith message is idempotent", function () {
+            this.obj.doSomething("hey");
+
+            this.message("calledWith", this.obj.doSomething, "");
+            this.message("calledWith", this.obj.doSomething, "");
+            this.message("calledWith", this.obj.doSomething, "");
+            assert.contains(
+                this.message("calledWith", this.obj.doSomething, ""),
+                '"hey"'
+            );
+        });
+
         it("assert.alwaysCalledWithExactly exception message", function () {
             this.obj.doSomething(1, 3, "hey");
             this.obj.doSomething(1, 3);


### PR DESCRIPTION
#### Purpose (TL;DR)

Fix bug where checking `calledWith()` on a spy was not idempotent. Previously, if called repeatedly in such a way that it generated multiple exceptions for a given spy, it would repeatedly quote the called arguments array.

#### Background (Problem in detail)

The best explainer is the failing test I added before fixing the issue:
```
it("assert.calledWith message is idempotent", function () {
    this.obj.doSomething("hey");

    this.message("calledWith", this.obj.doSomething, "");
    this.message("calledWith", this.obj.doSomething, "");
    this.message("calledWith", this.obj.doSomething, "");
    assert.contains(
        this.message("calledWith", this.obj.doSomething, ""),
        '"hey"'
    );
});
```
Which results in this AssertionError:
```
AssertionError: [assert.contains] Expected 'expected doSomething to be called with arguments \n' +
`\u001b[31m'"\\\\"\\\\\\\\\\\\"\\\\\\\\\\\\\\\\\\\\\\\\\\\\"hey\\\\\\\\\\\\\\\\\\\\\\\\\\\\"\\\\\\\\\\\\"\\\\""'\u001b[0m \u001b[32m''\u001b[0m ` to contain '"hey"'
+ expected - actual

-expected doSomething to be called with arguments
-'"\\"\\\\\\"\\\\\\\\\\\\\\"hey\\\\\\\\\\\\\\"\\\\\\"\\""' ''
+"hey"
```

As you can see, the argument is quoted recursively four times, resulting in an absurd number of backslashes. This is because the arguments array was modified in place while generating the error message.

Obviously this is pretty edge-case - most of the time error messages will only be generated once, because they will throw and end the test. But there's one instance of working around this bug in the Sinon tests themselves (I removed, the workaround, now that it is fixed), and I ran into this while trying to make improvements to [sinon-chai](https://github.com/domenic/sinon-chai), where I am also asserting based on the contents of the error messages, and ran into unexpected deeply-quoted strings.

#### Solution

We just escape a copy of the arguments, instead of escaping the arguments in place. Again, since this is usually only called once, this should have no other downstream effects.

#### How to verify

1. Check out this branch
2. `npm install`
3. `git checkout HEAD^` to get back to the broken state
4. Run the test suite, or `npm run test-node -- -f idempotent` if you're impatient
5. See that you get an overly-escaped argument in the errors
6. `git checkout idempotent-calledWith`
7. Run tests again, see that it is no longer over-escaped

#### Checklist for author

- [] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

`npm run lint` doesn't pass, but none of the errors are related to my changes - they're mostly missing JSDoc comments, and those are the only ones in the files that I modified.

#### Backports

It looks like this was introduced in v9.2.0 with commit 3b1fa42, so this could be backported to 9 and 10 as well - I can open up PRs for that as well once this PR is vetted.