### PR TITLE
Check call count type

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -159,10 +159,16 @@ function createAssertObject() {
         callCount: function assertCallCount(method, count) {
             verifyIsStub(method);
 
-            if (method.callCount !== count) {
-                var msg = `expected %n to be called ${timesInWords(
-                    count
-                )} but was called %c%C`;
+            var msg;
+            if (typeof count !== "number") {
+                msg =
+                    `expected ${format(count)} to be a number ` +
+                    `but was of type ${typeof count}`;
+                failAssertion(this, msg);
+            } else if (method.callCount !== count) {
+                msg =
+                    `expected %n to be called ${timesInWords(count)} ` +
+                    `but was called %c%C`;
                 failAssertion(this, method.printf(msg));
             } else {
                 assert.pass("callCount");

--- a/lib/sinon/proxy-call.js
+++ b/lib/sinon/proxy-call.js
@@ -220,7 +220,7 @@ var callProto = {
             }
         }
         if (this.stack) {
-            // Omit the error message and the two top stack frames in sinon itself:
+            // Emit the error message and the two top stack frames in sinon itself:
             callStr += (this.stack.split("\n")[3] || "unknown").replace(
                 /^\s*(?:at\s+|@)?/,
                 " at "

--- a/lib/sinon/proxy-call.js
+++ b/lib/sinon/proxy-call.js
@@ -220,7 +220,8 @@ var callProto = {
             }
         }
         if (this.stack) {
-            // Emit the error message and the two top stack frames in sinon itself:
+            // If we have a stack, add the first frame that's in end-user code
+            // Skip the first two frames because they will refer to Sinon code
             callStr += (this.stack.split("\n")[3] || "unknown").replace(
                 /^\s*(?:at\s+|@)?/,
                 " at "

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1438,7 +1438,8 @@ describe("assert", function () {
                         [].slice.call(arguments, 1)
                     );
                 } catch (e) {
-                    return e.message;
+                    // Strip off the stack frames we append
+                    return e.message.replace(/( at.*\(.*\)$)+/gm, "");
                 }
             };
         });
@@ -1454,10 +1455,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message("notCalled", this.obj.doSomething).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("notCalled", this.obj.doSomething),
                 "expected doSomething to not have been called but was called once\n    doSomething()"
             );
         });
@@ -1469,10 +1467,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message("notCalled", this.obj.doSomething).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("notCalled", this.obj.doSomething),
                 "expected doSomething to not have been called " +
                     "but was called 4 times\n    doSomething()\n    " +
                     "doSomething()\n    doSomething()\n    doSomething()"
@@ -1486,10 +1481,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message("notCalled", this.obj.doSomething).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("notCalled", this.obj.doSomething),
                 "expected doSomething to not have been called " +
                     "but was called 4 times\n    doSomething()\n    " +
                     "doSomething(3)\n    doSomething(42, 1)\n    doSomething()"
@@ -1573,10 +1565,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message("callCount", this.obj.doSomething, 3).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("callCount", this.obj.doSomething, 3),
                 "expected doSomething to be called thrice but was called once\n    doSomething()"
             );
         });
@@ -1586,20 +1575,14 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message("calledOnce", this.obj.doSomething).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("calledOnce", this.obj.doSomething),
                 "expected doSomething to be called once but was called twice\n    doSomething()\n    doSomething()"
             );
 
             this.obj.doSomething();
 
             assert.equals(
-                this.message("calledOnce", this.obj.doSomething).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("calledOnce", this.obj.doSomething),
                 "expected doSomething to be called once but was called " +
                     "thrice\n    doSomething()\n    doSomething()\n    doSomething()"
             );
@@ -1609,10 +1592,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message("calledTwice", this.obj.doSomething).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("calledTwice", this.obj.doSomething),
                 "expected doSomething to be called twice but was called once\n    doSomething()"
             );
         });
@@ -1624,10 +1604,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message("calledThrice", this.obj.doSomething).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("calledThrice", this.obj.doSomething),
                 "expected doSomething to be called thrice but was called 4 times\n" +
                     "    doSomething()\n    doSomething()\n    doSomething()\n    doSomething()"
             );
@@ -1715,13 +1692,7 @@ describe("assert", function () {
             this.obj.doSomething(4, 3, "hey");
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    1,
-                    3,
-                    "hey"
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, 1, 3, "hey"),
                 `expected doSomething to be called with arguments \n${color.red(
                     "4"
                 )} ${color.green("1")} \n3\n${inspect('"hey"')}`
@@ -1733,13 +1704,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 3, "not");
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    1,
-                    3,
-                    "hey"
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, 1, 3, "hey"),
                 `${
                     "expected doSomething to be called with arguments \n" +
                     "Call 1:\n"
@@ -1825,10 +1790,7 @@ describe("assert", function () {
             this.obj.doSomething(4);
 
             assert.equals(
-                this.message("calledWith", this.obj.doSomething, 1, 3).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("calledWith", this.obj.doSomething, 1, 3),
                 `expected doSomething to be called with arguments \n${color.red(
                     "4"
                 )} ${color.green("1")} \n${color.green("3")}`
@@ -1839,10 +1801,7 @@ describe("assert", function () {
             this.obj.doSomething(4, 3);
 
             assert.equals(
-                this.message("calledWith", this.obj.doSomething, 1).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("calledWith", this.obj.doSomething, 1),
                 `expected doSomething to be called with arguments \n${color.red(
                     "4"
                 )} ${color.green("1")} \n${color.red("3")}`
@@ -1858,7 +1817,7 @@ describe("assert", function () {
                     this.obj.doSomething,
                     match.any,
                     false
-                ).replace(/ at.*/g, ""),
+                ),
                 `${
                     "expected doSomething to be called with arguments \n" +
                     "true any\n"
@@ -1870,11 +1829,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    match.defined
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, match.defined),
                 `expected doSomething to be called with arguments \n ${color.red(
                     "defined"
                 )}`
@@ -1885,11 +1840,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    match.truthy
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, match.truthy),
                 `expected doSomething to be called with arguments \n ${color.red(
                     "truthy"
                 )}`
@@ -1900,11 +1851,7 @@ describe("assert", function () {
             this.obj.doSomething(true);
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    match.falsy
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, match.falsy),
                 `expected doSomething to be called with arguments \n${color.green(
                     "true"
                 )} ${color.red("falsy")}`
@@ -1915,11 +1862,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    match.same(1)
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, match.same(1)),
                 `expected doSomething to be called with arguments \n ${color.red(
                     "same(1)"
                 )}`
@@ -1931,11 +1874,7 @@ describe("assert", function () {
             var matcher = match.typeOf("string");
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    matcher
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, matcher),
                 `expected doSomething to be called with arguments \n ${color.red(
                     'typeOf("string")'
                 )}`
@@ -1949,11 +1888,7 @@ describe("assert", function () {
             });
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    matcher
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, matcher),
                 `expected doSomething to be called with arguments \n ${color.red(
                     "instanceOf(CustomType)"
                 )}`
@@ -1965,11 +1900,7 @@ describe("assert", function () {
             var matcher = match({ some: "value", and: 123 });
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    matcher
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, matcher),
                 `expected doSomething to be called with arguments \n ${color.red(
                     "match(some: value, and: 123)"
                 )}`
@@ -1980,11 +1911,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    match(true)
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, match(true)),
                 `expected doSomething to be called with arguments \n ${color.red(
                     "match(true)"
                 )}`
@@ -1995,11 +1922,7 @@ describe("assert", function () {
             this.obj.doSomething();
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    match(123)
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, match(123)),
                 `expected doSomething to be called with arguments \n ${color.red(
                     "match(123)"
                 )}`
@@ -2011,11 +1934,7 @@ describe("assert", function () {
             var matcher = match("Sinon");
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    matcher
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, matcher),
                 `expected doSomething to be called with arguments \n ${color.red(
                     'match("Sinon")'
                 )}`
@@ -2030,7 +1949,7 @@ describe("assert", function () {
                     "calledWith",
                     this.obj.doSomething,
                     match(/[a-z]+/)
-                ).replace(/ at.*/g, ""),
+                ),
                 `expected doSomething to be called with arguments \n ${color.red(
                     "match(/[a-z]+/)"
                 )}`
@@ -2046,11 +1965,7 @@ describe("assert", function () {
             });
 
             assert.equals(
-                this.message(
-                    "calledWith",
-                    this.obj.doSomething,
-                    matcher
-                ).replace(/ at.*/g, ""),
+                this.message("calledWith", this.obj.doSomething, matcher),
                 `expected doSomething to be called with arguments \n ${color.red(
                     "match(custom)"
                 )}`
@@ -2067,7 +1982,7 @@ describe("assert", function () {
                     4,
                     3,
                     "hey"
-                ).replace(/ at.*/g, ""),
+                ),
                 `expected doSomething to be called with match \n${color.red(
                     "1"
                 )} ${color.green("4")} \n3\n${inspect('"hey"')}`
@@ -2084,7 +1999,7 @@ describe("assert", function () {
                     this.obj.doSomething,
                     1,
                     "hey"
-                ).replace(/ at.*/g, ""),
+                ),
                 `${
                     "expected doSomething to always be called with arguments \n" +
                     "Call 1:\n" +
@@ -2107,7 +2022,7 @@ describe("assert", function () {
                     this.obj.doSomething,
                     1,
                     "hey"
-                ).replace(/ at.*/g, ""),
+                ),
                 `${
                     "expected doSomething to always be called with match \n" +
                     "Call 1:\n" +
@@ -2124,12 +2039,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 3, "hey");
 
             assert.equals(
-                this.message(
-                    "calledWithExactly",
-                    this.obj.doSomething,
-                    1,
-                    3
-                ).replace(/ at.*/g, ""),
+                this.message("calledWithExactly", this.obj.doSomething, 1, 3),
                 `expected doSomething to be called with exact arguments \n1\n3\n${color.red(
                     inspect('"hey"')
                 )}`
@@ -2144,7 +2054,7 @@ describe("assert", function () {
                     1,
                     3,
                     "bob"
-                ).replace(/ at.*/g, ""),
+                ),
                 "expected doSomething to be called once and with exact arguments "
             );
 
@@ -2156,7 +2066,7 @@ describe("assert", function () {
                     1,
                     3,
                     "bob"
-                ).replace(/ at.*/g, ""),
+                ),
                 `expected doSomething to be called once and with exact arguments \n${color.red(
                     "4"
                 )} ${color.green("1")} \n3\n${inspect('"bob"')}`
@@ -2164,10 +2074,7 @@ describe("assert", function () {
 
             this.obj.doSomething();
             assert.equals(
-                this.message(
-                    "calledOnceWithExactly",
-                    this.obj.doSomething
-                ).replace(/ at.*/g, ""),
+                this.message("calledOnceWithExactly", this.obj.doSomething),
                 `${
                     "expected doSomething to be called once and with exact arguments \n" +
                     "Call 1:\n"
@@ -2198,7 +2105,7 @@ describe("assert", function () {
                     this.obj.doSomething,
                     1,
                     3
-                ).replace(/ at.*/g, ""),
+                ),
                 `${
                     "expected doSomething to always be called with exact arguments \n" +
                     "Call 1:\n" +
@@ -2215,12 +2122,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 2, 3);
 
             assert.equals(
-                this.message(
-                    "neverCalledWith",
-                    this.obj.doSomething,
-                    1,
-                    2
-                ).replace(/ at.*/g, ""),
+                this.message("neverCalledWith", this.obj.doSomething, 1, 2),
                 "expected doSomething to never be called with arguments 1, 2\n    doSomething(1, 2, 3)"
             );
         });
@@ -2234,7 +2136,7 @@ describe("assert", function () {
                     this.obj.doSomething,
                     1,
                     2
-                ).replace(/ at.*/g, ""),
+                ),
                 "expected doSomething to never be called with match 1, 2\n    doSomething(1, 2, 3)"
             );
         });
@@ -2244,10 +2146,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 3);
 
             assert.equals(
-                this.message("threw", this.obj.doSomething).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("threw", this.obj.doSomething),
                 "doSomething did not throw exception\n    doSomething(1, 3, 'hey')\n    doSomething(1, 3)"
             );
         });
@@ -2257,10 +2156,7 @@ describe("assert", function () {
             this.obj.doSomething(1, 3);
 
             assert.equals(
-                this.message("alwaysThrew", this.obj.doSomething).replace(
-                    / at.*/g,
-                    ""
-                ),
+                this.message("alwaysThrew", this.obj.doSomething),
                 "doSomething did not always throw exception\n    doSomething(1, 3, 'hey')\n    doSomething(1, 3)"
             );
         });

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1438,7 +1438,8 @@ describe("assert", function () {
                         [].slice.call(arguments, 1)
                     );
                 } catch (e) {
-                    // Strip off the stack frames we append
+                    // We sometimes append stack frames to the message and they
+                    // make assertions messy, so strip those off here
                     return e.message.replace(/( at.*\(.*\)$)+/gm, "");
                 }
             };

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1570,6 +1570,15 @@ describe("assert", function () {
             );
         });
 
+        it("assert.callCount exception message with non-numeric argument", function () {
+            this.obj.doSomething();
+
+            assert.equals(
+                this.message("callCount", this.obj.doSomething, "3"),
+                "expected '3' to be a number but was of type string"
+            );
+        });
+
         it("assert.calledOnce exception message", function () {
             this.obj.doSomething();
             this.obj.doSomething();


### PR DESCRIPTION
#### Purpose (TL;DR)

Fix #2408 by checking the type of the argument to callCount and emitting a specfic error message if it is not a number

#### Details

I also refactored the assert tests a bit while I was here - the current code is manually removing the stack traces in each individual test, but since we already have a `message()` helper function to extract the message, I moved the stack trace stripping up into that, which streamlines the rest of the test cases quite a bit.

I also modified the regex to be more specific, and avoid accidentally stripping the end of messages that happen to have the word "at" in them.

#### How to verify

1. Check out this branch
2. `npm install`
3. Run the following test case:

```
const sinon = require('sinon');
const n = '10',
      s = sinon.spy();
for(let i=0; i < n; ++i) s();

sinon.assert.callCount(s, n);
```

You should get `expected '10' to be a number but was of type string`, rather than the current message which is `expected spy to be called 10 times but was called 10 times`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
