### PR TITLE
Fix bundling of cjs module

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 <p align=center>
 <a href="https://app.saucelabs.com/u/sinonjs">
   <img src="https://app.saucelabs.com/browser-matrix/sinonjs.svg" alt="Sauce Test Status"/>
-</a> 
+</a>
 </p>
 -->
 

--- a/build.cjs
+++ b/build.cjs
@@ -44,7 +44,6 @@ makeBundle(
     },
     function (bundle) {
         var script = preamble + bundle;
-        fs.writeFileSync("pkg/sinon.cjs", script);
         fs.writeFileSync("pkg/sinon.js", script); // WebWorker can only load js files
     }
 );

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
   "main": "./lib/sinon.js",
   "module": "./pkg/sinon-esm.js",
   "exports": {
-    "require": "./pkg/sinon.cjs",
+    "require": "./lib/sinon.js",
     "import": "./pkg/sinon-esm.js"
   },
   "type": "module",


### PR DESCRIPTION
Fix #2411 

Webpack can't bundle `pkg/sinon.cjs`, so going to use the original `lib/sinon.js` which bundles without issues.
I don't remember right now why I introduced `pkg/sinon.cjs` anymore ><;;