### PR TITLE
fix: actaully reset 'injectedKeys'

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -197,17 +197,15 @@ function Sandbox() {
     };
 
     sandbox.restoreContext = function restoreContext() {
-        let injectedKeys = sandbox.injectedKeys;
-
-        if (!injectedKeys) {
+        if (!sandbox.injectedKeys) {
             return;
         }
 
-        forEach(injectedKeys, function (injectedKey) {
+        forEach(sandbox.injectedKeys, function (injectedKey) {
             delete sandbox.injectInto[injectedKey];
         });
 
-        injectedKeys = [];
+        sandbox.injectedKeys = [];
     };
 
     function getFakeRestorer(object, property) {

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -205,7 +205,7 @@ function Sandbox() {
             delete sandbox.injectInto[injectedKey];
         });
 
-        sandbox.injectedKeys = [];
+        sandbox.injectedKeys.length = 0;
     };
 
     function getFakeRestorer(object, property) {

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -198,14 +198,13 @@ function Sandbox() {
 
     sandbox.restoreContext = function restoreContext() {
         let injectedKeys = sandbox.injectedKeys;
-        const injectInto = sandbox.injectInto;
 
         if (!injectedKeys) {
             return;
         }
 
         forEach(injectedKeys, function (injectedKey) {
-            delete injectInto[injectedKey];
+            delete sandbox.injectInto[injectedKey];
         });
 
         injectedKeys = [];


### PR DESCRIPTION
Re-assigning the local variable `injectedKeys` would not change `sandbox.injectedKeys`, thus `restoreContext` doesn't fully restore the context.

See:

https://lgtm.com/projects/g/sinonjs/sinon/snapshot/9e09e7d79bac5808ca98fac4f7419a20be4fc43d/files/lib/sinon/sandbox.js?sort=name&dir=ASC&mode=heatmap#x9f770d565ef51b7d:1