### PR TITLE
Re-introduce version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prettier:check": "prettier --check '**/*.{js,css,md}'",
     "prettier:write": "prettier --write '**/*.{js,css,md}'",
     "preversion": "./scripts/preversion.sh",
-    "version": "changes --commits --footer",
+    "version": "./scripts/version.sh",
     "postversion": "./scripts/postversion.sh"
   },
   "nyc": {

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -8,8 +8,12 @@ echo 'postversion tasks'
 
 # npm publish will generate the pkg/sinon.js that we use below
 echo 'publish to npm'
-git push --follow-tags
-npm publish
+if [ -n "$DRY_RUN" ]; then
+    npm publish --dry-run
+else
+    git push --follow-tags
+    npm publish
+fi
 
 # Now update the releases branch and archive the new release
 git checkout $ARCHIVE_BRANCH
@@ -27,5 +31,5 @@ cp "pkg/sinon.js" "./docs/releases/sinon-$PACKAGE_VERSION.js"
 git add "docs/releases/sinon-$PACKAGE_VERSION.js"
 git commit -n -m "Add version $PACKAGE_VERSION to releases"
 
-git push
+[ -n "$DRY_RUN" ] || git push
 git checkout $SOURCE_BRANCH

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
-ARCHIVE_BRANCH="releases"
+ARCHIVE_BRANCH=${ARCHIVE_BRANCH:-releases}
 SOURCE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 echo 'postversion tasks'
@@ -16,6 +16,7 @@ else
 fi
 
 # Now update the releases branch and archive the new release
+echo "archiving release from $SOURCE_BRANCH to $ARCHIVE_BRANCH"
 git checkout $ARCHIVE_BRANCH
 git merge --no-edit -m "Merge version $PACKAGE_VERSION" $SOURCE_BRANCH
 

--- a/scripts/update-changelog-page.sh
+++ b/scripts/update-changelog-page.sh
@@ -4,6 +4,7 @@ layout: default
 title: Changelog
 permalink: /releases/changelog
 ---
+
 # Changelog
 $(tail -n+2 CHANGES.md)
 EOL


### PR DESCRIPTION
#### Purpose (TL;DR)

Because of the merge mess with #2426, the `version` command in `package.json` was reverted, so that the new `version.sh` script isn't being used.

#### Solution

This PR also puts the `version.sh` script back, and persists a prettier fix in a generated file back to the generation of the file, so it doesn't keep popping up.

#### How to verify - mandatory

The only way to really, test this is to run `npm version`, but if #2436 is merged first, then we'll have a way to run that without publishing a release!

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
