### PR TITLE
Un-pin @sinonjs/fake-timers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@sinonjs/samsam": "^7.0.1",
         "diff": "^5.0.0",
         "nise": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^2.0.0",
-    "@sinonjs/fake-timers": "10.0.2",
+    "@sinonjs/fake-timers": "^10.0.2",
     "@sinonjs/samsam": "^7.0.1",
     "diff": "^5.0.0",
     "nise": "^5.1.2",


### PR DESCRIPTION
#### Purpose (TL;DR)
The commit upgrading from v9 to v10 appears to have accidentally dropped the caret from the version range, pinning it to a single version: https://github.com/sinonjs/sinon/commit/aa493da47d788025c0d512696651072973f301ec

Un-pinning the version will allow sinon and its consumers to automatically pick up new in-range versions of @sinonjs/fake-timers as they're released in the future.

#### How to verify

1. Check out this branch
2. `npm install`
3. Latest version of `@sinonjs/fake-timers` should still be installed

#### Checklist for author

- [x] `npm run lint` passes
