### PR TITLE
Fixed CSS selectors for Changelog page and changed the font size of blockquote to 16px.

### DIFF
--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -80,13 +80,13 @@ a {
         margin-top: 15px !important;
         margin-bottom: 30px !important;
     }
-    blockquote {
+    .container > blockquote {
         border: none;
         font-size: 24px;
         text-align: center;
         margin-bottom: 5px;
     }
-    em {
+    blockquote + p em {
         a {
             font-size: 16px;
             font-style: normal;

--- a/docs/_sass/bootstrap/_variables.scss
+++ b/docs/_sass/bootstrap/_variables.scss
@@ -847,7 +847,7 @@ $headings-small-color: $gray-light !default;
 //** Blockquote small color
 $blockquote-small-color: $gray-light !default;
 //** Blockquote font size
-$blockquote-font-size: ($font-size-base * 1.25) !default;
+$blockquote-font-size: ($font-size-base * 1) !default;
 //** Blockquote border color
 $blockquote-border-color: $gray-lighter !default;
 //** Page header border color


### PR DESCRIPTION
#### Purpose (TL;DR)

Fixed issue #2469 by ensuring the `blockquote` and `a` CSS selectors in the `_base.scss` file does not affect those found on the [Changelog](https://sinonjs.org/releases/changelog) page. The default font size of the `blockquote` element was also changed to `16px` as suggested on the issue. 

The style of quotes found on the root page retain their previous style and are unaffected by this change.

![2022-08-24_04-01-45PM](https://user-images.githubusercontent.com/4380557/186516923-ce4a8a72-9b96-4423-be60-2191fc720c99.jpg)

#### How to verify

1. Check out this branch
2. `cd docs`
3. `gem install bundler`
4. `bundle install`
5. `bundle exec jekyll serve`
6. Go to http://localhost:4000/releases/changelog