### PR TITLE
Use no-op for every function when restoring instances

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -131,7 +131,12 @@ stub.createStubInstance = function (constructor, overrides) {
         throw new TypeError("The constructor should be a function.");
     }
 
-    var stubbedObject = stub(Object.create(constructor.prototype));
+    // eslint-disable-next-line no-empty-function
+    const noop = () => {};
+    const defaultNoOpInstance = Object.create(constructor.prototype);
+    walkObject((obj, prop) => (obj[prop] = noop), defaultNoOpInstance);
+
+    const stubbedObject = stub(defaultNoOpInstance);
 
     forEach(Object.keys(overrides || {}), function (propertyName) {
         if (propertyName in stubbedObject) {

--- a/lib/sinon/util/core/walk-object.js
+++ b/lib/sinon/util/core/walk-object.js
@@ -5,9 +5,17 @@ var functionName = require("@sinonjs/commons").functionName;
 var getPropertyDescriptor = require("./get-property-descriptor");
 var walk = require("./walk");
 
-function walkObject(predicate, object, filter) {
+/**
+ * A utility that allows traversing an object, applying mutating functions on the properties
+ *
+ * @param {Function} mutator called on each property
+ * @param {object} object the object we are walking over
+ * @param {Function} filter a predicate (boolean function) that will decide whether or not to apply the mutator to the current property
+ * @returns {void} nothing
+ */
+function walkObject(mutator, object, filter) {
     var called = false;
-    var name = functionName(predicate);
+    var name = functionName(mutator);
 
     if (!object) {
         throw new Error(
@@ -26,11 +34,11 @@ function walkObject(predicate, object, filter) {
             if (filter) {
                 if (filter(object, prop)) {
                     called = true;
-                    predicate(object, prop);
+                    mutator(object, prop);
                 }
             } else {
                 called = true;
-                predicate(object, prop);
+                mutator(object, prop);
             }
         }
     });

--- a/lib/sinon/util/core/walk-object.js
+++ b/lib/sinon/util/core/walk-object.js
@@ -44,7 +44,9 @@ function walkObject(mutator, object, filter) {
     });
 
     if (!called) {
-        throw new Error(`Expected to ${name} methods on object but found none`);
+        throw new Error(
+            `Found no methods on object to which we could apply mutations`
+        );
     }
 
     return object;

--- a/test/restore-object-test.js
+++ b/test/restore-object-test.js
@@ -44,7 +44,10 @@ describe("restore-object", function () {
                     meh: "okay",
                 });
             },
-            { message: "Expected to restore methods on object but found none" }
+            {
+                message:
+                    "Found no methods on object to which we could apply mutations",
+            }
         );
     });
 

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -391,6 +391,25 @@ describe("Sandbox", function () {
                 { message: "Cannot stub foo. Property does not exist!" }
             );
         });
+
+        it("restores an instance where every function of the prototype has been replaced by a no-op (#2477)", function () {
+            const sandbox = this.sandbox;
+
+            class SystemUnderTest {
+                constructor() {
+                    this.privateGetter = () => 42;
+                }
+                getValue() {
+                    return this.privateGetter();
+                }
+            }
+
+            sandbox.createStubInstance(SystemUnderTest);
+            sandbox.restore();
+
+            refute.exception(sandbox.getValue);
+            assert.isUndefined(sandbox.getValue());
+        });
     });
 
     describe(".stub", function () {

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -404,11 +404,11 @@ describe("Sandbox", function () {
                 }
             }
 
-            sandbox.createStubInstance(SystemUnderTest);
+            const stubInstance = sandbox.createStubInstance(SystemUnderTest);
             sandbox.restore();
 
-            refute.exception(sandbox.getValue);
-            assert.isUndefined(sandbox.getValue());
+            refute.exception(stubInstance.getValue);
+            assert.isUndefined(stubInstance.getValue());
         });
     });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -3140,7 +3140,10 @@ describe("stub", function () {
                 function () {
                     createStubInstance(Class);
                 },
-                { message: "Expected to stub methods on object but found none" }
+                {
+                    message:
+                        "Found no methods on object to which we could apply mutations",
+                }
             );
         });
 

--- a/test/util/core/walk-object-test.js
+++ b/test/util/core/walk-object-test.js
@@ -46,7 +46,7 @@ describe("util/core/walk-object", function () {
                 },
                 {
                     message:
-                        "Expected to fnWithNoName methods on object but found none",
+                        "Found no methods on object to which we could apply mutations",
                 }
             );
         });
@@ -65,7 +65,7 @@ describe("util/core/walk-object", function () {
                 },
                 {
                     message:
-                        "Expected to undefined methods on object but found none",
+                        "Found no methods on object to which we could apply mutations",
                 }
             );
         });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fixes the issue brought up in #2477 by adding default no-op implementations of all the functions present on the prototype of a stub instance object. This avoids issues that might arise if code traverses an object that already has been restored by having a default set of no-op function to fiddle with, instead of accidentally invoking stuff on the prototype which might or might not depend on the constructor being run to work correctly.

#### How to verify - mandatory
`npm test` and check against the example in #2477 

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
