### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/_howto/stub-dependency.md
+++ b/docs/_howto/stub-dependency.md
@@ -3,7 +3,7 @@ layout: page
 title: How to stub a dependency of a module
 ---
 
-Sinon is a stubbing library, not a module interception library. Stubbing dependencies is highly dependant on your enviroment and the implementation. For Node environments, we usually recommend solutions targeting [link seams](../link-seams-commonjs/) or explicit dependency injection. Though in some more basic cases, you can get away with only using Sinon by modifying the module exports of the dependency.
+Sinon is a stubbing library, not a module interception library. Stubbing dependencies is highly dependant on your environment and the implementation. For Node environments, we usually recommend solutions targeting [link seams](../link-seams-commonjs/) or explicit dependency injection. Though in some more basic cases, you can get away with only using Sinon by modifying the module exports of the dependency.
 
 To stub a dependency (imported module) of a module under test you have to import it explicitly in your test and stub the desired method. For the stubbing to work, the stubbed method cannot be [destructured](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment), neither in the module under test nor in the test.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -188,7 +188,7 @@ Learn more about [fake XMLHttpRequest][fakexhr].
 
 ### Fake server
 
-The preceding example shows how flexible this API is. If it looks too laborous, you may like the fake server:
+The preceding example shows how flexible this API is. If it looks too laborious, you may like the fake server:
 
 ```javascript
 var server;


### PR DESCRIPTION
There are small typos in:
- docs/_howto/stub-dependency.md
- docs/index.md

Fixes:
- Should read `laborious` rather than `laborous`.
- Should read `environment` rather than `enviroment`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md