### PR TITLE
Add explicit export for `./*`

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,8 +118,11 @@
   "main": "./lib/sinon.js",
   "module": "./pkg/sinon-esm.js",
   "exports": {
-    "require": "./lib/sinon.js",
-    "import": "./pkg/sinon-esm.js"
+    ".": {
+      "require": "./lib/sinon.js",
+      "import": "./pkg/sinon-esm.js"
+    },
+    "./*": "./*"
   },
   "type": "module",
   "cdn": "./pkg/sinon.js",


### PR DESCRIPTION
#### Purpose

Add an explicit export entry for `package.json` to fix the following error when running karma:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in node_modules/sinon/package.json
```

 #### Background

https://github.com/nodejs/node/issues/33460

There is a lot of discussion around whether declaring `package.json` as "public API" via `exports` is a good or bad idea. My take is simply that we need to expose this as a workaround before node team decide what to do, otherwise it breaks many tools that relies on `package.json`.

#### How to verify

Dependabot update sinon 12.0.0 failed on CI and manually patching `package.json` tested and working locally.

E.g. https://github.com/ntkme/github-buttons/runs/4099992660?check_suite_focus=true

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
