### PR TITLE
Upgrade unimported to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "shelljs": "^0.8.4",
-        "unimported": "^1.19.1"
+        "unimported": "^1.20.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3312,21 +3312,21 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.170.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.170.0.tgz",
-      "integrity": "sha512-H1Fu8EM/F6MtOpHYpsFXPyySatowrXMWENxRmmKAfirfBr8kjHrms3YDuv82Nhn0xWaXV7Hhynp2tEaZsLhHLw==",
+      "version": "0.156.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.156.0.tgz",
+      "integrity": "sha512-OCE3oIixhOttaV4ahIGtxf9XfaDdxujiTnXuHu+0dvDVVDiSDJlQpgCWdDKqP0OHfFnxQKrjMamArDAXtrBtZw==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/flow-remove-types": {
-      "version": "2.170.0",
-      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.170.0.tgz",
-      "integrity": "sha512-OPcoc/v/Tw6gCM0268wQEEHRPtT65hCWMlIHQFwzgo5jb4mzUZJdzWd53ElX5w+BvnsQQDmB9nwKcwq4qXBsVA==",
+      "version": "2.156.0",
+      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.156.0.tgz",
+      "integrity": "sha512-ivU28S1ycaVo5anxlXdIVlrmqLD81JWFADa6oUjyoQg0va4zSyZCp5OYco74VZi7nm42O/yTNv1Y5Byc7bJF1Q==",
       "dev": true,
       "dependencies": {
-        "flow-parser": "^0.170.0",
+        "flow-parser": "^0.156.0",
         "pirates": "^3.0.2",
         "vlq": "^0.2.1"
       },
@@ -7266,14 +7266,14 @@
       ]
     },
     "node_modules/simple-git": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.48.0.tgz",
-      "integrity": "sha512-z4qtrRuaAFJS4PUd0g+xy7aN4y+RvEt/QTJpR184lhJguBA1S/LsVlvE/CM95RsYMOFJG3NGGDjqFCzKU19S/A==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.7.1.tgz",
+      "integrity": "sha512-+Osjtsumbtew2y9to0pOYjNzSIr4NkKGBg7Po5SUtjQhaJf2QBmiTX/9E9cv9rmc7oUiSGFIB9e7ys5ibnT9+A==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.3"
       },
       "funding": {
         "type": "github",
@@ -8103,9 +8103,9 @@
       }
     },
     "node_modules/unimported": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/unimported/-/unimported-1.19.1.tgz",
-      "integrity": "sha512-p/8XnPnJbL+QhaI5qoBjT4XyJjSz0cXqK6z5JJEIF7HItZLHDldU4XjojnwJEqwghN1fzWJ8bMkPxi614m1/bQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/unimported/-/unimported-1.20.0.tgz",
+      "integrity": "sha512-xTeUf10jQy1ONRekLYgbV3PZi9UXljY5g0oAN6DkawCBQfxerfhU61reU3+rmu9ikOSafEdBOBWmrLAxEKGqIg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/parser": "^4.28.1",
@@ -8114,19 +8114,22 @@
         "debug": "^4.3.2",
         "eslint": "^7.20.0",
         "file-entry-cache": "^6.0.1",
-        "flow-remove-types": "^2.145.0",
+        "flow-remove-types": "2.156.0",
         "glob": "^7.1.6",
         "json5": "^2.2.0",
         "ora": "^5.3.0",
         "read-pkg-up": "^7.0.1",
         "resolve": "^1.20.0",
-        "simple-git": "^2.38.0",
+        "simple-git": "^3.7.1",
         "term-size": "^2.2.1",
         "typescript": "^4.3.5",
         "yargs": "^16.2.0"
       },
       "bin": {
         "unimported": "bin/unimported.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/unimported/node_modules/@babel/code-frame": {
@@ -11682,18 +11685,18 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.170.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.170.0.tgz",
-      "integrity": "sha512-H1Fu8EM/F6MtOpHYpsFXPyySatowrXMWENxRmmKAfirfBr8kjHrms3YDuv82Nhn0xWaXV7Hhynp2tEaZsLhHLw==",
+      "version": "0.156.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.156.0.tgz",
+      "integrity": "sha512-OCE3oIixhOttaV4ahIGtxf9XfaDdxujiTnXuHu+0dvDVVDiSDJlQpgCWdDKqP0OHfFnxQKrjMamArDAXtrBtZw==",
       "dev": true
     },
     "flow-remove-types": {
-      "version": "2.170.0",
-      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.170.0.tgz",
-      "integrity": "sha512-OPcoc/v/Tw6gCM0268wQEEHRPtT65hCWMlIHQFwzgo5jb4mzUZJdzWd53ElX5w+BvnsQQDmB9nwKcwq4qXBsVA==",
+      "version": "2.156.0",
+      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.156.0.tgz",
+      "integrity": "sha512-ivU28S1ycaVo5anxlXdIVlrmqLD81JWFADa6oUjyoQg0va4zSyZCp5OYco74VZi7nm42O/yTNv1Y5Byc7bJF1Q==",
       "dev": true,
       "requires": {
-        "flow-parser": "^0.170.0",
+        "flow-parser": "^0.156.0",
         "pirates": "^3.0.2",
         "vlq": "^0.2.1"
       }
@@ -14661,14 +14664,14 @@
       "dev": true
     },
     "simple-git": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.48.0.tgz",
-      "integrity": "sha512-z4qtrRuaAFJS4PUd0g+xy7aN4y+RvEt/QTJpR184lhJguBA1S/LsVlvE/CM95RsYMOFJG3NGGDjqFCzKU19S/A==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.7.1.tgz",
+      "integrity": "sha512-+Osjtsumbtew2y9to0pOYjNzSIr4NkKGBg7Po5SUtjQhaJf2QBmiTX/9E9cv9rmc7oUiSGFIB9e7ys5ibnT9+A==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.3"
       }
     },
     "slash": {
@@ -15343,9 +15346,9 @@
       }
     },
     "unimported": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/unimported/-/unimported-1.19.1.tgz",
-      "integrity": "sha512-p/8XnPnJbL+QhaI5qoBjT4XyJjSz0cXqK6z5JJEIF7HItZLHDldU4XjojnwJEqwghN1fzWJ8bMkPxi614m1/bQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/unimported/-/unimported-1.20.0.tgz",
+      "integrity": "sha512-xTeUf10jQy1ONRekLYgbV3PZi9UXljY5g0oAN6DkawCBQfxerfhU61reU3+rmu9ikOSafEdBOBWmrLAxEKGqIg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/parser": "^4.28.1",
@@ -15354,13 +15357,13 @@
         "debug": "^4.3.2",
         "eslint": "^7.20.0",
         "file-entry-cache": "^6.0.1",
-        "flow-remove-types": "^2.145.0",
+        "flow-remove-types": "2.156.0",
         "glob": "^7.1.6",
         "json5": "^2.2.0",
         "ora": "^5.3.0",
         "read-pkg-up": "^7.0.1",
         "resolve": "^1.20.0",
-        "simple-git": "^2.38.0",
+        "simple-git": "^3.7.1",
         "term-size": "^2.2.1",
         "typescript": "^4.3.5",
         "yargs": "^16.2.0"

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
     "shelljs": "^0.8.4",
-    "unimported": "^1.19.1"
+    "unimported": "^1.20.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
This upgrades an insecure transitive dependency: simple-git

See https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-2421199