### PR TITLE
Drop node 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,7 +143,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -269,6 +269,7 @@ var defaultBehaviors = {
         Object.defineProperty(rootStub.rootObj, rootStub.propName, {
             value: newVal,
             enumerable: true,
+            writable: true,
             configurable:
                 rootStub.shadowsPropOnPrototype ||
                 isPropertyConfigurable(rootStub.rootObj, rootStub.propName),


### PR DESCRIPTION
This PR drops support for Node 12 and adds support for Node 18.


#### Purpose (TL;DR) - mandatory

<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

#### How to verify

1. Check out this branch2. 
1. `nvm install 18`
4. `npm install`
5. `npm test`
7. Observe tests pass
9. ... or observe that the tests pass in Node 18 in GitHub Actions :) 


#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
