### PR TITLE
fix throws().callsFake() precedence

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -31,6 +31,8 @@ function throwsException(fake, error, message) {
 var defaultBehaviors = {
     callsFake: function callsFake(fake, fn) {
         fake.fakeFn = fn;
+        fake.exception = undefined;
+        fake.exceptionCreator = undefined;
     },
 
     callsArg: function callsArg(fake, index) {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1407,6 +1407,28 @@ describe("stub", function () {
             refute(fakeFn.called);
             assert(returned === 3);
         });
+
+        it("supersedes previous throws(error)", function () {
+            var fakeFn = createStub().returns(5);
+            this.stub = createStub(this.object, "method");
+
+            this.stub.throws(new Error("error")).callsFake(fakeFn);
+            var returned = this.object.method(1, 2);
+
+            assert(fakeFn.called);
+            assert(returned === 5);
+        });
+
+        it("supersedes previous throws()", function () {
+            var fakeFn = createStub().returns(5);
+            this.stub = createStub(this.object, "method");
+
+            this.stub.throws().callsFake(fakeFn);
+            var returned = this.object.method(1, 2);
+
+            assert(fakeFn.called);
+            assert(returned === 5);
+        });
     });
 
     describe(".objectMethod", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fixes https://github.com/sinonjs/sinon/issues/2496 by cleaning any previous `exception*` behavior when `callsFake` is used.

 #### Background (Problem in detail)
* Issue https://github.com/sinonjs/sinon/issues/2496

Precedence among behaviors is defined by the behavior itself (cleaning other previously set behaviors) and by the order [at invocation time](https://github.com/sinonjs/sinon/blob/ddd0f25/lib/sinon/behavior.js#L162-L210).

Since `throws` behavior (`exception` and `exceptionHandler`) is the first one to run at invocation time, other behaviors can only define precedence on its own definition. That's why I modified `callsFake` behavior to clean `throws`

 #### Solution
When `callsFake` is chained on a stub it cleans previous `exception` and `exceptionHandler` values which essentially invalidates any previous `throws` or `throwsException` behaviours.

**Note:** I think this fix should not break any current usage, because any attempt to run the stubbed function would have raised an exception already and the developer would have noticed the same I did notice: callsFake was ignored, so that, probably they applied some workaround like restoring + callsFake OR recreating the stub + callsFake.

#### How to verify - mandatory
Run:
```
const fn = sinon.stub().throws('not mocked');
fn.callsFake(() => 'mocked behavior')

console.log(fn())
```

You should see:
```
mocked behavior
```

#### Checklist for author

- [x] `npm run lint` passes
- n/a References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
