### PR TITLE
Single release per major  version - changes to master branch

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,6 +6,7 @@ url: 'https://sinonjs.org'
 github_username: sinonjs
 sinon:
   current_release: v13.0.0
+  current_major_version: 13
 markdown: kramdown
 kramdown:
   input: GFM

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -12,7 +12,7 @@
 
     {% comment %}
     To make all documentation pages, regardless of version, lead search traffic to the latest version,
-    we need to point all the pages under /releases/v*/ to their latest version
+    we need to point all the pages under /releases/v*/ to the latest version
     {% endcomment %}
 
     {% assign url_parts = page.url | split: "/" %}
@@ -20,11 +20,11 @@
     {% if page.url contains "/releases/v" } %}
         {% assign canonical_page_url = "/releases/latest/" | append: url_parts[3] %}
 
-        {% if url_parts[2] != {site.sinon.current_release} %}
-            <script>
-                site.showBanner = true; // cannot dynamically create a globally available Liquid variable
-            </script>
-        {% endif %}
+        <script>
+            const releaseVersionWithPrefix = "{{ url_parts[2]}}";
+            const majorVersion = "{{site.sinon.current_major_version}}"
+            site.showBanner = releaseVersionWithPrefix != `v${majorVersion}`; // cannot dynamically create a globally available Liquid variable
+        </script>
     {% else %}
         {% assign canonical_page_url = page.url | replace:'index.html','' %}
     {% endif %}

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -7,7 +7,7 @@
         </a>
       </div>
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="{{ site.baseurl }}/releases/{{site.sinon.current_release}}">Documentation</a></li>
+        <li><a href="{{ site.baseurl }}/releases/v{{site.sinon.current_major_version}}">Documentation</a></li>
         <li><a href="{{ site.baseurl }}/releases/">Releases</a></li>
         <li><a href="{{ site.baseurl }}/guides/">Guides</a></li>
         <li><a href="{{ site.baseurl }}/how-to/">How To</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@
 ---
 
 {% assign current_release = site.sinon.current_release %}
+{% assign current_major = site.sinon.current_major_version %}
 
 ## Get Started
 
@@ -284,9 +285,9 @@ You've seen the most common tasks people tackle with Sinon.JS, yet we've only sc
 
 Christian Johansen's book [Test-Driven JavaScript Development][tddjs] covers some of the design philosophy and initial sketches for Sinon.JS.
 
-[fakes]: /releases/{{current_release}}/fakes
-[fakexhr]: /releases/{{current_release}}/fake-xhr-and-server
-[fakeserver]: /releases/{{current_release}}/fake-xhr-and-server#fake-server
-[clock]: /releases/{{current_release}}/fake-timers
-[api-docs]: /releases/{{current_release}}
+[fakes]: /releases/v{{current_major}}/fakes
+[fakexhr]: /releases/v{{current_major}}/fake-xhr-and-server
+[fakeserver]: /releases/v{{current_major}}/fake-xhr-and-server#fake-server
+[clock]: /releases/v{{current_major}}/fake-timers
+[api-docs]: /releases/v{{current_major}}
 [tddjs]: http://tddjs.com/

--- a/docs/release-source/release.md
+++ b/docs/release-source/release.md
@@ -3,6 +3,7 @@ layout: page
 title: API documentation - Sinon.JS
 skip_ad: true
 release_id: master
+sort_id: master
 ---
 
 # {{page.title}} - `{{page.release_id}}`

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -18,7 +18,7 @@ redirect_from:
 
 <div class="in-content releases">
     <ul>
-        {% assign sorted_releases = site.releases | sort | reverse %}
+        {% assign sorted_releases = site.releases | sort: "release_id" | reverse %}
         {% for release in sorted_releases %}
             {% assign url_parts = release.url | split: "/" %}
 
@@ -65,3 +65,7 @@ redirect_from:
         would download the latest browser bundle of Sinon 3.
     </p>
 </div>
+
+{% comment %}
+vim: ft=liquid
+{%endcomment %}

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -18,7 +18,7 @@ redirect_from:
 
 <div class="in-content releases">
     <ul>
-        {% assign sorted_releases = site.releases | sort: "release_id" | reverse %}
+        {% assign sorted_releases = site.releases | sort: "sort_id" | reverse %}
         {% for release in sorted_releases %}
             {% assign url_parts = release.url | split: "/" %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "proxyquireify": "^3.2.1",
         "puppeteer": "^13.1.2",
         "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
         "shelljs": "^0.8.4"
       },
       "funding": {
@@ -96,6 +97,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.16.8",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
@@ -126,6 +136,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -2556,21 +2575,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint-plugin-compat/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-jsdoc": {
       "version": "37.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.7.0.tgz",
@@ -2603,21 +2607,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-mocha": {
@@ -4162,6 +4151,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/istanbul-lib-processinfo": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
@@ -4749,6 +4747,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/md5.js": {
@@ -5534,6 +5541,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/nyc/node_modules/wrap-ansi": {
@@ -6656,12 +6672,18 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/serialize-javascript": {
@@ -8013,6 +8035,14 @@
         "json5": "^2.1.2",
         "semver": "^6.3.0",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/generator": {
@@ -8036,6 +8066,14 @@
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-environment-visitor": {
@@ -10107,15 +10145,6 @@
           "requires": {
             "p-limit": "^3.0.2"
           }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -10140,15 +10169,6 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -11187,6 +11207,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-processinfo": {
@@ -11630,6 +11658,14 @@
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "md5.js": {
@@ -12245,6 +12281,12 @@
           "requires": {
             "aggregate-error": "^3.0.0"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -13120,10 +13162,13 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "serialize-javascript": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "proxyquireify": "^3.2.1",
     "puppeteer": "^13.1.2",
     "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
     "shelljs": "^0.8.4"
   },
   "files": [

--- a/scripts/copy-documentation-for-new-release.sh
+++ b/scripts/copy-documentation-for-new-release.sh
@@ -41,6 +41,7 @@ function copy_source_to(){
     # replace `release_id: master` with `release_id: $FULL_VERSION` in
     # $FILE_PATH
     sed -i.bak "s/release_id: master/release_id: $FULL_VERSION/g" "$FILE_PATH"
+    sed -i.bak "s/sort_id: master/sort_id: $MAJOR_VERSION/g" "$FILE_PATH"
     rm "$FILE_PATH.bak"
 
     git add "$DIR"

--- a/scripts/copy-documentation-for-new-release.sh
+++ b/scripts/copy-documentation-for-new-release.sh
@@ -7,7 +7,8 @@ if [[ $# != 1 ]]; then
     exit 1
 fi
 
-RELEASE_VERSION=$(node -p "require('semver').major('$1')")
+FULL_VERSION="v$1"
+MAJOR_VERSION=v$(node -p "require('semver').major('$1')")
 SOURCE_PATH='docs/release-source/'
 
 function copy_source_to(){
@@ -37,18 +38,18 @@ function copy_source_to(){
     rm -r "$DIR/examples/node_modules"
     rm "$DIR/examples/package-lock.json"
 
-    # replace `release_id: master` with `release_id: $RELEASE_VERSION` in
+    # replace `release_id: master` with `release_id: $FULL_VERSION` in
     # $FILE_PATH
-    sed -i.bak "s/release_id: master/release_id: $RELEASE_VERSION/g" "$FILE_PATH"
+    sed -i.bak "s/release_id: master/release_id: $FULL_VERSION/g" "$FILE_PATH"
     rm "$FILE_PATH.bak"
 
     git add "$DIR"
     git add "$FILE_PATH"
 }
 
-copy_source_to "v$RELEASE_VERSION"
+copy_source_to "$MAJOR_VERSION"
 rm -r "docs/_releases/latest" \
     "docs/_releases/latest.md" 2>/dev/null
 copy_source_to "latest"
 
-git commit -m "Add release documentation for $RELEASE_VERSION"
+git commit -m "Add release documentation for $MAJOR_VERSION"

--- a/scripts/copy-documentation-for-new-release.sh
+++ b/scripts/copy-documentation-for-new-release.sh
@@ -7,7 +7,7 @@ if [[ $# != 1 ]]; then
     exit 1
 fi
 
-RELEASE_VERSION="v$1"
+RELEASE_VERSION=$(node -p "require('semver').major('$1')")
 SOURCE_PATH='docs/release-source/'
 
 function copy_source_to(){
@@ -46,7 +46,7 @@ function copy_source_to(){
     git add "$FILE_PATH"
 }
 
-copy_source_to "$RELEASE_VERSION"
+copy_source_to "v$RELEASE_VERSION"
 rm -r "docs/_releases/latest" \
     "docs/_releases/latest.md" 2>/dev/null
 copy_source_to "latest"

--- a/scripts/set-release-id-in-config-yml.cjs
+++ b/scripts/set-release-id-in-config-yml.cjs
@@ -1,12 +1,14 @@
 "use strict";
-var configYmlPath = "docs/_config.yml";
-var UTF8 = "utf8";
+const configYmlPath = "docs/_config.yml";
+const UTF8 = "utf8";
 
-var fs = require("fs");
-var yaml = require("js-yaml");
-var releaseId = `v${require("../package.json").version}`;
-var config = yaml.safeLoad(fs.readFileSync(configYmlPath, UTF8));
+const fs = require("fs");
+const yaml = require("js-yaml");
+const semver = require("semver");
+const releaseId = `v${require("../package.json").version}`;
+const config = yaml.safeLoad(fs.readFileSync(configYmlPath, UTF8));
 
 config.sinon.current_release = releaseId; // eslint-disable-line camelcase
+config.sinon.current_major_version = semver.major(releaseId); // eslint-disable-line camelcase
 
 fs.writeFileSync(configYmlPath, yaml.safeDump(config), UTF8);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
For a long time we have realized that having fully versioned docs for every single patch version of Sinon has been a bit overkill. It makes generating the Jekyll site slow and fixing errors in the docs is no fun when we are talking about 114 versions of the docs. This PR is the changes required to the `master` branch to ensure we just create a single set of docs for every major version. A later patch version will always replace the previous.

This PR is accompanied by another to the releases branch that updates the relevant old docs there to bring them inline.

Below you can see the effect:
- the url is now just /releases/v11/ ... not /releases/v11.0.2/
- the list of releases contains only one version per major
- the list is finally sorted correctly (numerically)

The final step, the sorting, required jumping through some hoops to get right, since Liquid just does alphabetical sorting,  but the solution is basically prepending `0` to all versions < 10 and using the major version as the sort key. This is seen in the PR to the releases branch.

![photo_2022-01-28 19 50 58](https://user-images.githubusercontent.com/618076/151604587-a1e0bb2d-fc1a-4113-884c-1a100da5f7fb.jpeg)
![photo_2022-01-28 19 50 48](https://user-images.githubusercontent.com/618076/151604591-ce00978c-5020-43ab-811d-4a2ca6ad7bfd.jpeg)

