### PR TITLE
Update sponsors and backers in README and homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,38 +64,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how you can contribute to 
 
 ## Backers
 
-Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/sinon#backer)]
+Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/sinon#backer)]
 
-<a href="https://opencollective.com/sinon/backer/0/website" target="_blank"><img src="https://opencollective.com/sinon/backer/0/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/1/website" target="_blank"><img src="https://opencollective.com/sinon/backer/1/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/2/website" target="_blank"><img src="https://opencollective.com/sinon/backer/2/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/3/website" target="_blank"><img src="https://opencollective.com/sinon/backer/3/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/4/website" target="_blank"><img src="https://opencollective.com/sinon/backer/4/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/5/website" target="_blank"><img src="https://opencollective.com/sinon/backer/5/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/6/website" target="_blank"><img src="https://opencollective.com/sinon/backer/6/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/7/website" target="_blank"><img src="https://opencollective.com/sinon/backer/7/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/8/website" target="_blank"><img src="https://opencollective.com/sinon/backer/8/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/9/website" target="_blank"><img src="https://opencollective.com/sinon/backer/9/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/10/website" target="_blank"><img src="https://opencollective.com/sinon/backer/10/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/11/website" target="_blank"><img src="https://opencollective.com/sinon/backer/11/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/12/website" target="_blank"><img src="https://opencollective.com/sinon/backer/12/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/13/website" target="_blank"><img src="https://opencollective.com/sinon/backer/13/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/14/website" target="_blank"><img src="https://opencollective.com/sinon/backer/14/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/15/website" target="_blank"><img src="https://opencollective.com/sinon/backer/15/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/16/website" target="_blank"><img src="https://opencollective.com/sinon/backer/16/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/17/website" target="_blank"><img src="https://opencollective.com/sinon/backer/17/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/18/website" target="_blank"><img src="https://opencollective.com/sinon/backer/18/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/19/website" target="_blank"><img src="https://opencollective.com/sinon/backer/19/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/20/website" target="_blank"><img src="https://opencollective.com/sinon/backer/20/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/21/website" target="_blank"><img src="https://opencollective.com/sinon/backer/21/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/22/website" target="_blank"><img src="https://opencollective.com/sinon/backer/22/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/23/website" target="_blank"><img src="https://opencollective.com/sinon/backer/23/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/24/website" target="_blank"><img src="https://opencollective.com/sinon/backer/24/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/25/website" target="_blank"><img src="https://opencollective.com/sinon/backer/25/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/26/website" target="_blank"><img src="https://opencollective.com/sinon/backer/26/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/27/website" target="_blank"><img src="https://opencollective.com/sinon/backer/27/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/28/website" target="_blank"><img src="https://opencollective.com/sinon/backer/28/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/backer/29/website" target="_blank"><img src="https://opencollective.com/sinon/backer/29/avatar.svg"></a>
+<a href="https://opencollective.com/sinon#backers" target="_blank"><img src="https://opencollective.com/sinon/backers.svg?width=890"></a>
+
 
 ## Sponsors
 
@@ -112,25 +84,6 @@ Become a sponsor and get your logo on our README on GitHub with a link to your s
 <a href="https://opencollective.com/sinon/sponsor/8/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/8/avatar.svg"></a>
 <a href="https://opencollective.com/sinon/sponsor/9/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/9/avatar.svg"></a>
 <a href="https://opencollective.com/sinon/sponsor/10/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/10/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/11/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/11/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/12/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/12/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/13/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/13/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/14/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/14/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/15/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/15/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/16/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/16/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/17/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/17/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/18/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/18/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/19/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/19/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/20/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/20/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/21/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/21/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/22/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/22/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/23/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/23/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/24/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/24/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/25/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/25/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/26/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/26/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/27/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/27/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/28/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/28/avatar.svg"></a>
-<a href="https://opencollective.com/sinon/sponsor/29/website" target="_blank"><img src="https://opencollective.com/sinon/sponsor/29/avatar.svg"></a>
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com
 
 <a href="https://opencollective.com/sinon#backers" target="_blank"><img src="https://opencollective.com/sinon/backers.svg?width=890"></a>
 
-
 ## Sponsors
 
 Become a sponsor and get your logo on our README on GitHub with a link to your site. [[Become a sponsor](https://opencollective.com/sinon#sponsor)]

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,21 +4,17 @@ published: false
 
 # Docs
 
-This folder structure contains the markdown files that becomes the Sinon.JS documentation site published to GitHub Pages. Eventually this will replace the current site at https://sinonjs.org.
+This folder structure contains the markdown files that is the Sinon.JS documentation site published to GitHub Pages.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on contributing documentation to Sinon.JS. This file also lists how to run the site locally.
 
 ## Documentation release process
 
-Whenever a new release is created using `npm version`, the tree from `release-source/release/` is copied into its own folder under `releases/` with an appropriate name.
-
+Whenever a new release is created using `npm version`, the tree from `release-source/release/` is copied into a folder under `releases/` with an appropriate name.
 Likewise, the `_releases/release.md` file is copied into a file matching the release name.
 
-### Example
+Currently, we keep a single folder per major release.
 
-Let's say that we're making a new `v2.0.3` release.
-
-- `release-source/release/` is copied into a new folder `_releases/v2.0.3/`
-- `release-source/release.md` is copied into a new file `_releases/v2.0.3.md`
+See `scripts/postversion.sh` for details on the exact process, as it changes over time.
 
 The release is packaged, tagged and pushed to GitHub. GitHub Pages will build a new site in a few minutes, and replace the old one.

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -33,97 +33,9 @@
               <span>Proudly Sponsored By</span>
             </p>
             <div class="people">
-              <a href="https://opencollective.com/sinon/sponsor/0/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/0/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/1/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/1/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/2/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/2/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/3/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/3/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/4/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/4/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/5/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/5/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/6/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/6/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/7/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/7/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/8/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/8/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/9/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/9/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/10/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/10/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/11/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/11/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/12/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/12/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/13/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/13/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/14/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/14/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/15/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/15/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/16/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/16/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/17/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/17/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/18/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/18/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/19/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/19/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/20/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/20/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/21/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/21/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/22/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/22/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/23/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/23/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/24/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/24/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/25/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/25/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/26/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/26/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/27/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/27/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/28/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/28/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/sponsor/29/website" target="_blank">
-                <img src="https://opencollective.com/sinon/sponsor/29/avatar.svg">
-              </a>
+                <object data="https://opencollective.com/sinon/tiers/sponsors.svg?button=false&margin=1" title="Sponsors"></object>
             </div>
+
             <div class="backer">
               <a target="blank" href="https://opencollective.com/sinon/">
                 Become a sponsor and get your logo on our README on GitHub with a link to your site
@@ -137,97 +49,9 @@
             <p class="centre-line">
               <span>Proudly Backed By</span>
             </p>
+
             <div class="people">
-              <a href="https://opencollective.com/sinon/backer/0/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/0/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/1/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/1/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/2/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/2/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/3/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/3/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/4/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/4/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/5/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/5/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/6/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/6/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/7/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/7/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/8/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/8/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/9/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/9/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/10/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/10/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/11/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/11/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/12/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/12/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/13/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/13/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/14/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/14/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/15/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/15/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/16/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/16/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/17/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/17/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/18/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/18/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/19/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/19/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/20/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/20/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/21/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/21/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/22/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/22/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/23/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/23/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/24/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/24/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/25/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/25/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/26/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/26/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/27/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/27/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/28/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/28/avatar.svg">
-              </a>
-              <a href="https://opencollective.com/sinon/backer/29/website" target="_blank">
-                <img src="https://opencollective.com/sinon/backer/29/avatar.svg">
-              </a>
+                <object data="https://opencollective.com/sinon/backers.svg?width=720&limit=200&button=false" data-md="https://opencollective.com/sinon/backers.svg?width=680&limit=108&button=false" data-sm="https://opencollective.com/sinon/backers.svg?width=300&limit=45&button=false" title="Backers" class=""></object>
             </div>
           </div>
           <div class="backer">


### PR DESCRIPTION
- Use automated fetching to keep sponsors updated
- Update wording

The big difference is that this is now dynamically kept up to date on the homepage with just _current_ sponsors for the "sponsors" tier. If we create other tiers (like Gold, Silver, Bronze) like [Parcel is doing](https://opencollective.com/parcel#support), we could differentiate on support level, but we are not quite there. It would perhaps make sense to have a second level support option for orgs/businesses, though, as it seems backing businesses are currently not listed with < 100$ contributions, unless they are listed as "individuals".

In the README I chose to keep the top ten supporters so far. Without it, it would look a bit anemic when not showing the historic support we have gotten 😄 

#### How to verify - mandatory

1. Check out this branch
2. Run the Jekyll process (see /docs/CONTRIBUTING.md for how)

##### The new look
<img width="885" alt="Skjermbilde 2023-03-27 kl  04 36 53" src="https://user-images.githubusercontent.com/618076/227829784-4762c047-13ef-413a-b01c-a23cb105f041.png">

