### PR TITLE
Fix up remaining merge issues from #2426

### DIFF
--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -9,7 +9,7 @@ echo 'postversion tasks'
 # npm publish will generate the pkg/sinon.js that we use below
 echo 'publish to npm'
 git push --follow-tags
-npm publish --dry-run
+npm publish
 
 # Now update the releases branch and archive the new release
 git checkout $ARCHIVE_BRANCH


### PR DESCRIPTION
#### Purpose (TL;DR)

Fix npm releases after a test commit slipped in in #2426 

 #### Background (Problem in detail)  - optional

This was left in place from the releases switchover, it was intended to
be removed before merging but I failed to communicate that adequately,
so it slipped in.

That commit also removed the post-build script, but that has since been
added back in already.

#### How to verify - mandatory

The only way to actually verify this, by its nature, is to run a release. It's a pretty simple change though.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
