### PR TITLE
Add dry run mode to `npm version`

### DIFF
--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -8,8 +8,12 @@ echo 'postversion tasks'
 
 # npm publish will generate the pkg/sinon.js that we use below
 echo 'publish to npm'
-git push --follow-tags
-npm publish
+if [ -n "$DRY_RUN" ]; then
+    npm publish --dry-run
+else
+    git push --follow-tags
+    npm publish
+fi
 
 # Now update the releases branch and archive the new release
 git checkout $ARCHIVE_BRANCH
@@ -27,5 +31,5 @@ cp "pkg/sinon.js" "./docs/releases/sinon-$PACKAGE_VERSION.js"
 git add "docs/releases/sinon-$PACKAGE_VERSION.js"
 git commit -n -m "Add version $PACKAGE_VERSION to releases"
 
-git push
+[ -n "$DRY_RUN" ] || git push
 git checkout $SOURCE_BRANCH

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
-ARCHIVE_BRANCH="releases"
+ARCHIVE_BRANCH=${ARCHIVE_BRANCH:-releases}
 SOURCE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 echo 'postversion tasks'
@@ -16,6 +16,7 @@ else
 fi
 
 # Now update the releases branch and archive the new release
+echo "archiving release from $SOURCE_BRANCH to $ARCHIVE_BRANCH"
 git checkout $ARCHIVE_BRANCH
 git merge --no-edit -m "Merge version $PACKAGE_VERSION" $SOURCE_BRANCH
 


### PR DESCRIPTION
#### Purpose (TL;DR)

Adds a dry-run mode to our `npm version` scripts

 #### Background (Problem in detail)  - optional

Currently there's no easy way to test `npm version` commands without actually publishing a release and pushing the updated branches to GitHub, which we obviously don't want to do.

#### Solution

The post-version script now looks for a `DRY_RUN` environment variable, which if set, will cause it to skip the following steps in the release process:
 - Actually publishing to npm (it runs `publish --dry-run` instead)
 -  Pushing the branches up to remote

#### How to verify - mandatory

Run `DRY_RUN=1 npm version` and it should _not_ actually publish a release! You may want to manually edit `postversion.sh` to disable the `npm publish` in the non-dry-run path though, just in case things are broken somehow.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

