### PR TITLE
Replace probot/stale with official stale action

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,13 @@
-# Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
-# Issues with these labels will never be considered stale
-exemptLabels:
-  - pinned
-  - security
-# Label to use when marking an issue as stale
-staleLabel: stale
-# Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-issue-message: "This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days."
+          stale-pr-message: "This pull request is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days."


### PR DESCRIPTION
The probot action is no longer listed in their catalog, clearly hasn't been working for awhile and isn't maintained anymore.

Let's hope the official one will be working for awhile 🤞.

See:
- https://github.com/probot/probot.github.io/pull/376
- https://probot.github.io/apps/stale/
- https://github.com/probot/stale