### PR TITLE
Make the --watch flag work again

### DIFF
--- a/lib/sinon/spy-formatters.js
+++ b/lib/sinon/spy-formatters.js
@@ -14,13 +14,14 @@ var slice = arrayProto.slice;
 
 function colorSinonMatchText(matcher, calledArg, calledArgMessage) {
     var calledArgumentMessage = calledArgMessage;
+    var matcherMessage = matcher.message;
     if (!matcher.test(calledArg)) {
-        matcher.message = color.red(matcher.message);
+        matcherMessage = color.red(matcher.message);
         if (calledArgumentMessage) {
             calledArgumentMessage = color.green(calledArgumentMessage);
         }
     }
-    return `${calledArgumentMessage} ${matcher.message}`;
+    return `${calledArgumentMessage} ${matcherMessage}`;
 }
 
 function colorDiffText(diff) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/samsam": "^7.0.1",
+        "@sinonjs/samsam": "^8.0.0",
         "diff": "^5.1.0",
         "nise": "^5.1.4",
         "supports-color": "^7.2.0"
@@ -737,10 +737,21 @@
         "type-detect": "4.0.8"
       }
     },
-    "node_modules/@sinonjs/samsam": {
+    "node_modules/@sinonjs/referee/node_modules/@sinonjs/samsam": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
       "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
@@ -9645,13 +9656,24 @@
           "requires": {
             "type-detect": "4.0.8"
           }
+        },
+        "@sinonjs/samsam": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+          "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^2.0.0",
+            "lodash.get": "^4.4.2",
+            "type-detect": "^4.0.8"
+          }
         }
       }
     },
     "@sinonjs/samsam": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
-      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "requires": {
         "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@sinonjs/commons": "^3.0.0",
     "@sinonjs/fake-timers": "^10.0.2",
-    "@sinonjs/samsam": "^7.0.1",
+    "@sinonjs/samsam": "^8.0.0",
     "diff": "^5.1.0",
     "nise": "^5.1.4",
     "supports-color": "^7.2.0"

--- a/test/spy-formatters-test.js
+++ b/test/spy-formatters-test.js
@@ -1,0 +1,21 @@
+"use strict";
+const { D } = require("./../lib/sinon/spy-formatters");
+const sinon = require("../lib/sinon");
+const { assert } = require("@sinonjs/referee");
+
+describe('formatter specifier "D"', function () {
+    it("should not mutate matchers passed as arguments", function () {
+        const matcher = sinon.match(function test() {
+            return false;
+        }, "something");
+        assert.equals(matcher.message, "something");
+
+        const stub = sinon.stub();
+
+        stub(1, 2, 3);
+        /* eslint-disable new-cap */
+        D(stub, [matcher]);
+
+        assert.equals(matcher.message, "something");
+    });
+});

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -173,6 +173,7 @@ describe("stub", function () {
                 test: func,
             };
             func.aProp = 42;
+
             createStub(object, "test");
 
             assert.equals(object.test.aProp, 42);
@@ -1535,14 +1536,14 @@ describe("stub", function () {
         });
 
         it("stubs methods of function", function () {
-            var func = function () {
-                return;
-            };
+            class FunctionType extends Function {
+                func2() {
+                    return 42;
+                }
+            }
+
+            var func = new FunctionType();
             func.func1 = function () {
-                return;
-            };
-            // eslint-disable-next-line no-proto
-            func.__proto__.func2 = function () {
                 return;
             };
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

We currently cannot use the `--watch` flag to Mocha as we tamper with the Function protype and keep state in the assertion tests. This PR should fix that

#### How to verify - mandatory

1. `npx mocha --watch`
2. Touch some file to trigger re-run
3. See all pass

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
