### PR TITLE
Be more general in stripping off stack frames to fix Firefox tests

### DIFF
--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1440,15 +1440,18 @@ describe("assert", function () {
                 } catch (e) {
                     // We sometimes append stack frames to the message and they
                     // make assertions messy, so strip those off here
-                    return e.message.replace(/( at.*\(.*\)$)+/gm, "");
+                    return e.message.replace(/ at.*/g, "");
                 }
             };
         });
 
         it("assert.called exception message", function () {
+            // The actual message here is "...called at least once but was
+            // never called" but everything after "at" gets stripped out
+            // becuase of how we strip off stack traces for comparison's sake
             assert.equals(
                 this.message("called", this.obj.doSomething),
-                "expected doSomething to have been called at least once but was never called"
+                "expected doSomething to have been called"
             );
         });
 

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1438,20 +1438,23 @@ describe("assert", function () {
                         [].slice.call(arguments, 1)
                     );
                 } catch (e) {
-                    // We sometimes append stack frames to the message and they
-                    // make assertions messy, so strip those off here
-                    return e.message.replace(/ at.*/g, "");
+                    /* We sometimes append stack frames to the message and they
+                     * make assertions messy, so strip those off here
+                     *
+                     * In the regex we assume that a stack frame will have at
+                     * least one "special character" (not a word or space) and
+                     * use that to make sure we don't strip off the end of
+                     * legitimate messages that end with "at least once..."
+                     */
+                    return e.message.replace(/ at.*?[^\w\s].*/g, "");
                 }
             };
         });
 
         it("assert.called exception message", function () {
-            // The actual message here is "...called at least once but was
-            // never called" but everything after "at" gets stripped out
-            // becuase of how we strip off stack traces for comparison's sake
             assert.equals(
                 this.message("called", this.obj.doSomething),
-                "expected doSomething to have been called"
+                "expected doSomething to have been called at least once but was never called"
             );
         });
 


### PR DESCRIPTION
#### Purpose (TL;DR)

This fixes a breaking change to tests in Firefox introduced in #2410, by reverting a small subset of that PR.

 #### Background (Problem in detail)

We're stripping off stack traces for comparison's sake in tests, and previously to #2410 we used a pretty non-specific regex to do so, which accidentally stripped off part of the assertion message "expected func() to have been called at least once", and thus were asserting that such an assertion results in the message "expected func() to have been called". This is technically incorrect, but also fairly harmless. Amusingly, the message itself is still semantically sound, just less specific than the original.

As part of a larger refactor in #2410, I attempted to make this regex more specific, and thus not incorrectly strip part of the assertion message along with the stack traces. This was successful in not stripping the message, but went too far in the other direction - the new regex is now too specific, and makes assumptions about stack traces that do not hold for Firefox's stack trace format.

#### Solution

It's likely possible to come up with a regex that will match both formats, while still not stripping off the ends of legitimate messages, but in the interest of expedience and simplicity, this PR simply reverts to the previous regex, and adjusts the one test affected to once again assert against the technically incorrect message.

#### How to verify - mandatory

1. Run the tests in this branch under Firefox (with SauceLabs, or elsewise)

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
