### PR TITLE
Re-introduce new version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prettier:check": "prettier --check '**/*.{js,css,md}'",
     "prettier:write": "prettier --write '**/*.{js,css,md}'",
     "preversion": "./scripts/preversion.sh",
-    "version": "changes --commits --footer",
+    "version": "./scripts/version.sh",
     "postversion": "./scripts/postversion.sh"
   },
   "nyc": {

--- a/scripts/update-changelog-page.sh
+++ b/scripts/update-changelog-page.sh
@@ -4,6 +4,7 @@ layout: default
 title: Changelog
 permalink: /releases/changelog
 ---
+
 # Changelog
 $(tail -n+2 CHANGES.md)
 EOL


### PR DESCRIPTION
#### Purpose (TL;DR)

Because of the merge mess with #2426, the `version` command in `package.json` was reverted, so that the new `version.sh` script isn't being used.

#### Solution

This PR also puts the `version.sh` script back, and persists a prettier fix in a generated file back to the generation of the file, so it doesn't keep popping up.

#### How to verify - mandatory

The only way to really, test this is to run `npm version`, but if #2436 is merged first, then we'll have a way to run that without publishing a release!

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
