### PR TITLE
Remove uses of `var`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,6 +7,7 @@ docs/js/
 docs/releases/
 docs/_releases/
 docs/assets/js/
+docs/vendor
 
 # has linting of its own
 docs/release-source/release/examples

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 # This project uses Prettier defaults, the config file is present in
 # order to trigger editor plugins to allow format on save behaviour
 overrides:
-  - files: "*.html"
-    options:
-      tabWidth: 2
+    - files: "*.html"
+      options:
+          tabWidth: 2

--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -1,15 +1,15 @@
 "use strict";
 
-var behavior = require("./sinon/behavior");
-var createSandbox = require("./sinon/create-sandbox");
-var extend = require("./sinon/util/core/extend");
-var fakeTimers = require("./sinon/util/fake-timers");
-var nise = require("nise");
-var Sandbox = require("./sinon/sandbox");
-var stub = require("./sinon/stub");
-var promise = require("./sinon/promise");
+const behavior = require("./sinon/behavior");
+const createSandbox = require("./sinon/create-sandbox");
+const extend = require("./sinon/util/core/extend");
+const fakeTimers = require("./sinon/util/fake-timers");
+const nise = require("nise");
+const Sandbox = require("./sinon/sandbox");
+const stub = require("./sinon/stub");
+const promise = require("./sinon/promise");
 
-var apiMethods = {
+const apiMethods = {
     createSandbox: createSandbox,
     assert: require("./sinon/assert"),
     match: require("@sinonjs/samsam").createMatcher,
@@ -41,8 +41,8 @@ var apiMethods = {
     promise: promise,
 };
 
-var sandbox = new Sandbox();
+const sandbox = new Sandbox();
 
-var api = extend(sandbox, apiMethods);
+const api = extend(sandbox, apiMethods);
 
 module.exports = api;

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -16,7 +16,6 @@ const join = arrayProto.join;
 const splice = arrayProto.splice;
 
 function createAssertObject() {
-
     const assert = {
         failException: "AssertError",
 
@@ -213,7 +212,6 @@ function createAssertObject() {
                   stringSlice(prop, 0, 1).toUpperCase() +
                   stringSlice(prop, 1);
     }
-
 
     mirrorPropAsAssertion(
         "called",

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -1,25 +1,126 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var calledInOrder = require("@sinonjs/commons").calledInOrder;
-var createMatcher = require("@sinonjs/samsam").createMatcher;
-var orderByFirstCall = require("@sinonjs/commons").orderByFirstCall;
-var timesInWords = require("./util/core/times-in-words");
-var inspect = require("util").inspect;
-var stringSlice = require("@sinonjs/commons").prototypes.string.slice;
-var globalObject = require("@sinonjs/commons").global;
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const calledInOrder = require("@sinonjs/commons").calledInOrder;
+const createMatcher = require("@sinonjs/samsam").createMatcher;
+const orderByFirstCall = require("@sinonjs/commons").orderByFirstCall;
+const timesInWords = require("./util/core/times-in-words");
+const inspect = require("util").inspect;
+const stringSlice = require("@sinonjs/commons").prototypes.string.slice;
+const globalObject = require("@sinonjs/commons").global;
 
-var arraySlice = arrayProto.slice;
-var concat = arrayProto.concat;
-var forEach = arrayProto.forEach;
-var join = arrayProto.join;
-var splice = arrayProto.splice;
+const arraySlice = arrayProto.slice;
+const concat = arrayProto.concat;
+const forEach = arrayProto.forEach;
+const join = arrayProto.join;
+const splice = arrayProto.splice;
 
 function createAssertObject() {
-    var assert;
+
+    const assert = {
+        failException: "AssertError",
+
+        fail: function fail(message) {
+            const error = new Error(message);
+            error.name = this.failException || assert.failException;
+
+            throw error;
+        },
+
+        pass: function pass() {
+            return;
+        },
+
+        callOrder: function assertCallOrder() {
+            verifyIsStub.apply(null, arguments);
+            let expected = "";
+            let actual = "";
+
+            if (!calledInOrder(arguments)) {
+                try {
+                    expected = join(arguments, ", ");
+                    const calls = arraySlice(arguments);
+                    let i = calls.length;
+                    while (i) {
+                        if (!calls[--i].called) {
+                            splice(calls, i, 1);
+                        }
+                    }
+                    actual = join(orderByFirstCall(calls), ", ");
+                } catch (e) {
+                    // If this fails, we'll just fall back to the blank string
+                }
+
+                failAssertion(
+                    this,
+                    `expected ${expected} to be called in order but were called as ${actual}`
+                );
+            } else {
+                assert.pass("callOrder");
+            }
+        },
+
+        callCount: function assertCallCount(method, count) {
+            verifyIsStub(method);
+
+            let msg;
+            if (typeof count !== "number") {
+                msg =
+                    `expected ${inspect(count)} to be a number ` +
+                    `but was of type ${typeof count}`;
+                failAssertion(this, msg);
+            } else if (method.callCount !== count) {
+                msg =
+                    `expected %n to be called ${timesInWords(count)} ` +
+                    `but was called %c%C`;
+                failAssertion(this, method.printf(msg));
+            } else {
+                assert.pass("callCount");
+            }
+        },
+
+        expose: function expose(target, options) {
+            if (!target) {
+                throw new TypeError("target is null or undefined");
+            }
+
+            const o = options || {};
+            const prefix =
+                (typeof o.prefix === "undefined" && "assert") || o.prefix;
+            const includeFail =
+                typeof o.includeFail === "undefined" || Boolean(o.includeFail);
+            const instance = this;
+
+            forEach(Object.keys(instance), function (method) {
+                if (
+                    method !== "expose" &&
+                    (includeFail || !/^(fail)/.test(method))
+                ) {
+                    target[exposedName(prefix, method)] = instance[method];
+                }
+            });
+
+            return target;
+        },
+
+        match: function match(actual, expectation) {
+            const matcher = createMatcher(expectation);
+            if (matcher.test(actual)) {
+                assert.pass("match");
+            } else {
+                const formatted = [
+                    "expected value to match",
+                    `    expected = ${inspect(expectation)}`,
+                    `    actual = ${inspect(actual)}`,
+                ];
+
+                failAssertion(this, join(formatted, "\n"));
+            }
+        },
+    };
 
     function verifyIsStub() {
-        var args = arraySlice(arguments);
+        const args = arraySlice(arguments);
 
         forEach(args, function (method) {
             if (!method) {
@@ -61,14 +162,14 @@ function createAssertObject() {
     }
 
     function failAssertion(object, msg) {
-        var obj = object || globalObject;
-        var failMethod = obj.fail || assert.fail;
+        const obj = object || globalObject;
+        const failMethod = obj.fail || assert.fail;
         failMethod.call(obj, msg);
     }
 
     function mirrorPropAsAssertion(name, method, message) {
-        var msg = message;
-        var meth = method;
+        let msg = message;
+        let meth = method;
         if (arguments.length === 2) {
             msg = method;
             meth = name;
@@ -77,8 +178,8 @@ function createAssertObject() {
         assert[name] = function (fake) {
             verifyIsStub(fake);
 
-            var args = arraySlice(arguments, 1);
-            var failed = false;
+            const args = arraySlice(arguments, 1);
+            let failed = false;
 
             verifyIsValidAssertion(name, args);
 
@@ -113,107 +214,6 @@ function createAssertObject() {
                   stringSlice(prop, 1);
     }
 
-    assert = {
-        failException: "AssertError",
-
-        fail: function fail(message) {
-            var error = new Error(message);
-            error.name = this.failException || assert.failException;
-
-            throw error;
-        },
-
-        pass: function pass() {
-            return;
-        },
-
-        callOrder: function assertCallOrder() {
-            verifyIsStub.apply(null, arguments);
-            var expected = "";
-            var actual = "";
-
-            if (!calledInOrder(arguments)) {
-                try {
-                    expected = join(arguments, ", ");
-                    var calls = arraySlice(arguments);
-                    var i = calls.length;
-                    while (i) {
-                        if (!calls[--i].called) {
-                            splice(calls, i, 1);
-                        }
-                    }
-                    actual = join(orderByFirstCall(calls), ", ");
-                } catch (e) {
-                    // If this fails, we'll just fall back to the blank string
-                }
-
-                failAssertion(
-                    this,
-                    `expected ${expected} to be called in order but were called as ${actual}`
-                );
-            } else {
-                assert.pass("callOrder");
-            }
-        },
-
-        callCount: function assertCallCount(method, count) {
-            verifyIsStub(method);
-
-            var msg;
-            if (typeof count !== "number") {
-                msg =
-                    `expected ${inspect(count)} to be a number ` +
-                    `but was of type ${typeof count}`;
-                failAssertion(this, msg);
-            } else if (method.callCount !== count) {
-                msg =
-                    `expected %n to be called ${timesInWords(count)} ` +
-                    `but was called %c%C`;
-                failAssertion(this, method.printf(msg));
-            } else {
-                assert.pass("callCount");
-            }
-        },
-
-        expose: function expose(target, options) {
-            if (!target) {
-                throw new TypeError("target is null or undefined");
-            }
-
-            var o = options || {};
-            var prefix =
-                (typeof o.prefix === "undefined" && "assert") || o.prefix;
-            var includeFail =
-                typeof o.includeFail === "undefined" || Boolean(o.includeFail);
-            var instance = this;
-
-            forEach(Object.keys(instance), function (method) {
-                if (
-                    method !== "expose" &&
-                    (includeFail || !/^(fail)/.test(method))
-                ) {
-                    target[exposedName(prefix, method)] = instance[method];
-                }
-            });
-
-            return target;
-        },
-
-        match: function match(actual, expectation) {
-            var matcher = createMatcher(expectation);
-            if (matcher.test(actual)) {
-                assert.pass("match");
-            } else {
-                var formatted = [
-                    "expected value to match",
-                    `    expected = ${inspect(expectation)}`,
-                    `    actual = ${inspect(actual)}`,
-                ];
-
-                failAssertion(this, join(formatted, "\n"));
-            }
-        },
-    };
 
     mirrorPropAsAssertion(
         "called",

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -1,28 +1,28 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var extend = require("./util/core/extend");
-var functionName = require("@sinonjs/commons").functionName;
-var nextTick = require("./util/core/next-tick");
-var valueToString = require("@sinonjs/commons").valueToString;
-var exportAsyncBehaviors = require("./util/core/export-async-behaviors");
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const extend = require("./util/core/extend");
+const functionName = require("@sinonjs/commons").functionName;
+const nextTick = require("./util/core/next-tick");
+const valueToString = require("@sinonjs/commons").valueToString;
+const exportAsyncBehaviors = require("./util/core/export-async-behaviors");
 
-var concat = arrayProto.concat;
-var join = arrayProto.join;
-var reverse = arrayProto.reverse;
-var slice = arrayProto.slice;
+const concat = arrayProto.concat;
+const join = arrayProto.join;
+const reverse = arrayProto.reverse;
+const slice = arrayProto.slice;
 
-var useLeftMostCallback = -1;
-var useRightMostCallback = -2;
+const useLeftMostCallback = -1;
+const useRightMostCallback = -2;
 
 function getCallback(behavior, args) {
-    var callArgAt = behavior.callArgAt;
+    const callArgAt = behavior.callArgAt;
 
     if (callArgAt >= 0) {
         return args[callArgAt];
     }
 
-    var argumentList;
+    let argumentList;
 
     if (callArgAt === useLeftMostCallback) {
         argumentList = args;
@@ -32,9 +32,9 @@ function getCallback(behavior, args) {
         argumentList = reverse(slice(args));
     }
 
-    var callArgProp = behavior.callArgProp;
+    const callArgProp = behavior.callArgProp;
 
-    for (var i = 0, l = argumentList.length; i < l; ++i) {
+    for (let i = 0, l = argumentList.length; i < l; ++i) {
         if (!callArgProp && typeof argumentList[i] === "function") {
             return argumentList[i];
         }
@@ -53,7 +53,7 @@ function getCallback(behavior, args) {
 
 function getCallbackError(behavior, func, args) {
     if (behavior.callArgAt < 0) {
-        var msg;
+        let msg;
 
         if (behavior.callArgProp) {
             msg = `${functionName(
@@ -80,8 +80,8 @@ function getCallbackError(behavior, func, args) {
 function ensureArgs(name, behavior, args) {
     // map function name to internal property
     //   callsArg => callArgAt
-    var property = name.replace(/sArg/, "ArgAt");
-    var index = behavior[property];
+    const property = name.replace(/sArg/, "ArgAt");
+    const index = behavior[property];
 
     if (index >= args.length) {
         throw new TypeError(
@@ -95,7 +95,7 @@ function ensureArgs(name, behavior, args) {
 function callCallback(behavior, args) {
     if (typeof behavior.callArgAt === "number") {
         ensureArgs("callsArg", behavior, args);
-        var func = getCallback(behavior, args);
+        const func = getCallback(behavior, args);
 
         if (typeof func !== "function") {
             throw new TypeError(getCallbackError(behavior, func, args));
@@ -119,9 +119,9 @@ function callCallback(behavior, args) {
     return undefined;
 }
 
-var proto = {
+const proto = {
     create: function create(stub) {
-        var behavior = extend({}, proto);
+        const behavior = extend({}, proto);
         delete behavior.create;
         delete behavior.addBehavior;
         delete behavior.createBehavior;
@@ -157,7 +157,7 @@ var proto = {
          * Note: callCallback intentionally happens before
          * everything else and cannot be moved lower
          */
-        var returnValue = callCallback(this, args);
+        const returnValue = callCallback(this, args);
 
         if (this.exception) {
             throw this.exception;
@@ -187,16 +187,16 @@ var proto = {
         } else if (this.reject) {
             return (this.promiseLibrary || Promise).reject(this.returnValue);
         } else if (this.callsThrough) {
-            var wrappedMethod = this.effectiveWrappedMethod();
+            const wrappedMethod = this.effectiveWrappedMethod();
 
             return wrappedMethod.apply(context, args);
         } else if (this.callsThroughWithNew) {
             // Get the original method (assumed to be a constructor in this case)
-            var WrappedClass = this.effectiveWrappedMethod();
+            const WrappedClass = this.effectiveWrappedMethod();
             // Turn the arguments object into a normal array
-            var argsArray = slice(args);
+            const argsArray = slice(args);
             // Call the constructor
-            var F = WrappedClass.bind.apply(
+            const F = WrappedClass.bind.apply(
                 WrappedClass,
                 concat([null], argsArray)
             );
@@ -211,7 +211,7 @@ var proto = {
     },
 
     effectiveWrappedMethod: function effectiveWrappedMethod() {
-        for (var stubb = this.stub; stubb; stubb = stubb.parent) {
+        for (let stubb = this.stub; stubb; stubb = stubb.parent) {
             if (stubb.wrappedMethod) {
                 return stubb.wrappedMethod;
             }
@@ -267,6 +267,6 @@ function addBehavior(stub, name, fn) {
 proto.addBehavior = addBehavior;
 proto.createBehavior = createBehavior;
 
-var asyncBehaviors = exportAsyncBehaviors(proto);
+const asyncBehaviors = exportAsyncBehaviors(proto);
 
 module.exports = extend.nonEnum({}, proto, asyncBehaviors);

--- a/lib/sinon/collect-own-methods.js
+++ b/lib/sinon/collect-own-methods.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var walk = require("./util/core/walk");
-var getPropertyDescriptor = require("./util/core/get-property-descriptor");
-var hasOwnProperty =
+const walk = require("./util/core/walk");
+const getPropertyDescriptor = require("./util/core/get-property-descriptor");
+const hasOwnProperty =
     require("@sinonjs/commons").prototypes.object.hasOwnProperty;
-var push = require("@sinonjs/commons").prototypes.array.push;
+const push = require("@sinonjs/commons").prototypes.array.push;
 
 function collectMethod(methods, object, prop, propOwner) {
     if (
@@ -17,7 +17,7 @@ function collectMethod(methods, object, prop, propOwner) {
 
 // This function returns an array of all the own methods on the passed object
 function collectOwnMethods(object) {
-    var methods = [];
+    const methods = [];
 
     walk(object, collectMethod.bind(null, methods, object));
 

--- a/lib/sinon/color.js
+++ b/lib/sinon/color.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var supportsColor = require("supports-color");
+const supportsColor = require("supports-color");
 
 function colorize(str, color) {
     if (supportsColor.stdout === false) {

--- a/lib/sinon/create-sandbox.js
+++ b/lib/sinon/create-sandbox.js
@@ -1,13 +1,13 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var Sandbox = require("./sandbox");
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const Sandbox = require("./sandbox");
 
-var forEach = arrayProto.forEach;
-var push = arrayProto.push;
+const forEach = arrayProto.forEach;
+const push = arrayProto.push;
 
 function prepareSandboxFromConfig(config) {
-    var sandbox = new Sandbox();
+    const sandbox = new Sandbox();
 
     if (config.useFakeServer) {
         if (typeof config.useFakeServer === "object") {
@@ -46,15 +46,15 @@ function createSandbox(config) {
         return new Sandbox();
     }
 
-    var configuredSandbox = prepareSandboxFromConfig(config);
+    const configuredSandbox = prepareSandboxFromConfig(config);
     configuredSandbox.args = configuredSandbox.args || [];
     configuredSandbox.injectedKeys = [];
     configuredSandbox.injectInto = config.injectInto;
-    var exposed = configuredSandbox.inject({});
+    const exposed = configuredSandbox.inject({});
 
     if (config.properties) {
         forEach(config.properties, function (prop) {
-            var value =
+            const value =
                 exposed[prop] || (prop === "sandbox" && configuredSandbox);
             exposeValue(configuredSandbox, config, prop, value);
         });

--- a/lib/sinon/create-stub-instance.js
+++ b/lib/sinon/create-stub-instance.js
@@ -20,7 +20,7 @@ module.exports = function createStubInstance(constructor, overrides) {
 
     forEach(Object.keys(overrides || {}), function (propertyName) {
         if (propertyName in stubbedObject) {
-            var value = overrides[propertyName];
+            const value = overrides[propertyName];
             if (isStub(value)) {
                 stubbedObject[propertyName] = value;
             } else {

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -1,21 +1,21 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var isPropertyConfigurable = require("./util/core/is-property-configurable");
-var exportAsyncBehaviors = require("./util/core/export-async-behaviors");
-var extend = require("./util/core/extend");
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const isPropertyConfigurable = require("./util/core/is-property-configurable");
+const exportAsyncBehaviors = require("./util/core/export-async-behaviors");
+const extend = require("./util/core/extend");
 
-var slice = arrayProto.slice;
+const slice = arrayProto.slice;
 
-var useLeftMostCallback = -1;
-var useRightMostCallback = -2;
+const useLeftMostCallback = -1;
+const useRightMostCallback = -2;
 
 function throwsException(fake, error, message) {
     if (typeof error === "function") {
         fake.exceptionCreator = error;
     } else if (typeof error === "string") {
         fake.exceptionCreator = function () {
-            var newException = new Error(message || "");
+            const newException = new Error(message || "");
             newException.name = error;
             return newException;
         };
@@ -28,7 +28,7 @@ function throwsException(fake, error, message) {
     }
 }
 
-var defaultBehaviors = {
+const defaultBehaviors = {
     callsFake: function callsFake(fake, fn) {
         fake.fakeFn = fn;
         fake.exception = undefined;
@@ -192,7 +192,7 @@ var defaultBehaviors = {
     },
 
     rejects: function rejects(fake, error, message) {
-        var reason;
+        let reason;
         if (typeof error === "string") {
             reason = new Error(message || "");
             reason.name = error;
@@ -233,7 +233,7 @@ var defaultBehaviors = {
     },
 
     get: function get(fake, getterFunction) {
-        var rootStub = fake.stub || fake;
+        const rootStub = fake.stub || fake;
 
         Object.defineProperty(rootStub.rootObj, rootStub.propName, {
             get: getterFunction,
@@ -247,7 +247,7 @@ var defaultBehaviors = {
     },
 
     set: function set(fake, setterFunction) {
-        var rootStub = fake.stub || fake;
+        const rootStub = fake.stub || fake;
 
         Object.defineProperty(
             rootStub.rootObj,
@@ -266,7 +266,7 @@ var defaultBehaviors = {
     },
 
     value: function value(fake, newVal) {
-        var rootStub = fake.stub || fake;
+        const rootStub = fake.stub || fake;
 
         Object.defineProperty(rootStub.rootObj, rootStub.propName, {
             value: newVal,
@@ -281,6 +281,6 @@ var defaultBehaviors = {
     },
 };
 
-var asyncBehaviors = exportAsyncBehaviors(defaultBehaviors);
+const asyncBehaviors = exportAsyncBehaviors(defaultBehaviors);
 
 module.exports = extend({}, defaultBehaviors, asyncBehaviors);

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var createProxy = require("./proxy");
-var nextTick = require("./util/core/next-tick");
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const createProxy = require("./proxy");
+const nextTick = require("./util/core/next-tick");
 
-var slice = arrayProto.slice;
-var promiseLib = Promise;
+const slice = arrayProto.slice;
+let promiseLib = Promise;
 
 module.exports = fake;
 
@@ -187,11 +187,11 @@ fake.usingPromise = function usingPromise(promiseLibrary) {
  * @returns {Function}
  */
 fake.yields = function yields() {
-    var values = slice(arguments);
+    const values = slice(arguments);
 
     // eslint-disable-next-line jsdoc/require-jsdoc
     function f() {
-        var callback = arguments[arguments.length - 1];
+        const callback = arguments[arguments.length - 1];
         if (typeof callback !== "function") {
             throw new TypeError("Expected last argument to be a function");
         }
@@ -223,11 +223,11 @@ fake.yields = function yields() {
  * @returns {Function}
  */
 fake.yieldsAsync = function yieldsAsync() {
-    var values = slice(arguments);
+    const values = slice(arguments);
 
     // eslint-disable-next-line jsdoc/require-jsdoc
     function f() {
-        var callback = arguments[arguments.length - 1];
+        const callback = arguments[arguments.length - 1];
         if (typeof callback !== "function") {
             throw new TypeError("Expected last argument to be a function");
         }
@@ -239,7 +239,7 @@ fake.yieldsAsync = function yieldsAsync() {
     return wrapFunc(f);
 };
 
-var uuid = 0;
+let uuid = 0;
 /**
  * Creates a proxy (sinon concept) from the passed function.
  *
@@ -248,25 +248,25 @@ var uuid = 0;
  * @returns {Function}
  */
 function wrapFunc(f) {
-    var proxy;
-    var fakeInstance = function () {
-        var firstArg, lastArg;
+    const fakeInstance = function () {
+        let firstArg, lastArg;
 
         if (arguments.length > 0) {
             firstArg = arguments[0];
             lastArg = arguments[arguments.length - 1];
         }
 
-        var callback =
+        const callback =
             lastArg && typeof lastArg === "function" ? lastArg : undefined;
 
+        /* eslint-disable no-use-before-define */
         proxy.firstArg = firstArg;
         proxy.lastArg = lastArg;
         proxy.callback = callback;
 
         return f && f.apply(this, arguments);
     };
-    proxy = createProxy(fakeInstance, f || fakeInstance);
+    const proxy = createProxy(fakeInstance, f || fakeInstance);
 
     proxy.displayName = "fake";
     proxy.id = `fake#${uuid++}`;

--- a/lib/sinon/mock-expectation.js
+++ b/lib/sinon/mock-expectation.js
@@ -1,21 +1,21 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var proxyInvoke = require("./proxy-invoke");
-var proxyCallToString = require("./proxy-call").toString;
-var timesInWords = require("./util/core/times-in-words");
-var extend = require("./util/core/extend");
-var match = require("@sinonjs/samsam").createMatcher;
-var stub = require("./stub");
-var assert = require("./assert");
-var deepEqual = require("@sinonjs/samsam").deepEqual;
-var inspect = require("util").inspect;
-var valueToString = require("@sinonjs/commons").valueToString;
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const proxyInvoke = require("./proxy-invoke");
+const proxyCallToString = require("./proxy-call").toString;
+const timesInWords = require("./util/core/times-in-words");
+const extend = require("./util/core/extend");
+const match = require("@sinonjs/samsam").createMatcher;
+const stub = require("./stub");
+const assert = require("./assert");
+const deepEqual = require("@sinonjs/samsam").deepEqual;
+const inspect = require("util").inspect;
+const valueToString = require("@sinonjs/commons").valueToString;
 
-var every = arrayProto.every;
-var forEach = arrayProto.forEach;
-var push = arrayProto.push;
-var slice = arrayProto.slice;
+const every = arrayProto.every;
+const forEach = arrayProto.forEach;
+const push = arrayProto.push;
+const slice = arrayProto.slice;
 
 function callCountInWords(callCount) {
     if (callCount === 0) {
@@ -26,11 +26,11 @@ function callCountInWords(callCount) {
 }
 
 function expectedCallCountInWords(expectation) {
-    var min = expectation.minCalls;
-    var max = expectation.maxCalls;
+    const min = expectation.minCalls;
+    const max = expectation.maxCalls;
 
     if (typeof min === "number" && typeof max === "number") {
-        var str = timesInWords(min);
+        let str = timesInWords(min);
 
         if (min !== max) {
             str = `at least ${str} and at most ${timesInWords(max)}`;
@@ -47,7 +47,7 @@ function expectedCallCountInWords(expectation) {
 }
 
 function receivedMinCalls(expectation) {
-    var hasMinLimit = typeof expectation.minCalls === "number";
+    const hasMinLimit = typeof expectation.minCalls === "number";
     return !hasMinLimit || expectation.callCount >= expectation.minCalls;
 }
 
@@ -60,17 +60,17 @@ function receivedMaxCalls(expectation) {
 }
 
 function verifyMatcher(possibleMatcher, arg) {
-    var isMatcher = match.isMatcher(possibleMatcher);
+    const isMatcher = match.isMatcher(possibleMatcher);
 
     return (isMatcher && possibleMatcher.test(arg)) || true;
 }
 
-var mockExpectation = {
+const mockExpectation = {
     minCalls: 1,
     maxCalls: 1,
 
     create: function create(methodName) {
-        var expectation = extend.nonEnum(stub(), mockExpectation);
+        const expectation = extend.nonEnum(stub(), mockExpectation);
         delete expectation.create;
         expectation.method = methodName;
 
@@ -143,7 +143,7 @@ var mockExpectation = {
     },
 
     verifyCallAllowed: function verifyCallAllowed(thisValue, args) {
-        var expectedArguments = this.expectedArguments;
+        const expectedArguments = this.expectedArguments;
 
         if (receivedMaxCalls(this)) {
             this.failed = true;
@@ -215,7 +215,7 @@ var mockExpectation = {
     },
 
     allowsCall: function allowsCall(thisValue, args) {
-        var expectedArguments = this.expectedArguments;
+        const expectedArguments = this.expectedArguments;
 
         if (this.met() && receivedMaxCalls(this)) {
             return false;
@@ -230,7 +230,7 @@ var mockExpectation = {
         }
 
         // eslint-disable-next-line no-underscore-dangle
-        var _args = args || [];
+        const _args = args || [];
 
         if (_args.length < expectedArguments.length) {
             return false;
@@ -273,18 +273,18 @@ var mockExpectation = {
     },
 
     toString: function () {
-        var args = slice(this.expectedArguments || []);
+        const args = slice(this.expectedArguments || []);
 
         if (!this.expectsExactArgCount) {
             push(args, "[...]");
         }
 
-        var callStr = proxyCallToString.call({
+        const callStr = proxyCallToString.call({
             proxy: this.method || "anonymous mock expectation",
             args: args,
         });
 
-        var message = `${callStr.replace(
+        const message = `${callStr.replace(
             ", [...",
             "[, ..."
         )} ${expectedCallCountInWords(this)}`;
@@ -311,7 +311,7 @@ var mockExpectation = {
     },
 
     fail: function fail(message) {
-        var exception = new Error(message);
+        const exception = new Error(message);
         exception.name = "ExpectationError";
 
         throw exception;

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -1,21 +1,21 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var mockExpectation = require("./mock-expectation");
-var proxyCallToString = require("./proxy-call").toString;
-var extend = require("./util/core/extend");
-var deepEqual = require("@sinonjs/samsam").deepEqual;
-var wrapMethod = require("./util/core/wrap-method");
-var usePromiseLibrary = require("./util/core/use-promise-library");
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const mockExpectation = require("./mock-expectation");
+const proxyCallToString = require("./proxy-call").toString;
+const extend = require("./util/core/extend");
+const deepEqual = require("@sinonjs/samsam").deepEqual;
+const wrapMethod = require("./util/core/wrap-method");
+const usePromiseLibrary = require("./util/core/use-promise-library");
 
-var concat = arrayProto.concat;
-var filter = arrayProto.filter;
-var forEach = arrayProto.forEach;
-var every = arrayProto.every;
-var join = arrayProto.join;
-var push = arrayProto.push;
-var slice = arrayProto.slice;
-var unshift = arrayProto.unshift;
+const concat = arrayProto.concat;
+const filter = arrayProto.filter;
+const forEach = arrayProto.forEach;
+const every = arrayProto.every;
+const join = arrayProto.join;
+const push = arrayProto.push;
+const slice = arrayProto.slice;
+const unshift = arrayProto.unshift;
 
 function mock(object) {
     if (!object || typeof object === "string") {
@@ -26,7 +26,7 @@ function mock(object) {
 }
 
 function each(collection, callback) {
-    var col = collection || [];
+    const col = collection || [];
 
     forEach(col, callback);
 }
@@ -47,7 +47,7 @@ extend(mock, {
             throw new TypeError("object is null");
         }
 
-        var mockObject = extend.nonEnum({}, mock, { object: object });
+        const mockObject = extend.nonEnum({}, mock, { object: object });
         delete mockObject.create;
 
         return mockObject;
@@ -66,7 +66,7 @@ extend(mock, {
 
         if (!this.expectations[method]) {
             this.expectations[method] = [];
-            var mockObject = this;
+            const mockObject = this;
 
             wrapMethod(this.object, method, function () {
                 return mockObject.invokeMethod(method, this, arguments);
@@ -75,7 +75,7 @@ extend(mock, {
             push(this.proxies, method);
         }
 
-        var expectation = mockExpectation.create(method);
+        const expectation = mockExpectation.create(method);
         expectation.wrappedMethod = this.object[method].wrappedMethod;
         push(this.expectations[method], expectation);
         usePromiseLibrary(this.promiseLibrary, expectation);
@@ -84,7 +84,7 @@ extend(mock, {
     },
 
     restore: function restore() {
-        var object = this.object;
+        const object = this.object;
 
         each(this.proxies, function (proxy) {
             if (typeof object[proxy].restore === "function") {
@@ -94,9 +94,9 @@ extend(mock, {
     },
 
     verify: function verify() {
-        var expectations = this.expectations || {};
-        var messages = this.failures ? slice(this.failures) : [];
-        var met = [];
+        const expectations = this.expectations || {};
+        const messages = this.failures ? slice(this.failures) : [];
+        const met = [];
 
         each(this.proxies, function (proxy) {
             each(expectations[proxy], function (expectation) {
@@ -128,17 +128,17 @@ extend(mock, {
     invokeMethod: function invokeMethod(method, thisValue, args) {
         /* if we cannot find any matching files we will explicitly call mockExpection#fail with error messages */
         /* eslint consistent-return: "off" */
-        var expectations =
+        const expectations =
             this.expectations && this.expectations[method]
                 ? this.expectations[method]
                 : [];
-        var currentArgs = args || [];
-        var available;
+        const currentArgs = args || [];
+        let available;
 
-        var expectationsWithMatchingArgs = filter(
+        const expectationsWithMatchingArgs = filter(
             expectations,
             function (expectation) {
-                var expectedArgs = expectation.expectedArguments || [];
+                const expectedArgs = expectation.expectedArguments || [];
 
                 return arrayEquals(
                     expectedArgs,
@@ -148,7 +148,7 @@ extend(mock, {
             }
         );
 
-        var expectationsToApply = filter(
+        const expectationsToApply = filter(
             expectationsWithMatchingArgs,
             function (expectation) {
                 return (
@@ -162,8 +162,8 @@ extend(mock, {
             return expectationsToApply[0].apply(thisValue, args);
         }
 
-        var messages = [];
-        var exhausted = 0;
+        const messages = [];
+        let exhausted = 0;
 
         forEach(expectationsWithMatchingArgs, function (expectation) {
             if (expectation.allowsCall(thisValue, args)) {
@@ -189,7 +189,7 @@ extend(mock, {
             })}`
         );
 
-        var err = new Error();
+        const err = new Error();
         if (!err.stack) {
             // PhantomJS does not serialize the stack trace until the error has been thrown
             try {

--- a/lib/sinon/promise.js
+++ b/lib/sinon/promise.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var fake = require("./fake");
-var isRestorable = require("./util/core/is-restorable");
+const fake = require("./fake");
+const isRestorable = require("./util/core/is-restorable");
 
-var STATUS_PENDING = "pending";
-var STATUS_RESOLVED = "resolved";
-var STATUS_REJECTED = "rejected";
+const STATUS_PENDING = "pending";
+const STATUS_RESOLVED = "resolved";
+const STATUS_REJECTED = "rejected";
 
 /**
  * Returns a fake for a given function or undefined. If no function is given, a
@@ -34,8 +34,8 @@ function getFakeExecutor(executor) {
  * @returns {Promise}
  */
 function promise(executor) {
-    var fakeExecutor = getFakeExecutor(executor);
-    var sinonPromise = new Promise(fakeExecutor);
+    const fakeExecutor = getFakeExecutor(executor);
+    const sinonPromise = new Promise(fakeExecutor);
 
     sinonPromise.status = STATUS_PENDING;
     sinonPromise

--- a/lib/sinon/proxy-call-util.js
+++ b/lib/sinon/proxy-call-util.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var push = require("@sinonjs/commons").prototypes.array.push;
+const push = require("@sinonjs/commons").prototypes.array.push;
 
 exports.incrementCallCount = function incrementCallCount(proxy) {
     proxy.called = true;
@@ -39,13 +39,13 @@ exports.delegateToCalls = function delegateToCalls(
             return false;
         }
 
-        var currentCall;
-        var matches = 0;
-        var returnValues = [];
+        let currentCall;
+        let matches = 0;
+        const returnValues = [];
 
-        for (var i = 0, l = this.callCount; i < l; i += 1) {
+        for (let i = 0, l = this.callCount; i < l; i += 1) {
             currentCall = this.getCall(i);
-            var returnValue = currentCall[actual || method].apply(
+            const returnValue = currentCall[actual || method].apply(
                 currentCall,
                 arguments
             );

--- a/lib/sinon/proxy-call.js
+++ b/lib/sinon/proxy-call.js
@@ -1,18 +1,18 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var match = require("@sinonjs/samsam").createMatcher;
-var deepEqual = require("@sinonjs/samsam").deepEqual;
-var functionName = require("@sinonjs/commons").functionName;
-var inspect = require("util").inspect;
-var valueToString = require("@sinonjs/commons").valueToString;
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const match = require("@sinonjs/samsam").createMatcher;
+const deepEqual = require("@sinonjs/samsam").deepEqual;
+const functionName = require("@sinonjs/commons").functionName;
+const inspect = require("util").inspect;
+const valueToString = require("@sinonjs/commons").valueToString;
 
-var concat = arrayProto.concat;
-var filter = arrayProto.filter;
-var join = arrayProto.join;
-var map = arrayProto.map;
-var reduce = arrayProto.reduce;
-var slice = arrayProto.slice;
+const concat = arrayProto.concat;
+const filter = arrayProto.filter;
+const join = arrayProto.join;
+const map = arrayProto.map;
+const reduce = arrayProto.reduce;
+const slice = arrayProto.slice;
 
 /**
  * @param proxy
@@ -20,14 +20,14 @@ var slice = arrayProto.slice;
  * @param args
  */
 function throwYieldError(proxy, text, args) {
-    var msg = functionName(proxy) + text;
+    let msg = functionName(proxy) + text;
     if (args.length) {
         msg += ` Received [${join(slice(args), ", ")}]`;
     }
     throw new Error(msg);
 }
 
-var callProto = {
+const callProto = {
     calledOn: function calledOn(thisValue) {
         if (match.isMatcher(thisValue)) {
             return thisValue.test(this.thisValue);
@@ -36,8 +36,8 @@ var callProto = {
     },
 
     calledWith: function calledWith() {
-        var self = this;
-        var calledWithArgs = slice(arguments);
+        const self = this;
+        const calledWithArgs = slice(arguments);
 
         if (calledWithArgs.length > self.args.length) {
             return false;
@@ -53,8 +53,8 @@ var callProto = {
     },
 
     calledWithMatch: function calledWithMatch() {
-        var self = this;
-        var calledWithMatchArgs = slice(arguments);
+        const self = this;
+        const calledWithMatchArgs = slice(arguments);
 
         if (calledWithMatchArgs.length > self.args.length) {
             return false;
@@ -63,7 +63,7 @@ var callProto = {
         return reduce(
             calledWithMatchArgs,
             function (prev, expectation, i) {
-                var actual = self.args[i];
+                const actual = self.args[i];
 
                 return prev && match(expectation).test(actual);
             },
@@ -137,7 +137,7 @@ var callProto = {
 
     callArgOnWith: function (pos, thisValue) {
         this.ensureArgIsAFunction(pos);
-        var args = slice(arguments, 2);
+        const args = slice(arguments, 2);
         return this.args[pos].apply(thisValue, args);
     },
 
@@ -156,8 +156,8 @@ var callProto = {
     },
 
     yieldOn: function (thisValue) {
-        var args = slice(this.args);
-        var yieldFn = filter(args, function (arg) {
+        const args = slice(this.args);
+        const yieldFn = filter(args, function (arg) {
             return typeof arg === "function";
         })[0];
 
@@ -180,11 +180,11 @@ var callProto = {
     },
 
     yieldToOn: function (prop, thisValue) {
-        var args = slice(this.args);
-        var yieldArg = filter(args, function (arg) {
+        const args = slice(this.args);
+        const yieldArg = filter(args, function (arg) {
             return arg && typeof arg[prop] === "function";
         })[0];
-        var yieldFn = yieldArg && yieldArg[prop];
+        const yieldFn = yieldArg && yieldArg[prop];
 
         if (!yieldFn) {
             throwYieldError(
@@ -200,14 +200,12 @@ var callProto = {
     },
 
     toString: function () {
-        var callStr = this.proxy ? `${String(this.proxy)}(` : "";
-        var formattedArgs;
-
         if (!this.args) {
             return ":(";
         }
 
-        formattedArgs = map(this.args, function (arg) {
+        let callStr = this.proxy ? `${String(this.proxy)}(` : "";
+        const formattedArgs = map(this.args, function (arg) {
             return inspect(arg);
         });
 
@@ -277,15 +275,15 @@ function createProxyCall(
         throw new TypeError("Call id is not a number");
     }
 
-    var firstArg, lastArg;
+    let firstArg, lastArg;
 
     if (args.length > 0) {
         firstArg = args[0];
         lastArg = args[args.length - 1];
     }
 
-    var proxyCall = Object.create(callProto);
-    var callback =
+    const proxyCall = Object.create(callProto);
+    const callback =
         lastArg && typeof lastArg === "function" ? lastArg : undefined;
 
     proxyCall.proxy = proxy;

--- a/lib/sinon/proxy-invoke.js
+++ b/lib/sinon/proxy-invoke.js
@@ -1,20 +1,20 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var proxyCallUtil = require("./proxy-call-util");
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const proxyCallUtil = require("./proxy-call-util");
 
-var push = arrayProto.push;
-var forEach = arrayProto.forEach;
-var concat = arrayProto.concat;
-var ErrorConstructor = Error.prototype.constructor;
-var bind = Function.prototype.bind;
+const push = arrayProto.push;
+const forEach = arrayProto.forEach;
+const concat = arrayProto.concat;
+const ErrorConstructor = Error.prototype.constructor;
+const bind = Function.prototype.bind;
 
-var callId = 0;
+let callId = 0;
 
 module.exports = function invoke(func, thisValue, args) {
-    var matchings = this.matchingFakes(args);
-    var currentCallId = callId++;
-    var exception, returnValue;
+    const matchings = this.matchingFakes(args);
+    const currentCallId = callId++;
+    let exception, returnValue;
 
     proxyCallUtil.incrementCallCount(this);
     push(this.thisValues, thisValue);
@@ -34,7 +34,7 @@ module.exports = function invoke(func, thisValue, args) {
     try {
         this.invoking = true;
 
-        var thisCall = this.getCall(this.callCount - 1);
+        const thisCall = this.getCall(this.callCount - 1);
 
         if (thisCall.calledWithNew()) {
             // Call through with `new`
@@ -62,7 +62,7 @@ module.exports = function invoke(func, thisValue, args) {
         push(matching.returnValues, returnValue);
     });
 
-    var err = new ErrorConstructor();
+    const err = new ErrorConstructor();
     // 1. Please do not get stack at this point. It may be so very slow, and not actually used
     // 2. PhantomJS does not serialize the stack trace until the error has been thrown:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack

--- a/lib/sinon/proxy.js
+++ b/lib/sinon/proxy.js
@@ -1,26 +1,26 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var extend = require("./util/core/extend");
-var functionToString = require("./util/core/function-to-string");
-var proxyCall = require("./proxy-call");
-var proxyCallUtil = require("./proxy-call-util");
-var proxyInvoke = require("./proxy-invoke");
-var inspect = require("util").inspect;
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const extend = require("./util/core/extend");
+const functionToString = require("./util/core/function-to-string");
+const proxyCall = require("./proxy-call");
+const proxyCallUtil = require("./proxy-call-util");
+const proxyInvoke = require("./proxy-invoke");
+const inspect = require("util").inspect;
 
-var push = arrayProto.push;
-var forEach = arrayProto.forEach;
-var slice = arrayProto.slice;
+const push = arrayProto.push;
+const forEach = arrayProto.forEach;
+const slice = arrayProto.slice;
 
-var emptyFakes = Object.freeze([]);
+const emptyFakes = Object.freeze([]);
 
 // Public API
-var proxyApi = {
+const proxyApi = {
     toString: functionToString,
 
     named: function named(name) {
         this.displayName = name;
-        var nameDescriptor = Object.getOwnPropertyDescriptor(this, "name");
+        const nameDescriptor = Object.getOwnPropertyDescriptor(this, "name");
         if (nameDescriptor && nameDescriptor.configurable) {
             // IE 11 functions don't have a name.
             // Safari 9 has names that are not configurable.
@@ -41,7 +41,7 @@ var proxyApi = {
     },
 
     getCall: function getCall(index) {
-        var i = index;
+        let i = index;
         if (i < 0) {
             // Negative indices means counting backwards from the last call
             i += this.callCount;
@@ -62,8 +62,8 @@ var proxyApi = {
     },
 
     getCalls: function () {
-        var calls = [];
-        var i;
+        const calls = [];
+        let i;
 
         for (i = 0; i < this.callCount; i++) {
             push(calls, this.getCall(i));
@@ -116,9 +116,9 @@ var proxyApi = {
 
     formatters: require("./spy-formatters"),
     printf: function (format) {
-        var spyInstance = this;
-        var args = slice(arguments, 1);
-        var formatter;
+        const spyInstance = this;
+        const args = slice(arguments, 1);
+        let formatter;
 
         return (format || "").replace(/%(.)/g, function (match, specifier) {
             formatter = proxyApi.formatters[specifier];
@@ -135,7 +135,7 @@ var proxyApi = {
 
     resetHistory: function () {
         if (this.invoking) {
-            var err = new Error(
+            const err = new Error(
                 "Cannot reset Sinon function while invoking it. " +
                     "Move the call to .resetHistory outside of the callback."
             );
@@ -172,7 +172,7 @@ var proxyApi = {
     },
 };
 
-var delegateToCalls = proxyCallUtil.delegateToCalls;
+const delegateToCalls = proxyCallUtil.delegateToCalls;
 delegateToCalls(proxyApi, "calledOn", true);
 delegateToCalls(proxyApi, "alwaysCalledOn", false, "calledOn");
 delegateToCalls(proxyApi, "calledWith", true);
@@ -241,7 +241,7 @@ delegateToCalls(proxyApi, "calledWithNew", true);
 delegateToCalls(proxyApi, "alwaysCalledWithNew", false, "calledWithNew");
 
 function createProxy(func, originalFunc) {
-    var proxy = wrapFunction(func, originalFunc);
+    const proxy = wrapFunction(func, originalFunc);
 
     // Inherit function properties:
     extend(proxy, func);
@@ -254,8 +254,8 @@ function createProxy(func, originalFunc) {
 }
 
 function wrapFunction(func, originalFunc) {
-    var arity = originalFunc.length;
-    var p;
+    const arity = originalFunc.length;
+    let p;
     // Do not change this to use an eval. Projects that depend on sinon block the use of eval.
     // ref: https://github.com/sinonjs/sinon/issues/710
     switch (arity) {
@@ -332,7 +332,7 @@ function wrapFunction(func, originalFunc) {
             break;
         /*eslint-enable*/
     }
-    var nameDescriptor = Object.getOwnPropertyDescriptor(originalFunc, "name");
+    const nameDescriptor = Object.getOwnPropertyDescriptor(originalFunc, "name");
     if (nameDescriptor && nameDescriptor.configurable) {
         // IE 11 functions don't have a name.
         // Safari 9 has names that are not configurable.

--- a/lib/sinon/proxy.js
+++ b/lib/sinon/proxy.js
@@ -332,7 +332,10 @@ function wrapFunction(func, originalFunc) {
             break;
         /*eslint-enable*/
     }
-    const nameDescriptor = Object.getOwnPropertyDescriptor(originalFunc, "name");
+    const nameDescriptor = Object.getOwnPropertyDescriptor(
+        originalFunc,
+        "name"
+    );
     if (nameDescriptor && nameDescriptor.configurable) {
         // IE 11 functions don't have a name.
         // Safari 9 has names that are not configurable.

--- a/lib/sinon/restore-object.js
+++ b/lib/sinon/restore-object.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var walkObject = require("./util/core/walk-object");
+const walkObject = require("./util/core/walk-object");
 
 function filter(object, property) {
     return object[property].restore && object[property].restore.sinon;

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -1,32 +1,32 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var logger = require("@sinonjs/commons").deprecated;
-var collectOwnMethods = require("./collect-own-methods");
-var getPropertyDescriptor = require("./util/core/get-property-descriptor");
-var isPropertyConfigurable = require("./util/core/is-property-configurable");
-var match = require("@sinonjs/samsam").createMatcher;
-var sinonAssert = require("./assert");
-var sinonClock = require("./util/fake-timers");
-var sinonMock = require("./mock");
-var sinonSpy = require("./spy");
-var sinonStub = require("./stub");
-var sinonCreateStubInstance = require("./create-stub-instance");
-var sinonFake = require("./fake");
-var valueToString = require("@sinonjs/commons").valueToString;
-var fakeServer = require("nise").fakeServer;
-var fakeXhr = require("nise").fakeXhr;
-var usePromiseLibrary = require("./util/core/use-promise-library");
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const logger = require("@sinonjs/commons").deprecated;
+const collectOwnMethods = require("./collect-own-methods");
+const getPropertyDescriptor = require("./util/core/get-property-descriptor");
+const isPropertyConfigurable = require("./util/core/is-property-configurable");
+const match = require("@sinonjs/samsam").createMatcher;
+const sinonAssert = require("./assert");
+const sinonClock = require("./util/fake-timers");
+const sinonMock = require("./mock");
+const sinonSpy = require("./spy");
+const sinonStub = require("./stub");
+const sinonCreateStubInstance = require("./create-stub-instance");
+const sinonFake = require("./fake");
+const valueToString = require("@sinonjs/commons").valueToString;
+const fakeServer = require("nise").fakeServer;
+const fakeXhr = require("nise").fakeXhr;
+const usePromiseLibrary = require("./util/core/use-promise-library");
 
-var DEFAULT_LEAK_THRESHOLD = 10000;
+const DEFAULT_LEAK_THRESHOLD = 10000;
 
-var filter = arrayProto.filter;
-var forEach = arrayProto.forEach;
-var push = arrayProto.push;
-var reverse = arrayProto.reverse;
+const filter = arrayProto.filter;
+const forEach = arrayProto.forEach;
+const push = arrayProto.push;
+const reverse = arrayProto.reverse;
 
 function applyOnEach(fakes, method) {
-    var matchingFakes = filter(fakes, function (fake) {
+    const matchingFakes = filter(fakes, function (fake) {
         return typeof fake[method] === "function";
     });
 
@@ -36,12 +36,12 @@ function applyOnEach(fakes, method) {
 }
 
 function Sandbox() {
-    var sandbox = this;
-    var fakeRestorers = [];
-    var promiseLib;
+    const sandbox = this;
+    let fakeRestorers = [];
+    let promiseLib;
 
-    var collection = [];
-    var loggedLeakWarning = false;
+    let collection = [];
+    let loggedLeakWarning = false;
     sandbox.leakThreshold = DEFAULT_LEAK_THRESHOLD;
 
     function addToCollection(object) {
@@ -72,9 +72,9 @@ function Sandbox() {
     };
 
     sandbox.createStubInstance = function createStubInstance() {
-        var stubbed = sinonCreateStubInstance.apply(null, arguments);
+        const stubbed = sinonCreateStubInstance.apply(null, arguments);
 
-        var ownMethods = collectOwnMethods(stubbed);
+        const ownMethods = collectOwnMethods(stubbed);
 
         forEach(ownMethods, function (method) {
             addToCollection(method);
@@ -133,7 +133,7 @@ function Sandbox() {
     };
 
     sandbox.mock = function mock() {
-        var m = sinonMock.apply(null, arguments);
+        const m = sinonMock.apply(null, arguments);
 
         addToCollection(m);
         usePromiseLibrary(promiseLib, m);
@@ -152,7 +152,7 @@ function Sandbox() {
 
     sandbox.resetHistory = function resetHistory() {
         function privateResetHistory(f) {
-            var method = f.resetHistory || f.reset;
+            const method = f.resetHistory || f.reset;
             if (method) {
                 method.call(f);
             }
@@ -164,7 +164,7 @@ function Sandbox() {
                 return;
             }
 
-            var methods = [];
+            const methods = [];
             if (fake.get) {
                 push(methods, fake.get);
             }
@@ -197,8 +197,8 @@ function Sandbox() {
     };
 
     sandbox.restoreContext = function restoreContext() {
-        var injectedKeys = sandbox.injectedKeys;
-        var injectInto = sandbox.injectInto;
+        let injectedKeys = sandbox.injectedKeys;
+        const injectInto = sandbox.injectInto;
 
         if (!injectedKeys) {
             return;
@@ -212,7 +212,7 @@ function Sandbox() {
     };
 
     function getFakeRestorer(object, property) {
-        var descriptor = getPropertyDescriptor(object, property);
+        const descriptor = getPropertyDescriptor(object, property);
 
         function restorer() {
             if (descriptor.isOwn) {
@@ -240,7 +240,7 @@ function Sandbox() {
     }
 
     sandbox.replace = function replace(object, property, replacement) {
-        var descriptor = getPropertyDescriptor(object, property);
+        const descriptor = getPropertyDescriptor(object, property);
 
         if (typeof descriptor === "undefined") {
             throw new TypeError(
@@ -285,7 +285,7 @@ function Sandbox() {
         property,
         replacement
     ) {
-        var descriptor = getPropertyDescriptor(object, property);
+        const descriptor = getPropertyDescriptor(object, property);
 
         if (typeof descriptor === "undefined") {
             throw new TypeError(
@@ -323,7 +323,7 @@ function Sandbox() {
         property,
         replacement
     ) {
-        var descriptor = getPropertyDescriptor(object, property);
+        const descriptor = getPropertyDescriptor(object, property);
 
         if (typeof descriptor === "undefined") {
             throw new TypeError(
@@ -358,14 +358,14 @@ function Sandbox() {
     };
 
     function commonPostInitSetup(args, spy) {
-        var object = args[0];
-        var property = args[1];
+        const object = args[0];
+        const property = args[1];
 
-        var isSpyingOnEntireObject =
+        const isSpyingOnEntireObject =
             typeof property === "undefined" && typeof object === "object";
 
         if (isSpyingOnEntireObject) {
-            var ownMethods = collectOwnMethods(spy);
+            const ownMethods = collectOwnMethods(spy);
 
             forEach(ownMethods, function (method) {
                 addToCollection(method);
@@ -381,18 +381,18 @@ function Sandbox() {
     }
 
     sandbox.spy = function spy() {
-        var createdSpy = sinonSpy.apply(sinonSpy, arguments);
+        const createdSpy = sinonSpy.apply(sinonSpy, arguments);
         return commonPostInitSetup(arguments, createdSpy);
     };
 
     sandbox.stub = function stub() {
-        var createdStub = sinonStub.apply(sinonStub, arguments);
+        const createdStub = sinonStub.apply(sinonStub, arguments);
         return commonPostInitSetup(arguments, createdStub);
     };
 
     // eslint-disable-next-line no-unused-vars
     sandbox.fake = function fake(f) {
-        var s = sinonFake.apply(sinonFake, arguments);
+        const s = sinonFake.apply(sinonFake, arguments);
 
         addToCollection(s);
 
@@ -400,10 +400,10 @@ function Sandbox() {
     };
 
     forEach(Object.keys(sinonFake), function (key) {
-        var fakeBehavior = sinonFake[key];
+        const fakeBehavior = sinonFake[key];
         if (typeof fakeBehavior === "function") {
             sandbox.fake[key] = function () {
-                var s = fakeBehavior.apply(fakeBehavior, arguments);
+                const s = fakeBehavior.apply(fakeBehavior, arguments);
 
                 addToCollection(s);
 
@@ -413,7 +413,7 @@ function Sandbox() {
     });
 
     sandbox.useFakeTimers = function useFakeTimers(args) {
-        var clock = sinonClock.useFakeTimers.call(null, args);
+        const clock = sinonClock.useFakeTimers.call(null, args);
 
         sandbox.clock = clock;
         addToCollection(clock);
@@ -426,7 +426,7 @@ function Sandbox() {
     };
 
     sandbox.verifyAndRestore = function verifyAndRestore() {
-        var exception;
+        let exception;
 
         try {
             sandbox.verify();
@@ -442,7 +442,7 @@ function Sandbox() {
     };
 
     sandbox.useFakeServer = function useFakeServer() {
-        var proto = sandbox.serverPrototype || fakeServer;
+        const proto = sandbox.serverPrototype || fakeServer;
 
         if (!proto || !proto.create) {
             return null;
@@ -455,7 +455,7 @@ function Sandbox() {
     };
 
     sandbox.useFakeXMLHttpRequest = function useFakeXMLHttpRequest() {
-        var xhr = fakeXhr.useFakeXMLHttpRequest();
+        const xhr = fakeXhr.useFakeXMLHttpRequest();
         addToCollection(xhr);
         return xhr;
     };

--- a/lib/sinon/spy-formatters.js
+++ b/lib/sinon/spy-formatters.js
@@ -1,20 +1,20 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var color = require("./color");
-var match = require("@sinonjs/samsam").createMatcher;
-var timesInWords = require("./util/core/times-in-words");
-var inspect = require("util").inspect;
-var jsDiff = require("diff");
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const color = require("./color");
+const match = require("@sinonjs/samsam").createMatcher;
+const timesInWords = require("./util/core/times-in-words");
+const inspect = require("util").inspect;
+const jsDiff = require("diff");
 
-var join = arrayProto.join;
-var map = arrayProto.map;
-var push = arrayProto.push;
-var slice = arrayProto.slice;
+const join = arrayProto.join;
+const map = arrayProto.map;
+const push = arrayProto.push;
+const slice = arrayProto.slice;
 
 function colorSinonMatchText(matcher, calledArg, calledArgMessage) {
-    var calledArgumentMessage = calledArgMessage;
-    var matcherMessage = matcher.message;
+    let calledArgumentMessage = calledArgMessage;
+    let matcherMessage = matcher.message;
     if (!matcher.test(calledArg)) {
         matcherMessage = color.red(matcher.message);
         if (calledArgumentMessage) {
@@ -25,8 +25,8 @@ function colorSinonMatchText(matcher, calledArg, calledArgMessage) {
 }
 
 function colorDiffText(diff) {
-    var objects = map(diff, function (part) {
-        var text = part.value;
+    const objects = map(diff, function (part) {
+        let text = part.value;
         if (part.added) {
             text = color.green(text);
         } else if (part.removed) {
@@ -58,23 +58,23 @@ module.exports = {
     },
 
     D: function (spyInstance, args) {
-        var message = "";
+        let message = "";
 
-        for (var i = 0, l = spyInstance.callCount; i < l; ++i) {
+        for (let i = 0, l = spyInstance.callCount; i < l; ++i) {
             // describe multiple calls
             if (l > 1) {
                 message += `\nCall ${i + 1}:`;
             }
-            var calledArgs = spyInstance.getCall(i).args;
-            var expectedArgs = slice(args);
+            const calledArgs = spyInstance.getCall(i).args;
+            const expectedArgs = slice(args);
 
             for (
-                var j = 0;
+                let j = 0;
                 j < calledArgs.length || j < expectedArgs.length;
                 ++j
             ) {
-                var calledArg = calledArgs[j];
-                var expectedArg = expectedArgs[j];
+                let calledArg = calledArgs[j];
+                let expectedArg = expectedArgs[j];
                 if (calledArg) {
                     calledArg = quoteStringValue(calledArg);
                 }
@@ -85,7 +85,7 @@ module.exports = {
 
                 message += "\n";
 
-                var calledArgMessage =
+                const calledArgMessage =
                     j < calledArgs.length ? inspect(calledArg) : "";
                 if (match.isMatcher(expectedArg)) {
                     message += colorSinonMatchText(
@@ -94,9 +94,9 @@ module.exports = {
                         calledArgMessage
                     );
                 } else {
-                    var expectedArgMessage =
+                    const expectedArgMessage =
                         j < expectedArgs.length ? inspect(expectedArg) : "";
-                    var diff = jsDiff.diffJson(
+                    const diff = jsDiff.diffJson(
                         calledArgMessage,
                         expectedArgMessage
                     );
@@ -109,11 +109,11 @@ module.exports = {
     },
 
     C: function (spyInstance) {
-        var calls = [];
+        const calls = [];
 
-        for (var i = 0, l = spyInstance.callCount; i < l; ++i) {
+        for (let i = 0, l = spyInstance.callCount; i < l; ++i) {
             // eslint-disable-next-line @sinonjs/no-prototype-methods/no-prototype-methods
-            var stringifiedCall = `    ${spyInstance.getCall(i).toString()}`;
+            let stringifiedCall = `    ${spyInstance.getCall(i).toString()}`;
             if (/\n/.test(calls[i - 1])) {
                 stringifiedCall = `\n${stringifiedCall}`;
             }
@@ -124,9 +124,9 @@ module.exports = {
     },
 
     t: function (spyInstance) {
-        var objects = [];
+        const objects = [];
 
-        for (var i = 0, l = spyInstance.callCount; i < l; ++i) {
+        for (let i = 0, l = spyInstance.callCount; i < l; ++i) {
             push(objects, inspect(spyInstance.thisValues[i]));
         }
 

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -1,28 +1,28 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var createProxy = require("./proxy");
-var extend = require("./util/core/extend");
-var functionName = require("@sinonjs/commons").functionName;
-var getPropertyDescriptor = require("./util/core/get-property-descriptor");
-var deepEqual = require("@sinonjs/samsam").deepEqual;
-var isEsModule = require("./util/core/is-es-module");
-var proxyCallUtil = require("./proxy-call-util");
-var walkObject = require("./util/core/walk-object");
-var wrapMethod = require("./util/core/wrap-method");
-var valueToString = require("@sinonjs/commons").valueToString;
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const createProxy = require("./proxy");
+const extend = require("./util/core/extend");
+const functionName = require("@sinonjs/commons").functionName;
+const getPropertyDescriptor = require("./util/core/get-property-descriptor");
+const deepEqual = require("@sinonjs/samsam").deepEqual;
+const isEsModule = require("./util/core/is-es-module");
+const proxyCallUtil = require("./proxy-call-util");
+const walkObject = require("./util/core/walk-object");
+const wrapMethod = require("./util/core/wrap-method");
+const valueToString = require("@sinonjs/commons").valueToString;
 
 /* cache references to library methods so that they also can be stubbed without problems */
-var forEach = arrayProto.forEach;
-var pop = arrayProto.pop;
-var push = arrayProto.push;
-var slice = arrayProto.slice;
-var filter = Array.prototype.filter;
+const forEach = arrayProto.forEach;
+const pop = arrayProto.pop;
+const push = arrayProto.push;
+const slice = arrayProto.slice;
+const filter = Array.prototype.filter;
 
-var uuid = 0;
+let uuid = 0;
 
 function matches(fake, args, strict) {
-    var margs = fake.matchingArguments;
+    const margs = fake.matchingArguments;
     if (
         margs.length <= args.length &&
         deepEqual(slice(args, 0, margs.length), margs)
@@ -33,16 +33,16 @@ function matches(fake, args, strict) {
 }
 
 // Public API
-var spyApi = {
+const spyApi = {
     withArgs: function () {
-        var args = slice(arguments);
-        var matching = pop(this.matchingFakes(args, true));
+        const args = slice(arguments);
+        const matching = pop(this.matchingFakes(args, true));
         if (matching) {
             return matching;
         }
 
-        var original = this;
-        var fake = this.instantiateFake();
+        const original = this;
+        const fake = this.instantiateFake();
         fake.matchingArguments = args;
         fake.parent = this;
         push(this.fakes, fake);
@@ -78,7 +78,7 @@ var spyApi = {
 };
 
 /* eslint-disable @sinonjs/no-prototype-methods/no-prototype-methods */
-var delegateToCalls = proxyCallUtil.delegateToCalls;
+const delegateToCalls = proxyCallUtil.delegateToCalls;
 delegateToCalls(spyApi, "callArg", false, "callArgWith", true, function () {
     throw new Error(
         `${this.toString()} cannot call arg since it was not yet invoked.`
@@ -131,8 +131,8 @@ delegateToCalls(
 );
 
 function createSpy(func) {
-    var name;
-    var funk = func;
+    let name;
+    let funk = func;
 
     if (typeof funk !== "function") {
         funk = function () {
@@ -142,7 +142,7 @@ function createSpy(func) {
         name = functionName(funk);
     }
 
-    var proxy = createProxy(funk, funk);
+    const proxy = createProxy(funk, funk);
 
     // Inherit spy API:
     extend.nonEnum(proxy, spyApi);
@@ -156,8 +156,6 @@ function createSpy(func) {
 }
 
 function spy(object, property, types) {
-    var descriptor, methodDesc;
-
     if (isEsModule(object)) {
         throw new TypeError("ES Modules cannot be spied");
     }
@@ -180,8 +178,8 @@ function spy(object, property, types) {
         return wrapMethod(object, property, createSpy(object[property]));
     }
 
-    descriptor = {};
-    methodDesc = getPropertyDescriptor(object, property);
+    const descriptor = {};
+    const methodDesc = getPropertyDescriptor(object, property);
 
     forEach(types, function (type) {
         descriptor[type] = createSpy(methodDesc[type]);

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -1,38 +1,39 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var behavior = require("./behavior");
-var behaviors = require("./default-behaviors");
-var createProxy = require("./proxy");
-var functionName = require("@sinonjs/commons").functionName;
-var hasOwnProperty =
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const behavior = require("./behavior");
+const behaviors = require("./default-behaviors");
+const createProxy = require("./proxy");
+const functionName = require("@sinonjs/commons").functionName;
+const hasOwnProperty =
     require("@sinonjs/commons").prototypes.object.hasOwnProperty;
-var isNonExistentProperty = require("./util/core/is-non-existent-property");
-var spy = require("./spy");
-var extend = require("./util/core/extend");
-var getPropertyDescriptor = require("./util/core/get-property-descriptor");
-var isEsModule = require("./util/core/is-es-module");
-var sinonType = require("./util/core/sinon-type");
-var wrapMethod = require("./util/core/wrap-method");
-var throwOnFalsyObject = require("./throw-on-falsy-object");
-var valueToString = require("@sinonjs/commons").valueToString;
-var walkObject = require("./util/core/walk-object");
+const isNonExistentProperty = require("./util/core/is-non-existent-property");
+const spy = require("./spy");
+const extend = require("./util/core/extend");
+const getPropertyDescriptor = require("./util/core/get-property-descriptor");
+const isEsModule = require("./util/core/is-es-module");
+const sinonType = require("./util/core/sinon-type");
+const wrapMethod = require("./util/core/wrap-method");
+const throwOnFalsyObject = require("./throw-on-falsy-object");
+const valueToString = require("@sinonjs/commons").valueToString;
+const walkObject = require("./util/core/walk-object");
 
-var forEach = arrayProto.forEach;
-var pop = arrayProto.pop;
-var slice = arrayProto.slice;
-var sort = arrayProto.sort;
+const forEach = arrayProto.forEach;
+const pop = arrayProto.pop;
+const slice = arrayProto.slice;
+const sort = arrayProto.sort;
 
-var uuid = 0;
+let uuid = 0;
 
 function createStub(originalFunc) {
-    var proxy;
+    // eslint-disable-next-line prefer-const
+    let proxy;
 
     function functionStub() {
-        var args = slice(arguments);
-        var matchings = proxy.matchingFakes(args);
+        const args = slice(arguments);
+        const matchings = proxy.matchingFakes(args);
 
-        var fnStub =
+        const fnStub =
             pop(
                 sort(matchings, function (a, b) {
                     return (
@@ -49,7 +50,7 @@ function createStub(originalFunc) {
     // Inherit stub API:
     extend.nonEnum(proxy, stub);
 
-    var name = originalFunc ? functionName(originalFunc) : null;
+    const name = originalFunc ? functionName(originalFunc) : null;
     extend.nonEnum(proxy, {
         fakes: [],
         instantiateFake: createStub,
@@ -83,16 +84,16 @@ function stub(object, property) {
         );
     }
 
-    var actualDescriptor = getPropertyDescriptor(object, property);
+    const actualDescriptor = getPropertyDescriptor(object, property);
 
     assertValidPropertyDescriptor(actualDescriptor, property);
 
-    var isObjectOrFunction =
+    const isObjectOrFunction =
         typeof object === "object" || typeof object === "function";
-    var isStubbingEntireObject =
+    const isStubbingEntireObject =
         typeof property === "undefined" && isObjectOrFunction;
-    var isCreatingNewStub = !object && typeof property === "undefined";
-    var isStubbingNonFuncProperty =
+    const isCreatingNewStub = !object && typeof property === "undefined";
+    const isStubbingNonFuncProperty =
         isObjectOrFunction &&
         typeof property !== "undefined" &&
         (typeof actualDescriptor === "undefined" ||
@@ -106,11 +107,11 @@ function stub(object, property) {
         return createStub();
     }
 
-    var func =
+    const func =
         typeof actualDescriptor.value === "function"
             ? actualDescriptor.value
             : null;
-    var s = createStub(func);
+    const s = createStub(func);
 
     extend.nonEnum(s, {
         rootObj: object,
@@ -173,14 +174,14 @@ function getDefaultBehavior(stubInstance) {
 }
 
 function getCurrentBehavior(stubInstance) {
-    var currentBehavior = stubInstance.behaviors[stubInstance.callCount - 1];
+    const currentBehavior = stubInstance.behaviors[stubInstance.callCount - 1];
     return currentBehavior && currentBehavior.isPresent()
         ? currentBehavior
         : getDefaultBehavior(stubInstance);
 }
 /*eslint-enable no-use-before-define*/
 
-var proto = {
+const proto = {
     resetBehavior: function () {
         this.defaultBehavior = null;
         this.behaviors = [];
@@ -224,7 +225,7 @@ var proto = {
     },
 
     withArgs: function withArgs() {
-        var fake = spy.withArgs.apply(this, arguments);
+        const fake = spy.withArgs.apply(this, arguments);
         if (this.defaultBehavior && this.defaultBehavior.promiseLibrary) {
             fake.defaultBehavior =
                 fake.defaultBehavior || behavior.create(fake);

--- a/lib/sinon/throw-on-falsy-object.js
+++ b/lib/sinon/throw-on-falsy-object.js
@@ -1,9 +1,9 @@
 "use strict";
-var valueToString = require("@sinonjs/commons").valueToString;
+const valueToString = require("@sinonjs/commons").valueToString;
 
 function throwOnFalsyObject(object, property) {
     if (property && !object) {
-        var type = object === null ? "null" : "undefined";
+        const type = object === null ? "null" : "undefined";
         throw new Error(
             `Trying to stub property '${valueToString(property)}' of ${type}`
         );

--- a/lib/sinon/util/core/export-async-behaviors.js
+++ b/lib/sinon/util/core/export-async-behaviors.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var reduce = arrayProto.reduce;
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const reduce = arrayProto.reduce;
 
 module.exports = function exportAsyncBehaviors(behaviorMethods) {
     return reduce(
@@ -10,7 +10,7 @@ module.exports = function exportAsyncBehaviors(behaviorMethods) {
             // need to avoid creating another async versions of the newly added async methods
             if (method.match(/^(callsArg|yields)/) && !method.match(/Async/)) {
                 acc[`${method}Async`] = function () {
-                    var result = behaviorMethods[method].apply(this, arguments);
+                    const result = behaviorMethods[method].apply(this, arguments);
                     this.callbackAsync = true;
                     return result;
                 };

--- a/lib/sinon/util/core/export-async-behaviors.js
+++ b/lib/sinon/util/core/export-async-behaviors.js
@@ -10,7 +10,10 @@ module.exports = function exportAsyncBehaviors(behaviorMethods) {
             // need to avoid creating another async versions of the newly added async methods
             if (method.match(/^(callsArg|yields)/) && !method.match(/Async/)) {
                 acc[`${method}Async`] = function () {
-                    const result = behaviorMethods[method].apply(this, arguments);
+                    const result = behaviorMethods[method].apply(
+                        this,
+                        arguments
+                    );
                     this.callbackAsync = true;
                     return result;
                 };

--- a/lib/sinon/util/core/extend.js
+++ b/lib/sinon/util/core/extend.js
@@ -1,15 +1,15 @@
 "use strict";
 
-var arrayProto = require("@sinonjs/commons").prototypes.array;
-var hasOwnProperty =
+const arrayProto = require("@sinonjs/commons").prototypes.array;
+const hasOwnProperty =
     require("@sinonjs/commons").prototypes.object.hasOwnProperty;
 
-var join = arrayProto.join;
-var push = arrayProto.push;
+const join = arrayProto.join;
+const push = arrayProto.push;
 
 // Adapted from https://developer.mozilla.org/en/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug
-var hasDontEnumBug = (function () {
-    var obj = {
+const hasDontEnumBug = (function () {
+    const obj = {
         constructor: function () {
             return "0";
         },
@@ -42,8 +42,8 @@ var hasDontEnumBug = (function () {
         },
     };
 
-    var result = [];
-    for (var prop in obj) {
+    const result = [];
+    for (const prop in obj) {
         if (hasOwnProperty(obj, prop)) {
             push(result, obj[prop]());
         }
@@ -52,7 +52,7 @@ var hasDontEnumBug = (function () {
 })();
 
 function extendCommon(target, sources, doCopy) {
-    var source, i, prop;
+    let source, i, prop;
 
     for (i = 0; i < sources.length; i++) {
         source = sources[i];
@@ -90,11 +90,11 @@ module.exports = function extend(target, ...sources) {
         target,
         sources,
         function copyValue(dest, source, prop) {
-            var destOwnPropertyDescriptor = Object.getOwnPropertyDescriptor(
+            const destOwnPropertyDescriptor = Object.getOwnPropertyDescriptor(
                 dest,
                 prop
             );
-            var sourceOwnPropertyDescriptor = Object.getOwnPropertyDescriptor(
+            const sourceOwnPropertyDescriptor = Object.getOwnPropertyDescriptor(
                 source,
                 prop
             );

--- a/lib/sinon/util/core/extend.js
+++ b/lib/sinon/util/core/extend.js
@@ -51,6 +51,13 @@ const hasDontEnumBug = (function () {
     return join(result, "") !== "0123456789";
 })();
 
+/**
+ *
+ * @param target
+ * @param sources
+ * @param doCopy
+ * @returns {*} target
+ */
 function extendCommon(target, sources, doCopy) {
     let source, i, prop;
 
@@ -77,12 +84,12 @@ function extendCommon(target, sources, doCopy) {
     return target;
 }
 
-/** Public: Extend target in place with all (own) properties, except 'name' when [[writable]] is false,
+/**
+ * Public: Extend target in place with all (own) properties, except 'name' when [[writable]] is false,
  *         from sources in-order. Thus, last source will override properties in previous sources.
  *
  * @param {object} target - The Object to extend
  * @param {object[]} sources - Objects to copy properties from.
- *
  * @returns {object} the extended target
  */
 module.exports = function extend(target, ...sources) {
@@ -130,12 +137,12 @@ module.exports = function extend(target, ...sources) {
     );
 };
 
-/** Public: Extend target in place with all (own) properties from sources in-order. Thus, last source will
+/**
+ * Public: Extend target in place with all (own) properties from sources in-order. Thus, last source will
  *         override properties in previous sources. Define the properties as non enumerable.
  *
  * @param {object} target - The Object to extend
  * @param {object[]} sources - Objects to copy properties from.
- *
  * @returns {object} the extended target
  */
 module.exports.nonEnum = function extendNonEnum(target, ...sources) {

--- a/lib/sinon/util/core/function-to-string.js
+++ b/lib/sinon/util/core/function-to-string.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = function toString() {
-    var i, prop, thisValue;
+    let i, prop, thisValue;
     if (this.getCall && this.callCount) {
         i = this.callCount;
 

--- a/lib/sinon/util/core/get-property-descriptor.js
+++ b/lib/sinon/util/core/get-property-descriptor.js
@@ -1,9 +1,9 @@
 "use strict";
 
 module.exports = function getPropertyDescriptor(object, property) {
-    var proto = object;
-    var descriptor;
-    var isOwn = Boolean(
+    let proto = object;
+    let descriptor;
+    const isOwn = Boolean(
         object && Object.getOwnPropertyDescriptor(object, property)
     );
 

--- a/lib/sinon/util/core/is-es-module.js
+++ b/lib/sinon/util/core/is-es-module.js
@@ -8,7 +8,6 @@
  * on weird error messages.
  *
  * @param {object} object The object to examine
- *
  * @returns {boolean} true when the object is a module
  */
 module.exports = function (object) {

--- a/lib/sinon/util/core/is-property-configurable.js
+++ b/lib/sinon/util/core/is-property-configurable.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var getPropertyDescriptor = require("./get-property-descriptor");
+const getPropertyDescriptor = require("./get-property-descriptor");
 
 function isPropertyConfigurable(obj, propName) {
-    var propertyDescriptor = getPropertyDescriptor(obj, propName);
+    const propertyDescriptor = getPropertyDescriptor(obj, propName);
 
     return propertyDescriptor ? propertyDescriptor.configurable : true;
 }

--- a/lib/sinon/util/core/next-tick.js
+++ b/lib/sinon/util/core/next-tick.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var globalObject = require("@sinonjs/commons").global;
-var getNextTick = require("./get-next-tick");
+const globalObject = require("@sinonjs/commons").global;
+const getNextTick = require("./get-next-tick");
 
 module.exports = getNextTick(globalObject.process, globalObject.setImmediate);

--- a/lib/sinon/util/core/times-in-words.js
+++ b/lib/sinon/util/core/times-in-words.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var array = [null, "once", "twice", "thrice"];
+const array = [null, "once", "twice", "thrice"];
 
 module.exports = function timesInWords(count) {
     return array[count] || `${count || 0} times`;

--- a/lib/sinon/util/core/use-promise-library.js
+++ b/lib/sinon/util/core/use-promise-library.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var forEach = Array.prototype.forEach;
+const forEach = Array.prototype.forEach;
 
 function usePromiseLibrary(library, fakes) {
     if (typeof library === "undefined") {

--- a/lib/sinon/util/core/walk-object.js
+++ b/lib/sinon/util/core/walk-object.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var functionName = require("@sinonjs/commons").functionName;
+const functionName = require("@sinonjs/commons").functionName;
 
-var getPropertyDescriptor = require("./get-property-descriptor");
-var walk = require("./walk");
+const getPropertyDescriptor = require("./get-property-descriptor");
+const walk = require("./walk");
 
 /**
  * A utility that allows traversing an object, applying mutating functions on the properties
@@ -14,8 +14,8 @@ var walk = require("./walk");
  * @returns {void} nothing
  */
 function walkObject(mutator, object, filter) {
-    var called = false;
-    var name = functionName(mutator);
+    let called = false;
+    const name = functionName(mutator);
 
     if (!object) {
         throw new Error(

--- a/lib/sinon/util/core/walk.js
+++ b/lib/sinon/util/core/walk.js
@@ -1,9 +1,10 @@
 "use strict";
 
-var forEach = require("@sinonjs/commons").prototypes.array.forEach;
+const forEach = require("@sinonjs/commons").prototypes.array.forEach;
 
 function walkInternal(obj, iterator, context, originalObj, seen) {
-    var proto, prop;
+    let prop;
+    const proto = Object.getPrototypeOf(obj);
 
     if (typeof Object.getOwnPropertyNames !== "function") {
         // We explicitly want to enumerate through all of the prototype's properties
@@ -19,7 +20,7 @@ function walkInternal(obj, iterator, context, originalObj, seen) {
     forEach(Object.getOwnPropertyNames(obj), function (k) {
         if (seen[k] !== true) {
             seen[k] = true;
-            var target =
+            const target =
                 typeof Object.getOwnPropertyDescriptor(obj, k).get ===
                 "function"
                     ? originalObj
@@ -28,7 +29,6 @@ function walkInternal(obj, iterator, context, originalObj, seen) {
         }
     });
 
-    proto = Object.getPrototypeOf(obj);
     if (proto) {
         walkInternal(proto, iterator, context, originalObj, seen);
     }

--- a/lib/sinon/util/core/wrap-method.js
+++ b/lib/sinon/util/core/wrap-method.js
@@ -2,13 +2,13 @@
 
 // eslint-disable-next-line no-empty-function
 const noop = () => {};
-var getPropertyDescriptor = require("./get-property-descriptor");
-var extend = require("./extend");
+const getPropertyDescriptor = require("./get-property-descriptor");
+const extend = require("./extend");
 const sinonType = require("./sinon-type");
-var hasOwnProperty =
+const hasOwnProperty =
     require("@sinonjs/commons").prototypes.object.hasOwnProperty;
-var valueToString = require("@sinonjs/commons").valueToString;
-var push = require("@sinonjs/commons").prototypes.array.push;
+const valueToString = require("@sinonjs/commons").valueToString;
+const push = require("@sinonjs/commons").prototypes.array.push;
 
 function isFunction(obj) {
     return (
@@ -18,7 +18,7 @@ function isFunction(obj) {
 }
 
 function mirrorProperties(target, source) {
-    for (var prop in source) {
+    for (const prop in source) {
         if (!hasOwnProperty(target, prop)) {
             target[prop] = source[prop];
         }
@@ -26,10 +26,10 @@ function mirrorProperties(target, source) {
 }
 
 function getAccessor(object, property, method) {
-    var accessors = ["get", "set"];
-    var descriptor = getPropertyDescriptor(object, property);
+    const accessors = ["get", "set"];
+    const descriptor = getPropertyDescriptor(object, property);
 
-    for (var i = 0; i < accessors.length; i++) {
+    for (let i = 0; i < accessors.length; i++) {
         if (
             descriptor[accessors[i]] &&
             descriptor[accessors[i]].name === method.name
@@ -41,7 +41,7 @@ function getAccessor(object, property, method) {
 }
 
 // Cheap way to detect if we have ES5 support.
-var hasES5Support = "keys" in Object;
+const hasES5Support = "keys" in Object;
 
 module.exports = function wrapMethod(object, property, method) {
     if (!object) {
@@ -55,7 +55,7 @@ module.exports = function wrapMethod(object, property, method) {
     }
 
     function checkWrappedMethod(wrappedMethod) {
-        var error;
+        let error;
 
         if (!isFunction(wrappedMethod)) {
             error = new TypeError(
@@ -70,7 +70,7 @@ module.exports = function wrapMethod(object, property, method) {
                 )} which is already wrapped`
             );
         } else if (wrappedMethod.calledBefore) {
-            var verb = wrappedMethod.returns ? "stubbed" : "spied on";
+            const verb = wrappedMethod.returns ? "stubbed" : "spied on";
             error = new TypeError(
                 `Attempted to wrap ${valueToString(
                     property
@@ -86,15 +86,9 @@ module.exports = function wrapMethod(object, property, method) {
         }
     }
 
-    var error,
-        wrappedMethods,
-        wrappedMethod,
-        i,
-        wrappedMethodDesc,
-        target,
-        accessor;
+    let error, wrappedMethod, i, wrappedMethodDesc, target, accessor;
 
-    wrappedMethods = [];
+    const wrappedMethods = [];
 
     function simplePropertyAssignment() {
         wrappedMethod = object[property];
@@ -104,12 +98,12 @@ module.exports = function wrapMethod(object, property, method) {
     }
 
     // Firefox has a problem when using hasOwn.call on objects from other frames.
-    var owned = object.hasOwnProperty
+    const owned = object.hasOwnProperty
         ? object.hasOwnProperty(property) // eslint-disable-line @sinonjs/no-prototype-methods/no-prototype-methods
         : hasOwnProperty(object, property);
 
     if (hasES5Support) {
-        var methodDesc =
+        const methodDesc =
             typeof method === "function" ? { value: method } : method;
         wrappedMethodDesc = getPropertyDescriptor(object, property);
 
@@ -132,7 +126,7 @@ module.exports = function wrapMethod(object, property, method) {
             throw error;
         }
 
-        var types = Object.keys(methodDesc);
+        const types = Object.keys(methodDesc);
         for (i = 0; i < types.length; i++) {
             wrappedMethod = wrappedMethodDesc[types[i]];
             checkWrappedMethod(wrappedMethod);
@@ -183,7 +177,7 @@ module.exports = function wrapMethod(object, property, method) {
 
     function restore() {
         accessor = getAccessor(object, property, this.wrappedMethod);
-        var descriptor;
+        let descriptor;
         // For prototype properties try to reset by delete first.
         // If this fails (ex: localStorage on mobile safari) then force a reset
         // via direct assignment.

--- a/lib/sinon/util/fake-timers.js
+++ b/lib/sinon/util/fake-timers.js
@@ -4,8 +4,13 @@ const extend = require("./core/extend");
 const FakeTimers = require("@sinonjs/fake-timers");
 const globalObject = require("@sinonjs/commons").global;
 
+/**
+ *
+ * @param config
+ * @param globalCtx
+ */
 function createClock(config, globalCtx) {
-    const FakeTimersCtx = FakeTimers;
+    let FakeTimersCtx = FakeTimers;
     if (globalCtx !== null && typeof globalCtx === "object") {
         FakeTimersCtx = FakeTimers.withGlobal(globalCtx);
     }
@@ -14,6 +19,11 @@ function createClock(config, globalCtx) {
     return clock;
 }
 
+/**
+ *
+ * @param obj
+ * @param globalPropName
+ */
 function addIfDefined(obj, globalPropName) {
     const globalProp = globalObject[globalPropName];
     if (typeof globalProp !== "undefined") {

--- a/lib/sinon/util/fake-timers.js
+++ b/lib/sinon/util/fake-timers.js
@@ -1,21 +1,21 @@
 "use strict";
 
-var extend = require("./core/extend");
-var FakeTimers = require("@sinonjs/fake-timers");
-var globalObject = require("@sinonjs/commons").global;
+const extend = require("./core/extend");
+const FakeTimers = require("@sinonjs/fake-timers");
+const globalObject = require("@sinonjs/commons").global;
 
 function createClock(config, globalCtx) {
-    var FakeTimersCtx = FakeTimers;
+    const FakeTimersCtx = FakeTimers;
     if (globalCtx !== null && typeof globalCtx === "object") {
         FakeTimersCtx = FakeTimers.withGlobal(globalCtx);
     }
-    var clock = FakeTimersCtx.install(config);
+    const clock = FakeTimersCtx.install(config);
     clock.restore = clock.uninstall;
     return clock;
 }
 
 function addIfDefined(obj, globalPropName) {
-    var globalProp = globalObject[globalPropName];
+    const globalProp = globalObject[globalPropName];
     if (typeof globalProp !== "undefined") {
         obj[globalPropName] = globalProp;
     }
@@ -26,11 +26,11 @@ function addIfDefined(obj, globalPropName) {
  * @returns {object} Returns a lolex clock instance
  */
 exports.useFakeTimers = function (dateOrConfig) {
-    var hasArguments = typeof dateOrConfig !== "undefined";
-    var argumentIsDateLike =
+    const hasArguments = typeof dateOrConfig !== "undefined";
+    const argumentIsDateLike =
         (typeof dateOrConfig === "number" || dateOrConfig instanceof Date) &&
         arguments.length === 1;
-    var argumentIsObject =
+    const argumentIsObject =
         dateOrConfig !== null &&
         typeof dateOrConfig === "object" &&
         arguments.length === 1;
@@ -48,8 +48,8 @@ exports.useFakeTimers = function (dateOrConfig) {
     }
 
     if (argumentIsObject) {
-        var config = extend.nonEnum({}, dateOrConfig);
-        var globalCtx = config.global;
+        const config = extend.nonEnum({}, dateOrConfig);
+        const globalCtx = config.global;
         delete config.global;
         return createClock(config, globalCtx);
     }
@@ -65,7 +65,7 @@ exports.clock = {
     },
 };
 
-var timers = {
+const timers = {
     setTimeout: setTimeout,
     clearTimeout: clearTimeout,
     setInterval: setInterval,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build": "node ./build.cjs",
     "build-docs": "cd docs; bundle exec jekyll build",
     "serve-docs": "cd docs; bundle exec jekyll serve --incremental --verbose",
-    "lint": "eslint '**/*.{js,cjs,mjs}'",
+    "lint": "eslint --max-warnings 99 '**/*.{js,cjs,mjs}'",
     "unimported": "unimported .",
     "pretest-webworker": "npm run build",
     "prebuild": "rimraf pkg && npm run check-dependencies",

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1,14 +1,14 @@
 "use strict";
 
-var color = require("../lib/sinon/color");
-var referee = require("@sinonjs/referee");
-var sinonStub = require("../lib/sinon/stub");
-var sinonSpy = require("../lib/sinon/spy");
-var sinonAssert = require("../lib/sinon/assert");
-var match = require("@sinonjs/samsam").createMatcher;
-var assert = referee.assert;
-var refute = referee.refute;
-var inspect = require("util").inspect;
+const color = require("../lib/sinon/color");
+const referee = require("@sinonjs/referee");
+const sinonStub = require("../lib/sinon/stub");
+const sinonSpy = require("../lib/sinon/spy");
+const sinonAssert = require("../lib/sinon/assert");
+const match = require("@sinonjs/samsam").createMatcher;
+const assert = referee.assert;
+const refute = referee.refute;
+const inspect = require("util").inspect;
 
 function requiresValidFake(method) {
     it("should fail with non-function fake", function () {
@@ -39,7 +39,7 @@ describe("assert", function () {
     });
 
     it("supports proxy property", function () {
-        var api = {
+        const api = {
             method: function () {
                 return;
             },
@@ -134,7 +134,7 @@ describe("assert", function () {
             });
 
             it("fails when method was not called", function () {
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.called(stub);
@@ -144,7 +144,7 @@ describe("assert", function () {
             });
 
             it("fails when called with more than one argument", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
 
                 assert.exception(function () {
@@ -153,7 +153,7 @@ describe("assert", function () {
             });
 
             it("does not fail when method was called", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
 
                 refute.exception(function () {
@@ -164,7 +164,7 @@ describe("assert", function () {
             });
 
             it("calls pass callback", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
 
                 refute.exception(function () {
@@ -199,7 +199,7 @@ describe("assert", function () {
             });
 
             it("fails when method was called", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
 
                 assert.exception(function () {
@@ -210,7 +210,7 @@ describe("assert", function () {
             });
 
             it("fails when called with more than one argument", function () {
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.notCalled(stub, 1);
@@ -218,7 +218,7 @@ describe("assert", function () {
             });
 
             it("passes when method was not called", function () {
-                var stub = this.stub;
+                const stub = this.stub;
 
                 refute.exception(function () {
                     sinonAssert.notCalled(stub);
@@ -228,7 +228,7 @@ describe("assert", function () {
             });
 
             it("should call pass callback", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 sinonAssert.notCalled(stub);
 
                 assert(sinonAssert.pass.calledOnce);
@@ -259,7 +259,7 @@ describe("assert", function () {
             });
 
             it("fails when method was not called", function () {
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.calledOnce(stub);
@@ -269,7 +269,7 @@ describe("assert", function () {
             });
 
             it("fails when called with more than one argument", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
 
                 assert.exception(function () {
@@ -278,7 +278,7 @@ describe("assert", function () {
             });
 
             it("passes when method was called", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
 
                 refute.exception(function () {
@@ -289,7 +289,7 @@ describe("assert", function () {
             });
 
             it("fails when method was called more than once", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
                 stub();
 
@@ -301,7 +301,7 @@ describe("assert", function () {
             });
 
             it("calls pass callback", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
                 sinonAssert.calledOnce(stub);
 
@@ -315,7 +315,7 @@ describe("assert", function () {
             requiresValidFake("calledTwice");
 
             it("fails if called once", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 this.stub();
 
                 assert.exception(function () {
@@ -324,7 +324,7 @@ describe("assert", function () {
             });
 
             it("fails when called with more than one argument", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 this.stub();
                 this.stub();
 
@@ -334,7 +334,7 @@ describe("assert", function () {
             });
 
             it("passes if called twice", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 this.stub();
                 this.stub();
 
@@ -344,7 +344,7 @@ describe("assert", function () {
             });
 
             it("calls pass callback", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
                 stub();
                 sinonAssert.calledTwice(stub);
@@ -359,7 +359,7 @@ describe("assert", function () {
             requiresValidFake("calledThrice");
 
             it("fails if called once", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 this.stub();
 
                 assert.exception(function () {
@@ -368,7 +368,7 @@ describe("assert", function () {
             });
 
             it("fails when called with more than one argument", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 this.stub();
                 this.stub();
                 this.stub();
@@ -379,7 +379,7 @@ describe("assert", function () {
             });
 
             it("passes if called thrice", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 this.stub();
                 this.stub();
                 this.stub();
@@ -390,7 +390,7 @@ describe("assert", function () {
             });
 
             it("calls pass callback", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
                 stub();
                 stub();
@@ -403,8 +403,8 @@ describe("assert", function () {
 
         describe(".callOrder", function () {
             it("passes when calls were done in right order", function () {
-                var spy1 = sinonSpy();
-                var spy2 = sinonSpy();
+                const spy1 = sinonSpy();
+                const spy2 = sinonSpy();
                 spy1();
                 spy2();
 
@@ -414,8 +414,8 @@ describe("assert", function () {
             });
 
             it("fails when calls were done in wrong order", function () {
-                var spy1 = sinonSpy();
-                var spy2 = sinonSpy();
+                const spy1 = sinonSpy();
+                const spy2 = sinonSpy();
                 spy2();
                 spy1();
 
@@ -427,10 +427,10 @@ describe("assert", function () {
             });
 
             it("passes when many calls were done in right order", function () {
-                var spy1 = sinonSpy();
-                var spy2 = sinonSpy();
-                var spy3 = sinonSpy();
-                var spy4 = sinonSpy();
+                const spy1 = sinonSpy();
+                const spy2 = sinonSpy();
+                const spy3 = sinonSpy();
+                const spy4 = sinonSpy();
                 spy1();
                 spy2();
                 spy3();
@@ -442,10 +442,10 @@ describe("assert", function () {
             });
 
             it("fails when one of many calls were done in wrong order", function () {
-                var spy1 = sinonSpy();
-                var spy2 = sinonSpy();
-                var spy3 = sinonSpy();
-                var spy4 = sinonSpy();
+                const spy1 = sinonSpy();
+                const spy2 = sinonSpy();
+                const spy3 = sinonSpy();
+                const spy4 = sinonSpy();
                 spy1();
                 spy2();
                 spy4();
@@ -459,7 +459,7 @@ describe("assert", function () {
             });
 
             it("calls pass callback", function () {
-                var stubs = [sinonSpy(), sinonSpy()];
+                const stubs = [sinonSpy(), sinonSpy()];
                 stubs[0]();
                 stubs[1]();
                 sinonAssert.callOrder(stubs[0], stubs[1]);
@@ -469,8 +469,8 @@ describe("assert", function () {
             });
 
             it("passes for multiple calls to same spy", function () {
-                var first = sinonSpy();
-                var second = sinonSpy();
+                const first = sinonSpy();
+                const second = sinonSpy();
 
                 first();
                 second();
@@ -482,8 +482,8 @@ describe("assert", function () {
             });
 
             it("fails if first spy was not called", function () {
-                var first = sinonSpy();
-                var second = sinonSpy();
+                const first = sinonSpy();
+                const second = sinonSpy();
 
                 second();
 
@@ -493,8 +493,8 @@ describe("assert", function () {
             });
 
             it("fails if second spy was not called", function () {
-                var first = sinonSpy();
-                var second = sinonSpy();
+                const first = sinonSpy();
+                const second = sinonSpy();
 
                 first();
 
@@ -506,7 +506,7 @@ describe("assert", function () {
 
         describe(".calledOn", function () {
             it("fails when method does not exist", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledOn");
 
                 assert.exception(function () {
@@ -518,7 +518,7 @@ describe("assert", function () {
             });
 
             it("fails when method is not stub", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledOn");
 
                 assert.exception(function () {
@@ -532,9 +532,9 @@ describe("assert", function () {
             });
 
             it("fails when method fails", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledOn").returns(false);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.calledOn(stub, object);
@@ -544,9 +544,9 @@ describe("assert", function () {
             });
 
             it("passes when method doesn't fail", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledOn").returns(true);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 sinonAssert.calledOn(stub, object);
 
@@ -554,7 +554,7 @@ describe("assert", function () {
             });
 
             it("calls pass callback", function () {
-                var obj = {};
+                const obj = {};
                 this.stub.call(obj);
                 sinonAssert.calledOn(this.stub, obj);
 
@@ -563,8 +563,8 @@ describe("assert", function () {
             });
 
             it("works with spyCall", function () {
-                var spy = sinonSpy();
-                var target = {};
+                const spy = sinonSpy();
+                const target = {};
                 spy();
                 spy.call(target);
 
@@ -574,8 +574,8 @@ describe("assert", function () {
             });
 
             it("fails when spyCall failed", function () {
-                var spy = sinonSpy();
-                var target = {};
+                const spy = sinonSpy();
+                const target = {};
                 spy();
                 spy.call(target);
 
@@ -617,7 +617,7 @@ describe("assert", function () {
 
             it("fails when method fails", function () {
                 sinonStub(this.stub, "calledWithNew").returns(false);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.calledWithNew(stub);
@@ -628,7 +628,7 @@ describe("assert", function () {
 
             it("passes when method doesn't fail", function () {
                 sinonStub(this.stub, "calledWithNew").returns(true);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 sinonAssert.calledWithNew(stub);
 
@@ -644,7 +644,7 @@ describe("assert", function () {
             });
 
             it("works with spyCall", function () {
-                var spy = sinonSpy();
+                const spy = sinonSpy();
                 spy();
                 new spy(); // eslint-disable-line no-new, new-cap
 
@@ -654,7 +654,7 @@ describe("assert", function () {
             });
 
             it("fails when spyCall failed", function () {
-                var spy = sinonSpy();
+                const spy = sinonSpy();
                 spy();
                 new spy(); // eslint-disable-line no-new, new-cap
 
@@ -696,7 +696,7 @@ describe("assert", function () {
 
             it("fails when method fails", function () {
                 sinonStub(this.stub, "alwaysCalledWithNew").returns(false);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.alwaysCalledWithNew(stub);
@@ -707,7 +707,7 @@ describe("assert", function () {
 
             it("passes when method doesn't fail", function () {
                 sinonStub(this.stub, "alwaysCalledWithNew").returns(true);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 sinonAssert.alwaysCalledWithNew(stub);
 
@@ -725,9 +725,9 @@ describe("assert", function () {
 
         describe(".calledWith", function () {
             it("fails when method fails", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledWith").returns(false);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.calledWith(stub, object, 1);
@@ -738,9 +738,9 @@ describe("assert", function () {
             });
 
             it("passes when method doesn't fail", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledWith").returns(true);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 refute.exception(function () {
                     sinonAssert.calledWith(stub, object, 1);
@@ -759,8 +759,8 @@ describe("assert", function () {
             });
 
             it("works with spyCall", function () {
-                var spy = sinonSpy();
-                var object = {};
+                const spy = sinonSpy();
+                const object = {};
                 spy();
                 spy(object);
 
@@ -770,8 +770,8 @@ describe("assert", function () {
             });
 
             it("fails when spyCall failed", function () {
-                var spy = sinonSpy();
-                var object = {};
+                const spy = sinonSpy();
+                const object = {};
                 spy();
                 spy(object);
 
@@ -785,9 +785,9 @@ describe("assert", function () {
 
         describe(".calledWithExactly", function () {
             it("fails when method fails", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledWithExactly").returns(false);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.calledWithExactly(stub, object, 1);
@@ -800,9 +800,9 @@ describe("assert", function () {
             });
 
             it("passes when method doesn't fail", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledWithExactly").returns(true);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 refute.exception(function () {
                     sinonAssert.calledWithExactly(stub, object, 1);
@@ -823,8 +823,8 @@ describe("assert", function () {
             });
 
             it("works with spyCall", function () {
-                var spy = sinonSpy();
-                var object = {};
+                const spy = sinonSpy();
+                const object = {};
                 spy();
                 spy(object);
 
@@ -834,8 +834,8 @@ describe("assert", function () {
             });
 
             it("fails when spyCall failed", function () {
-                var spy = sinonSpy();
-                var object = {};
+                const spy = sinonSpy();
+                const object = {};
                 spy();
                 spy(object);
 
@@ -852,9 +852,9 @@ describe("assert", function () {
             requiresValidFake("calledOnceWithExactly");
 
             it("fails when method fails", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledOnceWithExactly").returns(false);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.calledOnceWithExactly(stub, object, 1);
@@ -870,9 +870,9 @@ describe("assert", function () {
             });
 
             it("passes when method doesn't fail", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledOnceWithExactly").returns(true);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 refute.exception(function () {
                     sinonAssert.calledOnceWithExactly(stub, object, 1);
@@ -914,7 +914,7 @@ describe("assert", function () {
             });
 
             it("fails when method was not called", function () {
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.calledOnceWithExactly(stub);
@@ -924,7 +924,7 @@ describe("assert", function () {
             });
 
             it("fails when called with more than one argument", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
 
                 assert.exception(function () {
@@ -933,7 +933,7 @@ describe("assert", function () {
             });
 
             it("passes when method was called", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
 
                 refute.exception(function () {
@@ -944,7 +944,7 @@ describe("assert", function () {
             });
 
             it("fails when method was called more than once", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
                 stub();
 
@@ -961,9 +961,9 @@ describe("assert", function () {
             requiresValidFake("calledOnceWithMatch");
 
             it("fails when method fails", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledOnceWithMatch").returns(false);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.calledOnceWithMatch(stub, object, 1);
@@ -976,9 +976,9 @@ describe("assert", function () {
             });
 
             it("passes when method doesn't fail", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "calledOnceWithMatch").returns(true);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 refute.exception(function () {
                     sinonAssert.calledOnceWithMatch(stub, object, 1);
@@ -1017,7 +1017,7 @@ describe("assert", function () {
             });
 
             it("fails when method was not called", function () {
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.calledOnceWithMatch(stub);
@@ -1027,7 +1027,7 @@ describe("assert", function () {
             });
 
             it("fails when called with more than one argument", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
 
                 assert.exception(function () {
@@ -1036,7 +1036,7 @@ describe("assert", function () {
             });
 
             it("passes when method was called", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
 
                 refute.exception(function () {
@@ -1047,7 +1047,7 @@ describe("assert", function () {
             });
 
             it("fails when method was called more than once", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 stub();
                 stub();
 
@@ -1061,9 +1061,9 @@ describe("assert", function () {
 
         describe(".neverCalledWith", function () {
             it("fails when method fails", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "neverCalledWith").returns(false);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.neverCalledWith(stub, object, 1);
@@ -1074,9 +1074,9 @@ describe("assert", function () {
             });
 
             it("passes when method doesn't fail", function () {
-                var object = {};
+                const object = {};
                 sinonStub(this.stub, "neverCalledWith").returns(true);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 refute.exception(function () {
                     sinonAssert.neverCalledWith(stub, object, 1);
@@ -1098,7 +1098,7 @@ describe("assert", function () {
         describe(".threw", function () {
             it("fails when method fails", function () {
                 sinonStub(this.stub, "threw").returns(false);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.threw(stub, 1, 2);
@@ -1110,7 +1110,7 @@ describe("assert", function () {
 
             it("passes when method doesn't fail", function () {
                 sinonStub(this.stub, "threw").returns(true);
-                var stub = this.stub;
+                const stub = this.stub;
 
                 refute.exception(function () {
                     sinonAssert.threw(stub, 1, 2);
@@ -1130,7 +1130,7 @@ describe("assert", function () {
             });
 
             it("works with spyCall", function () {
-                var stub = sinonStub().throws("Error");
+                const stub = sinonStub().throws("Error");
                 assert.exception(function () {
                     stub();
                 });
@@ -1141,7 +1141,7 @@ describe("assert", function () {
             });
 
             it("fails when spyCall failed", function () {
-                var stub = sinonStub().returns("Error");
+                const stub = sinonStub().returns("Error");
                 stub();
 
                 assert.exception(function () {
@@ -1159,7 +1159,7 @@ describe("assert", function () {
             it("fails when method fails", function () {
                 this.stub();
                 this.stub();
-                var stub = this.stub;
+                const stub = this.stub;
 
                 assert.exception(function () {
                     sinonAssert.callCount(stub, 3);
@@ -1169,7 +1169,7 @@ describe("assert", function () {
             });
 
             it("passes when method doesn't fail", function () {
-                var stub = this.stub;
+                const stub = this.stub;
                 this.stub.callCount = 3;
 
                 refute.exception(function () {
@@ -1204,7 +1204,7 @@ describe("assert", function () {
             });
 
             it("fails if stub returns false", function () {
-                var stub = sinonStub();
+                const stub = sinonStub();
                 sinonStub(stub, "alwaysCalledOn").returns(false);
 
                 assert.exception(function () {
@@ -1215,7 +1215,7 @@ describe("assert", function () {
             });
 
             it("passes if stub returns true", function () {
-                var stub = sinonStub();
+                const stub = sinonStub();
                 sinonStub(stub, "alwaysCalledOn").returns(true);
 
                 sinonAssert.alwaysCalledOn(stub, {});
@@ -1259,7 +1259,7 @@ describe("assert", function () {
         });
 
         it("fails if stub returns false", function () {
-            var stub = sinonStub();
+            const stub = sinonStub();
             sinonStub(stub, "alwaysCalledWith").returns(false);
 
             assert.exception(function () {
@@ -1270,7 +1270,7 @@ describe("assert", function () {
         });
 
         it("passes if stub returns true", function () {
-            var stub = sinonStub();
+            const stub = sinonStub();
             sinonStub(stub, "alwaysCalledWith").returns(true);
 
             sinonAssert.alwaysCalledWith(stub, {}, []);
@@ -1279,7 +1279,7 @@ describe("assert", function () {
         });
 
         it("calls pass callback", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             spy("Hello");
             sinonAssert.alwaysCalledWith(spy, "Hello");
 
@@ -1300,7 +1300,7 @@ describe("assert", function () {
         });
 
         it("fails if stub returns false", function () {
-            var stub = sinonStub();
+            const stub = sinonStub();
             sinonStub(stub, "alwaysCalledWithExactly").returns(false);
 
             sinonAssert.alwaysCalledWithExactly(stub, {}, []);
@@ -1309,7 +1309,7 @@ describe("assert", function () {
         });
 
         it("passes if stub returns true", function () {
-            var stub = sinonStub();
+            const stub = sinonStub();
             sinonStub(stub, "alwaysCalledWithExactly").returns(true);
 
             sinonAssert.alwaysCalledWithExactly(stub, {}, []);
@@ -1318,7 +1318,7 @@ describe("assert", function () {
         });
 
         it("calls pass callback", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             spy("Hello");
             sinonAssert.alwaysCalledWithExactly(spy, "Hello");
 
@@ -1329,7 +1329,7 @@ describe("assert", function () {
 
     describe(".expose", function () {
         it("exposes asserts into object", function () {
-            var test = {};
+            const test = {};
             sinonAssert.expose(test);
 
             assert.isFunction(test.fail);
@@ -1377,7 +1377,7 @@ describe("assert", function () {
         });
 
         it("exposes asserts into object without prefixes", function () {
-            var test = {};
+            const test = {};
 
             sinonAssert.expose(test, { prefix: "" });
 
@@ -1393,7 +1393,7 @@ describe("assert", function () {
         });
 
         it("does not expose 'expose'", function () {
-            var test = {};
+            const test = {};
 
             sinonAssert.expose(test, { prefix: "" });
 
@@ -1496,7 +1496,7 @@ describe("assert", function () {
         });
 
         it("assert.callOrder exception message", function () {
-            var obj = {
+            const obj = {
                 doop: function () {
                     return;
                 },
@@ -1511,7 +1511,7 @@ describe("assert", function () {
             this.obj.doSomething();
             obj.foo();
 
-            var message = this.message(
+            const message = this.message(
                 "callOrder",
                 this.obj.doSomething,
                 obj.doop,
@@ -1525,7 +1525,7 @@ describe("assert", function () {
         });
 
         it("assert.callOrder with missing first call exception message", function () {
-            var obj = {
+            const obj = {
                 doop: function () {
                     return;
                 },
@@ -1538,7 +1538,7 @@ describe("assert", function () {
 
             obj.foo();
 
-            var message = this.message("callOrder", obj.doop, obj.foo);
+            const message = this.message("callOrder", obj.doop, obj.foo);
 
             assert.equals(
                 message,
@@ -1547,7 +1547,7 @@ describe("assert", function () {
         });
 
         it("assert.callOrder with missing last call exception message", function () {
-            var obj = {
+            const obj = {
                 doop: function () {
                     return;
                 },
@@ -1560,7 +1560,7 @@ describe("assert", function () {
 
             obj.doop();
 
-            var message = this.message("callOrder", obj.doop, obj.foo);
+            const message = this.message("callOrder", obj.doop, obj.foo);
 
             assert.equals(
                 message,
@@ -1631,12 +1631,12 @@ describe("assert", function () {
                 return "[Oh yeah]";
             };
 
-            var obj = {
+            const obj = {
                 toString: function () {
                     return "[Oh no]";
                 },
             };
-            var obj2 = {
+            const obj2 = {
                 toString: function () {
                     return "[Oh well]";
                 },
@@ -1660,12 +1660,12 @@ describe("assert", function () {
                 return "[Oh yeah]";
             };
 
-            var obj = {
+            const obj = {
                 toString: function () {
                     return "[Oh no]";
                 },
             };
-            var obj2 = {
+            const obj2 = {
                 toString: function () {
                     return "[Oh well]";
                 },
@@ -1735,7 +1735,7 @@ describe("assert", function () {
         });
 
         it("assert.calledWith exception message with large object arguments", function () {
-            var calledArg = [
+            const calledArg = [
                 {
                     first: "a",
                     second: { nest: true },
@@ -1746,7 +1746,7 @@ describe("assert", function () {
             ];
             this.obj.doSomething(calledArg);
 
-            var expectedArg = [
+            const expectedArg = [
                 {
                     first: "a",
                     second: { nest: true },
@@ -1756,7 +1756,7 @@ describe("assert", function () {
                 "fifth",
             ];
 
-            var actual = this.message(
+            const actual = this.message(
                 "calledWith",
                 this.obj.doSomething,
                 expectedArg
@@ -1771,13 +1771,13 @@ describe("assert", function () {
              *
              * @type {boolean}
              */
-            var usesCondensedFormat =
+            const usesCondensedFormat =
                 inspect([
                     { apple: "e4d13f88-9b9b-4e05-8abb-f76df2d4ef40" },
                     { pear: "841b661f-80f4-4560-9cf4-133dcffd240c" },
                 ]).indexOf("[ {") === 0;
 
-            var expected = usesCondensedFormat
+            const expected = usesCondensedFormat
                 ? `${
                       "expected doSomething to be called with arguments \n" +
                       "[ { first: 'a',\n" +
@@ -1887,7 +1887,7 @@ describe("assert", function () {
 
         it("assert.calledWith match.typeOf exception message", function () {
             this.obj.doSomething();
-            var matcher = match.typeOf("string");
+            const matcher = match.typeOf("string");
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, matcher),
@@ -1899,7 +1899,7 @@ describe("assert", function () {
 
         it("assert.calledWith match.instanceOf exception message", function () {
             this.obj.doSomething();
-            var matcher = match.instanceOf(function CustomType() {
+            const matcher = match.instanceOf(function CustomType() {
                 return;
             });
 
@@ -1913,7 +1913,7 @@ describe("assert", function () {
 
         it("assert.calledWith match object exception message", function () {
             this.obj.doSomething();
-            var matcher = match({ some: "value", and: 123 });
+            const matcher = match({ some: "value", and: 123 });
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, matcher),
@@ -1947,7 +1947,7 @@ describe("assert", function () {
 
         it("assert.calledWith match string exception message", function () {
             this.obj.doSomething();
-            var matcher = match("Sinon");
+            const matcher = match("Sinon");
 
             assert.equals(
                 this.message("calledWith", this.obj.doSomething, matcher),
@@ -1974,7 +1974,7 @@ describe("assert", function () {
 
         it("assert.calledWith match test function exception message", function () {
             this.obj.doSomething();
-            var matcher = match({
+            const matcher = match({
                 test: function custom() {
                     return;
                 },
@@ -2204,7 +2204,7 @@ describe("assert", function () {
             }
         });
 
-        var obj = {};
+        const obj = {};
 
         function setupSymbol(symbol) {
             obj[symbol] = function () {
@@ -2223,7 +2223,7 @@ describe("assert", function () {
         }
 
         it("should use the symbol's description in exception messages", function () {
-            var symbol = Symbol("Something Symbolic");
+            const symbol = Symbol("Something Symbolic");
             setupSymbol(symbol);
 
             assert.equals(
@@ -2237,7 +2237,7 @@ describe("assert", function () {
                 "occurred in exception messages, even if the symbol has no description",
             function () {
                 // eslint-disable-next-line symbol-description
-                var symbol = Symbol();
+                const symbol = Symbol();
                 setupSymbol(symbol);
 
                 assert.equals(

--- a/test/behavior-test.js
+++ b/test/behavior-test.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var sinon = require("../lib/sinon");
-var assert = require("@sinonjs/referee").assert;
+const sinon = require("../lib/sinon");
+const assert = require("@sinonjs/referee").assert;
 
 describe("behaviors", function () {
     it("adds and uses a custom behavior", function () {
@@ -9,7 +9,7 @@ describe("behaviors", function () {
             fake.returns(n);
         });
 
-        var stub = sinon.stub().returnsNum(42);
+        const stub = sinon.stub().returnsNum(42);
 
         assert.equals(stub(), 42);
     });

--- a/test/create-stub-instance-test.js
+++ b/test/create-stub-instance-test.js
@@ -1,27 +1,27 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var createStub = require("../lib/sinon/stub");
-var createStubInstance = require("../lib/sinon/create-stub-instance");
-var assert = referee.assert;
-var refute = referee.refute;
+const referee = require("@sinonjs/referee");
+const createStub = require("../lib/sinon/stub");
+const createStubInstance = require("../lib/sinon/create-stub-instance");
+const assert = referee.assert;
+const refute = referee.refute;
 
 describe("createStubInstance", function () {
     it("stubs existing methods", function () {
-        var Class = function () {
+        const Class = function () {
             return;
         };
         Class.prototype.method = function () {
             return;
         };
 
-        var stub = createStubInstance(Class);
+        const stub = createStubInstance(Class);
         stub.method.returns(3);
         assert.equals(3, stub.method());
     });
 
     it("throws with no methods to stub", function () {
-        var Class = function () {
+        const Class = function () {
             return;
         };
 
@@ -37,23 +37,23 @@ describe("createStubInstance", function () {
     });
 
     it("doesn't call the constructor", function () {
-        var Class = function (a, b) {
-            var c = a + b;
+        const Class = function (a, b) {
+            const c = a + b;
             throw c;
         };
         Class.prototype.method = function () {
             return;
         };
 
-        var stub = createStubInstance(Class);
+        const stub = createStubInstance(Class);
         refute.exception(function () {
             stub.method(3);
         });
     });
 
     it("retains non function values", function () {
-        var TYPE = "some-value";
-        var Class = function () {
+        const TYPE = "some-value";
+        const Class = function () {
             return;
         };
         Class.prototype.method = function () {
@@ -61,30 +61,30 @@ describe("createStubInstance", function () {
         };
         Class.prototype.type = TYPE;
 
-        var stub = createStubInstance(Class);
+        const stub = createStubInstance(Class);
         assert.equals(TYPE, stub.type);
     });
 
     it("has no side effects on the prototype", function () {
-        var proto = {
+        const proto = {
             method: function () {
                 throw new Error("error");
             },
         };
-        var Class = function () {
+        const Class = function () {
             return;
         };
         Class.prototype = proto;
 
-        var stub = createStubInstance(Class);
+        const stub = createStubInstance(Class);
         refute.exception(stub.method);
         assert.exception(proto.method);
     });
 
     it("throws exception for non function params", function () {
-        var types = [{}, 3, "hi!"];
+        const types = [{}, 3, "hi!"];
 
-        for (var i = 0; i < types.length; i++) {
+        for (let i = 0; i < types.length; i++) {
             // yes, it's silly to create functions in a loop, it's also a test
             // eslint-disable-next-line no-loop-func
             assert.exception(function () {
@@ -94,14 +94,14 @@ describe("createStubInstance", function () {
     });
 
     it("allows providing optional overrides", function () {
-        var Class = function () {
+        const Class = function () {
             return;
         };
         Class.prototype.method = function () {
             return;
         };
 
-        var stub = createStubInstance(Class, {
+        const stub = createStubInstance(Class, {
             method: createStub().returns(3),
         });
 
@@ -109,14 +109,14 @@ describe("createStubInstance", function () {
     });
 
     it("allows providing optional returned values", function () {
-        var Class = function () {
+        const Class = function () {
             return;
         };
         Class.prototype.method = function () {
             return;
         };
 
-        var stub = createStubInstance(Class, {
+        const stub = createStubInstance(Class, {
             method: 3,
         });
 
@@ -124,14 +124,14 @@ describe("createStubInstance", function () {
     });
 
     it("allows providing null as a return value", function () {
-        var Class = function () {
+        const Class = function () {
             return;
         };
         Class.prototype.method = function () {
             return;
         };
 
-        var stub = createStubInstance(Class, {
+        const stub = createStubInstance(Class, {
             method: null,
         });
 
@@ -139,7 +139,7 @@ describe("createStubInstance", function () {
     });
 
     it("throws an exception when trying to override non-existing property", function () {
-        var Class = function () {
+        const Class = function () {
             return;
         };
         Class.prototype.method = function () {

--- a/test/es2015/check-esm-bundle-is-runnable.js
+++ b/test/es2015/check-esm-bundle-is-runnable.js
@@ -55,7 +55,7 @@ async function evaluatePageContent() {
 
     // our "assertion framework" :)
     page.on("console", function (msg) {
-        var text = msg.text();
+        const text = msg.text();
 
         if (text.startsWith("sinon-result:works")) {
             browser.close();

--- a/test/extend-test.js
+++ b/test/extend-test.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var extend = require("../lib/sinon/util/core/extend");
-var assert = referee.assert;
+const referee = require("@sinonjs/referee");
+const extend = require("../lib/sinon/util/core/extend");
+const assert = referee.assert;
 
 describe("extend", function () {
     it("should return unaltered target when only one argument", function () {
-        var target = { hello: "world" };
+        const target = { hello: "world" };
 
         extend(target);
 
@@ -14,7 +14,7 @@ describe("extend", function () {
     });
 
     it("should copy all (own) properties into first argument, from all subsequent arguments", function () {
-        var target = { hello: "world" };
+        const target = { hello: "world" };
 
         extend(target, { a: "a" }, { b: "b" });
 
@@ -24,13 +24,13 @@ describe("extend", function () {
     });
 
     it("should copy toString method into target", function () {
-        var target = {
+        const target = {
             hello: "world",
             toString: function () {
                 return "hello world";
             },
         };
-        var source = {
+        const source = {
             toString: function () {
                 return "hello source";
             },
@@ -42,10 +42,10 @@ describe("extend", function () {
     });
 
     it("must copy the last occurring property into the target", function () {
-        var target = { a: 0, b: 0, c: 0, d: 0 };
-        var source1 = { a: 1, b: 1, c: 1 };
-        var source2 = { a: 2, b: 2 };
-        var source3 = { a: 3 };
+        const target = { a: 0, b: 0, c: 0, d: 0 };
+        const source1 = { a: 1, b: 1, c: 1 };
+        const source2 = { a: 2, b: 2 };
+        const source3 = { a: 3 };
 
         extend(target, source1, source2, source3);
 
@@ -56,19 +56,19 @@ describe("extend", function () {
     });
 
     it("copies all properties", function () {
-        var object1 = {
+        const object1 = {
             prop1: null,
             prop2: false,
         };
 
-        var object2 = {
+        const object2 = {
             prop3: "hey",
             prop4: 4,
         };
 
-        var result = extend({}, object1, object2);
+        const result = extend({}, object1, object2);
 
-        var expected = {
+        const expected = {
             prop1: null,
             prop2: false,
             prop3: "hey",
@@ -79,7 +79,7 @@ describe("extend", function () {
     });
 
     it("copies accessor properties into the target", function () {
-        var target = {
+        const target = {
             hello: "hello",
         };
         const obj = {
@@ -132,7 +132,7 @@ describe("extend", function () {
 
     context("when 'name' property is not writable", function () {
         it("does not attempt to write to the property", function () {
-            var object1 = { prop1: null };
+            const object1 = { prop1: null };
 
             Object.defineProperty(object1, "name", {
                 configurable: false,
@@ -141,14 +141,14 @@ describe("extend", function () {
                 writable: false,
             });
 
-            var object2 = {
+            const object2 = {
                 prop2: "hey",
                 name: "write-attempt",
             };
 
-            var result = extend(object1, object2);
+            const result = extend(object1, object2);
 
-            var expected = {
+            const expected = {
                 prop1: null,
                 prop2: "hey",
                 name: "not-writable",

--- a/test/fake-test.js
+++ b/test/fake-test.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var sinon = require("../lib/sinon.js");
-var createProxy = require("../lib/sinon/proxy");
-var fake = sinon.fake;
-var referee = require("@sinonjs/referee");
-var assert = referee.assert;
-var refute = referee.refute;
+const sinon = require("../lib/sinon.js");
+const createProxy = require("../lib/sinon/proxy");
+const fake = sinon.fake;
+const referee = require("@sinonjs/referee");
+const assert = referee.assert;
+const refute = referee.refute;
 
 referee.add("isProxy", {
     assert: function assertIsProxy(actual) {
@@ -26,7 +26,7 @@ referee.add("isProxy", {
 
 function verifyProxy(func, argument) {
     it("should return a Sinon proxy", function () {
-        var actual = argument ? func(argument) : func();
+        const actual = argument ? func(argument) : func();
 
         assert.isProxy(actual);
     });
@@ -42,7 +42,7 @@ function requirePromiseSupport() {
     }
 }
 
-var hasFunctionNameSupport = noop.name === "noop";
+const hasFunctionNameSupport = noop.name === "noop";
 
 describe("fake", function () {
     describe("module", function () {
@@ -64,10 +64,10 @@ describe("fake", function () {
             function method() {
                 return this.foo;
             }
-            var o = { foo: 42 };
-            var fakeMethod = fake(method);
+            const o = { foo: 42 };
+            const fakeMethod = fake(method);
 
-            var result = fakeMethod.call(o);
+            const result = fakeMethod.call(o);
 
             assert.equals(fakeMethod.callCount, 1);
             assert.equals(result, 42);
@@ -80,7 +80,16 @@ describe("fake", function () {
     });
 
     it("should reject non-Function argument", function () {
-        var nonFuncs = ["", 123, new Date(), {}, false, undefined, true, null];
+        const nonFuncs = [
+            "",
+            123,
+            new Date(),
+            {},
+            false,
+            undefined,
+            true,
+            null,
+        ];
 
         nonFuncs.forEach(function (nf) {
             assert.exception(function () {
@@ -91,11 +100,11 @@ describe("fake", function () {
 
     describe(".callback", function () {
         it("it should be a reference for the callback in the last call", function () {
-            var f = fake();
-            var callback1 = function () {
+            const f = fake();
+            const callback1 = function () {
                 return;
             };
-            var callback2 = function () {
+            const callback2 = function () {
                 return;
             };
 
@@ -112,7 +121,7 @@ describe("fake", function () {
 
     describe(".displayName", function () {
         it("should be 'fake'", function () {
-            var fakes = [
+            const fakes = [
                 fake(),
                 fake.returns(42),
                 fake.throws(new Error()),
@@ -130,7 +139,7 @@ describe("fake", function () {
 
     describe(".id", function () {
         it("should start with 'fake#'", function () {
-            for (var i = 0; i < 100; i++) {
+            for (let i = 0; i < 100; i++) {
                 assert.isTrue(fake().id.indexOf("fake#") === 0);
             }
         });
@@ -138,7 +147,7 @@ describe("fake", function () {
 
     describe(".firstArg", function () {
         it("should be the first argument from the last call", function () {
-            var f = fake();
+            const f = fake();
             f(41, 42, 43);
             assert.equals(f.firstArg, 41);
 
@@ -167,7 +176,7 @@ describe("fake", function () {
 
     describe(".lastArg", function () {
         it("should be the last argument from the last call", function () {
-            var f = fake();
+            const f = fake();
             f(41, 42, 43);
             assert.equals(f.lastArg, 43);
 
@@ -196,9 +205,9 @@ describe("fake", function () {
 
     describe(".returns", function () {
         it("should return a function that returns the argument", function () {
-            var expected = 42;
-            var myFake = fake.returns(expected);
-            var actual = myFake();
+            const expected = 42;
+            const myFake = fake.returns(expected);
+            const actual = myFake();
 
             assert.equals(actual, expected);
         });
@@ -209,8 +218,8 @@ describe("fake", function () {
 
     describe(".throws", function () {
         it("should return a function that throws an Error, that is the argument", function () {
-            var expectedMessage = "42";
-            var myFake = fake.throws(expectedMessage);
+            const expectedMessage = "42";
+            const myFake = fake.throws(expectedMessage);
 
             assert.exception(function () {
                 myFake();
@@ -229,8 +238,8 @@ describe("fake", function () {
         verifyProxy(fake.throws, "42");
 
         it("should return the same error type as it is passed", function () {
-            var expected = new TypeError("hello sailor");
-            var myFake = fake.throws(expected);
+            const expected = new TypeError("hello sailor");
+            const myFake = fake.throws(expected);
 
             /* eslint-disable no-restricted-syntax */
             try {
@@ -243,8 +252,8 @@ describe("fake", function () {
 
         describe("when passed a String", function () {
             it("should throw an Error", function () {
-                var expected = "lorem ipsum";
-                var myFake = fake.throws(expected);
+                const expected = "lorem ipsum";
+                const myFake = fake.throws(expected);
 
                 /* eslint-disable no-restricted-syntax */
                 try {
@@ -261,8 +270,8 @@ describe("fake", function () {
         before(requirePromiseSupport);
 
         it("should return a function that resolves to the argument", function () {
-            var expected = 42;
-            var myFake = fake.resolves(expected);
+            const expected = 42;
+            const myFake = fake.resolves(expected);
 
             return myFake().then(function (actual) {
                 assert.equals(actual, expected);
@@ -277,8 +286,8 @@ describe("fake", function () {
         before(requirePromiseSupport);
 
         it("should return a function that rejects to the argument", function () {
-            var expectedMessage = "42";
-            var myFake = fake.rejects(expectedMessage);
+            const expectedMessage = "42";
+            const myFake = fake.rejects(expectedMessage);
 
             return myFake().catch(function (actual) {
                 assert.equals(actual.message, expectedMessage);
@@ -289,8 +298,8 @@ describe("fake", function () {
         verifyProxy(fake.rejects, "42");
 
         it("should return the same error type as it is passed", function () {
-            var expected = new TypeError("hello world");
-            var myFake = fake.rejects(expected);
+            const expected = new TypeError("hello world");
+            const myFake = fake.rejects(expected);
 
             return myFake().catch(function (actual) {
                 assert.isTrue(actual instanceof TypeError);
@@ -298,8 +307,8 @@ describe("fake", function () {
         });
 
         it("should reject with an Error when passed a String", function () {
-            var expected = "lorem ipsum";
-            var myFake = fake.rejects(expected);
+            const expected = "lorem ipsum";
+            const myFake = fake.rejects(expected);
 
             return myFake().catch(function (actual) {
                 assert.isTrue(actual instanceof Error);
@@ -312,8 +321,8 @@ describe("fake", function () {
         verifyProxy(fake.yields, noop, "42", "43");
 
         it("should call a callback with the provided values", function () {
-            var callback = sinon.spy();
-            var myFake = fake.yields("one", "two", "three");
+            const callback = sinon.spy();
+            const myFake = fake.yields("one", "two", "three");
 
             myFake(callback);
 
@@ -322,8 +331,8 @@ describe("fake", function () {
         });
 
         it("should call the last function argument", function () {
-            var callback = sinon.spy();
-            var myFake = fake.yields();
+            const callback = sinon.spy();
+            const myFake = fake.yields();
 
             myFake(function () {
                 return;
@@ -333,7 +342,7 @@ describe("fake", function () {
         });
 
         it("should throw if the last argument is not a function", function () {
-            var myFake = fake.yields();
+            const myFake = fake.yields();
 
             assert.exception(function () {
                 myFake(function () {
@@ -348,8 +357,8 @@ describe("fake", function () {
         verifyProxy(fake.yieldsAsync, noop, "42", "43");
 
         it("should call the callback asynchronously with the provided values", function (done) {
-            var callback = sinon.spy();
-            var myFake = fake.yieldsAsync("one", "two", "three");
+            const callback = sinon.spy();
+            const myFake = fake.yieldsAsync("one", "two", "three");
 
             myFake(callback);
 
@@ -364,8 +373,8 @@ describe("fake", function () {
         });
 
         it("should call the last function argument", function (done) {
-            var callback = sinon.spy();
-            var myFake = fake.yieldsAsync();
+            const callback = sinon.spy();
+            const myFake = fake.yieldsAsync();
 
             myFake(function () {
                 return;
@@ -381,7 +390,7 @@ describe("fake", function () {
         });
 
         it("should throw if the last argument is not a function", function () {
-            var myFake = fake.yieldsAsync();
+            const myFake = fake.yieldsAsync();
 
             assert.exception(function () {
                 myFake(function () {
@@ -393,22 +402,22 @@ describe("fake", function () {
 
     describe(".named", function () {
         before(function beforeFunc() {
-            var desc = Object.getOwnPropertyDescriptor(beforeFunc, "name");
+            const desc = Object.getOwnPropertyDescriptor(beforeFunc, "name");
             if (!desc || !desc.configurable) {
                 this.skip();
             }
         });
 
         it("should set the name of the fake to the given string", function () {
-            var myFake = fake().named("something");
+            const myFake = fake().named("something");
 
             assert.equals(myFake.name, "something");
         });
     });
 
     describe(".calledBefore/After", function () {
-        var fakeA;
-        var fakeB;
+        let fakeA;
+        let fakeB;
 
         beforeEach(function () {
             fakeA = fake();
@@ -470,8 +479,8 @@ describe("fake", function () {
 
     describe(".printf", function () {
         it("is delegated to proxy", function () {
-            var myFake = fake();
-            var proxy = createProxy(noop, noop);
+            const myFake = fake();
+            const proxy = createProxy(noop, noop);
 
             assert.same(myFake.printf, proxy.printf);
         });
@@ -486,14 +495,14 @@ describe("fake", function () {
         });
 
         it("should set the promise used by resolve", function () {
-            var promise = {
+            const promise = {
                 resolve: function (value) {
                     return Promise.resolve(value);
                 },
             };
-            var object = {};
+            const object = {};
 
-            var myFake = fake.usingPromise(promise).resolves(object);
+            const myFake = fake.usingPromise(promise).resolves(object);
 
             return myFake().then(function (actual) {
                 assert.same(actual, object, "Same object resolved");
@@ -501,14 +510,14 @@ describe("fake", function () {
         });
 
         it("should set the promise used by reject", function () {
-            var promise = {
+            const promise = {
                 reject: function (err) {
                     return Promise.reject(err);
                 },
             };
-            var reason = new Error();
+            const reason = new Error();
 
-            var myFake = fake.usingPromise(promise).rejects(reason);
+            const myFake = fake.usingPromise(promise).rejects(reason);
 
             return myFake()
                 .then(function () {

--- a/test/get-config.js
+++ b/test/get-config.js
@@ -1,13 +1,13 @@
 "use strict";
 
-var defaultConfig = require("../lib/sinon/util/core/default-config");
-var hasOwnProperty =
+const defaultConfig = require("../lib/sinon/util/core/default-config");
+const hasOwnProperty =
     require("@sinonjs/commons").prototypes.object.hasOwnProperty;
 
 module.exports = function getConfig(custom) {
-    var config = {};
-    var prop;
-    var kustom = custom || {};
+    const config = {};
+    let prop;
+    const kustom = custom || {};
 
     for (prop in defaultConfig) {
         if (hasOwnProperty(defaultConfig, prop)) {

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -1,13 +1,13 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var sinon = require("../../lib/sinon");
-var createStub = require("../../lib/sinon/stub");
-var assert = referee.assert;
-var refute = referee.refute;
-var globalContext = typeof global !== "undefined" ? global : window;
-var globalXHR = globalContext.XMLHttpRequest;
-var globalAXO = globalContext.ActiveXObject;
+const referee = require("@sinonjs/referee");
+const sinon = require("../../lib/sinon");
+const createStub = require("../../lib/sinon/stub");
+const assert = referee.assert;
+const refute = referee.refute;
+const globalContext = typeof global !== "undefined" ? global : window;
+const globalXHR = globalContext.XMLHttpRequest;
+const globalAXO = globalContext.ActiveXObject;
 
 describe("issues", function () {
     beforeEach(function () {
@@ -20,10 +20,10 @@ describe("issues", function () {
 
     it("#283", function () {
         function testSinonFakeTimersWith(interval, ticks) {
-            var clock = sinon.useFakeTimers();
+            const clock = sinon.useFakeTimers();
 
-            var spy = sinon.spy();
-            var id = setInterval(spy, interval);
+            const spy = sinon.spy();
+            const id = setInterval(spy, interval);
             assert(!spy.calledOnce);
             clock.tick(ticks);
             assert(spy.callCount === Math.floor(ticks / interval));
@@ -49,8 +49,8 @@ describe("issues", function () {
             });
 
             it("stub out fs.readFileSync", function () {
-                var fs = require("fs");
-                var testCase = this;
+                const fs = require("fs");
+                const testCase = this;
 
                 refute.exception(function () {
                     testCase.sandbox.stub(fs, "readFileSync");
@@ -65,7 +65,7 @@ describe("issues", function () {
             // Issue #624 shows that useFakeTimers is not idempotent when it comes to
             // using Date.now
             // This test verifies that it's working, at least for Date.now
-            var clock;
+            let clock;
 
             clock = sinon.useFakeTimers(new Date("2014-12-29").getTime());
             assert.equals(clock.now, Date.now());
@@ -80,10 +80,10 @@ describe("issues", function () {
 
     describe("#852 - createStubInstance on inherited constructors", function () {
         it("must not throw error", function () {
-            var A = function () {
+            const A = function () {
                 return;
             };
-            var B = function () {
+            const B = function () {
                 return;
             };
 
@@ -101,7 +101,7 @@ describe("issues", function () {
 
     describe("#852(2) - createStubInstance should on same constructor", function () {
         it("must be idempotent", function () {
-            var A = function () {
+            const A = function () {
                 return;
             };
             A.prototype.meth = function () {
@@ -128,14 +128,14 @@ describe("issues", function () {
         });
 
         it("should not rename spies", function () {
-            var nameDescriptor = Object.getOwnPropertyDescriptor(bob, "name");
-            var expectedName =
+            const nameDescriptor = Object.getOwnPropertyDescriptor(bob, "name");
+            const expectedName =
                 nameDescriptor && nameDescriptor.configurable ? "bob" : "proxy";
-            var spy = sinon.spy(bob);
+            const spy = sinon.spy(bob);
 
             assert.equals(spy.name, expectedName);
 
-            var obj = { methodName: spy };
+            const obj = { methodName: spy };
             assert.equals(spy.name, expectedName);
 
             spy();
@@ -164,7 +164,7 @@ describe("issues", function () {
                 }
             }
 
-            var oldWatch;
+            let oldWatch;
 
             // eslint-disable-next-line no-restricted-syntax
             try {
@@ -177,7 +177,7 @@ describe("issues", function () {
                     };
                 }
 
-                var stubbedObject = sinon.stub({
+                const stubbedObject = sinon.stub({
                     watch: function () {
                         return;
                     },
@@ -197,9 +197,9 @@ describe("issues", function () {
 
     describe("#1154", function () {
         it("Ensures different matchers will not be tested against each other", function () {
-            var match = sinon.match;
-            var stub = sinon.stub;
-            var readFile = stub();
+            const match = sinon.match;
+            const stub = sinon.stub;
+            const readFile = stub();
 
             function endsWith(str, suffix) {
                 return str.indexOf(suffix) + suffix.length === str.length;
@@ -213,12 +213,12 @@ describe("issues", function () {
                 return endsWith(fileName, "suffixb");
             }
 
-            var argsA = match(suffixA);
-            var argsB = match(suffixB);
+            const argsA = match(suffixA);
+            const argsB = match(suffixB);
 
-            var firstFake = readFile.withArgs(argsA);
+            const firstFake = readFile.withArgs(argsA);
 
-            var secondFake = readFile.withArgs(argsB);
+            const secondFake = readFile.withArgs(argsB);
 
             assert(firstFake !== secondFake);
         });
@@ -226,7 +226,7 @@ describe("issues", function () {
 
     describe("#1372 - sandbox.resetHistory", function () {
         it("should reset spies", function () {
-            var spy = this.sandbox.spy();
+            const spy = this.sandbox.spy();
 
             spy();
             assert.equals(spy.callCount, 1);
@@ -243,8 +243,8 @@ describe("issues", function () {
 
     describe("#1398", function () {
         it("Call order takes into account both calledBefore and callCount", function () {
-            var s1 = sinon.spy();
-            var s2 = sinon.spy();
+            const s1 = sinon.spy();
+            const s2 = sinon.spy();
 
             s1();
             s2();
@@ -257,7 +257,7 @@ describe("issues", function () {
     });
 
     describe("#1474 - promise library should be propagated through fakes and behaviors", function () {
-        var stub;
+        let stub;
 
         function makeAssertions(fake, expected) {
             assert.isFunction(fake.then);
@@ -273,9 +273,9 @@ describe("issues", function () {
         });
 
         beforeEach(function () {
-            var promiseLib = {
+            const promiseLib = {
                 resolve: function (value) {
-                    var promise = Promise.resolve(value);
+                    const promise = Promise.resolve(value);
                     promise.tap = function () {
                         return `tap ${value}`;
                     };
@@ -307,12 +307,12 @@ describe("issues", function () {
     });
 
     describe("#1456", function () {
-        var sandbox;
+        let sandbox;
 
         function throwsOnUnconfigurableProperty() {
             /* eslint-disable no-restricted-syntax */
             try {
-                var preDescriptor = Object.getOwnPropertyDescriptor(
+                const preDescriptor = Object.getOwnPropertyDescriptor(
                     window,
                     "innerHeight"
                 ); //backup val
@@ -376,7 +376,7 @@ describe("issues", function () {
     });
 
     describe("#1512 - sandbox.stub(obj,protoMethod)", function () {
-        var sandbox;
+        let sandbox;
 
         beforeEach(function () {
             sandbox = sinon.createSandbox();
@@ -387,21 +387,21 @@ describe("issues", function () {
         });
 
         it("can stub methods on the prototype", function () {
-            var proto = {
+            const proto = {
                 someFunction: function () {
                     return;
                 },
             };
-            var instance = Object.create(proto);
+            const instance = Object.create(proto);
 
-            var stub = sandbox.stub(instance, "someFunction");
+            const stub = sandbox.stub(instance, "someFunction");
             instance.someFunction();
             assert(stub.called);
         });
     });
 
     describe("#1521 - stubbing Array.prototype.filter", function () {
-        var orgFilter;
+        let orgFilter;
 
         before(function () {
             orgFilter = Array.prototype.filter;
@@ -413,7 +413,7 @@ describe("issues", function () {
         });
 
         it("should be possible stub filter", function () {
-            var stub = sinon.stub(Array.prototype, "filter");
+            const stub = sinon.stub(Array.prototype, "filter");
             [1, 2, 3].filter(function () {
                 return false;
             });
@@ -437,13 +437,13 @@ describe("issues", function () {
 
     describe("#1442 - callThrough with a mock expectation", function () {
         it("should call original method", function () {
-            var foo = {
+            const foo = {
                 bar: function () {
                     return;
                 },
             };
 
-            var mock = this.sandbox.mock(foo);
+            const mock = this.sandbox.mock(foo);
             mock.expects("bar").callThrough();
 
             foo.bar();
@@ -454,7 +454,7 @@ describe("issues", function () {
 
     describe("#1648 - resetHistory ", function () {
         it("should reset property spies", function () {
-            var obj = {
+            const obj = {
                 func: function () {
                     return;
                 },
@@ -463,9 +463,9 @@ describe("issues", function () {
                 },
             };
 
-            var sandbox = sinon.createSandbox();
-            var spyFunc = sandbox.spy(obj, "func");
-            var spyProp = sandbox.spy(obj, "prop", ["get"]);
+            const sandbox = sinon.createSandbox();
+            const spyFunc = sandbox.spy(obj, "func");
+            const spyProp = sandbox.spy(obj, "prop", ["get"]);
 
             refute.isTrue(spyFunc.called);
             refute.isTrue(spyProp.get.called);
@@ -488,7 +488,7 @@ describe("issues", function () {
     // and thus were not restorable
     describe("#1775 - sinon.restore", function () {
         it("should restore all stubs", function () {
-            var myApi = {
+            const myApi = {
                 someMethod: function someMethod() {
                     // eslint-disable-next-line no-console
                     console.log("test method!");
@@ -502,7 +502,7 @@ describe("issues", function () {
         });
 
         it("should restore all spies", function () {
-            var myApi = {
+            const myApi = {
                 someMethod: function someMethod() {
                     // eslint-disable-next-line no-console
                     console.log("test method!");
@@ -516,7 +516,7 @@ describe("issues", function () {
         });
 
         it("should restore all mocks", function () {
-            var myApi = {
+            const myApi = {
                 someMethod: function someMethod() {
                     // eslint-disable-next-line no-console
                     console.log("test method!");
@@ -532,7 +532,7 @@ describe("issues", function () {
 
     describe("#1801 - sinon.restore spied fakeTimers", function () {
         it("should restore spied fake timers", function () {
-            var originalSetTimeout = setTimeout;
+            const originalSetTimeout = setTimeout;
 
             sinon.useFakeTimers();
             sinon.spy(globalContext, "setTimeout");
@@ -559,12 +559,12 @@ describe("issues", function () {
 
     describe("#1709 - deepEqual fails on cyclic references", function () {
         it("should not blow up", function () {
-            var spy = sinon.spy();
+            const spy = sinon.spy();
 
-            var firstObj = {};
+            const firstObj = {};
             firstObj.aKeyName = firstObj;
 
-            var secondObj = {};
+            const secondObj = {};
             secondObj.aKeyName = secondObj;
 
             spy(firstObj);
@@ -575,7 +575,7 @@ describe("issues", function () {
 
     describe("#1796 - cannot stub Array.prototype.sort", function () {
         it("it should not fail with RangeError", function () {
-            var stub = sinon.stub(Array.prototype, "sort");
+            const stub = sinon.stub(Array.prototype, "sort");
 
             refute.exception(function () {
                 [1, 2, 3].sort();
@@ -587,13 +587,13 @@ describe("issues", function () {
 
     describe("#1900 - calledWith returns false positive", function () {
         it("should return false when call args don't match", function () {
-            var spy = sinon.spy();
-            var dateOne = new Date("2018-07-01");
-            var dateTwo = new Date("2018-07-31");
+            const spy = sinon.spy();
+            const dateOne = new Date("2018-07-01");
+            const dateTwo = new Date("2018-07-31");
 
             spy(dateOne);
 
-            var calledWith = spy.calledWith(dateTwo);
+            const calledWith = spy.calledWith(dateTwo);
             assert.same(calledWith, false);
         });
     });
@@ -611,18 +611,18 @@ describe("issues", function () {
             ClassWithoutProps.prototype.constructor = ClassWithoutProps;
             AnotherClassWithoutProps.prototype.constructor =
                 AnotherClassWithoutProps;
-            var arg1 = new ClassWithoutProps(); //arg1.constructor.name === ClassWithoutProps
-            var arg2 = new AnotherClassWithoutProps(); //arg2.constructor.name === Object
-            var stub = sinon.stub();
+            const arg1 = new ClassWithoutProps(); //arg1.constructor.name === ClassWithoutProps
+            const arg2 = new AnotherClassWithoutProps(); //arg2.constructor.name === Object
+            const stub = sinon.stub();
             stub.withArgs(arg1).returns(5);
-            var result = stub(arg2);
+            const result = stub(arg2);
             assert.same(result, undefined); //[ERR_ASSERTION]: 5 === undefined
         });
     });
 
     describe("#1887", function () {
         it("should not break stub behavior using multiple `match.any`", function () {
-            var stub = sinon.stub();
+            const stub = sinon.stub();
 
             stub.withArgs(
                 sinon.match.any,
@@ -642,7 +642,7 @@ describe("issues", function () {
 
     describe("#1986", function () {
         it("should not set `lastArg` to undefined when last argument is `false`", function () {
-            var fake = sinon.fake();
+            const fake = sinon.fake();
 
             fake(99, false);
 
@@ -652,16 +652,16 @@ describe("issues", function () {
 
     describe("#1964", function () {
         it("should allow callThrough on a withArgs fake", function () {
-            var calledThrough = false;
-            var obj = {
+            let calledThrough = false;
+            const obj = {
                 method: function () {
                     calledThrough = true;
                 },
             };
 
-            var baseStub = sinon.stub(obj, "method");
+            const baseStub = sinon.stub(obj, "method");
             baseStub.throws("Should always hit the withArgs fake");
-            var argsStub = baseStub.withArgs("foo").callThrough();
+            const argsStub = baseStub.withArgs("foo").callThrough();
 
             obj.method("foo");
 
@@ -680,7 +680,7 @@ describe("issues", function () {
             return;
         };
 
-        var sandbox;
+        let sandbox;
         beforeEach(function () {
             sandbox = sinon.createStubInstance(Foo);
         });
@@ -721,14 +721,14 @@ describe("issues", function () {
         };
 
         it("should override the method", function () {
-            var thing = sinon.createStubInstance(Foo, {
+            const thing = sinon.createStubInstance(Foo, {
                 testMethod: sinon.stub().returns(2),
             });
             assert.equals(thing.testMethod(), 2);
         });
 
         it("should support calling without object binding", function () {
-            var createStubInstance = sinon.createStubInstance;
+            const createStubInstance = sinon.createStubInstance;
             refute.exception(function () {
                 createStubInstance(Foo);
             });
@@ -737,8 +737,8 @@ describe("issues", function () {
 
     describe("#2065", function () {
         it("should restore the state of lastArg on the stub when resetting the sandbox", function () {
-            var sandbox = sinon.createSandbox();
-            var fake = sandbox.fake();
+            const sandbox = sinon.createSandbox();
+            const fake = sandbox.fake();
             fake(1, 2, 3);
             assert.equals(fake.lastArg, 3);
             sandbox.reset();
@@ -748,8 +748,8 @@ describe("issues", function () {
 
     describe("#2226 - props on prototype are not restored correctly", function () {
         function createObjectWithPropFromPrototype() {
-            var proto = {};
-            var obj = {};
+            const proto = {};
+            const obj = {};
 
             Object.setPrototypeOf(obj, proto);
             Object.defineProperty(proto, "test", { writable: true, value: 1 });
@@ -757,21 +757,21 @@ describe("issues", function () {
         }
 
         it("should restore fakes shadowing prototype props correctly", function () {
-            var obj = createObjectWithPropFromPrototype();
+            const obj = createObjectWithPropFromPrototype();
 
-            var originalPropertyDescriptor = Object.getOwnPropertyDescriptor(
+            const originalPropertyDescriptor = Object.getOwnPropertyDescriptor(
                 obj,
                 "test"
             );
 
             sinon.replace(obj, "test", 2);
-            var replacedPropertyDescriptor = Object.getOwnPropertyDescriptor(
+            const replacedPropertyDescriptor = Object.getOwnPropertyDescriptor(
                 obj,
                 "test"
             );
 
             sinon.restore();
-            var restoredPropertyDescriptor = Object.getOwnPropertyDescriptor(
+            const restoredPropertyDescriptor = Object.getOwnPropertyDescriptor(
                 obj,
                 "test"
             );
@@ -782,20 +782,20 @@ describe("issues", function () {
         });
 
         it("should restore stubs shadowing prototype props correctly", function () {
-            var obj = createObjectWithPropFromPrototype();
-            var originalPropertyDescriptor = Object.getOwnPropertyDescriptor(
+            const obj = createObjectWithPropFromPrototype();
+            const originalPropertyDescriptor = Object.getOwnPropertyDescriptor(
                 obj,
                 "test"
             );
 
             sinon.stub(obj, "test").value(2);
-            var replacedPropertyDescriptor = Object.getOwnPropertyDescriptor(
+            const replacedPropertyDescriptor = Object.getOwnPropertyDescriptor(
                 obj,
                 "test"
             );
 
             sinon.restore();
-            var restoredPropertyDescriptor = Object.getOwnPropertyDescriptor(
+            const restoredPropertyDescriptor = Object.getOwnPropertyDescriptor(
                 obj,
                 "test"
             );

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -1,28 +1,28 @@
 "use strict";
 
-var match = require("@sinonjs/samsam").createMatcher;
-var referee = require("@sinonjs/referee");
-var sinonMock = require("../lib/sinon/mock");
-var sinonExpectation = require("../lib/sinon/mock-expectation");
-var sinonStub = require("../lib/sinon/stub");
-var sinonSpy = require("../lib/sinon/spy");
-var assert = referee.assert;
-var refute = referee.refute;
+const match = require("@sinonjs/samsam").createMatcher;
+const referee = require("@sinonjs/referee");
+const sinonMock = require("../lib/sinon/mock");
+const sinonExpectation = require("../lib/sinon/mock-expectation");
+const sinonStub = require("../lib/sinon/stub");
+const sinonSpy = require("../lib/sinon/spy");
+const assert = referee.assert;
+const refute = referee.refute;
 
 describe("sinonMock", function () {
     it("creates anonymous mock functions", function () {
-        var expectation = sinonMock();
+        const expectation = sinonMock();
         assert.equals(expectation.method, "Anonymous mock");
     });
 
     it("creates named anonymous mock functions", function () {
-        var expectation = sinonMock("functionName");
+        const expectation = sinonMock("functionName");
         assert.equals(expectation.method, "functionName");
     });
 
     describe(".create", function () {
         it("returns function with expects method", function () {
-            var mock = sinonMock.create({});
+            const mock = sinonMock.create({});
 
             assert.isFunction(mock.expects);
         });
@@ -47,7 +47,7 @@ describe("sinonMock", function () {
         });
 
         it("throws without method", function () {
-            var mock = this.mock;
+            const mock = this.mock;
 
             assert.exception(
                 function () {
@@ -58,14 +58,14 @@ describe("sinonMock", function () {
         });
 
         it("returns expectation", function () {
-            var result = this.mock.expects("someMethod");
+            const result = this.mock.expects("someMethod");
 
             assert.isFunction(result);
             assert.equals(result.method, "someMethod");
         });
 
         it("throws if expecting a non-existent method", function () {
-            var mock = this.mock;
+            const mock = this.mock;
 
             assert.exception(function () {
                 mock.expects("someMethod2");
@@ -80,14 +80,14 @@ describe("sinonMock", function () {
         });
 
         it("creates unnamed expectation", function () {
-            var anonMock = sinonExpectation.create();
+            const anonMock = sinonExpectation.create();
             anonMock.never();
 
             assert(anonMock.verify());
         });
 
         it("uses 'anonymous mock expectation' for unnamed expectation", function () {
-            var anonMock = sinonExpectation.create();
+            const anonMock = sinonExpectation.create();
             anonMock.once();
 
             assert.exception(
@@ -108,7 +108,7 @@ describe("sinonMock", function () {
         });
 
         it("is invokable", function () {
-            var expectation = this.expectation;
+            const expectation = this.expectation;
 
             refute.exception(function () {
                 expectation();
@@ -117,7 +117,7 @@ describe("sinonMock", function () {
 
         describe(".returns", function () {
             it("returns configured return value", function () {
-                var object = {};
+                const object = {};
                 this.expectation.returns(object);
 
                 assert.same(this.expectation(), object);
@@ -126,7 +126,7 @@ describe("sinonMock", function () {
 
         describe("call", function () {
             it("is called with correct this value", function () {
-                var object = { method: this.expectation };
+                const object = { method: this.expectation };
                 object.method();
 
                 assert(this.expectation.calledOn(object));
@@ -135,7 +135,7 @@ describe("sinonMock", function () {
 
         describe(".callCount", function () {
             it("onlys be invokable once by default", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation();
 
                 assert.exception(
@@ -147,7 +147,7 @@ describe("sinonMock", function () {
             });
 
             it("throw readable error", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation();
 
                 assert.exception(expectation, {
@@ -158,7 +158,7 @@ describe("sinonMock", function () {
 
         describe(".callCountNever", function () {
             it("is not callable", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.never();
 
                 assert.exception(
@@ -176,7 +176,7 @@ describe("sinonMock", function () {
 
         describe(".callCountOnce", function () {
             it("allows one call", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.once();
                 expectation();
 
@@ -195,7 +195,7 @@ describe("sinonMock", function () {
 
         describe(".callCountTwice", function () {
             it("allows two calls", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.twice();
                 expectation();
                 expectation();
@@ -215,7 +215,7 @@ describe("sinonMock", function () {
 
         describe(".callCountThrice", function () {
             it("allows three calls", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.thrice();
                 expectation();
                 expectation();
@@ -236,7 +236,7 @@ describe("sinonMock", function () {
 
         describe(".callCountExactly", function () {
             it("allows specified number of calls", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.exactly(2);
                 expectation();
                 expectation();
@@ -254,7 +254,7 @@ describe("sinonMock", function () {
             });
 
             it("throws without argument", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
 
                 assert.exception(
                     function () {
@@ -265,7 +265,7 @@ describe("sinonMock", function () {
             });
 
             it("throws without number", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
 
                 assert.exception(
                     function () {
@@ -277,7 +277,7 @@ describe("sinonMock", function () {
 
             it("throws with Symbol", function () {
                 if (typeof Symbol === "function") {
-                    var expectation = this.expectation;
+                    const expectation = this.expectation;
 
                     assert.exception(
                         function () {
@@ -296,7 +296,7 @@ describe("sinonMock", function () {
 
         describe(".atLeast", function () {
             it("throws without argument", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
 
                 assert.exception(
                     function () {
@@ -307,7 +307,7 @@ describe("sinonMock", function () {
             });
 
             it("throws without number", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
 
                 assert.exception(
                     function () {
@@ -319,7 +319,7 @@ describe("sinonMock", function () {
 
             it("throws with Symbol", function () {
                 if (typeof Symbol === "function") {
-                    var expectation = this.expectation;
+                    const expectation = this.expectation;
 
                     assert.exception(
                         function () {
@@ -340,7 +340,7 @@ describe("sinonMock", function () {
             });
 
             it("allows any number of calls", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.atLeast(2);
                 expectation();
                 expectation();
@@ -376,12 +376,12 @@ describe("sinonMock", function () {
             });
 
             it("should not throw when exceeding at least expectation", function () {
-                var obj = {
+                const obj = {
                     foobar: function () {
                         return;
                     },
                 };
-                var mock = sinonMock(obj);
+                const mock = sinonMock(obj);
                 mock.expects("foobar").atLeast(1);
 
                 obj.foobar();
@@ -393,12 +393,12 @@ describe("sinonMock", function () {
             });
 
             it("should not throw when exceeding at least expectation and withargs", function () {
-                var obj = {
+                const obj = {
                     foobar: function () {
                         return;
                     },
                 };
-                var mock = sinonMock(obj);
+                const mock = sinonMock(obj);
 
                 mock.expects("foobar").withArgs("arg1");
                 mock.expects("foobar").atLeast(1).withArgs("arg2");
@@ -413,7 +413,7 @@ describe("sinonMock", function () {
 
         describe(".atMost", function () {
             it("throws without argument", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
 
                 assert.exception(
                     function () {
@@ -424,7 +424,7 @@ describe("sinonMock", function () {
             });
 
             it("throws without number", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
 
                 assert.exception(
                     function () {
@@ -436,7 +436,7 @@ describe("sinonMock", function () {
 
             it("throws with Symbol", function () {
                 if (typeof Symbol === "function") {
-                    var expectation = this.expectation;
+                    const expectation = this.expectation;
 
                     assert.exception(
                         function () {
@@ -457,7 +457,7 @@ describe("sinonMock", function () {
             });
 
             it("allows fewer calls", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.atMost(2);
 
                 refute.exception(function () {
@@ -481,7 +481,7 @@ describe("sinonMock", function () {
             });
 
             it("should not be met with excessive calls", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 this.expectation.atMost(2);
                 this.expectation();
                 this.expectation();
@@ -525,7 +525,7 @@ describe("sinonMock", function () {
             });
 
             it("throws with excessive calls", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation();
                 expectation();
                 expectation();
@@ -560,7 +560,7 @@ describe("sinonMock", function () {
         });
 
         describe(".withArgs", function () {
-            var expectedException = function (name) {
+            const expectedException = function (name) {
                 return {
                     test: function (actual) {
                         // eslint-disable-next-line mocha/no-setup-in-describe
@@ -584,7 +584,7 @@ describe("sinonMock", function () {
             });
 
             it("throws when called without args", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.withArgs(1, 2, 3);
 
                 assert.exception(
@@ -596,7 +596,7 @@ describe("sinonMock", function () {
             });
 
             it("throws when called with too few args", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.withArgs(1, 2, 3);
 
                 assert.exception(
@@ -608,7 +608,7 @@ describe("sinonMock", function () {
             });
 
             it("throws when called with wrong args", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.withArgs(1, 2, 3);
 
                 assert.exception(function () {
@@ -617,7 +617,7 @@ describe("sinonMock", function () {
             });
 
             it("allows excessive args", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.withArgs(1, 2, 3);
 
                 refute.exception(function () {
@@ -633,7 +633,7 @@ describe("sinonMock", function () {
             });
 
             it("allows no args called with excessive args", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.withArgs();
 
                 refute.exception(function () {
@@ -655,7 +655,7 @@ describe("sinonMock", function () {
             });
 
             it("throws when sinon matchers fail", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
 
                 this.expectation.withArgs(
                     match.number,
@@ -671,12 +671,12 @@ describe("sinonMock", function () {
             });
 
             it("should not throw when expectation withArgs using matcher", function () {
-                var obj = {
+                const obj = {
                     foobar: function () {
                         return;
                     },
                 };
-                var mock = sinonMock(obj);
+                const mock = sinonMock(obj);
                 mock.expects("foobar").withArgs(match.string);
 
                 refute.exception(function () {
@@ -701,7 +701,7 @@ describe("sinonMock", function () {
             });
 
             it("throws when called without args", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.withExactArgs(1, 2, 3);
 
                 assert.exception(
@@ -713,7 +713,7 @@ describe("sinonMock", function () {
             });
 
             it("throws when called with too few args", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.withExactArgs(1, 2, 3);
 
                 assert.exception(
@@ -725,7 +725,7 @@ describe("sinonMock", function () {
             });
 
             it("throws when called with wrong args", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.withExactArgs(1, 2, 3);
 
                 assert.exception(
@@ -737,7 +737,7 @@ describe("sinonMock", function () {
             });
 
             it("should not allow excessive args", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.withExactArgs(1, 2, 3);
 
                 assert.exception(
@@ -756,7 +756,7 @@ describe("sinonMock", function () {
             });
 
             it("does not allow excessive args with no expected args", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.withExactArgs();
 
                 assert.exception(
@@ -781,7 +781,7 @@ describe("sinonMock", function () {
             });
 
             it("throws if called on wrong object", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
                 expectation.on({});
 
                 assert.exception(
@@ -794,7 +794,7 @@ describe("sinonMock", function () {
 
             it("throws if calls on wrong Symbol", function () {
                 if (typeof Symbol === "function") {
-                    var expectation = sinonExpectation.create("method");
+                    const expectation = sinonExpectation.create("method");
                     expectation.on(Symbol("apple pie"));
 
                     assert.exception(
@@ -815,7 +815,7 @@ describe("sinonMock", function () {
         describe(".verify", function () {
             it("pass if met", function () {
                 sinonStub(sinonExpectation, "pass");
-                var expectation = this.expectation;
+                const expectation = this.expectation;
 
                 expectation();
                 expectation.verify();
@@ -825,7 +825,7 @@ describe("sinonMock", function () {
             });
 
             it("throws if not called enough times", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
 
                 assert.exception(
                     function () {
@@ -836,7 +836,7 @@ describe("sinonMock", function () {
             });
 
             it("throws readable error", function () {
-                var expectation = this.expectation;
+                const expectation = this.expectation;
 
                 assert.exception(
                     function () {
@@ -879,7 +879,7 @@ describe("sinonMock", function () {
         });
 
         it("restores if not met", function () {
-            var mock = this.mock;
+            const mock = this.mock;
             mock.expects("method");
 
             assert.exception(
@@ -893,7 +893,7 @@ describe("sinonMock", function () {
         });
 
         it("includes all calls in error message", function () {
-            var mock = this.mock;
+            const mock = this.mock;
             mock.expects("method").thrice();
             mock.expects("method").once().withArgs(42);
 
@@ -910,7 +910,7 @@ describe("sinonMock", function () {
         });
 
         it("includes exact expected arguments in error message", function () {
-            var mock = this.mock;
+            const mock = this.mock;
             mock.expects("method").once().withExactArgs(42);
 
             assert.exception(
@@ -924,7 +924,7 @@ describe("sinonMock", function () {
         });
 
         it("includes received call count in error message", function () {
-            var mock = this.mock;
+            const mock = this.mock;
             mock.expects("method").thrice().withExactArgs(42);
             this.object.method(42);
 
@@ -939,8 +939,8 @@ describe("sinonMock", function () {
         });
 
         it("includes unexpected calls in error message", function () {
-            var mock = this.mock;
-            var object = this.object;
+            const mock = this.mock;
+            const object = this.object;
 
             mock.expects("method").thrice().withExactArgs(42);
 
@@ -956,8 +956,8 @@ describe("sinonMock", function () {
         });
 
         it("includes met expectations in error message", function () {
-            var mock = this.mock;
-            var object = this.object;
+            const mock = this.mock;
+            const object = this.object;
 
             mock.expects("method").once().withArgs(1);
             mock.expects("method").thrice().withExactArgs(42);
@@ -977,7 +977,7 @@ describe("sinonMock", function () {
         });
 
         it("includes met expectations in error message from verify", function () {
-            var mock = this.mock;
+            const mock = this.mock;
 
             mock.expects("method").once().withArgs(1);
             mock.expects("method").thrice().withExactArgs(42);
@@ -995,7 +995,7 @@ describe("sinonMock", function () {
         });
 
         it("reports min calls in error message", function () {
-            var mock = this.mock;
+            const mock = this.mock;
             mock.expects("method").atLeast(1);
 
             assert.exception(
@@ -1010,8 +1010,8 @@ describe("sinonMock", function () {
         });
 
         it("reports max calls in error message", function () {
-            var mock = this.mock;
-            var object = this.object;
+            const mock = this.mock;
+            const object = this.object;
 
             mock.expects("method").atMost(2);
 
@@ -1029,8 +1029,8 @@ describe("sinonMock", function () {
         });
 
         it("reports min calls in met expectation", function () {
-            var mock = this.mock;
-            var object = this.object;
+            const mock = this.mock;
+            const object = this.object;
 
             mock.expects("method").atLeast(1);
             mock.expects("method").withArgs(2).once();
@@ -1051,7 +1051,7 @@ describe("sinonMock", function () {
         });
 
         it("reports max and min calls in error messages", function () {
-            var mock = this.mock;
+            const mock = this.mock;
             mock.expects("method").atLeast(1).atMost(2);
 
             assert.exception(
@@ -1066,8 +1066,8 @@ describe("sinonMock", function () {
         });
 
         it("fails even if the original expectation exception was caught", function () {
-            var mock = this.mock;
-            var object = this.object;
+            const mock = this.mock;
+            const object = this.object;
 
             mock.expects("method").once();
 
@@ -1086,9 +1086,9 @@ describe("sinonMock", function () {
         });
 
         it("does not call pass if no expectations", function () {
-            var pass = sinonStub(sinonExpectation, "pass");
+            const pass = sinonStub(sinonExpectation, "pass");
 
-            var mock = this.mock;
+            const mock = this.mock;
             mock.expects("method").never();
             delete mock.expectations;
 
@@ -1114,9 +1114,9 @@ describe("sinonMock", function () {
         });
 
         it("must return the mock", function () {
-            var mockPromise = {};
+            const mockPromise = {};
 
-            var actual = this.mock.usingPromise(mockPromise);
+            const actual = this.mock.usingPromise(mockPromise);
 
             assert.same(actual, this.mock);
         });
@@ -1126,8 +1126,8 @@ describe("sinonMock", function () {
                 return this.skip();
             }
 
-            var resolveValue = {};
-            var mockPromise = {
+            const resolveValue = {};
+            const mockPromise = {
                 resolve: sinonStub().resolves(resolveValue),
             };
 
@@ -1181,7 +1181,7 @@ describe("sinonMock", function () {
         it("verifies mock", function () {
             this.mock.expects("method");
             this.object.method();
-            var mock = this.mock;
+            const mock = this.mock;
 
             refute.exception(function () {
                 assert(mock.verify());
@@ -1190,7 +1190,7 @@ describe("sinonMock", function () {
 
         it("verifies mock with unmet expectations", function () {
             this.mock.expects("method");
-            var mock = this.mock;
+            const mock = this.mock;
 
             assert.exception(
                 function () {
@@ -1214,7 +1214,7 @@ describe("sinonMock", function () {
         });
 
         it("queues expectations", function () {
-            var object = this.object;
+            const object = this.object;
 
             refute.exception(function () {
                 object.method();
@@ -1222,7 +1222,7 @@ describe("sinonMock", function () {
         });
 
         it("starts on next expectation when first is met", function () {
-            var object = this.object;
+            const object = this.object;
             object.method();
 
             assert.exception(
@@ -1234,7 +1234,7 @@ describe("sinonMock", function () {
         });
 
         it("fails on last expectation", function () {
-            var object = this.object;
+            const object = this.object;
             object.method();
             object.method.call(this.thisValue);
 
@@ -1247,12 +1247,12 @@ describe("sinonMock", function () {
         });
 
         it("allows mock calls in any order", function () {
-            var object = {
+            const object = {
                 method: function () {
                     return;
                 },
             };
-            var mock = sinonMock(object);
+            const mock = sinonMock(object);
             mock.expects("method").once().withArgs(42);
             mock.expects("method").twice().withArgs("Yeah");
 
@@ -1280,7 +1280,7 @@ describe("sinonMock", function () {
 
     describe("mock function", function () {
         it("returns mock method", function () {
-            var mock = sinonMock();
+            const mock = sinonMock();
 
             assert.isFunction(mock);
             assert.isFunction(mock.atLeast);
@@ -1288,7 +1288,7 @@ describe("sinonMock", function () {
         });
 
         it("returns mock object", function () {
-            var mock = sinonMock({});
+            const mock = sinonMock({});
 
             assert.isObject(mock);
             assert.isFunction(mock.expects);
@@ -1298,8 +1298,8 @@ describe("sinonMock", function () {
 
     describe(".yields", function () {
         it("invokes only argument as callback", function () {
-            var mock = sinonMock().yields();
-            var spy = sinonSpy();
+            const mock = sinonMock().yields();
+            const spy = sinonSpy();
             mock(spy);
 
             assert(spy.calledOnce);
@@ -1307,7 +1307,7 @@ describe("sinonMock", function () {
         });
 
         it("throws understandable error if no callback is passed", function () {
-            var mock = sinonMock().yields();
+            const mock = sinonMock().yields();
 
             assert.exception(mock, {
                 message: "stub expected to yield, but no callback was passed.",

--- a/test/promise-test.js
+++ b/test/promise-test.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var sinon = require("../lib/sinon.js");
-var { assert, refute } = require("@sinonjs/referee");
+const sinon = require("../lib/sinon.js");
+const { assert, refute } = require("@sinonjs/referee");
 
 async function getPromiseStatus(promise) {
-    var status = "pending";
-    var value = null;
+    let status = "pending";
+    let value = null;
     promise
         .then(function (val) {
             status = "resolved";
@@ -24,9 +24,9 @@ async function getPromiseStatus(promise) {
 describe("promise", function () {
     context("with default executor", function () {
         it("returns an unresolved promise", async function () {
-            var promise = sinon.promise();
+            const promise = sinon.promise();
 
-            var { status, value } = await getPromiseStatus(promise);
+            const { status, value } = await getPromiseStatus(promise);
             assert.equals(promise.toString(), "[object Promise]");
             assert.equals(status, "pending");
             assert.isNull(value);
@@ -36,12 +36,12 @@ describe("promise", function () {
         });
 
         it("resolves the promise", async function () {
-            var result = Symbol("promise result");
-            var promise = sinon.promise();
+            const result = Symbol("promise result");
+            const promise = sinon.promise();
 
-            var returnValue = promise.resolve(result);
+            const returnValue = promise.resolve(result);
 
-            var { status, value } = await getPromiseStatus(promise);
+            const { status, value } = await getPromiseStatus(promise);
             assert.equals(status, "resolved");
             assert.same(value, result);
             assert.equals(promise.status, status);
@@ -51,12 +51,12 @@ describe("promise", function () {
         });
 
         it("rejects the promise", async function () {
-            var error = new Error("promise error");
-            var promise = sinon.promise();
+            const error = new Error("promise error");
+            const promise = sinon.promise();
 
-            var returnValue = promise.reject(error);
+            const returnValue = promise.reject(error);
 
-            var { status, value } = await getPromiseStatus(promise);
+            const { status, value } = await getPromiseStatus(promise);
             assert.equals(status, "rejected");
             assert.same(value, error);
             assert.equals(promise.status, status);
@@ -68,7 +68,7 @@ describe("promise", function () {
         });
 
         context("with resolved promise", function () {
-            var promise;
+            let promise;
 
             beforeEach(function () {
                 promise = sinon.promise();
@@ -101,7 +101,7 @@ describe("promise", function () {
         });
 
         context("with rejected promise", function () {
-            var promise;
+            let promise;
 
             beforeEach(function () {
                 promise = sinon.promise();
@@ -136,7 +136,7 @@ describe("promise", function () {
 
     context("with custom executor", function () {
         it("accepts a fake as the custom executor", function () {
-            var executor = sinon.fake();
+            const executor = sinon.fake();
 
             sinon.promise(executor);
 
@@ -147,7 +147,7 @@ describe("promise", function () {
         });
 
         it("accepts a stub as the custom executor", function () {
-            var executor = sinon.stub();
+            const executor = sinon.stub();
 
             sinon.promise(executor);
 
@@ -158,7 +158,7 @@ describe("promise", function () {
         });
 
         it("accepts a function as the custom executor", function () {
-            var args;
+            let args;
             function executor(resolve, reject) {
                 args = [resolve, reject];
             }
@@ -171,12 +171,12 @@ describe("promise", function () {
         });
 
         it("sets resolvedValue when custom executor resolves", async function () {
-            var result = Symbol("executor result");
+            const result = Symbol("executor result");
             function executor(resolve) {
                 resolve(result);
             }
 
-            var promise = sinon.promise(executor);
+            const promise = sinon.promise(executor);
 
             await assert.resolves(promise, result);
             assert.equals(promise.status, "resolved");
@@ -185,12 +185,12 @@ describe("promise", function () {
         });
 
         it("sets rejectedValue when custom executor fails", async function () {
-            var reason = new Error("executor failure");
+            const reason = new Error("executor failure");
             function executor(resolve, reject) {
                 reject(reason);
             }
 
-            var promise = sinon.promise(executor);
+            const promise = sinon.promise(executor);
 
             await assert.rejects(promise, reason);
             assert.equals(promise.status, "rejected");
@@ -199,8 +199,8 @@ describe("promise", function () {
         });
 
         it("resolves the promise", async function () {
-            var result = Symbol("promise result");
-            var promise = sinon.promise(sinon.fake());
+            const result = Symbol("promise result");
+            const promise = sinon.promise(sinon.fake());
 
             promise.resolve(result);
 
@@ -211,8 +211,8 @@ describe("promise", function () {
         });
 
         it("rejects the promise", async function () {
-            var error = new Error("promise error");
-            var promise = sinon.promise(sinon.fake());
+            const error = new Error("promise error");
+            const promise = sinon.promise(sinon.fake());
 
             promise.reject(error);
 

--- a/test/proxy-call-test.js
+++ b/test/proxy-call-test.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var proxyCall = require("../lib/sinon/proxy-call");
-var sinonSpy = require("../lib/sinon/spy");
-var sinonStub = require("../lib/sinon/stub");
-var assert = referee.assert;
-var refute = referee.refute;
+const referee = require("@sinonjs/referee");
+const proxyCall = require("../lib/sinon/proxy-call");
+const sinonSpy = require("../lib/sinon/spy");
+const sinonStub = require("../lib/sinon/stub");
+const assert = referee.assert;
+const refute = referee.refute;
 
 function spyCallSetUp() {
     this.thisValue = {};
@@ -37,19 +37,19 @@ function spyCallCalledTests(method) {
         beforeEach(spyCallSetUp);
 
         it("returns true if all args match", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert(this.call[method](args[0], args[1], args[2]));
         });
 
         it("returns true if first args match", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert(this.call[method](args[0], args[1]));
         });
 
         it("returns true if first arg match", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert(this.call[method](args[0]));
         });
@@ -59,7 +59,7 @@ function spyCallCalledTests(method) {
         });
 
         it("returns false for too many args", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert.isFalse(
                 this.call[method](args[0], args[1], args[2], args[3], {})
@@ -67,7 +67,7 @@ function spyCallCalledTests(method) {
         });
 
         it("returns false for wrong arg", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert.isFalse(this.call[method](args[0], args[2]));
         });
@@ -80,19 +80,19 @@ function spyCallNotCalledTests(method) {
         beforeEach(spyCallSetUp);
 
         it("returns false if all args match", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert.isFalse(this.call[method](args[0], args[1], args[2]));
         });
 
         it("returns false if first args match", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert.isFalse(this.call[method](args[0], args[1]));
         });
 
         it("returns false if first arg match", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert.isFalse(this.call[method](args[0]));
         });
@@ -102,13 +102,13 @@ function spyCallNotCalledTests(method) {
         });
 
         it("returns true for too many args", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert(this.call[method](args[0], args[1], args[2], args[3], {}));
         });
 
         it("returns true for wrong arg", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert(this.call[method](args[0], args[2]));
         });
@@ -120,9 +120,9 @@ describe("sinonSpy.call", function () {
         beforeEach(spyCallSetUp);
 
         it("gets call object", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             spy();
-            var firstCall = spy.getCall(0);
+            const firstCall = spy.getCall(0);
 
             assert.isFunction(firstCall.calledOn);
             assert.isFunction(firstCall.calledWith);
@@ -130,7 +130,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("stores given call id", function () {
-            var call = proxyCall(
+            const call = proxyCall(
                 function () {
                     return;
                 },
@@ -158,27 +158,27 @@ describe("sinonSpy.call", function () {
 
         // This is actually a spy test:
         it("records ascending call id's", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             spy();
 
             assert(this.call.callId < spy.getCall(0).callId);
         });
 
         it("exposes thisValue property", function () {
-            var spy = sinonSpy();
-            var obj = {};
+            const spy = sinonSpy();
+            const obj = {};
             spy.call(obj);
 
             assert.same(spy.getCall(0).thisValue, obj);
         });
 
         it("has methods to test relative ordering", function () {
-            var spy = sinonSpy();
-            for (var i = 0; i < 4; i++) {
+            const spy = sinonSpy();
+            for (let i = 0; i < 4; i++) {
                 spy.call({});
             }
 
-            var calls = [0, 1, 2, 3].map(function (idx) {
+            const calls = [0, 1, 2, 3].map(function (idx) {
                 return spy.getCall(idx);
             });
 
@@ -226,7 +226,7 @@ describe("sinonSpy.call", function () {
         beforeEach(spyCallSetUp);
 
         it("returns true when all args match", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert(
                 this.call.calledWithExactly(args[0], args[1], args[2], args[3])
@@ -234,7 +234,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns false for too many args", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert.isFalse(
                 this.call.calledWithExactly(
@@ -248,13 +248,13 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns false for too few args", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert.isFalse(this.call.calledWithExactly(args[0], args[1]));
         });
 
         it("returns false for unmatching args", function () {
-            var args = this.args;
+            const args = this.args;
 
             assert.isFalse(
                 this.call.calledWithExactly(args[0], args[1], args[1])
@@ -262,7 +262,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns true for no arguments", function () {
-            var call = proxyCall(
+            const call = proxyCall(
                 function () {
                     return;
                 },
@@ -277,7 +277,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns false when called with no args but matching one", function () {
-            var call = proxyCall(
+            const call = proxyCall(
                 function () {
                     return;
                 },
@@ -296,7 +296,7 @@ describe("sinonSpy.call", function () {
         beforeEach(spyCallCallSetup);
 
         it("calls argument at specified index", function () {
-            var callback = sinonSpy();
+            const callback = sinonSpy();
             this.args.push(1, 2, callback);
 
             this.call.callArg(2);
@@ -306,7 +306,7 @@ describe("sinonSpy.call", function () {
 
         it("throws if argument at specified index is not callable", function () {
             this.args.push(1);
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -320,7 +320,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("throws if no index is specified", function () {
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -331,18 +331,18 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns callbacks return value", function () {
-            var callback = sinonSpy(function () {
+            const callback = sinonSpy(function () {
                 return "useful value";
             });
             this.args.push(1, 2, callback);
 
-            var returnValue = this.call.callArg(2);
+            const returnValue = this.call.callArg(2);
 
             assert.equals(returnValue, "useful value");
         });
 
         it("throws if index is not number", function () {
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -357,8 +357,8 @@ describe("sinonSpy.call", function () {
         beforeEach(spyCallCallSetup);
 
         it("calls argument at specified index", function () {
-            var callback = sinonSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const callback = sinonSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(1, 2, callback);
 
             this.call.callArgOn(2, thisObj);
@@ -368,9 +368,9 @@ describe("sinonSpy.call", function () {
         });
 
         it("throws if argument at specified index is not callable", function () {
-            var thisObj = { name1: "value1", name2: "value2" };
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(1);
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -384,20 +384,20 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns callbacks return value", function () {
-            var callback = sinonSpy(function () {
+            const callback = sinonSpy(function () {
                 return "useful value";
             });
-            var thisObj = { name1: "value1", name2: "value2" };
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(1, 2, callback);
 
-            var returnValue = this.call.callArgOn(2, thisObj);
+            const returnValue = this.call.callArgOn(2, thisObj);
 
             assert.equals(returnValue, "useful value");
         });
 
         it("throws if index is not number", function () {
-            var thisObj = { name1: "value1", name2: "value2" };
-            var call = this.call;
+            const thisObj = { name1: "value1", name2: "value2" };
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -412,8 +412,8 @@ describe("sinonSpy.call", function () {
         beforeEach(spyCallCallSetup);
 
         it("calls argument at specified index with provided args", function () {
-            var object = {};
-            var callback = sinonSpy();
+            const object = {};
+            const callback = sinonSpy();
             this.args.push(1, callback);
 
             this.call.callArgWith(1, object);
@@ -422,7 +422,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("calls callback without args", function () {
-            var callback = sinonSpy();
+            const callback = sinonSpy();
             this.args.push(1, callback);
 
             this.call.callArgWith(1);
@@ -431,9 +431,9 @@ describe("sinonSpy.call", function () {
         });
 
         it("calls callback wit multiple args", function () {
-            var object = {};
-            var array = [];
-            var callback = sinonSpy();
+            const object = {};
+            const array = [];
+            const callback = sinonSpy();
             this.args.push(1, 2, callback);
 
             this.call.callArgWith(2, object, array);
@@ -442,19 +442,19 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns callbacks return value", function () {
-            var object = {};
-            var callback = sinonSpy(function () {
+            const object = {};
+            const callback = sinonSpy(function () {
                 return "useful value";
             });
             this.args.push(1, callback);
 
-            var returnValue = this.call.callArgWith(1, object);
+            const returnValue = this.call.callArgWith(1, object);
 
             assert.equals(returnValue, "useful value");
         });
 
         it("throws if no index is specified", function () {
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -465,7 +465,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("throws if index is not number", function () {
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -480,9 +480,9 @@ describe("sinonSpy.call", function () {
         beforeEach(spyCallCallSetup);
 
         it("calls argument at specified index with provided args", function () {
-            var object = {};
-            var thisObj = { name1: "value1", name2: "value2" };
-            var callback = sinonSpy();
+            const object = {};
+            const thisObj = { name1: "value1", name2: "value2" };
+            const callback = sinonSpy();
             this.args.push(1, callback);
 
             this.call.callArgOnWith(1, thisObj, object);
@@ -492,8 +492,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("calls callback without args", function () {
-            var callback = sinonSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const callback = sinonSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(1, callback);
 
             this.call.callArgOnWith(1, thisObj);
@@ -503,10 +503,10 @@ describe("sinonSpy.call", function () {
         });
 
         it("calls callback with multiple args", function () {
-            var object = {};
-            var array = [];
-            var thisObj = { name1: "value1", name2: "value2" };
-            var callback = sinonSpy();
+            const object = {};
+            const array = [];
+            const thisObj = { name1: "value1", name2: "value2" };
+            const callback = sinonSpy();
             this.args.push(1, 2, callback);
 
             this.call.callArgOnWith(2, thisObj, object, array);
@@ -516,22 +516,22 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns callbacks return value", function () {
-            var object = {};
-            var thisObj = { name1: "value1", name2: "value2" };
-            var callback = sinonSpy(function () {
+            const object = {};
+            const thisObj = { name1: "value1", name2: "value2" };
+            const callback = sinonSpy(function () {
                 return "useful value";
             });
             this.args.push(1, callback);
 
-            var returnValue = this.call.callArgOnWith(1, thisObj, object);
+            const returnValue = this.call.callArgOnWith(1, thisObj, object);
 
             assert.equals(returnValue, "useful value");
         });
 
         it("throws if argument at specified index is not callable", function () {
-            var thisObj = { name1: "value1", name2: "value2" };
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(1, 2, 1);
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -545,8 +545,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("throws if index is not number", function () {
-            var thisObj = { name1: "value1", name2: "value2" };
-            var call = this.call;
+            const thisObj = { name1: "value1", name2: "value2" };
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -559,11 +559,11 @@ describe("sinonSpy.call", function () {
 
     describe(".callback", function () {
         it("it should be a reference for the callback", function () {
-            var spy = sinonSpy();
-            var callback1 = function () {
+            const spy = sinonSpy();
+            const callback1 = function () {
                 return;
             };
-            var callback2 = function () {
+            const callback2 = function () {
                 return;
             };
 
@@ -580,7 +580,7 @@ describe("sinonSpy.call", function () {
 
     describe(".firstArg", function () {
         it("should be the first argument from the call", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
 
             spy(41, 42, 43);
             assert.equals(spy.getCall(0).firstArg, 41);
@@ -598,7 +598,7 @@ describe("sinonSpy.call", function () {
 
     describe(".lastArg", function () {
         it("should be the last argument from the call", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
 
             spy(41, 42, 43);
             assert.equals(spy.getCall(0).lastArg, 43);
@@ -618,7 +618,7 @@ describe("sinonSpy.call", function () {
         beforeEach(spyCallCallSetup);
 
         it("invokes only argument as callback", function () {
-            var callback = sinonSpy();
+            const callback = sinonSpy();
             this.args.push(callback);
 
             this.call.yield();
@@ -628,7 +628,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("throws understandable error if no callback is passed", function () {
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -643,7 +643,7 @@ describe("sinonSpy.call", function () {
         it("includes stub name and actual arguments in error", function () {
             this.proxy.displayName = "somethingAwesome";
             this.args.push(23, 42);
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -657,7 +657,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes last argument as callback", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             this.args.push(24, {}, spy);
 
             this.call.yield();
@@ -667,8 +667,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes first of two callbacks", function () {
-            var spy = sinonSpy();
-            var spy2 = sinonSpy();
+            const spy = sinonSpy();
+            const spy2 = sinonSpy();
             this.args.push(24, {}, spy, spy2);
 
             this.call.yield();
@@ -678,8 +678,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes callback with arguments", function () {
-            var obj = { id: 42 };
-            var spy = sinonSpy();
+            const obj = { id: 42 };
+            const spy = sinonSpy();
             this.args.push(spy);
 
             this.call.yield(obj, "Crazy");
@@ -688,12 +688,12 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns callbacks return value", function () {
-            var spy = sinonSpy(function () {
+            const spy = sinonSpy(function () {
                 return "useful value";
             });
             this.args.push(24, {}, spy);
 
-            var returnValue = this.call.yield();
+            const returnValue = this.call.yield();
 
             assert.equals(returnValue, "useful value");
         });
@@ -702,7 +702,7 @@ describe("sinonSpy.call", function () {
             this.args.push(function () {
                 throw new Error("d'oh!");
             });
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(function () {
                 call.yield();
@@ -712,7 +712,7 @@ describe("sinonSpy.call", function () {
 
     describe("call.invokeCallback", function () {
         it("is alias for yield", function () {
-            var call = proxyCall(
+            const call = proxyCall(
                 function () {
                     return;
                 },
@@ -731,8 +731,8 @@ describe("sinonSpy.call", function () {
         beforeEach(spyCallCallSetup);
 
         it("invokes only argument as callback", function () {
-            var callback = sinonSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const callback = sinonSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(callback);
 
             this.call.yieldOn(thisObj);
@@ -743,8 +743,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("throws understandable error if no callback is passed", function () {
-            var call = this.call;
-            var thisObj = { name1: "value1", name2: "value2" };
+            const call = this.call;
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -759,8 +759,8 @@ describe("sinonSpy.call", function () {
         it("includes stub name and actual arguments in error", function () {
             this.proxy.displayName = "somethingAwesome";
             this.args.push(23, 42);
-            var call = this.call;
-            var thisObj = { name1: "value1", name2: "value2" };
+            const call = this.call;
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -774,8 +774,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes last argument as callback", function () {
-            var spy = sinonSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = sinonSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(24, {}, spy);
 
             this.call.yieldOn(thisObj);
@@ -786,9 +786,9 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes first of two callbacks", function () {
-            var spy = sinonSpy();
-            var spy2 = sinonSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = sinonSpy();
+            const spy2 = sinonSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(24, {}, spy, spy2);
 
             this.call.yieldOn(thisObj);
@@ -799,9 +799,9 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes callback with arguments", function () {
-            var obj = { id: 42 };
-            var spy = sinonSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const obj = { id: 42 };
+            const spy = sinonSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(spy);
 
             this.call.yieldOn(thisObj, obj, "Crazy");
@@ -811,13 +811,13 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns callbacks return value", function () {
-            var spy = sinonSpy(function () {
+            const spy = sinonSpy(function () {
                 return "useful value";
             });
-            var thisObj = { name1: "value1", name2: "value2" };
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(24, {}, spy);
 
-            var returnValue = this.call.yieldOn(thisObj);
+            const returnValue = this.call.yieldOn(thisObj);
 
             assert.equals(returnValue, "useful value");
         });
@@ -826,8 +826,8 @@ describe("sinonSpy.call", function () {
             this.args.push(function () {
                 throw new Error("d'oh!");
             });
-            var call = this.call;
-            var thisObj = { name1: "value1", name2: "value2" };
+            const call = this.call;
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(function () {
                 call.yieldOn(thisObj);
@@ -839,7 +839,7 @@ describe("sinonSpy.call", function () {
         beforeEach(spyCallCallSetup);
 
         it("invokes only argument as callback", function () {
-            var callback = sinonSpy();
+            const callback = sinonSpy();
             this.args.push({
                 success: callback,
             });
@@ -851,7 +851,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("throws understandable error if no callback is passed", function () {
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -867,7 +867,7 @@ describe("sinonSpy.call", function () {
         it("includes stub name and actual arguments in error", function () {
             this.proxy.displayName = "somethingAwesome";
             this.args.push(23, 42);
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(
                 function () {
@@ -882,7 +882,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes property on last argument as callback", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             this.args.push(24, {}, { success: spy });
 
             this.call.yieldTo("success");
@@ -892,8 +892,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes first of two possible callbacks", function () {
-            var spy = sinonSpy();
-            var spy2 = sinonSpy();
+            const spy = sinonSpy();
+            const spy2 = sinonSpy();
             this.args.push(24, {}, { error: spy }, { error: spy2 });
 
             this.call.yieldTo("error");
@@ -903,8 +903,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes callback with arguments", function () {
-            var obj = { id: 42 };
-            var spy = sinonSpy();
+            const obj = { id: 42 };
+            const spy = sinonSpy();
             this.args.push({ success: spy });
 
             this.call.yieldTo("success", obj, "Crazy");
@@ -913,12 +913,12 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns callbacks return value", function () {
-            var spy = sinonSpy(function () {
+            const spy = sinonSpy(function () {
                 return "useful value";
             });
             this.args.push(24, {}, { success: spy });
 
-            var returnValue = this.call.yieldTo("success");
+            const returnValue = this.call.yieldTo("success");
 
             assert.equals(returnValue, "useful value");
         });
@@ -929,7 +929,7 @@ describe("sinonSpy.call", function () {
                     throw new Error("d'oh!");
                 },
             });
-            var call = this.call;
+            const call = this.call;
 
             assert.exception(function () {
                 call.yieldTo("success");
@@ -941,8 +941,8 @@ describe("sinonSpy.call", function () {
         beforeEach(spyCallCallSetup);
 
         it("invokes only argument as callback", function () {
-            var callback = sinonSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const callback = sinonSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push({
                 success: callback,
             });
@@ -955,8 +955,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("throws understandable error if no callback is passed", function () {
-            var call = this.call;
-            var thisObj = { name1: "value1", name2: "value2" };
+            const call = this.call;
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -971,8 +971,8 @@ describe("sinonSpy.call", function () {
 
         it("throws understandable error if symbol prop is not found", function () {
             if (typeof Symbol === "function") {
-                var call = this.call;
-                var symbol = Symbol("apple pie");
+                const call = this.call;
+                const symbol = Symbol("apple pie");
 
                 assert.exception(
                     function () {
@@ -989,8 +989,8 @@ describe("sinonSpy.call", function () {
         it("includes stub name and actual arguments in error", function () {
             this.proxy.displayName = "somethingAwesome";
             this.args.push(23, 42);
-            var call = this.call;
-            var thisObj = { name1: "value1", name2: "value2" };
+            const call = this.call;
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -1005,8 +1005,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes property on last argument as callback", function () {
-            var spy = sinonSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = sinonSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(24, {}, { success: spy });
 
             this.call.yieldToOn("success", thisObj);
@@ -1017,9 +1017,9 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes first of two possible callbacks", function () {
-            var spy = sinonSpy();
-            var spy2 = sinonSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = sinonSpy();
+            const spy2 = sinonSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(24, {}, { error: spy }, { error: spy2 });
 
             this.call.yieldToOn("error", thisObj);
@@ -1030,9 +1030,9 @@ describe("sinonSpy.call", function () {
         });
 
         it("invokes callback with arguments", function () {
-            var obj = { id: 42 };
-            var spy = sinonSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const obj = { id: 42 };
+            const spy = sinonSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push({ success: spy });
 
             this.call.yieldToOn("success", thisObj, obj, "Crazy");
@@ -1042,13 +1042,13 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns callbacks return value", function () {
-            var spy = sinonSpy(function () {
+            const spy = sinonSpy(function () {
                 return "useful value";
             });
-            var thisObj = { name1: "value1", name2: "value2" };
+            const thisObj = { name1: "value1", name2: "value2" };
             this.args.push(24, {}, { success: spy });
 
-            var returnValue = this.call.yieldToOn("success", thisObj);
+            const returnValue = this.call.yieldToOn("success", thisObj);
 
             assert.equals(returnValue, "useful value");
         });
@@ -1059,8 +1059,8 @@ describe("sinonSpy.call", function () {
                     throw new Error("d'oh!");
                 },
             });
-            var call = this.call;
-            var thisObj = { name1: "value1", name2: "value2" };
+            const call = this.call;
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(function () {
                 call.yieldToOn("success", thisObj);
@@ -1076,7 +1076,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("includes spy name", function () {
-            var object = { doIt: sinonSpy() };
+            const object = { doIt: sinonSpy() };
             object.doIt();
 
             assert.equals(
@@ -1086,7 +1086,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("includes single argument", function () {
-            var object = { doIt: sinonSpy() };
+            const object = { doIt: sinonSpy() };
             object.doIt(42);
 
             assert.equals(
@@ -1096,7 +1096,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("includes all arguments", function () {
-            var object = { doIt: sinonSpy() };
+            const object = { doIt: sinonSpy() };
             object.doIt(42, "Hey");
 
             assert.equals(
@@ -1106,7 +1106,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("includes explicit return value", function () {
-            var object = { doIt: sinonStub().returns(42) };
+            const object = { doIt: sinonStub().returns(42) };
             object.doIt(42, "Hey");
 
             assert.equals(
@@ -1116,7 +1116,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("includes empty string return value", function () {
-            var object = { doIt: sinonStub().returns("") };
+            const object = { doIt: sinonStub().returns("") };
             object.doIt(42, "Hey");
 
             assert.equals(
@@ -1126,7 +1126,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("includes exception", function () {
-            var object = { doIt: sinonStub().throws("TypeError") };
+            const object = { doIt: sinonStub().throws("TypeError") };
 
             assert.exception(function () {
                 object.doIt();
@@ -1139,7 +1139,9 @@ describe("sinonSpy.call", function () {
         });
 
         it("includes exception message if any", function () {
-            var object = { doIt: sinonStub().throws("TypeError", "Oh noes!") };
+            const object = {
+                doIt: sinonStub().throws("TypeError", "Oh noes!"),
+            };
 
             assert.exception(function () {
                 object.doIt();
@@ -1153,7 +1155,7 @@ describe("sinonSpy.call", function () {
 
         // these tests are ensuring that call.toString is handled by sinonFormat
         it("formats arguments with sinonFormat", function () {
-            var object = { doIt: sinonSpy() };
+            const object = { doIt: sinonSpy() };
 
             object.doIt(42);
 
@@ -1164,7 +1166,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("formats return value with sinonFormat", function () {
-            var object = { doIt: sinonStub().returns(42) };
+            const object = { doIt: sinonStub().returns(42) };
 
             object.doIt();
 
@@ -1181,8 +1183,8 @@ describe("sinonSpy.call", function () {
                 this.skip();
             }
 
-            var stub1 = sinonStub().resolves(1);
-            var stub2 = sinonStub().returns(1);
+            const stub1 = sinonStub().resolves(1);
+            const stub2 = sinonStub().returns(1);
 
             await stub2(await stub1());
 
@@ -1203,7 +1205,7 @@ describe("sinonSpy.call", function () {
                 this.skip();
             }
 
-            var object = { doIt: sinonSpy() };
+            const object = { doIt: sinonSpy() };
             object.doIt();
 
             const [name, stackFrame] = object.doIt
@@ -1226,19 +1228,19 @@ describe("sinonSpy.call", function () {
         });
 
         it("creates original object", function () {
-            var myInstance = new this.CustomConstructor();
+            const myInstance = new this.CustomConstructor();
 
             assert(this.customPrototype.isPrototypeOf(myInstance));
         });
 
         it("does not interfere with instanceof", function () {
-            var myInstance = new this.CustomConstructor();
+            const myInstance = new this.CustomConstructor();
 
             assert(myInstance instanceof this.CustomConstructor);
         });
 
         it("records usage", function () {
-            var myInstance = new this.CustomConstructor(); // eslint-disable-line no-unused-vars
+            const myInstance = new this.CustomConstructor(); // eslint-disable-line no-unused-vars
 
             assert(this.CustomConstructor.called);
         });
@@ -1246,7 +1248,7 @@ describe("sinonSpy.call", function () {
 
     describe("functions", function () {
         it("throws if spying on non-existent property", function () {
-            var myObj = {};
+            const myObj = {};
 
             assert.exception(function () {
                 sinonSpy(myObj, "ouch");
@@ -1262,7 +1264,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("haves toString method", function () {
-            var obj = {
+            const obj = {
                 meth: function () {
                     return;
                 },
@@ -1273,7 +1275,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("toString should say 'spy' when unable to infer name", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
 
             assert.equals(spy.toString(), "spy");
         });
@@ -1282,7 +1284,7 @@ describe("sinonSpy.call", function () {
             function myTestFunc() {
                 return;
             }
-            var spy = sinonSpy(myTestFunc);
+            const spy = sinonSpy(myTestFunc);
 
             assert.equals(spy.toString(), "myTestFunc");
         });
@@ -1292,13 +1294,13 @@ describe("sinonSpy.call", function () {
                 return;
             }
             myTestFunc.displayName = "My custom method";
-            var spy = sinonSpy(myTestFunc);
+            const spy = sinonSpy(myTestFunc);
 
             assert.equals(spy.toString(), "My custom method");
         });
 
         it("toString should prefer property name if possible", function () {
-            var obj = {};
+            const obj = {};
             obj.meth = sinonSpy();
             obj.meth();
 
@@ -1321,7 +1323,7 @@ describe("sinonSpy.call", function () {
         }
 
         it("resets spy state", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             spy();
 
             spy.resetHistory();
@@ -1330,7 +1332,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("resets call order state", function () {
-            var spies = [sinonSpy(), sinonSpy()];
+            const spies = [sinonSpy(), sinonSpy()];
             spies[0]();
             spies[1]();
 
@@ -1340,13 +1342,13 @@ describe("sinonSpy.call", function () {
         });
 
         it("resets fakes returned by withArgs", function () {
-            var spy = sinonSpy();
-            var fakeA = spy.withArgs("a");
-            var fakeB = spy.withArgs("b");
+            const spy = sinonSpy();
+            const fakeA = spy.withArgs("a");
+            const fakeB = spy.withArgs("b");
             spy("a");
             spy("b");
             spy("c");
-            var fakeC = spy.withArgs("c");
+            const fakeC = spy.withArgs("c");
 
             spy.resetHistory();
 
@@ -1358,21 +1360,21 @@ describe("sinonSpy.call", function () {
 
     describe(".withArgs", function () {
         it("defines withArgs method", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
 
             assert.isFunction(spy.withArgs);
         });
 
         it("records single call", function () {
-            var spy = sinonSpy().withArgs(1);
+            const spy = sinonSpy().withArgs(1);
             spy(1);
 
             assert.equals(spy.callCount, 1);
         });
 
         it("records non-matching call on original spy", function () {
-            var spy = sinonSpy();
-            var argSpy = spy.withArgs(1);
+            const spy = sinonSpy();
+            const argSpy = spy.withArgs(1);
             spy(1);
             spy(2);
 
@@ -1381,8 +1383,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("records non-matching call with several arguments separately", function () {
-            var spy = sinonSpy();
-            var argSpy = spy.withArgs(1, "str", {});
+            const spy = sinonSpy();
+            const argSpy = spy.withArgs(1, "str", {});
             spy(1);
             spy(1, "str", {});
 
@@ -1391,8 +1393,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("records for partial argument match", function () {
-            var spy = sinonSpy();
-            var argSpy = spy.withArgs(1, "str", {});
+            const spy = sinonSpy();
+            const argSpy = spy.withArgs(1, "str", {});
             spy(1);
             spy(1, "str", {});
             spy(1, "str", {}, []);
@@ -1402,11 +1404,11 @@ describe("sinonSpy.call", function () {
         });
 
         it("records filtered spy when original throws", function () {
-            var spy = sinonSpy(function () {
+            const spy = sinonSpy(function () {
                 throw new Error("Oops");
             });
 
-            var argSpy = spy.withArgs({}, []);
+            const argSpy = spy.withArgs({}, []);
 
             assert.exception(function () {
                 spy(1);
@@ -1421,9 +1423,9 @@ describe("sinonSpy.call", function () {
         });
 
         it("returns existing override for arguments", function () {
-            var spy = sinonSpy();
-            var argSpy = spy.withArgs({}, []);
-            var another = spy.withArgs({}, []);
+            const spy = sinonSpy();
+            const argSpy = spy.withArgs({}, []);
+            const another = spy.withArgs({}, []);
             spy();
             spy({}, []);
             spy({}, [], 2);
@@ -1435,8 +1437,8 @@ describe("sinonSpy.call", function () {
         });
 
         it("chains withArgs calls on original spy", function () {
-            var spy = sinonSpy();
-            var numArgSpy = spy.withArgs({}, []).withArgs(3);
+            const spy = sinonSpy();
+            const numArgSpy = spy.withArgs({}, []).withArgs(3);
             spy();
             spy({}, []);
             spy(3);
@@ -1447,7 +1449,7 @@ describe("sinonSpy.call", function () {
         });
 
         it("initializes filtered spy with callCount", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             spy("a");
             spy("b");
             spy("b");
@@ -1455,9 +1457,9 @@ describe("sinonSpy.call", function () {
             spy("c");
             spy("c");
 
-            var argSpy1 = spy.withArgs("a");
-            var argSpy2 = spy.withArgs("b");
-            var argSpy3 = spy.withArgs("c");
+            const argSpy1 = spy.withArgs("a");
+            const argSpy2 = spy.withArgs("b");
+            const argSpy3 = spy.withArgs("c");
 
             assert.equals(argSpy1.callCount, 1);
             assert.equals(argSpy2.callCount, 2);
@@ -1471,14 +1473,14 @@ describe("sinonSpy.call", function () {
         });
 
         it("initializes filtered spy with first, second, third and last call", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             spy("a", 1);
             spy("b", 2);
             spy("b", 3);
             spy("b", 4);
 
-            var argSpy1 = spy.withArgs("a");
-            var argSpy2 = spy.withArgs("b");
+            const argSpy1 = spy.withArgs("a");
+            const argSpy2 = spy.withArgs("b");
 
             assert(argSpy1.firstCall.calledWithExactly("a", 1));
             assert(argSpy1.lastCall.calledWithExactly("a", 1));
@@ -1489,13 +1491,13 @@ describe("sinonSpy.call", function () {
         });
 
         it("initializes filtered spy with arguments", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             spy("a");
             spy("b");
             spy("b", "c", "d");
 
-            var argSpy1 = spy.withArgs("a");
-            var argSpy2 = spy.withArgs("b");
+            const argSpy1 = spy.withArgs("a");
+            const argSpy2 = spy.withArgs("b");
 
             assert(argSpy1.getCall(0).calledWithExactly("a"));
             assert(argSpy2.getCall(0).calledWithExactly("b"));
@@ -1503,16 +1505,16 @@ describe("sinonSpy.call", function () {
         });
 
         it("initializes filtered spy with thisValues", function () {
-            var spy = sinonSpy();
-            var thisValue1 = {};
-            var thisValue2 = {};
-            var thisValue3 = {};
+            const spy = sinonSpy();
+            const thisValue1 = {};
+            const thisValue2 = {};
+            const thisValue3 = {};
             spy.call(thisValue1, "a");
             spy.call(thisValue2, "b");
             spy.call(thisValue3, "b");
 
-            var argSpy1 = spy.withArgs("a");
-            var argSpy2 = spy.withArgs("b");
+            const argSpy1 = spy.withArgs("a");
+            const argSpy2 = spy.withArgs("b");
 
             assert(argSpy1.getCall(0).calledOn(thisValue1));
             assert(argSpy2.getCall(0).calledOn(thisValue2));
@@ -1520,15 +1522,15 @@ describe("sinonSpy.call", function () {
         });
 
         it("initializes filtered spy with return values", function () {
-            var spy = sinonSpy(function (value) {
+            const spy = sinonSpy(function (value) {
                 return value;
             });
             spy("a");
             spy("b");
             spy("b");
 
-            var argSpy1 = spy.withArgs("a");
-            var argSpy2 = spy.withArgs("b");
+            const argSpy1 = spy.withArgs("a");
+            const argSpy2 = spy.withArgs("b");
 
             assert(argSpy1.getCall(0).returned("a"));
             assert(argSpy2.getCall(0).returned("b"));
@@ -1536,21 +1538,21 @@ describe("sinonSpy.call", function () {
         });
 
         it("initializes filtered spy with call order", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             spy("a");
             spy("b");
             spy("b");
 
-            var argSpy1 = spy.withArgs("a");
-            var argSpy2 = spy.withArgs("b");
+            const argSpy1 = spy.withArgs("a");
+            const argSpy2 = spy.withArgs("b");
 
             assert(argSpy2.getCall(0).calledAfter(argSpy1.getCall(0)));
             assert(argSpy2.getCall(1).calledAfter(argSpy1.getCall(0)));
         });
 
         it("initializes filtered spy with exceptions", function () {
-            var spy = sinonSpy(function (x, y) {
-                var error = new Error();
+            const spy = sinonSpy(function (x, y) {
+                const error = new Error();
                 error.name = y;
                 throw error;
             });
@@ -1565,8 +1567,8 @@ describe("sinonSpy.call", function () {
                 spy("b", "3");
             });
 
-            var argSpy1 = spy.withArgs("a");
-            var argSpy2 = spy.withArgs("b");
+            const argSpy1 = spy.withArgs("a");
+            const argSpy2 = spy.withArgs("b");
 
             assert(argSpy1.getCall(0).threw("1"));
             assert(argSpy2.getCall(0).threw("2"));
@@ -1575,7 +1577,7 @@ describe("sinonSpy.call", function () {
     });
 
     it("captures a stack trace", function () {
-        var spy = sinonSpy();
+        const spy = sinonSpy();
         spy();
         assert.isString(spy.getCall(0).stack);
     });

--- a/test/proxy-test.js
+++ b/test/proxy-test.js
@@ -1,18 +1,18 @@
 "use strict";
 
-var assert = require("@sinonjs/referee").assert;
-var extend = require("../lib/sinon/util/core/extend");
-var createProxy = require("../lib/sinon/proxy");
+const assert = require("@sinonjs/referee").assert;
+const extend = require("../lib/sinon/util/core/extend");
+const createProxy = require("../lib/sinon/proxy");
 
-var color = require("../lib/sinon/color");
-var sinonSpy = require("../lib/sinon/spy");
-var sinonStub = require("../lib/sinon/stub");
-var functionName = require("@sinonjs/commons").functionName;
+const color = require("../lib/sinon/color");
+const sinonSpy = require("../lib/sinon/spy");
+const sinonStub = require("../lib/sinon/stub");
+const functionName = require("@sinonjs/commons").functionName;
 
-var uuid = 0;
+let uuid = 0;
 function createFaux(func) {
-    var name;
-    var funk = func;
+    let name;
+    let funk = func;
 
     if (typeof funk !== "function") {
         funk = function () {
@@ -22,7 +22,7 @@ function createFaux(func) {
         name = functionName(funk);
     }
 
-    var proxy = createProxy(funk, funk);
+    const proxy = createProxy(funk, funk);
 
     extend.nonEnum(proxy, {
         displayName: name || "faux",
@@ -37,25 +37,25 @@ describe("proxy", function () {
     describe(".printf", function () {
         describe("name", function () {
             it("named", function () {
-                var named = createFaux(function cool() {
+                const named = createFaux(function cool() {
                     return;
                 });
                 assert.equals(named.printf("%n"), "cool");
             });
             it("anon", function () {
-                var anon = sinonSpy(function () {
+                const anon = sinonSpy(function () {
                     return;
                 });
                 assert.equals(anon.printf("%n"), "spy");
 
-                var noFn = sinonSpy();
+                const noFn = sinonSpy();
                 assert.equals(noFn.printf("%n"), "spy");
             });
         });
 
         it("count", function () {
             // Throwing just to make sure it has no effect.
-            var faux = createFaux(sinonStub().throws());
+            const faux = createFaux(sinonStub().throws());
             function call() {
                 assert.exception(function () {
                     faux();
@@ -75,7 +75,7 @@ describe("proxy", function () {
         describe("calls", function () {
             it("oneLine", function () {
                 function verify(arg, expected) {
-                    var faux = createFaux();
+                    const faux = createFaux();
                     faux(arg);
                     assert.equals(
                         faux.printf("%C").replace(/ at.*/g, ""),
@@ -96,8 +96,8 @@ describe("proxy", function () {
             });
 
             it("multiline", function () {
-                var str = "faux\ntest";
-                var faux = createFaux();
+                const str = "faux\ntest";
+                const faux = createFaux();
 
                 faux(str);
                 faux(str);
@@ -122,7 +122,7 @@ describe("proxy", function () {
         });
 
         it("thisValues", function () {
-            var faux = createFaux();
+            const faux = createFaux();
             faux();
             assert.equals(faux.printf("%t"), "undefined");
 
@@ -132,13 +132,13 @@ describe("proxy", function () {
         });
 
         it("unmatched", function () {
-            var faux = createFaux();
+            const faux = createFaux();
 
             assert.equals(faux.printf("%λ"), "%λ");
         });
 
         it("*", function () {
-            var faux = createFaux();
+            const faux = createFaux();
 
             assert.equals(
                 faux.printf("%*", 1.4567, "a", true, {}, [], undefined, null),
@@ -149,13 +149,13 @@ describe("proxy", function () {
 
         describe("arguments", function () {
             it("no calls", function () {
-                var faux = createFaux();
+                const faux = createFaux();
 
                 assert.equals(faux.printf("%D"), "");
             });
 
             it("single call with arguments", function () {
-                var faux = createFaux();
+                const faux = createFaux();
 
                 faux(1, "a", true, false, [], {}, null, undefined);
 
@@ -170,7 +170,7 @@ describe("proxy", function () {
             });
 
             it("single call without arguments", function () {
-                var faux = createFaux();
+                const faux = createFaux();
 
                 faux();
 
@@ -178,7 +178,7 @@ describe("proxy", function () {
             });
 
             it("multiple calls with arguments", function () {
-                var faux = createFaux();
+                const faux = createFaux();
 
                 faux(1, "a", true);
                 faux(false, [], {});
@@ -197,7 +197,7 @@ describe("proxy", function () {
             });
 
             it("multiple calls without arguments", function () {
-                var faux = createFaux();
+                const faux = createFaux();
 
                 faux();
                 faux();

--- a/test/restore-object-test.js
+++ b/test/restore-object-test.js
@@ -1,12 +1,12 @@
 "use strict";
 /* eslint-disable no-empty-function */
 
-var referee = require("@sinonjs/referee");
-var sinonSpy = require("../lib/sinon/spy");
-var sinonStub = require("../lib/sinon/stub");
-var restoreObject = require("../lib/sinon/restore-object.js");
-var assert = referee.assert;
-var refute = referee.refute;
+const referee = require("@sinonjs/referee");
+const sinonSpy = require("../lib/sinon/spy");
+const sinonStub = require("../lib/sinon/stub");
+const restoreObject = require("../lib/sinon/restore-object.js");
+const assert = referee.assert;
+const refute = referee.refute;
 
 describe("restore-object", function () {
     it("is defined", function () {
@@ -52,7 +52,7 @@ describe("restore-object", function () {
     });
 
     it("works with mixed spies and stubs", function () {
-        var object = {
+        let object = {
             who: function () {},
             what: function () {},
             when: function () {},
@@ -72,7 +72,7 @@ describe("restore-object", function () {
     });
 
     it("restores entire spied object", function () {
-        var object = sinonSpy({
+        let object = sinonSpy({
             foo: function () {},
             bar: function () {},
         });
@@ -84,7 +84,7 @@ describe("restore-object", function () {
     });
 
     it("restores entire stubbed object", function () {
-        var object = sinonStub({
+        let object = sinonStub({
             foo: function () {},
             bar: function () {},
         });

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1,29 +1,29 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var samsam = require("@sinonjs/samsam");
-var assert = referee.assert;
-var deprecated = require("@sinonjs/commons").deprecated;
-var refute = referee.refute;
-var fakeXhr = require("nise").fakeXhr;
-var fakeServerWithClock = require("nise").fakeServerWithClock;
-var fakeServer = require("nise").fakeServer;
-var match = require("@sinonjs/samsam").createMatcher;
-var Sandbox = require("../lib/sinon/sandbox");
-var createSandbox = require("../lib/sinon/create-sandbox");
-var sinonFake = require("../lib/sinon/fake");
-var sinonSpy = require("../lib/sinon/spy");
-var sinonStub = require("../lib/sinon/stub");
-var sinonConfig = require("./get-config");
-var sinonClock = require("../lib/sinon/util/fake-timers");
+const referee = require("@sinonjs/referee");
+const samsam = require("@sinonjs/samsam");
+const assert = referee.assert;
+const deprecated = require("@sinonjs/commons").deprecated;
+const refute = referee.refute;
+const fakeXhr = require("nise").fakeXhr;
+const fakeServerWithClock = require("nise").fakeServerWithClock;
+const fakeServer = require("nise").fakeServer;
+const match = require("@sinonjs/samsam").createMatcher;
+const Sandbox = require("../lib/sinon/sandbox");
+const createSandbox = require("../lib/sinon/create-sandbox");
+const sinonFake = require("../lib/sinon/fake");
+const sinonSpy = require("../lib/sinon/spy");
+const sinonStub = require("../lib/sinon/stub");
+const sinonConfig = require("./get-config");
+const sinonClock = require("../lib/sinon/util/fake-timers");
 
-var supportsAjax =
+const supportsAjax =
     typeof XMLHttpRequest !== "undefined" ||
     typeof ActiveXObject !== "undefined";
-var supportPromise = typeof Promise !== "undefined";
-var globalContext = typeof global !== "undefined" ? global : window;
-var globalXHR = globalContext.XMLHttpRequest;
-var globalAXO = globalContext.ActiveXObject;
+const supportPromise = typeof Promise !== "undefined";
+const globalContext = typeof global !== "undefined" ? global : window;
+const globalXHR = globalContext.XMLHttpRequest;
+const globalAXO = globalContext.ActiveXObject;
 
 if (!assert.stub) {
     require("./test-helper");
@@ -46,20 +46,20 @@ describe("Sandbox", function () {
     }
 
     it("exposes match", function () {
-        var sandbox = new Sandbox();
+        const sandbox = new Sandbox();
 
         assert.same(sandbox.match, match);
     });
 
     it("can be reset without failing when pre-configured to use a fake server", function () {
-        var sandbox = createSandbox({ useFakeServer: true });
+        const sandbox = createSandbox({ useFakeServer: true });
         refute.exception(function () {
             sandbox.reset();
         });
     });
 
     it("can be reset without failing when configured to use a fake server", function () {
-        var sandbox = new Sandbox();
+        const sandbox = new Sandbox();
         sandbox.useFakeServer();
         refute.exception(function () {
             sandbox.reset();
@@ -72,13 +72,13 @@ describe("Sandbox", function () {
         });
 
         it("returns a mock", function () {
-            var object = {
+            const object = {
                 method: function () {
                     return;
                 },
             };
 
-            var actual = this.sandbox.mock(object);
+            const actual = this.sandbox.mock(object);
             actual.expects("method");
 
             assert.equals(typeof actual.verify, "function");
@@ -86,19 +86,19 @@ describe("Sandbox", function () {
         });
 
         it("adds mock to fake array", function () {
-            var fakes = this.sandbox.getFakes();
-            var object = {
+            const fakes = this.sandbox.getFakes();
+            const object = {
                 method: function () {
                     return;
                 },
             };
-            var expected = this.sandbox.mock(object);
+            const expected = this.sandbox.mock(object);
 
             assert(fakes.indexOf(expected) !== -1);
         });
 
         it("appends mocks to fake array", function () {
-            var fakes = this.sandbox.getFakes();
+            const fakes = this.sandbox.getFakes();
 
             this.sandbox.mock({});
             this.sandbox.mock({});
@@ -113,7 +113,7 @@ describe("Sandbox", function () {
         });
 
         it("appends mocks and stubs to fake array", function () {
-            var fakes = this.sandbox.getFakes();
+            const fakes = this.sandbox.getFakes();
 
             this.sandbox.mock(
                 {
@@ -136,7 +136,7 @@ describe("Sandbox", function () {
         });
 
         describe("warns of potential leak when", function () {
-            var warn;
+            let warn;
 
             beforeEach(function () {
                 warn = this.sandbox.stub(deprecated, "printWarning");
@@ -174,7 +174,7 @@ describe("Sandbox", function () {
             });
 
             function createTooManyFakes(sandbox) {
-                for (var i = 0; i < sandbox.leakThreshold; i++) {
+                for (let i = 0; i < sandbox.leakThreshold; i++) {
                     sandbox.spy();
                 }
             }
@@ -183,19 +183,18 @@ describe("Sandbox", function () {
 
     describe(".spy", function () {
         it("should return a spy", function () {
-            var sandbox = createSandbox();
-            var spy = sandbox.spy();
+            const sandbox = createSandbox();
+            const spy = sandbox.spy();
 
             assert.isFunction(spy);
             assert.equals(spy.displayName, "spy");
         });
 
         it("should add a spy to the internal collection", function () {
-            var sandbox = createSandbox();
-            var fakes = sandbox.getFakes();
-            var expected;
+            const sandbox = createSandbox();
+            const fakes = sandbox.getFakes();
 
-            expected = sandbox.spy();
+            const expected = sandbox.spy();
 
             assert.isTrue(fakes.indexOf(expected) !== -1);
         });
@@ -207,20 +206,20 @@ describe("Sandbox", function () {
         });
 
         it("stubs existing methods", function () {
-            var Class = function () {
+            const Class = function () {
                 return;
             };
             Class.prototype.method = function () {
                 return;
             };
 
-            var stub = this.sandbox.createStubInstance(Class);
+            const stub = this.sandbox.createStubInstance(Class);
             stub.method.returns(3);
             assert.equals(3, stub.method());
         });
 
         it("should require a function", function () {
-            var sandbox = this.sandbox;
+            const sandbox = this.sandbox;
 
             assert.exception(
                 function () {
@@ -234,7 +233,7 @@ describe("Sandbox", function () {
         });
 
         it("resets all stub methods on reset()", function () {
-            var Class = function () {
+            const Class = function () {
                 return;
             };
             Class.prototype.method1 = function () {
@@ -247,7 +246,7 @@ describe("Sandbox", function () {
                 return;
             };
 
-            var stub = this.sandbox.createStubInstance(Class);
+            const stub = this.sandbox.createStubInstance(Class);
             stub.method1.returns(1);
             stub.method2.returns(2);
             stub.method3.returns(3);
@@ -261,64 +260,64 @@ describe("Sandbox", function () {
         });
 
         it("doesn't stub fake methods", function () {
-            var Class = function () {
+            const Class = function () {
                 return;
             };
             Class.prototype.noop = noop;
 
-            var stub = this.sandbox.createStubInstance(Class);
+            const stub = this.sandbox.createStubInstance(Class);
             assert.exception(function () {
                 stub.method.returns(3);
             });
         });
 
         it("doesn't call the constructor", function () {
-            var Class = function (a, b) {
-                var c = a + b;
+            const Class = function (a, b) {
+                const c = a + b;
                 throw c;
             };
             Class.prototype.method = function () {
                 return;
             };
 
-            var stub = this.sandbox.createStubInstance(Class);
+            const stub = this.sandbox.createStubInstance(Class);
             refute.exception(function () {
                 stub.method(3);
             });
         });
 
         it("retains non function values", function () {
-            var TYPE = "some-value";
-            var Class = function () {
+            const TYPE = "some-value";
+            const Class = function () {
                 return;
             };
             Class.prototype.noop = noop;
             Class.prototype.type = TYPE;
 
-            var stub = this.sandbox.createStubInstance(Class);
+            const stub = this.sandbox.createStubInstance(Class);
             assert.equals(TYPE, stub.type);
         });
 
         it("has no side effects on the prototype", function () {
-            var proto = {
+            const proto = {
                 method: function () {
                     throw new Error("error");
                 },
             };
-            var Class = function () {
+            const Class = function () {
                 return;
             };
             Class.prototype = proto;
 
-            var stub = this.sandbox.createStubInstance(Class);
+            const stub = this.sandbox.createStubInstance(Class);
             refute.exception(stub.method);
             assert.exception(proto.method);
         });
 
         it("throws exception for non function params", function () {
-            var types = [{}, 3, "hi!"];
+            const types = [{}, 3, "hi!"];
 
-            for (var i = 0; i < types.length; i++) {
+            for (let i = 0; i < types.length; i++) {
                 // yes, it's silly to create functions in a loop, it's also a test
                 /* eslint-disable-next-line no-loop-func */
                 assert.exception(function () {
@@ -328,14 +327,14 @@ describe("Sandbox", function () {
         });
 
         it("allows providing optional overrides", function () {
-            var Class = function () {
+            const Class = function () {
                 return;
             };
             Class.prototype.method = function () {
                 return;
             };
 
-            var stub = this.sandbox.createStubInstance(Class, {
+            const stub = this.sandbox.createStubInstance(Class, {
                 method: sinonStub().returns(3),
             });
 
@@ -343,14 +342,14 @@ describe("Sandbox", function () {
         });
 
         it("allows providing optional returned values", function () {
-            var Class = function () {
+            const Class = function () {
                 return;
             };
             Class.prototype.method = function () {
                 return;
             };
 
-            var stub = this.sandbox.createStubInstance(Class, {
+            const stub = this.sandbox.createStubInstance(Class, {
                 method: 3,
             });
 
@@ -358,14 +357,14 @@ describe("Sandbox", function () {
         });
 
         it("allows providing null as a return value", function () {
-            var Class = function () {
+            const Class = function () {
                 return;
             };
             Class.prototype.method = function () {
                 return;
             };
 
-            var stub = this.sandbox.createStubInstance(Class, {
+            const stub = this.sandbox.createStubInstance(Class, {
                 method: null,
             });
 
@@ -373,14 +372,14 @@ describe("Sandbox", function () {
         });
 
         it("throws an exception when trying to override non-existing property", function () {
-            var Class = function () {
+            const Class = function () {
                 return;
             };
             Class.prototype.method = function () {
                 return;
             };
 
-            var sandbox = this.sandbox;
+            const sandbox = this.sandbox;
 
             assert.exception(
                 function () {
@@ -418,7 +417,7 @@ describe("Sandbox", function () {
         });
 
         it("fails if stubbing property on null", function () {
-            var sandbox = this.sandbox;
+            const sandbox = this.sandbox;
 
             assert.exception(
                 function () {
@@ -432,7 +431,7 @@ describe("Sandbox", function () {
 
         it("fails if stubbing symbol on null", function () {
             if (typeof Symbol === "function") {
-                var sandbox = this.sandbox;
+                const sandbox = this.sandbox;
 
                 assert.exception(
                     function () {
@@ -447,7 +446,7 @@ describe("Sandbox", function () {
         });
 
         it("creates a stub", function () {
-            var object = {
+            const object = {
                 method: function () {
                     return;
                 },
@@ -459,19 +458,19 @@ describe("Sandbox", function () {
         });
 
         it("adds stub to fake array", function () {
-            var fakes = this.sandbox.getFakes();
-            var object = {
+            const fakes = this.sandbox.getFakes();
+            const object = {
                 method: function () {
                     return;
                 },
             };
-            var stub = this.sandbox.stub(object, "method");
+            const stub = this.sandbox.stub(object, "method");
 
             assert.isTrue(fakes.indexOf(stub) !== -1);
         });
 
         it("appends stubs to fake array", function () {
-            var fakes = this.sandbox.getFakes();
+            const fakes = this.sandbox.getFakes();
 
             this.sandbox.stub(
                 {
@@ -494,8 +493,8 @@ describe("Sandbox", function () {
         });
 
         it("adds all object methods to fake array", function () {
-            var fakes = this.sandbox.getFakes();
-            var object = {
+            const fakes = this.sandbox.getFakes();
+            const object = {
                 method: function () {
                     return;
                 },
@@ -520,7 +519,7 @@ describe("Sandbox", function () {
         });
 
         it("returns a stubbed object", function () {
-            var object = {
+            const object = {
                 method: function () {
                     return;
                 },
@@ -529,7 +528,7 @@ describe("Sandbox", function () {
         });
 
         it("returns a stubbed method", function () {
-            var object = {
+            const object = {
                 method: function () {
                     return;
                 },
@@ -549,7 +548,7 @@ describe("Sandbox", function () {
             });
 
             it("stubs environment property", function () {
-                var originalPrintWarning = deprecated.printWarning;
+                const originalPrintWarning = deprecated.printWarning;
                 deprecated.printWarning = function () {
                     return;
                 };
@@ -569,7 +568,7 @@ describe("Sandbox", function () {
         });
 
         it("stubs number property", function () {
-            var originalPrintWarning = deprecated.printWarning;
+            const originalPrintWarning = deprecated.printWarning;
             deprecated.printWarning = function () {
                 return;
             };
@@ -582,7 +581,7 @@ describe("Sandbox", function () {
         });
 
         it("restores number property", function () {
-            var originalPrintWarning = deprecated.printWarning;
+            const originalPrintWarning = deprecated.printWarning;
             deprecated.printWarning = function () {
                 return;
             };
@@ -596,13 +595,13 @@ describe("Sandbox", function () {
         });
 
         it("fails if property does not exist", function () {
-            var originalPrintWarning = deprecated.printWarning;
+            const originalPrintWarning = deprecated.printWarning;
             deprecated.printWarning = function () {
                 return;
             };
 
-            var sandbox = this.sandbox;
-            var object = {};
+            const sandbox = this.sandbox;
+            const object = {};
 
             assert.exception(function () {
                 sandbox.stub(object, "prop", 1);
@@ -613,10 +612,10 @@ describe("Sandbox", function () {
 
         it("fails if Symbol does not exist", function () {
             if (typeof Symbol === "function") {
-                var sandbox = this.sandbox;
-                var object = {};
+                const sandbox = this.sandbox;
+                const object = {};
 
-                var originalPrintWarning = deprecated.printWarning;
+                const originalPrintWarning = deprecated.printWarning;
                 deprecated.printWarning = function () {
                     return;
                 };
@@ -639,38 +638,36 @@ describe("Sandbox", function () {
 
     describe(".fake", function () {
         it("should return a fake", function () {
-            var sandbox = createSandbox();
-            var fake = sandbox.fake();
+            const sandbox = createSandbox();
+            const fake = sandbox.fake();
 
             assert.isFunction(fake);
             assert.equals(fake.displayName, "fake");
         });
 
         it("should add a fake to the internal collection", function () {
-            var sandbox = createSandbox();
-            var fakes = sandbox.getFakes();
-            var expected;
+            const sandbox = createSandbox();
+            const fakes = sandbox.getFakes();
 
-            expected = sandbox.fake();
+            const expected = sandbox.fake();
 
             assert.isTrue(fakes.indexOf(expected) !== -1);
         });
 
         describe(".returns", function () {
             it("should return a fake behavior", function () {
-                var sandbox = createSandbox();
-                var fake = sandbox.fake.returns();
+                const sandbox = createSandbox();
+                const fake = sandbox.fake.returns();
 
                 assert.isFunction(fake);
                 assert.equals(fake.displayName, "fake");
             });
 
             it("should add a fake behavior to the internal collection", function () {
-                var sandbox = createSandbox();
-                var fakes = sandbox.getFakes();
-                var expected;
+                const sandbox = createSandbox();
+                const fakes = sandbox.getFakes();
 
-                expected = sandbox.fake.returns();
+                const expected = sandbox.fake.returns();
 
                 assert.isTrue(fakes.indexOf(expected) !== -1);
             });
@@ -678,19 +675,18 @@ describe("Sandbox", function () {
 
         describe(".throws", function () {
             it("should return a fake behavior", function () {
-                var sandbox = createSandbox();
-                var fake = sandbox.fake.throws();
+                const sandbox = createSandbox();
+                const fake = sandbox.fake.throws();
 
                 assert.isFunction(fake);
                 assert.equals(fake.displayName, "fake");
             });
 
             it("should add a fake behavior to the internal collection", function () {
-                var sandbox = createSandbox();
-                var fakes = sandbox.getFakes();
-                var expected;
+                const sandbox = createSandbox();
+                const fakes = sandbox.getFakes();
 
-                expected = sandbox.fake.throws();
+                const expected = sandbox.fake.throws();
 
                 assert.isTrue(fakes.indexOf(expected) !== -1);
             });
@@ -698,19 +694,18 @@ describe("Sandbox", function () {
 
         describe(".resolves", function () {
             it("should return a fake behavior", function () {
-                var sandbox = createSandbox();
-                var fake = sandbox.fake.resolves();
+                const sandbox = createSandbox();
+                const fake = sandbox.fake.resolves();
 
                 assert.isFunction(fake);
                 assert.equals(fake.displayName, "fake");
             });
 
             it("should add a fake behavior to the internal collection", function () {
-                var sandbox = createSandbox();
-                var fakes = sandbox.getFakes();
-                var expected;
+                const sandbox = createSandbox();
+                const fakes = sandbox.getFakes();
 
-                expected = sandbox.fake.resolves();
+                const expected = sandbox.fake.resolves();
 
                 assert.isTrue(fakes.indexOf(expected) !== -1);
             });
@@ -718,19 +713,18 @@ describe("Sandbox", function () {
 
         describe(".rejects", function () {
             it("should return a fake behavior", function () {
-                var sandbox = createSandbox();
-                var fake = sandbox.fake.rejects();
+                const sandbox = createSandbox();
+                const fake = sandbox.fake.rejects();
 
                 assert.isFunction(fake);
                 assert.equals(fake.displayName, "fake");
             });
 
             it("should add a fake behavior to the internal collection", function () {
-                var sandbox = createSandbox();
-                var fakes = sandbox.getFakes();
-                var expected;
+                const sandbox = createSandbox();
+                const fakes = sandbox.getFakes();
 
-                expected = sandbox.fake.rejects();
+                const expected = sandbox.fake.rejects();
 
                 assert.isTrue(fakes.indexOf(expected) !== -1);
             });
@@ -738,19 +732,18 @@ describe("Sandbox", function () {
 
         describe(".yields", function () {
             it("should return a fake behavior", function () {
-                var sandbox = createSandbox();
-                var fake = sandbox.fake.yields();
+                const sandbox = createSandbox();
+                const fake = sandbox.fake.yields();
 
                 assert.isFunction(fake);
                 assert.equals(fake.displayName, "fake");
             });
 
             it("should add a fake behavior to the internal collection", function () {
-                var sandbox = createSandbox();
-                var fakes = sandbox.getFakes();
-                var expected;
+                const sandbox = createSandbox();
+                const fakes = sandbox.getFakes();
 
-                expected = sandbox.fake.yields();
+                const expected = sandbox.fake.yields();
 
                 assert.isTrue(fakes.indexOf(expected) !== -1);
             });
@@ -758,19 +751,18 @@ describe("Sandbox", function () {
 
         describe(".yieldsAsync", function () {
             it("should return a fake behavior", function () {
-                var sandbox = createSandbox();
-                var fake = sandbox.fake.yieldsAsync();
+                const sandbox = createSandbox();
+                const fake = sandbox.fake.yieldsAsync();
 
                 assert.isFunction(fake);
                 assert.equals(fake.displayName, "fake");
             });
 
             it("should add a fake behavior to the internal collection", function () {
-                var sandbox = createSandbox();
-                var fakes = sandbox.getFakes();
-                var expected;
+                const sandbox = createSandbox();
+                const fakes = sandbox.getFakes();
 
-                expected = sandbox.fake.yieldsAsync();
+                const expected = sandbox.fake.yieldsAsync();
 
                 assert.isTrue(fakes.indexOf(expected) !== -1);
             });
@@ -802,7 +794,7 @@ describe("Sandbox", function () {
         });
 
         it("calls restore when restore throws", function () {
-            var sandbox = this.sandbox;
+            const sandbox = this.sandbox;
 
             sandbox.verify = sinonSpy();
             sandbox.restore = sinonStub().throws();
@@ -821,13 +813,13 @@ describe("Sandbox", function () {
         });
 
         it("should replace a function property", function () {
-            var replacement = function replacement() {
+            const replacement = function replacement() {
                 return;
             };
-            var existing = function existing() {
+            const existing = function existing() {
                 return;
             };
-            var object = {
+            const object = {
                 property: existing,
             };
 
@@ -841,9 +833,9 @@ describe("Sandbox", function () {
         });
 
         it("should replace a non-function property", function () {
-            var replacement = "replacement";
-            var existing = "existing";
-            var object = {
+            const replacement = "replacement";
+            const existing = "existing";
+            const object = {
                 property: existing,
             };
 
@@ -857,9 +849,9 @@ describe("Sandbox", function () {
         });
 
         it("should replace an inherited property", function () {
-            var replacement = "replacement";
-            var existing = "existing";
-            var object = Object.create({
+            const replacement = "replacement";
+            const existing = "existing";
+            const object = Object.create({
                 property: existing,
             });
 
@@ -873,7 +865,7 @@ describe("Sandbox", function () {
         });
 
         it("should error on missing descriptor", function () {
-            var sandbox = this.sandbox;
+            const sandbox = this.sandbox;
 
             assert.exception(
                 function () {
@@ -888,8 +880,8 @@ describe("Sandbox", function () {
         });
 
         it("should error on missing replacement", function () {
-            var sandbox = this.sandbox;
-            var object = Object.create({
+            const sandbox = this.sandbox;
+            const object = Object.create({
                 property: "catpants",
             });
 
@@ -905,12 +897,12 @@ describe("Sandbox", function () {
         });
 
         it("should refuse to replace a non-function with a function", function () {
-            var sandbox = this.sandbox;
-            var replacement = function () {
+            const sandbox = this.sandbox;
+            const replacement = function () {
                 return "replacement";
             };
-            var existing = "existing";
-            var object = {
+            const existing = "existing";
+            const object = {
                 property: existing,
             };
 
@@ -923,9 +915,9 @@ describe("Sandbox", function () {
         });
 
         it("should refuse to replace a function with a non-function", function () {
-            var sandbox = this.sandbox;
-            var replacement = "replacement";
-            var object = {
+            const sandbox = this.sandbox;
+            const replacement = "replacement";
+            const object = {
                 property: function () {
                     return "apple pie";
                 },
@@ -940,8 +932,8 @@ describe("Sandbox", function () {
         });
 
         it("should refuse to replace a fake twice", function () {
-            var sandbox = this.sandbox;
-            var object = {
+            const sandbox = this.sandbox;
+            const object = {
                 property: function () {
                     return "apple pie";
                 },
@@ -961,8 +953,8 @@ describe("Sandbox", function () {
         });
 
         it("should refuse to replace a string twice", function () {
-            var sandbox = this.sandbox;
-            var object = {
+            const sandbox = this.sandbox;
+            const object = {
                 property: "original",
             };
 
@@ -980,21 +972,25 @@ describe("Sandbox", function () {
         });
 
         it("should return the replacement argument", function () {
-            var replacement = "replacement";
-            var existing = "existing";
-            var object = {
+            const replacement = "replacement";
+            const existing = "existing";
+            const object = {
                 property: existing,
             };
 
-            var actual = this.sandbox.replace(object, "property", replacement);
+            const actual = this.sandbox.replace(
+                object,
+                "property",
+                replacement
+            );
 
             assert.equals(actual, replacement);
         });
 
         describe("when asked to replace a getter", function () {
             it("should throw an Error", function () {
-                var sandbox = this.sandbox;
-                var object = {
+                const sandbox = this.sandbox;
+                const object = {
                     get foo() {
                         return "bar";
                     },
@@ -1014,8 +1010,8 @@ describe("Sandbox", function () {
 
         describe("when asked to replace a setter", function () {
             it("should throw an Error", function () {
-                var sandbox = this.sandbox;
-                var object = {
+                const sandbox = this.sandbox;
+                const object = {
                     // eslint-disable-next-line accessor-pairs
                     set foo(value) {
                         this.prop = value;
@@ -1041,8 +1037,8 @@ describe("Sandbox", function () {
         });
 
         it("should replace getters", function () {
-            var expected = "baz";
-            var object = {
+            const expected = "baz";
+            const object = {
                 get foo() {
                     return "bar";
                 },
@@ -1058,23 +1054,27 @@ describe("Sandbox", function () {
         });
 
         it("should return replacement", function () {
-            var replacement = sinonFake.returns("baz");
-            var object = {
+            const replacement = sinonFake.returns("baz");
+            const object = {
                 get foo() {
                     return "bar";
                 },
             };
 
-            var actual = this.sandbox.replaceGetter(object, "foo", replacement);
+            const actual = this.sandbox.replaceGetter(
+                object,
+                "foo",
+                replacement
+            );
 
             assert.equals(actual, replacement);
         });
 
         it("should replace an inherited property", function () {
-            var expected = "baz";
-            var replacement = sinonFake.returns(expected);
-            var existing = "existing";
-            var object = Object.create({
+            const expected = "baz";
+            const replacement = sinonFake.returns(expected);
+            const existing = "existing";
+            const object = Object.create({
                 get foo() {
                     return existing;
                 },
@@ -1090,7 +1090,7 @@ describe("Sandbox", function () {
         });
 
         it("should error on missing descriptor", function () {
-            var sandbox = this.sandbox;
+            const sandbox = this.sandbox;
 
             assert.exception(
                 function () {
@@ -1105,8 +1105,8 @@ describe("Sandbox", function () {
         });
 
         it("should error when descriptor has no getter", function () {
-            var sandbox = this.sandbox;
-            var object = {
+            const sandbox = this.sandbox;
+            const object = {
                 // eslint-disable-next-line accessor-pairs
                 set catpants(_) {
                     return;
@@ -1126,9 +1126,9 @@ describe("Sandbox", function () {
 
         describe("when called with a non-function replacement argument", function () {
             it("should throw a TypeError", function () {
-                var sandbox = this.sandbox;
-                var expected = "baz";
-                var object = {
+                const sandbox = this.sandbox;
+                const expected = "baz";
+                const object = {
                     get foo() {
                         return "bar";
                     },
@@ -1147,8 +1147,8 @@ describe("Sandbox", function () {
         });
 
         it("allows restoring getters", function () {
-            var expected = "baz";
-            var object = {
+            const expected = "baz";
+            const object = {
                 get foo() {
                     return "bar";
                 },
@@ -1166,8 +1166,8 @@ describe("Sandbox", function () {
         });
 
         it("should refuse to replace a getter twice", function () {
-            var sandbox = this.sandbox;
-            var object = {
+            const sandbox = this.sandbox;
+            const object = {
                 get foo() {
                     return "bar";
                 },
@@ -1197,7 +1197,7 @@ describe("Sandbox", function () {
         });
 
         it("should replace setter", function () {
-            var object = {
+            const object = {
                 // eslint-disable-next-line accessor-pairs
                 set foo(value) {
                     this.prop = value;
@@ -1215,30 +1215,34 @@ describe("Sandbox", function () {
         });
 
         it("should return replacement", function () {
-            var object = {
+            const object = {
                 // eslint-disable-next-line accessor-pairs
                 set foo(value) {
                     this.prop = value;
                 },
                 prop: "bar",
             };
-            var replacement = function (val) {
+            const replacement = function (val) {
                 this.prop = `${val}bla`;
             };
-            var actual = this.sandbox.replaceSetter(object, "foo", replacement);
+            const actual = this.sandbox.replaceSetter(
+                object,
+                "foo",
+                replacement
+            );
 
             assert.equals(actual, replacement);
         });
 
         it("should replace an inherited property", function () {
-            var object = Object.create({
+            const object = Object.create({
                 // eslint-disable-next-line accessor-pairs
                 set foo(value) {
                     this.prop = value;
                 },
                 prop: "bar",
             });
-            var replacement = function (value) {
+            const replacement = function (value) {
                 this.prop = `${value}blabla`;
             };
 
@@ -1252,7 +1256,7 @@ describe("Sandbox", function () {
         });
 
         it("should error on missing descriptor", function () {
-            var sandbox = this.sandbox;
+            const sandbox = this.sandbox;
 
             assert.exception(
                 function () {
@@ -1267,8 +1271,8 @@ describe("Sandbox", function () {
         });
 
         it("should error when descriptor has no setter", function () {
-            var sandbox = this.sandbox;
-            var object = {
+            const sandbox = this.sandbox;
+            const object = {
                 get catpants() {
                     return;
                 },
@@ -1287,8 +1291,8 @@ describe("Sandbox", function () {
 
         describe("when called with a non-function replacement argument", function () {
             it("should throw a TypeError", function () {
-                var sandbox = this.sandbox;
-                var object = {
+                const sandbox = this.sandbox;
+                const object = {
                     // eslint-disable-next-line accessor-pairs
                     set foo(value) {
                         this.prop = value;
@@ -1309,7 +1313,7 @@ describe("Sandbox", function () {
         });
 
         it("allows restoring setters", function () {
-            var object = {
+            const object = {
                 // eslint-disable-next-line accessor-pairs
                 set foo(value) {
                     this.prop = value;
@@ -1329,8 +1333,8 @@ describe("Sandbox", function () {
         });
 
         it("should refuse to replace a setter twice", function () {
-            var sandbox = this.sandbox;
-            var object = {
+            const sandbox = this.sandbox;
+            const object = {
                 // eslint-disable-next-line accessor-pairs
                 set foo(value) {
                     return;
@@ -1357,8 +1361,8 @@ describe("Sandbox", function () {
 
     describe(".reset", function () {
         beforeEach(function () {
-            var sandbox = (this.sandbox = createSandbox());
-            var fakes = sandbox.getFakes();
+            const sandbox = (this.sandbox = createSandbox());
+            const fakes = sandbox.getFakes();
 
             fakes.push({
                 reset: sinonSpy(),
@@ -1371,8 +1375,8 @@ describe("Sandbox", function () {
         });
 
         it("calls reset on all fakes", function () {
-            var fake0 = this.sandbox.getFakes()[0];
-            var fake1 = this.sandbox.getFakes()[1];
+            const fake0 = this.sandbox.getFakes()[0];
+            const fake1 = this.sandbox.getFakes()[1];
 
             this.sandbox.reset();
 
@@ -1381,8 +1385,8 @@ describe("Sandbox", function () {
         });
 
         it("calls resetHistory on all fakes", function () {
-            var fake0 = this.sandbox.getFakes()[0];
-            var fake1 = this.sandbox.getFakes()[1];
+            const fake0 = this.sandbox.getFakes()[0];
+            const fake1 = this.sandbox.getFakes()[1];
 
             this.sandbox.reset();
 
@@ -1391,7 +1395,7 @@ describe("Sandbox", function () {
         });
 
         it("resets fake behaviours", function () {
-            var fake = this.sandbox.fake();
+            const fake = this.sandbox.fake();
             fake(1234);
 
             this.sandbox.reset();
@@ -1402,16 +1406,16 @@ describe("Sandbox", function () {
 
     describe(".resetBehavior", function () {
         beforeEach(function () {
-            var sandbox = (this.sandbox = createSandbox());
-            var fakes = sandbox.getFakes();
+            const sandbox = (this.sandbox = createSandbox());
+            const fakes = sandbox.getFakes();
 
             fakes.push({ resetBehavior: sinonSpy() });
             fakes.push({ resetBehavior: sinonSpy() });
         });
 
         it("calls resetBehavior on all fakes", function () {
-            var fake0 = this.sandbox.getFakes()[0];
-            var fake1 = this.sandbox.getFakes()[1];
+            const fake0 = this.sandbox.getFakes()[0];
+            const fake1 = this.sandbox.getFakes()[1];
 
             this.sandbox.resetBehavior();
 
@@ -1422,21 +1426,21 @@ describe("Sandbox", function () {
 
     describe(".resetHistory", function () {
         beforeEach(function () {
-            var sandbox = (this.sandbox = createSandbox());
-            var fakes = (this.fakes = sandbox.getFakes());
+            const sandbox = (this.sandbox = createSandbox());
+            const fakes = (this.fakes = sandbox.getFakes());
 
-            var spy1 = sinonSpy();
+            const spy1 = sinonSpy();
             spy1();
             fakes.push(spy1);
 
-            var spy2 = sinonSpy();
+            const spy2 = sinonSpy();
             spy2();
             fakes.push(spy2);
         });
 
         it("resets the history on all fakes", function () {
-            var fake0 = this.fakes[0];
-            var fake1 = this.fakes[1];
+            const fake0 = this.fakes[0];
+            const fake1 = this.fakes[1];
 
             this.sandbox.resetHistory();
 
@@ -1467,7 +1471,7 @@ describe("Sandbox", function () {
         });
 
         it("returns clock object", function () {
-            var clock = this.sandbox.useFakeTimers();
+            const clock = this.sandbox.useFakeTimers();
 
             assert.isObject(clock);
             assert.isFunction(clock.tick);
@@ -1487,7 +1491,7 @@ describe("Sandbox", function () {
         });
 
         it("passes arguments to sinon.useFakeTimers", function () {
-            var useFakeTimersStub = sinonStub(
+            const useFakeTimersStub = sinonStub(
                 sinonClock,
                 "useFakeTimers"
             ).returns({});
@@ -1510,7 +1514,7 @@ describe("Sandbox", function () {
         });
 
         it("restores the fakeTimer clock created by the sandbox when the sandbox is restored", function () {
-            var originalSetTimeout = setTimeout;
+            const originalSetTimeout = setTimeout;
 
             this.sandbox.useFakeTimers();
             refute.same(setTimeout, originalSetTimeout, "fakeTimers installed");
@@ -1521,7 +1525,7 @@ describe("Sandbox", function () {
         });
 
         it("restores spied fake timers when the sandbox is restored", function () {
-            var originalSetTimeout = setTimeout;
+            const originalSetTimeout = setTimeout;
 
             this.sandbox.useFakeTimers();
             this.sandbox.spy(globalContext, "setTimeout");
@@ -1550,9 +1554,9 @@ describe("Sandbox", function () {
         });
 
         it("must return the sandbox", function () {
-            var mockPromise = {};
+            const mockPromise = {};
 
-            var actual = this.sandbox.usingPromise(mockPromise);
+            const actual = this.sandbox.usingPromise(mockPromise);
 
             assert.same(actual, this.sandbox);
         });
@@ -1562,13 +1566,13 @@ describe("Sandbox", function () {
                 return this.skip();
             }
 
-            var resolveValue = {};
-            var mockPromise = {
+            const resolveValue = {};
+            const mockPromise = {
                 resolve: sinonStub().resolves(resolveValue),
             };
 
             this.sandbox.usingPromise(mockPromise);
-            var stub = this.sandbox.stub().resolves();
+            const stub = this.sandbox.stub().resolves();
 
             return stub().then(function (action) {
                 assert.same(resolveValue, action);
@@ -1582,11 +1586,11 @@ describe("Sandbox", function () {
                 return this.skip();
             }
 
-            var resolveValue = {};
-            var mockPromise = {
+            const resolveValue = {};
+            const mockPromise = {
                 resolve: sinonStub().resolves(resolveValue),
             };
-            var stubbedObject = {
+            const stubbedObject = {
                 stubbedMethod: function () {
                     return;
                 },
@@ -1607,18 +1611,18 @@ describe("Sandbox", function () {
                 return this.skip();
             }
 
-            var resolveValue = {};
-            var mockPromise = {
+            const resolveValue = {};
+            const mockPromise = {
                 resolve: sinonStub().resolves(resolveValue),
             };
-            var mockedObject = {
+            const mockedObject = {
                 mockedMethod: function () {
                     return;
                 },
             };
 
             this.sandbox.usingPromise(mockPromise);
-            var mock = this.sandbox.mock(mockedObject);
+            const mock = this.sandbox.mock(mockedObject);
             mock.expects("mockedMethod").resolves({});
 
             return mockedObject.mockedMethod().then(function (action) {
@@ -1641,7 +1645,7 @@ describe("Sandbox", function () {
                 });
 
                 it("calls sinon.useFakeXMLHttpRequest", function () {
-                    var stubXhr = {
+                    const stubXhr = {
                         restore: function () {
                             return;
                         },
@@ -1650,7 +1654,7 @@ describe("Sandbox", function () {
                     this.sandbox
                         .stub(fakeXhr, "useFakeXMLHttpRequest")
                         .returns(stubXhr);
-                    var returnedXhr = this.sandbox.useFakeXMLHttpRequest();
+                    const returnedXhr = this.sandbox.useFakeXMLHttpRequest();
 
                     assert(fakeXhr.useFakeXMLHttpRequest.called);
                     assert.equals(stubXhr, returnedXhr);
@@ -1699,33 +1703,33 @@ describe("Sandbox", function () {
                 });
 
                 it("returns server", function () {
-                    var server = this.sandbox.useFakeServer();
+                    const server = this.sandbox.useFakeServer();
 
                     assert.isObject(server);
                     assert.isFunction(server.restore);
                 });
 
                 it("exposes server property", function () {
-                    var server = this.sandbox.useFakeServer();
+                    const server = this.sandbox.useFakeServer();
 
                     assert.same(this.sandbox.server, server);
                 });
 
                 it("creates server", function () {
-                    var server = this.sandbox.useFakeServer();
+                    const server = this.sandbox.useFakeServer();
 
                     assert(fakeServer.isPrototypeOf(server));
                 });
 
                 it("creates server without clock by default", function () {
-                    var server = this.sandbox.useFakeServer();
+                    const server = this.sandbox.useFakeServer();
 
                     refute(fakeServerWithClock.isPrototypeOf(server));
                 });
 
                 it("creates server with clock", function () {
                     this.sandbox.serverPrototype = fakeServerWithClock;
-                    var server = this.sandbox.useFakeServer();
+                    const server = this.sandbox.useFakeServer();
 
                     assert(fakeServerWithClock.isPrototypeOf(server));
                 });
@@ -1768,7 +1772,7 @@ describe("Sandbox", function () {
             /* eslint-disable no-empty-function, accessor-pairs */
             this.sandbox.inject(this.obj);
 
-            var myObj = { a: function () {} };
+            const myObj = { a: function () {} };
             function MyClass() {}
             MyClass.prototype.method1 = noop;
             Object.defineProperty(myObj, "b", {
@@ -1785,7 +1789,7 @@ describe("Sandbox", function () {
             refute.exception(
                 function () {
                     this.obj.createStubInstance(MyClass);
-                    var fake = this.obj.fake();
+                    const fake = this.obj.fake();
                     this.obj.replace(myObj, "a", fake);
                     this.obj.replaceGetter(myObj, "b", fake);
                     this.obj.replaceSetter(myObj, "c", fake);
@@ -1814,7 +1818,7 @@ describe("Sandbox", function () {
         });
 
         it("should return object", function () {
-            var injected = this.sandbox.inject({});
+            const injected = this.sandbox.inject({});
 
             assert.isObject(injected);
             assert.isFunction(injected.spy);
@@ -1839,12 +1843,12 @@ describe("Sandbox", function () {
                     this.sandbox.useFakeTimers();
                     this.sandbox.inject(this.obj);
 
-                    var spy = sinonSpy();
+                    const spy = sinonSpy();
                     setTimeout(spy, 10);
 
                     this.sandbox.clock.tick(10);
 
-                    var xhr = window.XMLHttpRequest
+                    const xhr = window.XMLHttpRequest
                         ? new XMLHttpRequest()
                         : new ActiveXObject("Microsoft.XMLHTTP"); //eslint-disable-line no-undef
 
@@ -1861,8 +1865,8 @@ describe("Sandbox", function () {
 
     describe(".verify", function () {
         it("calls verify on all fakes", function () {
-            var sandbox = createSandbox();
-            var fakes = sandbox.getFakes();
+            const sandbox = createSandbox();
+            const fakes = sandbox.getFakes();
 
             fakes.push({ verify: sinonSpy() });
             fakes.push({ verify: sinonSpy() });
@@ -1877,7 +1881,7 @@ describe("Sandbox", function () {
 
     describe(".restore", function () {
         it("throws when passed arguments", function () {
-            var sandbox = new Sandbox();
+            const sandbox = new Sandbox();
 
             assert.exception(
                 function () {
@@ -1892,8 +1896,8 @@ describe("Sandbox", function () {
 
         // https://github.com/sinonjs/sinon/issues/2192
         it("restores all fields of a spied object", function () {
-            var sandbox = new Sandbox();
-            var o = {
+            const sandbox = new Sandbox();
+            const o = {
                 foo: function () {
                     return 42;
                 },
@@ -1906,8 +1910,8 @@ describe("Sandbox", function () {
         });
 
         it("restores all fields of a stubbed object", function () {
-            var sandbox = new Sandbox();
-            var o = {
+            const sandbox = new Sandbox();
+            const o = {
                 foo: function () {
                     return 42;
                 },
@@ -1935,7 +1939,7 @@ describe("Sandbox", function () {
         });
 
         it("yields stub, mock as arguments", function () {
-            var sandbox = createSandbox(
+            const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["stub", "mock"],
                 })
@@ -1949,7 +1953,7 @@ describe("Sandbox", function () {
         });
 
         it("yields spy, stub, mock as arguments", function () {
-            var sandbox = createSandbox(
+            const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["spy", "stub", "mock"],
                 })
@@ -1963,7 +1967,7 @@ describe("Sandbox", function () {
         });
 
         it("does not yield server when not faking xhr", function () {
-            var sandbox = createSandbox(
+            const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["server", "stub", "mock"],
                     useFakeServer: false,
@@ -1978,13 +1982,13 @@ describe("Sandbox", function () {
         });
 
         it("does not inject properties if they are already present", function () {
-            var server = function () {
+            const server = function () {
                 return;
             };
-            var clock = {};
-            var spy = false;
-            var object = { server: server, clock: clock, spy: spy };
-            var sandbox = createSandbox(
+            const clock = {};
+            const spy = false;
+            const object = { server: server, clock: clock, spy: spy };
+            const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["server", "clock", "spy"],
                     injectInto: object,
@@ -2001,7 +2005,7 @@ describe("Sandbox", function () {
         if (supportsAjax) {
             describe("ajax options", function () {
                 it("yields server when faking xhr", function () {
-                    var sandbox = createSandbox(
+                    const sandbox = createSandbox(
                         sinonConfig({
                             properties: ["server", "stub", "mock"],
                         })
@@ -2016,7 +2020,7 @@ describe("Sandbox", function () {
                 });
 
                 it("uses serverWithClock when faking xhr", function () {
-                    var sandbox = createSandbox(
+                    const sandbox = createSandbox(
                         sinonConfig({
                             properties: ["server"],
                             useFakeServer: fakeServerWithClock,
@@ -2032,13 +2036,13 @@ describe("Sandbox", function () {
                 });
 
                 it("uses fakeServer as the serverPrototype by default", function () {
-                    var sandbox = createSandbox();
+                    const sandbox = createSandbox();
 
                     assert.same(sandbox.serverPrototype, fakeServer);
                 });
 
                 it("uses configured implementation as the serverPrototype", function () {
-                    var sandbox = createSandbox({
+                    const sandbox = createSandbox({
                         useFakeServer: fakeServerWithClock,
                     });
 
@@ -2046,7 +2050,7 @@ describe("Sandbox", function () {
                 });
 
                 it("yields clock when faking timers", function () {
-                    var sandbox = createSandbox(
+                    const sandbox = createSandbox(
                         sinonConfig({
                             properties: ["server", "clock"],
                         })
@@ -2059,9 +2063,9 @@ describe("Sandbox", function () {
                 });
 
                 it("injects properties into object", function () {
-                    var object = {};
+                    const object = {};
 
-                    var sandbox = createSandbox(
+                    const sandbox = createSandbox(
                         sinonConfig({
                             properties: ["server", "clock"],
                             injectInto: object,
@@ -2080,9 +2084,9 @@ describe("Sandbox", function () {
                 });
 
                 it("should inject server and clock when only enabling them", function () {
-                    var object = {};
+                    const object = {};
 
-                    var sandbox = createSandbox(
+                    const sandbox = createSandbox(
                         sinonConfig({
                             injectInto: object,
                             useFakeTimers: true,
@@ -2107,7 +2111,7 @@ describe("Sandbox", function () {
         // This is currently testing the internals of useFakeTimers, we could possibly change it to be based on
         // behavior.
         it("fakes specified timers", function () {
-            var sandbox = createSandbox(
+            const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["clock"],
                     useFakeTimers: { toFake: ["Date", "setTimeout"] },
@@ -2124,9 +2128,9 @@ describe("Sandbox", function () {
         });
 
         it("injects sandbox", function () {
-            var object = {};
+            const object = {};
 
-            var sandbox = createSandbox(
+            const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["sandbox", "spy"],
                     injectInto: object,
@@ -2141,9 +2145,9 @@ describe("Sandbox", function () {
         });
 
         it("injects match", function () {
-            var object = {};
+            const object = {};
 
-            var sandbox = createSandbox(
+            const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["match"],
                     injectInto: object,
@@ -2158,11 +2162,11 @@ describe("Sandbox", function () {
 
     describe("getters and setters", function () {
         it("allows stubbing getters", function () {
-            var object = {
+            const object = {
                 foo: "bar",
             };
 
-            var sandbox = new Sandbox();
+            const sandbox = new Sandbox();
             sandbox.stub(object, "foo").get(function () {
                 return "baz";
             });
@@ -2171,11 +2175,11 @@ describe("Sandbox", function () {
         });
 
         it("allows restoring getters", function () {
-            var object = {
+            const object = {
                 foo: "bar",
             };
 
-            var sandbox = new Sandbox();
+            const sandbox = new Sandbox();
             sandbox.stub(object, "foo").get(function () {
                 return "baz";
             });
@@ -2186,12 +2190,12 @@ describe("Sandbox", function () {
         });
 
         it("allows stubbing setters", function () {
-            var object = {
+            const object = {
                 foo: undefined,
                 prop: "bar",
             };
 
-            var sandbox = new Sandbox();
+            const sandbox = new Sandbox();
             sandbox.stub(object, "foo").set(function (val) {
                 object.prop = `${val}bla`;
             });
@@ -2202,11 +2206,11 @@ describe("Sandbox", function () {
         });
 
         it("allows restoring setters", function () {
-            var object = {
+            const object = {
                 prop: "bar",
             };
 
-            var sandbox = new Sandbox();
+            const sandbox = new Sandbox();
             sandbox.stub(object, "prop").set(function setterFn(val) {
                 object.prop = `${val}bla`;
             });
@@ -2221,8 +2225,8 @@ describe("Sandbox", function () {
 
     describe(".assert", function () {
         it("allows rebinding of .fail on a per-sandbox level", function () {
-            var sandboxA = createSandbox();
-            var sandboxB = createSandbox();
+            const sandboxA = createSandbox();
+            const sandboxB = createSandbox();
 
             sandboxA.assert.failException = "CustomErrorA";
             sandboxB.assert.failException = "CustomErrorB";

--- a/test/shared-spy-stub-everything-tests.js
+++ b/test/shared-spy-stub-everything-tests.js
@@ -2,13 +2,13 @@
 /* eslint-disable jsdoc/require-jsdoc */
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var assert = referee.assert;
-var refute = referee.refute;
+const referee = require("@sinonjs/referee");
+const assert = referee.assert;
+const refute = referee.refute;
 
 module.exports = function shared(createSpyOrStub) {
     it("replaces all methods of an object when no property is given", function () {
-        var obj = {
+        const obj = {
             func1: function () {
                 return;
             },
@@ -34,7 +34,7 @@ module.exports = function shared(createSpyOrStub) {
         Obj.prototype.func1 = function () {
             return;
         };
-        var obj = new Obj();
+        const obj = new Obj();
 
         createSpyOrStub(obj);
 
@@ -42,7 +42,7 @@ module.exports = function shared(createSpyOrStub) {
     });
 
     it("returns object", function () {
-        var object = {
+        const object = {
             func1: function () {
                 return;
             },
@@ -52,7 +52,7 @@ module.exports = function shared(createSpyOrStub) {
     });
 
     it("only replaces functions", function () {
-        var object = {
+        const object = {
             foo: "bar",
             baz: function () {
                 return;
@@ -65,7 +65,7 @@ module.exports = function shared(createSpyOrStub) {
     });
 
     it("handles non-enumerable properties", function () {
-        var obj = {
+        const obj = {
             func1: function () {
                 return;
             },
@@ -101,7 +101,7 @@ module.exports = function shared(createSpyOrStub) {
             configurable: true,
         });
 
-        var obj = new Obj();
+        const obj = new Obj();
 
         createSpyOrStub(obj);
 
@@ -109,7 +109,7 @@ module.exports = function shared(createSpyOrStub) {
     });
 
     it("does not replace non-enumerable properties from Object.prototype", function () {
-        var obj = {
+        const obj = {
             noop: function () {
                 return;
             },
@@ -123,12 +123,12 @@ module.exports = function shared(createSpyOrStub) {
     });
 
     it("does not fail on overrides", function () {
-        var parent = {
+        const parent = {
             func: function () {
                 return;
             },
         };
-        var child = Object.create(parent);
+        const child = Object.create(parent);
         child.func = function () {
             return;
         };
@@ -139,7 +139,7 @@ module.exports = function shared(createSpyOrStub) {
     });
 
     it("throws on non-existent property", function () {
-        var myObj = {
+        const myObj = {
             ignoreme: function () {
                 return;
             },
@@ -153,7 +153,7 @@ module.exports = function shared(createSpyOrStub) {
     });
 
     it("throws on data property descriptors that are not writable or configurable", function () {
-        var myObj = {};
+        const myObj = {};
         Object.defineProperty(myObj, "ignoreme", {
             writable: false,
             configurable: false,
@@ -167,7 +167,7 @@ module.exports = function shared(createSpyOrStub) {
     });
 
     it("throws on accessor property descriptors that are not configurable", function () {
-        var myObj = {};
+        const myObj = {};
         Object.defineProperty(myObj, "ignoreme", {
             get: function (key) {
                 return this[key];
@@ -186,7 +186,7 @@ module.exports = function shared(createSpyOrStub) {
     });
 
     it("throws on data descriptors that are not stubbable", function () {
-        var myObj = {};
+        const myObj = {};
         Object.defineProperty(myObj, "ignoreme", {
             writable: false,
             configurable: false,

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var assert = require("@sinonjs/referee").assert;
-var functionName = require("@sinonjs/commons").functionName;
-var Sandbox = require("../lib/sinon/sandbox");
-var proxyquire = require("proxyquire");
+const assert = require("@sinonjs/referee").assert;
+const functionName = require("@sinonjs/commons").functionName;
+const Sandbox = require("../lib/sinon/sandbox");
+const proxyquire = require("proxyquire");
 
 describe("sinon module", function () {
-    var sinon, fakeNise;
+    let sinon, fakeNise;
 
     before(function () {
         if (typeof Promise !== "function") {
@@ -110,7 +110,7 @@ describe("sinon module", function () {
         });
 
         describe("useFakeXMLHttpRequest", function () {
-            var nise;
+            let nise;
 
             beforeEach(function () {
                 // use full sinon for this test as it compares sinon instance

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var createSpy = require("../lib/sinon/spy");
-var createProxy = require("../lib/sinon/proxy");
-var match = require("@sinonjs/samsam").createMatcher;
-var globalContext = typeof global !== "undefined" ? global : window;
-var assert = referee.assert;
-var refute = referee.refute;
+const referee = require("@sinonjs/referee");
+const createSpy = require("../lib/sinon/spy");
+const createProxy = require("../lib/sinon/proxy");
+const match = require("@sinonjs/samsam").createMatcher;
+const globalContext = typeof global !== "undefined" ? global : window;
+const assert = referee.assert;
+const refute = referee.refute;
 
 function spyCalledTests(method) {
     return function () {
@@ -78,8 +78,8 @@ function spyCalledTests(method) {
         // a hasOwnProperty function.
         describe("when called with an Object without a prototype", function () {
             it("must not throw", function () {
-                var spy = this.spy;
-                var objectWithoutPrototype = Object.create(null);
+                const spy = this.spy;
+                const objectWithoutPrototype = Object.create(null);
 
                 objectWithoutPrototype.something = 2;
 
@@ -210,7 +210,7 @@ function spyNeverCalledTests(method) {
 }
 
 function verifyFunctionName(func, expectedName) {
-    var descriptor = Object.getOwnPropertyDescriptor(func, "name");
+    const descriptor = Object.getOwnPropertyDescriptor(func, "name");
     if (descriptor && descriptor.configurable) {
         // IE 11 functions don't have a name.
         // Safari 9 has names that are not configurable.
@@ -228,7 +228,7 @@ describe("spy", function () {
     });
 
     it("does not throw when calling anonymous spy", function () {
-        var spy = createSpy();
+        const spy = createSpy();
 
         refute.exception(spy);
 
@@ -236,43 +236,43 @@ describe("spy", function () {
     });
 
     it("returns spy function", function () {
-        var func = function () {
+        const func = function () {
             return;
         };
-        var spy = createSpy(func);
+        const spy = createSpy(func);
 
         assert.isFunction(spy);
         refute.same(func, spy);
     });
 
     it("mirrors custom properties on function", function () {
-        var func = function () {
+        const func = function () {
             return;
         };
         func.myProp = 42;
-        var spy = createSpy(func);
+        const spy = createSpy(func);
 
         assert.equals(spy.myProp, func.myProp);
     });
 
     it("does not define create method", function () {
-        var spy = createSpy();
+        const spy = createSpy();
 
         assert.isUndefined(spy.create);
     });
 
     it("does not overwrite original create property", function () {
-        var func = function () {
+        const func = function () {
             return;
         };
-        var object = (func.create = {});
-        var spy = createSpy(func);
+        const object = (func.create = {});
+        const spy = createSpy(func);
 
         assert.same(spy.create, object);
     });
 
     it("sets up logging arrays", function () {
-        var spy = createSpy();
+        const spy = createSpy();
 
         assert.isArray(spy.args);
         assert.isArray(spy.returnValues);
@@ -281,19 +281,19 @@ describe("spy", function () {
     });
 
     it("works with getters", function () {
-        var object = {
+        const object = {
             get property() {
                 return 42;
             },
         };
-        var spy = createSpy(object, "property", ["get"]);
+        const spy = createSpy(object, "property", ["get"]);
 
         assert.equals(object.property, 42);
         assert(spy.get.calledOnce);
     });
 
     it("works with setters", function () {
-        var object = {
+        const object = {
             get test() {
                 return this.property;
             },
@@ -301,7 +301,7 @@ describe("spy", function () {
                 this.property = value * 2;
             },
         };
-        var spy = createSpy(object, "test", ["set"]);
+        const spy = createSpy(object, "test", ["set"]);
 
         object.test = 42;
         assert(spy.set.calledOnce);
@@ -312,7 +312,7 @@ describe("spy", function () {
     });
 
     it("works with setters and getters combined", function () {
-        var object = {
+        const object = {
             get test() {
                 return this.property;
             },
@@ -320,7 +320,7 @@ describe("spy", function () {
                 this.property = value * 2;
             },
         };
-        var spy = createSpy(object, "test", ["get", "set"]);
+        const spy = createSpy(object, "test", ["get", "set"]);
 
         object.test = 42;
         assert(spy.set.calledOnce);
@@ -330,7 +330,7 @@ describe("spy", function () {
     });
 
     it("sets wrappedMethod on getter and setter", function () {
-        var object = {
+        const object = {
             get test() {
                 return this.property;
             },
@@ -339,9 +339,9 @@ describe("spy", function () {
             },
         };
 
-        var descriptor1 = Object.getOwnPropertyDescriptor(object, "test");
-        var spy = createSpy(object, "test", ["get", "set"]);
-        var descriptor2 = Object.getOwnPropertyDescriptor(object, "test");
+        const descriptor1 = Object.getOwnPropertyDescriptor(object, "test");
+        const spy = createSpy(object, "test", ["get", "set"]);
+        const descriptor2 = Object.getOwnPropertyDescriptor(object, "test");
 
         refute.equals(descriptor1, descriptor2);
 
@@ -355,7 +355,7 @@ describe("spy", function () {
         spy.get.restore();
         spy.set.restore();
 
-        var descriptor3 = Object.getOwnPropertyDescriptor(object, "test");
+        const descriptor3 = Object.getOwnPropertyDescriptor(object, "test");
         assert.equals(descriptor1, descriptor3);
     });
 
@@ -462,7 +462,7 @@ describe("spy", function () {
             );
         }
 
-        var object = {
+        const object = {
             f1: function () {
                 return;
             },
@@ -472,7 +472,7 @@ describe("spy", function () {
         };
 
         // f1: the order of withArgs(1), withArgs(1, 1)
-        var spy1 = createSpy(object, "f1");
+        const spy1 = createSpy(object, "f1");
         assert.equals(spy1.callCount, 0);
         assert.equals(spy1.withArgs(1).callCount, 0);
         assert.equals(spy1.withArgs(1, 1).callCount, 0);
@@ -488,7 +488,7 @@ describe("spy", function () {
         assertSpy(spy1);
 
         // f2: the order of withArgs(1, 1), withArgs(1)
-        var spy2 = createSpy(object, "f2");
+        const spy2 = createSpy(object, "f2");
         assert.equals(spy2.callCount, 0);
         assert.equals(spy2.withArgs(1, 1).callCount, 0);
         assert.equals(spy2.withArgs(1).callCount, 0);
@@ -506,8 +506,8 @@ describe("spy", function () {
 
     describe(".named", function () {
         it("sets name and displayName", function () {
-            var spy = createSpy();
-            var retval = spy.named("beep");
+            const spy = createSpy();
+            const retval = spy.named("beep");
             assert.equals(spy.displayName, "beep");
             verifyFunctionName(spy, "beep");
             assert.same(spy, retval);
@@ -516,9 +516,9 @@ describe("spy", function () {
 
     describe("call", function () {
         it("calls underlying function", function () {
-            var called = false;
+            let called = false;
 
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 called = true;
             });
 
@@ -532,57 +532,57 @@ describe("spy", function () {
                 return;
             }
 
-            var SpyClass = createSpy(TestClass);
+            const SpyClass = createSpy(TestClass);
 
-            var instance = new SpyClass();
+            const instance = new SpyClass();
 
             assert(instance instanceof TestClass);
         });
 
         it("passs arguments to function", function () {
-            var actualArgs;
+            let actualArgs;
 
-            var func = function (a, b, c, d) {
+            const func = function (a, b, c, d) {
                 actualArgs = [a, b, c, d];
             };
 
-            var args = [1, {}, [], ""];
-            var spy = createSpy(func);
+            const args = [1, {}, [], ""];
+            const spy = createSpy(func);
             spy(args[0], args[1], args[2], args[3]);
 
             assert.equals(actualArgs, args);
         });
 
         it("maintains this binding", function () {
-            var actualThis;
+            let actualThis;
 
-            var func = function () {
+            const func = function () {
                 actualThis = this;
             };
 
-            var object = {};
-            var spy = createSpy(func);
+            const object = {};
+            const spy = createSpy(func);
             spy.call(object);
 
             assert.same(actualThis, object);
         });
 
         it("returns function's return value", function () {
-            var object = {};
+            const object = {};
 
-            var func = function () {
+            const func = function () {
                 return object;
             };
 
-            var spy = createSpy(func);
-            var actualReturn = spy();
+            const spy = createSpy(func);
+            const actualReturn = spy();
 
             assert.same(actualReturn, object);
         });
 
         it("throws if function throws", function () {
-            var err = new Error();
-            var spy = createSpy(function () {
+            const err = new Error();
+            const spy = createSpy(function () {
                 throw err;
             });
 
@@ -594,14 +594,14 @@ describe("spy", function () {
                 return;
             }
 
-            var spy = createSpy(test);
+            const spy = createSpy(test);
 
             assert.equals(spy.displayName, "test");
             verifyFunctionName(spy, "test");
         });
 
         it("retains function length 0", function () {
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 return;
             });
 
@@ -610,7 +610,7 @@ describe("spy", function () {
 
         it("retains function length 1", function () {
             // eslint-disable-next-line no-unused-vars
-            var spy = createSpy(function (a) {
+            const spy = createSpy(function (a) {
                 return;
             });
 
@@ -619,7 +619,7 @@ describe("spy", function () {
 
         it("retains function length 2", function () {
             // eslint-disable-next-line no-unused-vars
-            var spy = createSpy(function (a, b) {
+            const spy = createSpy(function (a, b) {
                 return;
             });
 
@@ -628,7 +628,7 @@ describe("spy", function () {
 
         it("retains function length 3", function () {
             // eslint-disable-next-line no-unused-vars
-            var spy = createSpy(function (a, b, c) {
+            const spy = createSpy(function (a, b, c) {
                 return;
             });
 
@@ -637,7 +637,7 @@ describe("spy", function () {
 
         it("retains function length 4", function () {
             // eslint-disable-next-line no-unused-vars
-            var spy = createSpy(function (a, b, c, d) {
+            const spy = createSpy(function (a, b, c, d) {
                 return;
             });
 
@@ -646,10 +646,10 @@ describe("spy", function () {
 
         it("retains function length 12", function () {
             // eslint-disable-next-line no-unused-vars
-            var func12Args = function (a, b, c, d, e, f, g, h, i, j, k, l) {
+            const func12Args = function (a, b, c, d, e, f, g, h, i, j, k, l) {
                 return;
             };
-            var spy = createSpy(func12Args);
+            const spy = createSpy(func12Args);
 
             assert.equals(spy.length, 12);
         });
@@ -824,7 +824,7 @@ describe("spy", function () {
         });
 
         it("is true if called with thisValue", function () {
-            var object = {};
+            const object = {};
             this.spy.call(object);
 
             assert(this.spy.calledOn(object));
@@ -838,7 +838,7 @@ describe("spy", function () {
             });
 
             it("is true if called on object at least once", function () {
-                var object = {};
+                const object = {};
                 this.spy();
                 this.spy.call({});
                 this.spy.call(object);
@@ -849,7 +849,7 @@ describe("spy", function () {
         });
 
         it("returns false if not called on object", function () {
-            var object = {};
+            const object = {};
             this.spy.call(object);
             this.spy();
 
@@ -857,7 +857,7 @@ describe("spy", function () {
         });
 
         it("is true if called with matcher that returns true", function () {
-            var matcher = match(function () {
+            const matcher = match(function () {
                 return true;
             });
             this.spy();
@@ -866,7 +866,7 @@ describe("spy", function () {
         });
 
         it("is false if called with matcher that returns false", function () {
-            var matcher = match(function () {
+            const matcher = match(function () {
                 return false;
             });
             this.spy();
@@ -875,8 +875,8 @@ describe("spy", function () {
         });
 
         it("invokes matcher.test with given object", function () {
-            var expected = {};
-            var actual;
+            const expected = {};
+            let actual;
             this.spy.call(expected);
 
             this.spy.calledOn(
@@ -899,14 +899,14 @@ describe("spy", function () {
         });
 
         it("is true if called with thisValue once", function () {
-            var object = {};
+            const object = {};
             this.spy.call(object);
 
             assert(this.spy.alwaysCalledOn(object));
         });
 
         it("is true if called with thisValue many times", function () {
-            var object = {};
+            const object = {};
             this.spy.call(object);
             this.spy.call(object);
             this.spy.call(object);
@@ -916,7 +916,7 @@ describe("spy", function () {
         });
 
         it("is false if called with another object atleast once", function () {
-            var object = {};
+            const object = {};
             this.spy.call(object);
             this.spy.call(object);
             this.spy.call(object);
@@ -927,7 +927,7 @@ describe("spy", function () {
         });
 
         it("is false if never called with expected object", function () {
-            var object = {};
+            const object = {};
             this.spy();
             this.spy();
             this.spy();
@@ -946,7 +946,7 @@ describe("spy", function () {
         });
 
         it("is true if called with new", function () {
-            var result = new this.spy(); // eslint-disable-line no-unused-vars, new-cap
+            const result = new this.spy(); // eslint-disable-line no-unused-vars, new-cap
 
             assert(this.spy.calledWithNew());
         });
@@ -956,10 +956,10 @@ describe("spy", function () {
                 return;
             }
             MyThing.prototype = {};
-            var ns = { MyThing: MyThing };
+            const ns = { MyThing: MyThing };
             createSpy(ns, "MyThing");
 
-            var result = new ns.MyThing(); // eslint-disable-line no-unused-vars
+            const result = new ns.MyThing(); // eslint-disable-line no-unused-vars
             assert(ns.MyThing.calledWithNew());
         });
 
@@ -977,9 +977,9 @@ describe("spy", function () {
             });
 
             it("is true if called with new at least once", function () {
-                var object = {};
+                const object = {};
                 this.spy();
-                var a = new this.spy(); // eslint-disable-line no-unused-vars, new-cap
+                const a = new this.spy(); // eslint-disable-line no-unused-vars, new-cap
                 this.spy(object);
                 this.spy(window);
 
@@ -991,10 +991,10 @@ describe("spy", function () {
             function MyThing() {
                 return {};
             }
-            var object = { MyThing: MyThing };
+            const object = { MyThing: MyThing };
             createSpy(object, "MyThing");
 
-            var result = new object.MyThing(); // eslint-disable-line no-unused-vars
+            const result = new object.MyThing(); // eslint-disable-line no-unused-vars
 
             assert(object.MyThing.calledWithNew());
         });
@@ -1011,7 +1011,7 @@ describe("spy", function () {
             });
 
             it("is false when called on spied native function", function () {
-                var log = { info: console.log }; // eslint-disable-line no-console
+                const log = { info: console.log }; // eslint-disable-line no-console
                 createSpy(log, "info");
 
                 // by logging an empty string, we're not polluting the test console output
@@ -1033,9 +1033,9 @@ describe("spy", function () {
 
         it("is true if always called with new", function () {
             /*eslint-disable no-unused-vars, new-cap*/
-            var result = new this.spy();
-            var result2 = new this.spy();
-            var result3 = new this.spy();
+            const result = new this.spy();
+            const result2 = new this.spy();
+            const result3 = new this.spy();
             /*eslint-enable no-unused-vars, new-cap*/
 
             assert(this.spy.alwaysCalledWithNew());
@@ -1043,8 +1043,8 @@ describe("spy", function () {
 
         it("is false if called as function once", function () {
             /*eslint-disable no-unused-vars, new-cap*/
-            var result = new this.spy();
-            var result2 = new this.spy();
+            const result = new this.spy();
+            const result2 = new this.spy();
             /*eslint-enable no-unused-vars, new-cap*/
             this.spy();
 
@@ -1058,7 +1058,7 @@ describe("spy", function () {
         });
 
         it("contains one object", function () {
-            var object = {};
+            const object = {};
             this.spy.call(object);
 
             assert.equals(this.spy.thisValues, [object]);
@@ -1068,7 +1068,7 @@ describe("spy", function () {
             function MyConstructor() {
                 return;
             }
-            var objects = [{}, [], new MyConstructor(), { id: 243 }];
+            const objects = [{}, [], new MyConstructor(), { id: 243 }];
             this.spy();
             this.spy.call(objects[0]);
             this.spy.call(objects[1]);
@@ -1230,7 +1230,7 @@ describe("spy", function () {
         });
 
         it("stacks up arguments in nested array", function () {
-            var objects = [{}, [], { id: 324 }];
+            const objects = [{}, [], { id: 324 }];
             this.spy(1, objects[0], 3);
             this.spy(1, 2, objects[1]);
             this.spy(objects[2], 2, 3);
@@ -1273,8 +1273,8 @@ describe("spy", function () {
         });
 
         it("returns true for one exact match", function () {
-            var object = {};
-            var array = [];
+            const object = {};
+            const array = [];
             this.spy({}, []);
             this.spy(object, []);
             this.spy(object, array);
@@ -1467,8 +1467,8 @@ describe("spy", function () {
         });
 
         it("returns false for one exact match", function () {
-            var object = {};
-            var array = [];
+            const object = {};
+            const array = [];
             this.spy({}, []);
             this.spy(object, []);
             this.spy(object, array);
@@ -1477,8 +1477,8 @@ describe("spy", function () {
         });
 
         it("returns true for only exact matches", function () {
-            var object = {};
-            var array = [];
+            const object = {};
+            const array = [];
 
             this.spy(object, array);
             this.spy(object, array);
@@ -1488,8 +1488,8 @@ describe("spy", function () {
         });
 
         it("returns false for no exact matches", function () {
-            var object = {};
-            var array = [];
+            const object = {};
+            const array = [];
 
             this.spy(object, array, null);
             this.spy(object, array, undefined);
@@ -1514,9 +1514,9 @@ describe("spy", function () {
         });
 
         it("returns exception thrown by function", function () {
-            var err = new Error();
+            const err = new Error();
 
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 throw err;
             });
 
@@ -1578,9 +1578,9 @@ describe("spy", function () {
         });
 
         it("returns true when spy threw", function () {
-            var err = new Error();
+            const err = new Error();
 
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 throw err;
             });
 
@@ -1620,7 +1620,7 @@ describe("spy", function () {
         });
 
         it("returns false if some calls did not throw", function () {
-            var callCount = 0;
+            let callCount = 0;
 
             this.spy = createSpy(function () {
                 callCount += 1;
@@ -1656,7 +1656,7 @@ describe("spy", function () {
     describe(".exceptions", function () {
         beforeEach(function () {
             this.spy = createSpy();
-            var error = (this.error = {});
+            const error = (this.error = {});
 
             this.spyWithTypeError = createSpy(function () {
                 throw error;
@@ -1677,10 +1677,10 @@ describe("spy", function () {
         });
 
         it("stacks up exceptions and undefined", function () {
-            var calls = 0;
-            var err = this.error;
+            let calls = 0;
+            const err = this.error;
 
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 calls += 1;
 
                 if (calls % 2 === 0) {
@@ -1709,21 +1709,21 @@ describe("spy", function () {
 
     describe(".returned", function () {
         it("returns true when no argument", function () {
-            var spy = createSpy();
+            const spy = createSpy();
             spy();
 
             assert(spy.returned());
         });
 
         it("returns true for undefined when no explicit return", function () {
-            var spy = createSpy();
+            const spy = createSpy();
             spy();
 
             assert(spy.returned(undefined));
         });
 
         it("returns true when returned value once", function () {
-            var values = [
+            const values = [
                 {},
                 2,
                 "hey",
@@ -1731,7 +1731,7 @@ describe("spy", function () {
                     return;
                 },
             ];
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 return values[spy.callCount];
             });
 
@@ -1744,7 +1744,7 @@ describe("spy", function () {
         });
 
         it("returns false when value is never returned", function () {
-            var values = [
+            const values = [
                 {},
                 2,
                 "hey",
@@ -1752,7 +1752,7 @@ describe("spy", function () {
                     return;
                 },
             ];
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 return values[spy.callCount];
             });
 
@@ -1765,8 +1765,8 @@ describe("spy", function () {
         });
 
         it("returns true when value is returned several times", function () {
-            var object = { id: 42 };
-            var spy = createSpy(function () {
+            const object = { id: 42 };
+            const spy = createSpy(function () {
                 return object;
             });
 
@@ -1778,8 +1778,8 @@ describe("spy", function () {
         });
 
         it("compares values deeply", function () {
-            var object = { deep: { id: 42 } };
-            var spy = createSpy(function () {
+            const object = { deep: { id: 42 } };
+            const spy = createSpy(function () {
                 return object;
             });
 
@@ -1789,8 +1789,8 @@ describe("spy", function () {
         });
 
         it("compares values strictly using match.same", function () {
-            var object = { id: 42 };
-            var spy = createSpy(function () {
+            const object = { id: 42 };
+            const spy = createSpy(function () {
                 return object;
             });
 
@@ -1803,7 +1803,7 @@ describe("spy", function () {
 
     describe(".returnValues", function () {
         it("contains undefined when function does not return explicitly", function () {
-            var spy = createSpy();
+            const spy = createSpy();
             spy();
 
             assert.equals(spy.returnValues.length, 1);
@@ -1811,9 +1811,9 @@ describe("spy", function () {
         });
 
         it("contains return value", function () {
-            var object = { id: 42 };
+            const object = { id: 42 };
 
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 return object;
             });
 
@@ -1823,7 +1823,7 @@ describe("spy", function () {
         });
 
         it("contains undefined when function throws", function () {
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 throw new Error();
             });
 
@@ -1834,42 +1834,42 @@ describe("spy", function () {
         });
 
         it("contains the created object for spied constructors", function () {
-            var Spy = createSpy(function () {
+            const Spy = createSpy(function () {
                 return;
             });
 
-            var result = new Spy();
+            const result = new Spy();
 
             assert.equals(Spy.returnValues[0], result);
         });
 
         it("contains the return value for spied constructors that explicitly return objects", function () {
-            var Spy = createSpy(function () {
+            const Spy = createSpy(function () {
                 return { isExplicitlyCreatedValue: true };
             });
 
-            var result = new Spy();
+            const result = new Spy();
 
             assert.isTrue(result.isExplicitlyCreatedValue);
             assert.equals(Spy.returnValues[0], result);
         });
 
         it("contains the created object for spied constructors that explicitly return primitive values", function () {
-            var Spy = createSpy(function () {
+            const Spy = createSpy(function () {
                 return 10;
             });
 
-            var result = new Spy();
+            const result = new Spy();
 
             refute.equals(result, 10);
             assert.equals(Spy.returnValues[0], result);
         });
 
         it("stacks up return values", function () {
-            var calls = 0;
+            let calls = 0;
 
             /*eslint consistent-return: "off"*/
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 calls += 1;
 
                 if (calls % 2 === 0) {
@@ -2100,37 +2100,36 @@ describe("spy", function () {
 
     describe(".firstCall", function () {
         it("is undefined by default", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isNull(spy.firstCall);
         });
 
         it("is equal to getCall(0) result after first call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
 
-            var call0 = spy.getCall(0);
+            const call0 = spy.getCall(0);
             assert.equals(spy.firstCall.callId, call0.callId);
             assert.same(spy.firstCall.spy, call0.spy);
         });
 
         it("is equal to getCall(0) after first call when control flow has continued after invocation", function () {
-            var spy;
+            // eslint-disable-next-line
+            const spy = createSpy(runAsserts);
 
             function runAsserts() {
-                var call0 = spy.getCall(0);
+                const call0 = spy.getCall(0);
                 assert.equals(spy.firstCall.callId, call0.callId);
                 assert.same(spy.firstCall.spy, call0.spy);
             }
-
-            spy = createSpy(runAsserts);
 
             spy();
         });
 
         it("is tracked even if exceptions are thrown", function () {
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 throw new Error("an exception");
             });
 
@@ -2140,7 +2139,7 @@ describe("spy", function () {
         });
 
         it("has correct returnValue", function () {
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 return 42;
             });
 
@@ -2151,8 +2150,8 @@ describe("spy", function () {
         });
 
         it("has correct exception", function () {
-            var err = new Error();
-            var spy = createSpy(function () {
+            const err = new Error();
+            const spy = createSpy(function () {
                 throw err;
             });
 
@@ -2165,25 +2164,25 @@ describe("spy", function () {
 
     describe(".secondCall", function () {
         it("is null by default", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isNull(spy.secondCall);
         });
 
         it("stills be null after first call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
             spy();
 
             assert.isNull(spy.secondCall);
         });
 
         it("is equal to getCall(1) result after second call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
             spy();
 
-            var call1 = spy.getCall(1);
+            const call1 = spy.getCall(1);
             assert.equals(spy.secondCall.callId, call1.callId);
             assert.same(spy.secondCall.spy, call1.spy);
         });
@@ -2191,13 +2190,13 @@ describe("spy", function () {
 
     describe(".thirdCall", function () {
         it("is undefined by default", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isNull(spy.thirdCall);
         });
 
         it("stills be undefined after second call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
             spy();
             spy();
 
@@ -2205,13 +2204,13 @@ describe("spy", function () {
         });
 
         it("is equal to getCall(1) result after second call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
             spy();
             spy();
 
-            var call2 = spy.getCall(2);
+            const call2 = spy.getCall(2);
             assert.equals(spy.thirdCall.callId, call2.callId);
             assert.same(spy.thirdCall.spy, call2.spy);
         });
@@ -2219,7 +2218,7 @@ describe("spy", function () {
 
     describe(".getCall", function () {
         it("is null for indexes >= length", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
 
@@ -2228,7 +2227,7 @@ describe("spy", function () {
         });
 
         it("is null for indexes < -length", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
 
@@ -2237,7 +2236,7 @@ describe("spy", function () {
         });
 
         it("is same as last call when passed index -1", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
             spy();
@@ -2248,7 +2247,7 @@ describe("spy", function () {
         });
 
         it("is same as n-1th call when passed index -2", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
             spy();
@@ -2261,13 +2260,13 @@ describe("spy", function () {
 
     describe(".lastCall", function () {
         it("is undefined by default", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isNull(spy.lastCall);
         });
 
         it("is same as firstCall after first call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
 
@@ -2276,7 +2275,7 @@ describe("spy", function () {
         });
 
         it("is same as secondCall after second call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
             spy();
@@ -2286,7 +2285,7 @@ describe("spy", function () {
         });
 
         it("is same as thirdCall after third call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
             spy();
@@ -2297,20 +2296,20 @@ describe("spy", function () {
         });
 
         it("is equal to getCall(3) result after fourth call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
             spy();
             spy();
             spy();
 
-            var call3 = spy.getCall(3);
+            const call3 = spy.getCall(3);
             assert.equals(spy.lastCall.callId, call3.callId);
             assert.same(spy.lastCall.spy, call3.spy);
         });
 
         it("is equal to getCall(4) result after fifth call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
             spy();
@@ -2318,7 +2317,7 @@ describe("spy", function () {
             spy();
             spy();
 
-            var call4 = spy.getCall(4);
+            const call4 = spy.getCall(4);
             assert.equals(spy.lastCall.callId, call4.callId);
             assert.same(spy.lastCall.spy, call4.spy);
         });
@@ -2326,14 +2325,14 @@ describe("spy", function () {
 
     describe(".getCalls", function () {
         it("returns an empty Array by default", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isArray(spy.getCalls());
             assert.equals(spy.getCalls().length, 0);
         });
 
         it("is analogous to using getCall(n)", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy();
             spy();
@@ -2344,14 +2343,14 @@ describe("spy", function () {
 
     describe(".callArg", function () {
         it("is function", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isFunction(spy.callArg);
         });
 
         it("invokes argument at index for all calls", function () {
-            var spy = createSpy();
-            var callback = createSpy();
+            const spy = createSpy();
+            const callback = createSpy();
             spy(1, 2, callback);
             spy(3, 4, callback);
 
@@ -2362,7 +2361,7 @@ describe("spy", function () {
         });
 
         it("throws if argument at index is not a function", function () {
-            var spy = createSpy();
+            const spy = createSpy();
             spy();
 
             assert.exception(
@@ -2374,7 +2373,7 @@ describe("spy", function () {
         });
 
         it("throws if spy was not yet invoked", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.exception(
                 function () {
@@ -2388,12 +2387,12 @@ describe("spy", function () {
         });
 
         it("includes spy name in error message", function () {
-            var api = {
+            const api = {
                 someMethod: function () {
                     return;
                 },
             };
-            var spy = createSpy(api, "someMethod");
+            const spy = createSpy(api, "someMethod");
 
             assert.exception(
                 function () {
@@ -2407,7 +2406,7 @@ describe("spy", function () {
         });
 
         it("throws if index is not a number", function () {
-            var spy = createSpy();
+            const spy = createSpy();
             spy();
 
             assert.exception(
@@ -2419,10 +2418,10 @@ describe("spy", function () {
         });
 
         it("passs additional arguments", function () {
-            var spy = createSpy();
-            var callback = createSpy();
-            var array = [];
-            var object = {};
+            const spy = createSpy();
+            const callback = createSpy();
+            const array = [];
+            const object = {};
             spy(callback);
 
             spy.callArg(0, "abc", 123, array, object);
@@ -2431,16 +2430,16 @@ describe("spy", function () {
         });
 
         it("returns callbacks return values for all calls", function () {
-            var spy = createSpy();
-            var i = 0;
-            var callback = createSpy(function () {
+            const spy = createSpy();
+            let i = 0;
+            const callback = createSpy(function () {
                 i++;
                 return `useful value ${i}`;
             });
             spy(1, 2, callback);
             spy(3, 4, callback);
 
-            var returnValues = spy.callArg(2);
+            const returnValues = spy.callArg(2);
 
             assert.equals(returnValues, ["useful value 1", "useful value 2"]);
         });
@@ -2448,15 +2447,15 @@ describe("spy", function () {
 
     describe(".callArgOn", function () {
         it("is function", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isFunction(spy.callArgOn);
         });
 
         it("invokes argument at index for all calls", function () {
-            var spy = createSpy();
-            var callback = createSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const callback = createSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             spy(1, 2, callback);
             spy(3, 4, callback);
 
@@ -2468,8 +2467,8 @@ describe("spy", function () {
         });
 
         it("throws if argument at index is not a function", function () {
-            var spy = createSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             spy();
 
             assert.exception(
@@ -2481,8 +2480,8 @@ describe("spy", function () {
         });
 
         it("throws if spy was not yet invoked", function () {
-            var spy = createSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -2496,13 +2495,13 @@ describe("spy", function () {
         });
 
         it("includes spy name in error message", function () {
-            var api = {
+            const api = {
                 someMethod: function () {
                     return;
                 },
             };
-            var spy = createSpy(api, "someMethod");
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy(api, "someMethod");
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -2516,8 +2515,8 @@ describe("spy", function () {
         });
 
         it("throws if index is not a number", function () {
-            var spy = createSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             spy();
 
             assert.exception(
@@ -2529,11 +2528,11 @@ describe("spy", function () {
         });
 
         it("pass additional arguments", function () {
-            var spy = createSpy();
-            var callback = createSpy();
-            var array = [];
-            var object = {};
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const callback = createSpy();
+            const array = [];
+            const object = {};
+            const thisObj = { name1: "value1", name2: "value2" };
             spy(callback);
 
             spy.callArgOn(0, thisObj, "abc", 123, array, object);
@@ -2543,17 +2542,17 @@ describe("spy", function () {
         });
 
         it("returns callbacks return values for all calls", function () {
-            var spy = createSpy();
-            var i = 0;
-            var callback = createSpy(function () {
+            const spy = createSpy();
+            let i = 0;
+            const callback = createSpy(function () {
                 i++;
                 return `useful value ${i}`;
             });
-            var thisObj = { name1: "value1", name2: "value2" };
+            const thisObj = { name1: "value1", name2: "value2" };
             spy(1, 2, callback);
             spy(3, 4, callback);
 
-            var returnValues = spy.callArgOn(2, thisObj);
+            const returnValues = spy.callArgOn(2, thisObj);
 
             assert.equals(returnValues, ["useful value 1", "useful value 2"]);
         });
@@ -2561,7 +2560,7 @@ describe("spy", function () {
 
     describe(".callArgWith", function () {
         it("is alias for callArg", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.same(spy.callArgWith, spy.callArg);
         });
@@ -2569,7 +2568,7 @@ describe("spy", function () {
 
     describe(".callArgOnWith", function () {
         it("is alias for callArgOn", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.same(spy.callArgOnWith, spy.callArgOn);
         });
@@ -2577,14 +2576,14 @@ describe("spy", function () {
 
     describe(".yield", function () {
         it("is function", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isFunction(spy.yield);
         });
 
         it("invokes first function arg for all calls", function () {
-            var spy = createSpy();
-            var callback = createSpy();
+            const spy = createSpy();
+            const callback = createSpy();
             spy(1, 2, callback);
             spy(3, 4, callback);
 
@@ -2595,7 +2594,7 @@ describe("spy", function () {
         });
 
         it("throws if spy was not yet invoked", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.exception(
                 function () {
@@ -2608,12 +2607,12 @@ describe("spy", function () {
         });
 
         it("includes spy name in error message", function () {
-            var api = {
+            const api = {
                 someMethod: function () {
                     return;
                 },
             };
-            var spy = createSpy(api, "someMethod");
+            const spy = createSpy(api, "someMethod");
 
             assert.exception(
                 function () {
@@ -2627,10 +2626,10 @@ describe("spy", function () {
         });
 
         it("passs additional arguments", function () {
-            var spy = createSpy();
-            var callback = createSpy();
-            var array = [];
-            var object = {};
+            const spy = createSpy();
+            const callback = createSpy();
+            const array = [];
+            const object = {};
             spy(callback);
 
             spy.yield("abc", 123, array, object);
@@ -2639,16 +2638,16 @@ describe("spy", function () {
         });
 
         it("returns callbacks return values for all calls", function () {
-            var spy = createSpy();
-            var i = 0;
-            var callback = createSpy(function () {
+            const spy = createSpy();
+            let i = 0;
+            const callback = createSpy(function () {
                 i++;
                 return `useful value ${i}`;
             });
             spy(1, 2, callback);
             spy(3, 4, callback);
 
-            var returnValues = spy.yield();
+            const returnValues = spy.yield();
 
             assert.equals(returnValues, ["useful value 1", "useful value 2"]);
         });
@@ -2656,7 +2655,7 @@ describe("spy", function () {
 
     describe(".invokeCallback", function () {
         it("is alias for yield", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.same(spy.invokeCallback, spy.yield);
         });
@@ -2664,15 +2663,15 @@ describe("spy", function () {
 
     describe(".yieldOn", function () {
         it("is function", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isFunction(spy.yieldOn);
         });
 
         it("invokes first function arg for all calls", function () {
-            var spy = createSpy();
-            var callback = createSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const callback = createSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             spy(1, 2, callback);
             spy(3, 4, callback);
 
@@ -2684,8 +2683,8 @@ describe("spy", function () {
         });
 
         it("throws if spy was not yet invoked", function () {
-            var spy = createSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -2698,13 +2697,13 @@ describe("spy", function () {
         });
 
         it("includes spy name in error message", function () {
-            var api = {
+            const api = {
                 someMethod: function () {
                     return;
                 },
             };
-            var spy = createSpy(api, "someMethod");
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy(api, "someMethod");
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -2718,11 +2717,11 @@ describe("spy", function () {
         });
 
         it("pass additional arguments", function () {
-            var spy = createSpy();
-            var callback = createSpy();
-            var array = [];
-            var object = {};
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const callback = createSpy();
+            const array = [];
+            const object = {};
+            const thisObj = { name1: "value1", name2: "value2" };
             spy(callback);
 
             spy.yieldOn(thisObj, "abc", 123, array, object);
@@ -2732,17 +2731,17 @@ describe("spy", function () {
         });
 
         it("returns callbacks return values for all calls", function () {
-            var spy = createSpy();
-            var i = 0;
-            var callback = createSpy(function () {
+            const spy = createSpy();
+            let i = 0;
+            const callback = createSpy(function () {
                 i++;
                 return `useful value ${i}`;
             });
-            var thisObj = { name1: "value1", name2: "value2" };
+            const thisObj = { name1: "value1", name2: "value2" };
             spy(1, 2, callback);
             spy(3, 4, callback);
 
-            var returnValues = spy.yieldOn(thisObj);
+            const returnValues = spy.yieldOn(thisObj);
 
             assert.equals(returnValues, ["useful value 1", "useful value 2"]);
         });
@@ -2750,14 +2749,14 @@ describe("spy", function () {
 
     describe(".yieldTo", function () {
         it("is function", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isFunction(spy.yieldTo);
         });
 
         it("invokes first function arg for all calls", function () {
-            var spy = createSpy();
-            var callback = createSpy();
+            const spy = createSpy();
+            const callback = createSpy();
             spy(1, 2, { success: callback });
             spy(3, 4, { success: callback });
 
@@ -2768,7 +2767,7 @@ describe("spy", function () {
         });
 
         it("throws if spy was not yet invoked", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.exception(
                 function () {
@@ -2782,12 +2781,12 @@ describe("spy", function () {
         });
 
         it("includes spy name in error message", function () {
-            var api = {
+            const api = {
                 someMethod: function () {
                     return;
                 },
             };
-            var spy = createSpy(api, "someMethod");
+            const spy = createSpy(api, "someMethod");
 
             assert.exception(
                 function () {
@@ -2805,7 +2804,7 @@ describe("spy", function () {
                 this.skip();
             }
 
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.exception(
                 function () {
@@ -2819,10 +2818,10 @@ describe("spy", function () {
         });
 
         it("pass additional arguments", function () {
-            var spy = createSpy();
-            var callback = createSpy();
-            var array = [];
-            var object = {};
+            const spy = createSpy();
+            const callback = createSpy();
+            const array = [];
+            const object = {};
             spy({ test: callback });
 
             spy.yieldTo("test", "abc", 123, array, object);
@@ -2831,16 +2830,16 @@ describe("spy", function () {
         });
 
         it("returns callbacks return values for all calls", function () {
-            var spy = createSpy();
-            var i = 0;
-            var callback = createSpy(function () {
+            const spy = createSpy();
+            let i = 0;
+            const callback = createSpy(function () {
                 i++;
                 return `useful value ${i}`;
             });
             spy(1, 2, { success: callback });
             spy(3, 4, { success: callback });
 
-            var returnValues = spy.yieldTo("success");
+            const returnValues = spy.yieldTo("success");
 
             assert.equals(returnValues, ["useful value 1", "useful value 2"]);
         });
@@ -2848,15 +2847,15 @@ describe("spy", function () {
 
     describe(".yieldToOn", function () {
         it("is function", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isFunction(spy.yieldToOn);
         });
 
         it("invokes first function arg for all calls", function () {
-            var spy = createSpy();
-            var callback = createSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const callback = createSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
             spy(1, 2, { success: callback });
             spy(3, 4, { success: callback });
 
@@ -2868,8 +2867,8 @@ describe("spy", function () {
         });
 
         it("throws if spy was not yet invoked", function () {
-            var spy = createSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -2883,13 +2882,13 @@ describe("spy", function () {
         });
 
         it("includes spy name in error message", function () {
-            var api = {
+            const api = {
                 someMethod: function () {
                     return;
                 },
             };
-            var spy = createSpy(api, "someMethod");
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy(api, "someMethod");
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -2907,8 +2906,8 @@ describe("spy", function () {
                 this.skip();
             }
 
-            var spy = createSpy();
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const thisObj = { name1: "value1", name2: "value2" };
 
             assert.exception(
                 function () {
@@ -2922,11 +2921,11 @@ describe("spy", function () {
         });
 
         it("pass additional arguments", function () {
-            var spy = createSpy();
-            var callback = createSpy();
-            var array = [];
-            var object = {};
-            var thisObj = { name1: "value1", name2: "value2" };
+            const spy = createSpy();
+            const callback = createSpy();
+            const array = [];
+            const object = {};
+            const thisObj = { name1: "value1", name2: "value2" };
             spy({ test: callback });
 
             spy.yieldToOn("test", thisObj, "abc", 123, array, object);
@@ -2936,17 +2935,17 @@ describe("spy", function () {
         });
 
         it("returns callbacks return values for all calls", function () {
-            var spy = createSpy();
-            var i = 0;
-            var callback = createSpy(function () {
+            const spy = createSpy();
+            let i = 0;
+            const callback = createSpy(function () {
                 i++;
                 return `useful value ${i}`;
             });
-            var thisObj = { name1: "value1", name2: "value2" };
+            const thisObj = { name1: "value1", name2: "value2" };
             spy(1, 2, { success: callback });
             spy(3, 4, { success: callback });
 
-            var returnValues = spy.yieldToOn("success", thisObj);
+            const returnValues = spy.yieldToOn("success", thisObj);
 
             assert.equals(returnValues, ["useful value 1", "useful value 2"]);
         });
@@ -2954,13 +2953,13 @@ describe("spy", function () {
 
     describe(".throwArg", function () {
         it("should be a function", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.isFunction(spy.throwArg);
         });
 
         it("should throw if spy hasn't been called", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.exception(
                 function () {
@@ -2976,7 +2975,7 @@ describe("spy", function () {
         });
 
         it("should throw if there aren't enough arguments in the previous spy call", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             spy("only", "four", "arguments", "here");
 
@@ -2994,8 +2993,8 @@ describe("spy", function () {
         });
 
         it("should throw specified argument", function () {
-            var spy = createSpy();
-            var expectedError = new TypeError("catpants");
+            const spy = createSpy();
+            const expectedError = new TypeError("catpants");
 
             spy(true, false, null, expectedError, "meh");
             assert.exception(
@@ -3014,14 +3013,14 @@ describe("spy", function () {
 
     describe(".resetHistory", function () {
         it("return same object", function () {
-            var spy = createSpy();
-            var reset = spy.resetHistory();
+            const spy = createSpy();
+            const reset = spy.resetHistory();
 
             assert(reset === spy);
         });
 
         it("throws if called during spy invocation", function () {
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 spy.resetHistory();
             });
 
@@ -3031,19 +3030,19 @@ describe("spy", function () {
 
     describe(".length", function () {
         it("is zero by default", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             assert.equals(spy.length, 0);
         });
 
         it("matches the function length", function () {
-            var api = {
+            const api = {
                 // eslint-disable-next-line no-unused-vars
                 someMethod: function (a, b, c) {
                     return;
                 },
             };
-            var spy = createSpy(api, "someMethod");
+            const spy = createSpy(api, "someMethod");
 
             assert.equals(spy.length, 3);
         });
@@ -3088,7 +3087,7 @@ describe("spy", function () {
 
     describe(".id", function () {
         it("should start with 'spy#'", function () {
-            for (var i = 0; i < 10; i++) {
+            for (let i = 0; i < 10; i++) {
                 assert.isTrue(createSpy().id.indexOf("spy#") === 0);
             }
         });
@@ -3096,7 +3095,7 @@ describe("spy", function () {
 
     describe("non enumerable properties", function () {
         it("create and call spy apis", function () {
-            var spy = createSpy();
+            const spy = createSpy();
             assert.equals(Object.keys(spy), []);
 
             // call spy and verify no enumerable properties are added
@@ -3127,11 +3126,11 @@ describe("spy", function () {
         });
 
         it("create spy from function", function () {
-            var func = function () {
+            const func = function () {
                 throw new Error("aError");
             };
             func.aProp = 42;
-            var spy = createSpy(func);
+            const spy = createSpy(func);
 
             assert.equals(spy.aProp, 42);
             assert.equals(Object.keys(spy), Object.keys(func));
@@ -3149,12 +3148,12 @@ describe("spy", function () {
 
     describe(".printf", function () {
         it("is delegated to proxy", function () {
-            var f = function () {
+            const f = function () {
                 throw new Error("aError");
             };
 
-            var spy = createSpy();
-            var proxy = createProxy(f, f);
+            const spy = createSpy();
+            const proxy = createProxy(f, f);
 
             assert.same(spy.printf, proxy.printf);
         });

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1,17 +1,17 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var createStub = require("../lib/sinon/stub");
-var createSpy = require("../lib/sinon/spy");
-var createProxy = require("../lib/sinon/proxy");
-var match = require("@sinonjs/samsam").createMatcher;
-var assert = referee.assert;
-var refute = referee.refute;
-var fail = referee.fail;
-var globalContext = typeof global !== "undefined" ? global : window;
+const referee = require("@sinonjs/referee");
+const createStub = require("../lib/sinon/stub");
+const createSpy = require("../lib/sinon/spy");
+const createProxy = require("../lib/sinon/proxy");
+const match = require("@sinonjs/samsam").createMatcher;
+const assert = referee.assert;
+const refute = referee.refute;
+const fail = referee.fail;
+const globalContext = typeof global !== "undefined" ? global : window;
 
 function verifyFunctionName(func, expectedName) {
-    var descriptor = Object.getOwnPropertyDescriptor(func, "name");
+    const descriptor = Object.getOwnPropertyDescriptor(func, "name");
     if (descriptor && descriptor.configurable) {
         // IE 11 functions don't have a name.
         // Safari 9 has names that are not configurable.
@@ -22,7 +22,7 @@ function verifyFunctionName(func, expectedName) {
 
 describe("stub", function () {
     it("is spy", function () {
-        var stub = createStub();
+        const stub = createStub();
 
         assert.isFalse(stub.called);
         assert.isFunction(stub.calledWith);
@@ -30,7 +30,7 @@ describe("stub", function () {
     });
 
     it("does not define create method", function () {
-        var stub = createStub();
+        const stub = createStub();
 
         assert.isUndefined(stub.create);
     });
@@ -62,12 +62,12 @@ describe("stub", function () {
     });
 
     it("should contain asynchronous versions of callsArg*, and yields* methods", function () {
-        var stub = createStub();
+        const stub = createStub();
 
-        var syncVersions = 0;
-        var asyncVersions = 0;
+        let syncVersions = 0;
+        let asyncVersions = 0;
 
-        for (var method in stub) {
+        for (const method in stub) {
             if (
                 stub.hasOwnProperty(method) &&
                 method.match(/^(callsArg|yields)/)
@@ -88,8 +88,8 @@ describe("stub", function () {
     });
 
     it("should allow overriding async behavior with sync behavior", function () {
-        var stub = createStub();
-        var callback = createSpy();
+        const stub = createStub();
+        const callback = createSpy();
 
         stub.callsArgAsync(1);
         stub.callsArg(1);
@@ -99,7 +99,7 @@ describe("stub", function () {
     });
 
     it("should works with combination of withArgs arguments", function () {
-        var stub = createStub();
+        const stub = createStub();
         stub.returns(0);
         stub.withArgs(1, 1).returns(2);
         stub.withArgs(1).returns(1);
@@ -112,7 +112,7 @@ describe("stub", function () {
     });
 
     it("should work with combination of withArgs arguments", function () {
-        var stub = createStub();
+        const stub = createStub();
 
         stub.withArgs(1).returns(42);
         stub(1);
@@ -121,13 +121,13 @@ describe("stub", function () {
     });
 
     it("retains function name", function () {
-        var object = {
+        const object = {
             test: function test() {
                 return;
             },
         };
 
-        var stub = createStub(object, "test");
+        const stub = createStub(object, "test");
 
         assert.equals(stub.displayName, "test");
         verifyFunctionName(stub, "test");
@@ -135,7 +135,7 @@ describe("stub", function () {
 
     describe("non enumerable properties", function () {
         it("create and call spy apis", function () {
-            var stub = createStub();
+            const stub = createStub();
             assert.equals(Object.keys(stub), []);
 
             // call spy and verify no enumerable properties are added
@@ -166,10 +166,10 @@ describe("stub", function () {
         });
 
         it("create stub from function on object", function () {
-            var func = function () {
+            const func = function () {
                 throw new Error("aError");
             };
-            var object = {
+            const object = {
                 test: func,
             };
             func.aProp = 42;
@@ -189,27 +189,27 @@ describe("stub", function () {
 
     describe(".returns", function () {
         it("returns specified value", function () {
-            var stub = createStub();
-            var object = {};
+            const stub = createStub();
+            const object = {};
             stub.returns(object);
 
             assert.same(stub(), object);
         });
 
         it("returns should return stub", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.same(stub.returns(""), stub);
         });
 
         it("returns undefined", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.isUndefined(stub());
         });
 
         it("supersedes previous throws", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.throws().returns(1);
 
             refute.exception(function () {
@@ -218,15 +218,15 @@ describe("stub", function () {
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub().returns(2);
-            var stub = createStub().callsFake(fakeFn).returns(1);
+            const fakeFn = createStub().returns(2);
+            const stub = createStub().callsFake(fakeFn).returns(1);
 
             assert.equals(stub(), 1);
             refute(fakeFn.called);
         });
 
         it("throws only on the first call", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.returns("no exception");
             stub.onFirstCall().throws();
 
@@ -253,8 +253,8 @@ describe("stub", function () {
         });
 
         it("returns a promise to the specified value", function () {
-            var stub = createStub();
-            var object = {};
+            const stub = createStub();
+            const object = {};
             stub.resolves(object);
 
             return stub().then(function (actual) {
@@ -263,13 +263,13 @@ describe("stub", function () {
         });
 
         it("should return the same stub", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.same(stub.resolves(""), stub);
         });
 
         it("supersedes previous throws", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.throws().resolves(1);
 
             refute.exception(function () {
@@ -278,15 +278,15 @@ describe("stub", function () {
         });
 
         it("supersedes previous rejects", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.rejects(Error("should be superseded")).resolves(1);
 
             return stub().then();
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub().resolves(2);
-            var stub = createStub().callsFake(fakeFn).resolves(1);
+            const fakeFn = createStub().resolves(2);
+            const stub = createStub().callsFake(fakeFn).resolves(1);
 
             return stub().then(function (actual) {
                 assert.same(actual, 1);
@@ -295,15 +295,15 @@ describe("stub", function () {
         });
 
         it("can be superseded by returns", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.resolves(2).returns(1);
 
             assert.equals(stub(), 1);
         });
 
         it("does not invoke Promise.resolve when the behavior is added to the stub", function () {
-            var resolveSpy = createSpy(Promise, "resolve");
-            var stub = createStub();
+            const resolveSpy = createSpy(Promise, "resolve");
+            const stub = createStub();
             stub.resolves(2);
 
             assert.equals(resolveSpy.callCount, 0);
@@ -324,8 +324,8 @@ describe("stub", function () {
         });
 
         it("returns a promise which rejects for the specified reason", function () {
-            var stub = createStub();
-            var reason = new Error();
+            const stub = createStub();
+            const reason = new Error();
             stub.rejects(reason);
 
             return stub()
@@ -338,14 +338,14 @@ describe("stub", function () {
         });
 
         it("should return the same stub", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.same(stub.rejects({}), stub);
         });
 
         it("specifies exception message", function () {
-            var stub = createStub();
-            var message = "Oh no!";
+            const stub = createStub();
+            const message = "Oh no!";
             stub.rejects("Error", message);
 
             return stub()
@@ -358,7 +358,7 @@ describe("stub", function () {
         });
 
         it("does not specify exception message if not provided", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.rejects("Error");
 
             return stub()
@@ -371,7 +371,7 @@ describe("stub", function () {
         });
 
         it("rejects for a generic reason", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.rejects();
 
             return stub()
@@ -384,16 +384,16 @@ describe("stub", function () {
         });
 
         it("can be superseded by returns", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.rejects(2).returns(1);
 
             assert.equals(stub(), 1);
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub().resolves(2);
-            var reason = new Error();
-            var stub = createStub().callsFake(fakeFn).rejects(reason);
+            const fakeFn = createStub().resolves(2);
+            const reason = new Error();
+            const stub = createStub().callsFake(fakeFn).rejects(reason);
 
             return stub()
                 .then(function () {
@@ -406,8 +406,8 @@ describe("stub", function () {
         });
 
         it("does not invoke Promise.reject when the behavior is added to the stub", function () {
-            var rejectSpy = createSpy(Promise, "reject");
-            var stub = createStub();
+            const rejectSpy = createSpy(Promise, "reject");
+            const stub = createStub();
             stub.rejects(2);
 
             assert.equals(rejectSpy.callCount, 0);
@@ -428,7 +428,7 @@ describe("stub", function () {
         });
 
         it("returns a promise resolved with this", function () {
-            var instance = {};
+            const instance = {};
             instance.stub = createStub();
             instance.stub.resolvesThis();
 
@@ -438,9 +438,9 @@ describe("stub", function () {
         });
 
         it("returns a promise resolved with the context bound with stub#call", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.resolvesThis();
-            var object = {};
+            const object = {};
 
             return stub.call(object).then(function (actual) {
                 assert.same(actual, object);
@@ -448,9 +448,9 @@ describe("stub", function () {
         });
 
         it("returns a promise resolved with the context bound with stub#apply", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.resolvesThis();
-            var object = {};
+            const object = {};
 
             return stub.apply(object).then(function (actual) {
                 assert.same(actual, object);
@@ -458,13 +458,13 @@ describe("stub", function () {
         });
 
         it("returns the stub itself, allowing to chain function calls", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.same(stub.resolvesThis(), stub);
         });
 
         it("overrides throws behavior for error objects", function () {
-            var instance = {};
+            const instance = {};
             instance.stub = createStub().throws(new Error()).resolvesThis();
 
             return instance.stub().then(function (actual) {
@@ -473,7 +473,7 @@ describe("stub", function () {
         });
 
         it("overrides throws behavior for dynamically created errors", function () {
-            var instance = {};
+            const instance = {};
             instance.stub = createStub().throws().resolvesThis();
 
             return instance.stub().then(function (actual) {
@@ -482,9 +482,9 @@ describe("stub", function () {
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeInstance = {};
-            var fakeFn = createStub().resolves(fakeInstance);
-            var instance = {};
+            const fakeInstance = {};
+            const fakeFn = createStub().resolves(fakeInstance);
+            const instance = {};
             instance.stub = createStub().callsFake(fakeFn).resolvesThis();
 
             return instance.stub().then(function (actual) {
@@ -508,8 +508,8 @@ describe("stub", function () {
         });
 
         it("returns a promise to the argument at specified index", function () {
-            var stub = createStub();
-            var object = {};
+            const stub = createStub();
+            const object = {};
             stub.resolvesArg(0);
 
             return stub(object).then(function (actual) {
@@ -518,8 +518,8 @@ describe("stub", function () {
         });
 
         it("returns a promise to the argument at another specified index", function () {
-            var stub = createStub();
-            var object = {};
+            const stub = createStub();
+            const object = {};
             stub.resolvesArg(2);
 
             return stub("ignored", "ignored again", object).then(function (
@@ -530,13 +530,13 @@ describe("stub", function () {
         });
 
         it("should return the same stub", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.same(stub.resolvesArg(1), stub);
         });
 
         it("supersedes previous throws", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.throws().resolvesArg(1);
 
             refute.exception(function () {
@@ -545,7 +545,7 @@ describe("stub", function () {
         });
 
         it("supersedes previous rejects", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.rejects(Error("should be superseded")).resolvesArg(1);
 
             return stub("zero", "one").then(function (actual) {
@@ -554,8 +554,8 @@ describe("stub", function () {
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub().resolves("fake");
-            var stub = createStub().callsFake(fakeFn).resolvesArg(1);
+            const fakeFn = createStub().resolves("fake");
+            const stub = createStub().callsFake(fakeFn).resolvesArg(1);
 
             return stub("zero", "one").then(function (actual) {
                 assert.same(actual, "one");
@@ -564,15 +564,15 @@ describe("stub", function () {
         });
 
         it("does not invoke Promise.resolve when the behavior is added to the stub", function () {
-            var resolveSpy = createSpy(Promise, "resolve");
-            var stub = createStub();
+            const resolveSpy = createSpy(Promise, "resolve");
+            const stub = createStub();
             stub.resolvesArg(2);
 
             assert(resolveSpy.notCalled);
         });
 
         it("throws if index is not a number", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.exception(
                 function () {
@@ -583,7 +583,7 @@ describe("stub", function () {
         });
 
         it("throws without enough arguments", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.resolvesArg(3);
 
             assert.exception(
@@ -601,29 +601,29 @@ describe("stub", function () {
 
     describe(".returnsArg", function () {
         it("returns argument at specified index", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.returnsArg(0);
-            var object = {};
+            const object = {};
 
             assert.same(stub(object), object);
         });
 
         it("returns stub", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.same(stub.returnsArg(0), stub);
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub().returns("fake");
-            var stub = createStub().callsFake(fakeFn).returnsArg(0);
+            const fakeFn = createStub().returns("fake");
+            const stub = createStub().callsFake(fakeFn).returnsArg(0);
 
             assert.equals(stub("myarg"), "myarg");
             refute(fakeFn.called);
         });
 
         it("throws if no index is specified", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.exception(
                 function () {
@@ -634,7 +634,7 @@ describe("stub", function () {
         });
 
         it("should throw without enough arguments", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.returnsArg(3);
 
             assert.exception(
@@ -652,9 +652,9 @@ describe("stub", function () {
 
     describe(".throwsArg", function () {
         it("throws argument at specified index", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.throwsArg(0);
-            var expectedError = new Error("The expected error message");
+            const expectedError = new Error("The expected error message");
 
             assert.exception(
                 function () {
@@ -667,13 +667,13 @@ describe("stub", function () {
         });
 
         it("returns stub", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.same(stub.throwsArg(0), stub);
         });
 
         it("throws TypeError if no index is specified", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.exception(
                 function () {
@@ -684,7 +684,7 @@ describe("stub", function () {
         });
 
         it("should throw without enough arguments", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.throwsArg(3);
 
             assert.exception(
@@ -700,8 +700,8 @@ describe("stub", function () {
         });
 
         it("should work with call-based behavior", function () {
-            var stub = createStub();
-            var expectedError = new Error("catpants");
+            const stub = createStub();
+            const expectedError = new Error("catpants");
 
             stub.returns(1);
             stub.onSecondCall().throwsArg(1);
@@ -721,7 +721,7 @@ describe("stub", function () {
         });
 
         it("should be reset by .resetBehavior", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             stub.throwsArg(0);
             stub.resetBehavior();
@@ -732,9 +732,9 @@ describe("stub", function () {
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub();
-            var stub = createStub().callsFake(fakeFn).throwsArg(1);
-            var expectedError = new Error("catpants");
+            const fakeFn = createStub();
+            const stub = createStub().callsFake(fakeFn).throwsArg(1);
+            const expectedError = new Error("catpants");
 
             assert.exception(
                 function () {
@@ -751,7 +751,7 @@ describe("stub", function () {
 
     describe(".returnsThis", function () {
         it("stub returns this", function () {
-            var instance = {};
+            const instance = {};
             instance.stub = createStub();
             instance.stub.returnsThis();
 
@@ -759,7 +759,7 @@ describe("stub", function () {
         });
 
         it("stub returns undefined when detached", function () {
-            var thisValue = (function () {
+            const thisValue = (function () {
                 return this;
             })();
 
@@ -767,7 +767,7 @@ describe("stub", function () {
                 this.skip();
             }
 
-            var stub = createStub();
+            const stub = createStub();
             stub.returnsThis();
 
             // Due to strict mode, would be `global` otherwise
@@ -775,25 +775,25 @@ describe("stub", function () {
         });
 
         it("stub respects call/apply", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.returnsThis();
-            var object = {};
+            const object = {};
 
             assert.same(stub.call(object), object);
             assert.same(stub.apply(object), object);
         });
 
         it("returns stub", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.same(stub.returnsThis(), stub);
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeInstance = {};
-            var fakeFn = createStub().returns(fakeInstance);
+            const fakeInstance = {};
+            const fakeFn = createStub().returns(fakeInstance);
 
-            var instance = {};
+            const instance = {};
             instance.stub = createStub();
             instance.stub.callsFake(fakeFn).returnsThis();
 
@@ -810,26 +810,26 @@ describe("stub", function () {
         });
 
         it("should exist and be a function", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert(stub.usingPromise);
             assert.isFunction(stub.usingPromise);
         });
 
         it("should return the current stub", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.same(stub.usingPromise(Promise), stub);
         });
 
         it("should set the promise used by resolve", function () {
-            var stub = createStub();
-            var promise = {
+            const stub = createStub();
+            const promise = {
                 resolve: createStub().callsFake(function (value) {
                     return Promise.resolve(value);
                 }),
             };
-            var object = {};
+            const object = {};
 
             stub.usingPromise(promise).resolves(object);
 
@@ -847,13 +847,13 @@ describe("stub", function () {
         });
 
         it("should set the promise used by reject", function () {
-            var stub = createStub();
-            var promise = {
+            const stub = createStub();
+            const promise = {
                 reject: createStub().callsFake(function (err) {
                     return Promise.reject(err);
                 }),
             };
-            var reason = new Error();
+            const reason = new Error();
 
             stub.usingPromise(promise).rejects(reason);
 
@@ -877,22 +877,22 @@ describe("stub", function () {
 
     describe(".throws", function () {
         it("throws specified exception", function () {
-            var stub = createStub();
-            var error = new Error();
+            const stub = createStub();
+            const error = new Error();
             stub.throws(error);
 
             assert.exception(stub, error);
         });
 
         it("returns stub", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.same(stub.throws({}), stub);
         });
 
         it("sets type of exception to throw", function () {
-            var stub = createStub();
-            var exceptionType = "TypeError";
+            const stub = createStub();
+            const exceptionType = "TypeError";
             stub.throws(exceptionType);
 
             assert.exception(function () {
@@ -901,8 +901,8 @@ describe("stub", function () {
         });
 
         it("specifies exception message", function () {
-            var stub = createStub();
-            var message = "Oh no!";
+            const stub = createStub();
+            const message = "Oh no!";
             stub.throws("Error", message);
 
             assert.exception(stub, {
@@ -911,7 +911,7 @@ describe("stub", function () {
         });
 
         it("does not specify exception message if not provided", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.throws("Error");
 
             assert.exception(stub, {
@@ -920,14 +920,14 @@ describe("stub", function () {
         });
 
         it("throws generic error", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.throws();
 
             assert.exception(stub, "Error");
         });
 
         it("throws an exception created using a function", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             stub.throws(function () {
                 return new Error("not implemented");
@@ -941,7 +941,7 @@ describe("stub", function () {
         });
 
         describe("lazy instantiation of exceptions", function () {
-            var errorSpy;
+            let errorSpy;
             beforeEach(function () {
                 this.originalError = globalContext.Error;
                 errorSpy = createSpy(globalContext, "Error");
@@ -955,7 +955,7 @@ describe("stub", function () {
             });
 
             it("uses a lazily created exception for the generic error", function () {
-                var stub = createStub();
+                const stub = createStub();
                 stub.throws();
 
                 assert.isFalse(errorSpy.called);
@@ -964,7 +964,7 @@ describe("stub", function () {
             });
 
             it("uses a lazily created exception for the named error", function () {
-                var stub = createStub();
+                const stub = createStub();
                 stub.throws("Named Error", "error message");
 
                 assert.isFalse(errorSpy.called);
@@ -976,7 +976,7 @@ describe("stub", function () {
             });
 
             it("uses a lazily created exception provided by a function", function () {
-                var stub = createStub();
+                const stub = createStub();
 
                 stub.throws(function () {
                     return new Error("not implemented");
@@ -990,8 +990,8 @@ describe("stub", function () {
             });
 
             it("does not use a lazily created exception if the error object is provided", function () {
-                var stub = createStub();
-                var exception = new Error();
+                const stub = createStub();
+                const exception = new Error();
                 stub.throws(exception);
 
                 assert.same(errorSpy.callCount, 1);
@@ -1001,7 +1001,7 @@ describe("stub", function () {
         });
 
         it("resets 'invoking' flag", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.throws();
 
             assert.exception(stub);
@@ -1010,9 +1010,9 @@ describe("stub", function () {
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub();
-            var expectedError = new Error("error");
-            var stub = createStub().callsFake(fakeFn).throws(expectedError);
+            const fakeFn = createStub();
+            const expectedError = new Error("error");
+            const stub = createStub().callsFake(fakeFn).throws(expectedError);
 
             assert.exception(stub, {
                 message: expectedError.message,
@@ -1028,7 +1028,7 @@ describe("stub", function () {
 
         it("calls argument at specified index", function () {
             this.stub.callsArg(2);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, 2, callback);
 
@@ -1051,7 +1051,7 @@ describe("stub", function () {
         });
 
         it("throws if no index is specified", function () {
-            var stub = this.stub;
+            const stub = this.stub;
 
             assert.exception(
                 function () {
@@ -1062,7 +1062,7 @@ describe("stub", function () {
         });
 
         it("throws if index is not number", function () {
-            var stub = this.stub;
+            const stub = this.stub;
 
             assert.exception(
                 function () {
@@ -1073,7 +1073,7 @@ describe("stub", function () {
         });
 
         it("should throw without enough arguments", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.callsArg(3);
 
             assert.exception(
@@ -1089,8 +1089,8 @@ describe("stub", function () {
         });
 
         it("returns result of invocant", function () {
-            var stub = this.stub.callsArg(0);
-            var callback = createStub().returns("return value");
+            const stub = this.stub.callsArg(0);
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), "return value");
             assert(callback.calledOnce);
@@ -1103,9 +1103,9 @@ describe("stub", function () {
         });
 
         it("calls argument at specified index with provided args", function () {
-            var object = {};
+            const object = {};
             this.stub.callsArgWith(1, object);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, callback);
 
@@ -1113,14 +1113,14 @@ describe("stub", function () {
         });
 
         it("returns function", function () {
-            var stub = this.stub.callsArgWith(2, 3);
+            const stub = this.stub.callsArgWith(2, 3);
 
             assert.isFunction(stub);
         });
 
         it("calls callback without args", function () {
             this.stub.callsArgWith(1);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, callback);
 
@@ -1128,10 +1128,10 @@ describe("stub", function () {
         });
 
         it("calls callback with multiple args", function () {
-            var object = {};
-            var array = [];
+            const object = {};
+            const array = [];
             this.stub.callsArgWith(1, object, array);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, callback);
 
@@ -1139,7 +1139,7 @@ describe("stub", function () {
         });
 
         it("throws if no index is specified", function () {
-            var stub = this.stub;
+            const stub = this.stub;
 
             assert.exception(
                 function () {
@@ -1150,7 +1150,7 @@ describe("stub", function () {
         });
 
         it("throws if index is not number", function () {
-            var stub = this.stub;
+            const stub = this.stub;
 
             assert.exception(
                 function () {
@@ -1161,8 +1161,8 @@ describe("stub", function () {
         });
 
         it("returns result of invocant", function () {
-            var stub = this.stub.callsArgWith(0, "test");
-            var callback = createStub().returns("return value");
+            const stub = this.stub.callsArgWith(0, "test");
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), "return value");
             assert(callback.calledOnce);
@@ -1179,7 +1179,7 @@ describe("stub", function () {
 
         it("calls argument at specified index", function () {
             this.stub.callsArgOn(2, this.fakeContext);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, 2, callback);
 
@@ -1189,7 +1189,7 @@ describe("stub", function () {
 
         it("calls argument at specified index with undefined context", function () {
             this.stub.callsArgOn(2, undefined);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, 2, callback);
 
@@ -1199,7 +1199,7 @@ describe("stub", function () {
 
         it("calls argument at specified index with number context", function () {
             this.stub.callsArgOn(2, 5);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, 2, callback);
 
@@ -1208,7 +1208,7 @@ describe("stub", function () {
         });
 
         it("returns stub", function () {
-            var stub = this.stub.callsArgOn(2, this.fakeContext);
+            const stub = this.stub.callsArgOn(2, this.fakeContext);
 
             assert.isFunction(stub);
         });
@@ -1225,7 +1225,7 @@ describe("stub", function () {
         });
 
         it("throws if no index is specified", function () {
-            var stub = this.stub;
+            const stub = this.stub;
 
             assert.exception(
                 function () {
@@ -1236,7 +1236,7 @@ describe("stub", function () {
         });
 
         it("throws if index is not number", function () {
-            var stub = this.stub;
+            const stub = this.stub;
 
             assert.exception(
                 function () {
@@ -1247,8 +1247,8 @@ describe("stub", function () {
         });
 
         it("returns result of invocant", function () {
-            var stub = this.stub.callsArgOn(0, this.fakeContext);
-            var callback = createStub().returns("return value");
+            const stub = this.stub.callsArgOn(0, this.fakeContext);
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), "return value");
             assert(callback.calledOnce);
@@ -1263,9 +1263,9 @@ describe("stub", function () {
         });
 
         it("calls argument at specified index with provided args", function () {
-            var object = {};
+            const object = {};
             this.stub.callsArgOnWith(1, this.fakeContext, object);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, callback);
 
@@ -1274,9 +1274,9 @@ describe("stub", function () {
         });
 
         it("calls argument at specified index with provided args and undefined context", function () {
-            var object = {};
+            const object = {};
             this.stub.callsArgOnWith(1, undefined, object);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, callback);
 
@@ -1285,9 +1285,9 @@ describe("stub", function () {
         });
 
         it("calls argument at specified index with provided args and number context", function () {
-            var object = {};
+            const object = {};
             this.stub.callsArgOnWith(1, 5, object);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, callback);
 
@@ -1296,9 +1296,9 @@ describe("stub", function () {
         });
 
         it("calls argument at specified index with provided args with undefined context", function () {
-            var object = {};
+            const object = {};
             this.stub.callsArgOnWith(1, undefined, object);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, callback);
 
@@ -1307,9 +1307,9 @@ describe("stub", function () {
         });
 
         it("calls argument at specified index with provided args with number context", function () {
-            var object = {};
+            const object = {};
             this.stub.callsArgOnWith(1, 5, object);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, callback);
 
@@ -1318,14 +1318,14 @@ describe("stub", function () {
         });
 
         it("returns function", function () {
-            var stub = this.stub.callsArgOnWith(2, this.fakeContext, 3);
+            const stub = this.stub.callsArgOnWith(2, this.fakeContext, 3);
 
             assert.isFunction(stub);
         });
 
         it("calls callback without args", function () {
             this.stub.callsArgOnWith(1, this.fakeContext);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, callback);
 
@@ -1334,10 +1334,10 @@ describe("stub", function () {
         });
 
         it("calls callback with multiple args", function () {
-            var object = {};
-            var array = [];
+            const object = {};
+            const array = [];
             this.stub.callsArgOnWith(1, this.fakeContext, object, array);
-            var callback = createStub();
+            const callback = createStub();
 
             this.stub(1, callback);
 
@@ -1346,7 +1346,7 @@ describe("stub", function () {
         });
 
         it("throws if no index is specified", function () {
-            var stub = this.stub;
+            const stub = this.stub;
 
             assert.exception(
                 function () {
@@ -1357,7 +1357,7 @@ describe("stub", function () {
         });
 
         it("throws if index is not number", function () {
-            var stub = this.stub;
+            const stub = this.stub;
 
             assert.exception(
                 function () {
@@ -1368,9 +1368,9 @@ describe("stub", function () {
         });
 
         it("returns result of invocant", function () {
-            var object = {};
-            var stub = this.stub.callsArgOnWith(0, this.fakeContext, object);
-            var callback = createStub().returns("return value");
+            const object = {};
+            const stub = this.stub.callsArgOnWith(0, this.fakeContext, object);
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), "return value");
             assert(callback.calledOnce);
@@ -1387,7 +1387,7 @@ describe("stub", function () {
         });
 
         it("uses provided function as stub", function () {
-            var fakeFn = createStub();
+            const fakeFn = createStub();
             this.stub = createStub(this.object, "method");
 
             this.stub.callsFake(fakeFn);
@@ -1398,33 +1398,33 @@ describe("stub", function () {
         });
 
         it("is overwritten by subsequent stub behavior", function () {
-            var fakeFn = createStub();
+            const fakeFn = createStub();
             this.stub = createStub(this.object, "method");
 
             this.stub.callsFake(fakeFn).returns(3);
-            var returned = this.object.method(1, 2);
+            const returned = this.object.method(1, 2);
 
             refute(fakeFn.called);
             assert(returned === 3);
         });
 
         it("supersedes previous throws(error)", function () {
-            var fakeFn = createStub().returns(5);
+            const fakeFn = createStub().returns(5);
             this.stub = createStub(this.object, "method");
 
             this.stub.throws(new Error("error")).callsFake(fakeFn);
-            var returned = this.object.method(1, 2);
+            const returned = this.object.method(1, 2);
 
             assert(fakeFn.called);
             assert(returned === 5);
         });
 
         it("supersedes previous throws()", function () {
-            var fakeFn = createStub().returns(5);
+            const fakeFn = createStub().returns(5);
             this.stub = createStub(this.object, "method");
 
             this.stub.throws().callsFake(fakeFn);
-            var returned = this.object.method(1, 2);
+            const returned = this.object.method(1, 2);
 
             assert(fakeFn.called);
             assert(returned === 5);
@@ -1446,7 +1446,7 @@ describe("stub", function () {
         });
 
         it("throws when third argument is provided", function () {
-            var object = this.object;
+            const object = this.object;
 
             assert.exception(
                 function () {
@@ -1461,14 +1461,14 @@ describe("stub", function () {
         });
 
         it("stubbed method should be proper stub", function () {
-            var stub = createStub(this.object, "method");
+            const stub = createStub(this.object, "method");
 
             assert.isFunction(stub.returns);
             assert.isFunction(stub.throws);
         });
 
         it("stub should be spy", function () {
-            var stub = createStub(this.object, "method");
+            const stub = createStub(this.object, "method");
             this.object.method();
 
             assert(stub.called);
@@ -1476,7 +1476,7 @@ describe("stub", function () {
         });
 
         it("stub should affect spy", function () {
-            var stub = createStub(this.object, "method");
+            const stub = createStub(this.object, "method");
             stub.throws("TypeError");
 
             assert.exception(this.object.method);
@@ -1485,7 +1485,7 @@ describe("stub", function () {
         });
 
         it("handles threw properly for lazily instantiated Errors", function () {
-            var stub = createStub(this.object, "method");
+            const stub = createStub(this.object, "method");
             stub.throws(function () {
                 return new TypeError();
             });
@@ -1496,14 +1496,14 @@ describe("stub", function () {
         });
 
         it("returns standalone stub without arguments", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.isFunction(stub);
             assert.isFalse(stub.called);
         });
 
         it("successfully stubs falsy properties", function () {
-            var obj = {
+            const obj = {
                 0: function () {
                     return;
                 },
@@ -1528,7 +1528,7 @@ describe("stub", function () {
         require("./shared-spy-stub-everything-tests")(createStub);
 
         it("returns function", function () {
-            var func = function () {
+            const func = function () {
                 return;
             };
 
@@ -1542,7 +1542,7 @@ describe("stub", function () {
                 }
             }
 
-            var func = new FunctionType();
+            const func = new FunctionType();
             func.func1 = function () {
                 return;
             };
@@ -1554,14 +1554,14 @@ describe("stub", function () {
         });
 
         it("does not call getter during restore", function () {
-            var obj = {
+            const obj = {
                 get prop() {
                     fail("should not call getter");
                     return;
                 },
             };
 
-            var stub = createStub(obj, "prop").get(function () {
+            const stub = createStub(obj, "prop").get(function () {
                 return 43;
             });
             assert.equals(obj.prop, 43);
@@ -1572,7 +1572,7 @@ describe("stub", function () {
 
     describe("stubbed function", function () {
         it("has toString method", function () {
-            var obj = {
+            const obj = {
                 meth: function () {
                     return;
                 },
@@ -1583,13 +1583,13 @@ describe("stub", function () {
         });
 
         it("toString should say 'stub' when unable to infer name", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.equals(stub.toString(), "stub");
         });
 
         it("toString should prefer property name if possible", function () {
-            var obj = {};
+            const obj = {};
             obj.meth = createStub();
             obj.meth();
 
@@ -1599,8 +1599,8 @@ describe("stub", function () {
 
     describe(".yields", function () {
         it("invokes only argument as callback", function () {
-            var stub = createStub().yields();
-            var spy = createSpy();
+            const stub = createStub().yields();
+            const spy = createSpy();
             stub(spy);
 
             assert(spy.calledOnce);
@@ -1608,7 +1608,7 @@ describe("stub", function () {
         });
 
         it("throws understandable error if no callback is passed", function () {
-            var stub = createStub().yields();
+            const stub = createStub().yields();
 
             assert.exception(stub, {
                 message: "stub expected to yield, but no callback was passed.",
@@ -1616,12 +1616,12 @@ describe("stub", function () {
         });
 
         it("includes stub name and actual arguments in error", function () {
-            var myObj = {
+            const myObj = {
                 somethingAwesome: function () {
                     return;
                 },
             };
-            var stub = createStub(myObj, "somethingAwesome").yields();
+            const stub = createStub(myObj, "somethingAwesome").yields();
 
             assert.exception(
                 function () {
@@ -1635,8 +1635,8 @@ describe("stub", function () {
         });
 
         it("invokes last argument as callback", function () {
-            var stub = createStub().yields();
-            var spy = createSpy();
+            const stub = createStub().yields();
+            const spy = createSpy();
             stub(24, {}, spy);
 
             assert(spy.calledOnce);
@@ -1644,9 +1644,9 @@ describe("stub", function () {
         });
 
         it("invokes first of two callbacks", function () {
-            var stub = createStub().yields();
-            var spy = createSpy();
-            var spy2 = createSpy();
+            const stub = createStub().yields();
+            const spy = createSpy();
+            const spy2 = createSpy();
             stub(24, {}, spy, spy2);
 
             assert(spy.calledOnce);
@@ -1654,18 +1654,18 @@ describe("stub", function () {
         });
 
         it("invokes callback with arguments", function () {
-            var obj = { id: 42 };
-            var stub = createStub().yields(obj, "Crazy");
-            var spy = createSpy();
+            const obj = { id: 42 };
+            const stub = createStub().yields(obj, "Crazy");
+            const spy = createSpy();
             stub(spy);
 
             assert(spy.calledWith(obj, "Crazy"));
         });
 
         it("throws if callback throws", function () {
-            var obj = { id: 42 };
-            var stub = createStub().yields(obj, "Crazy");
-            var callback = createStub().throws();
+            const obj = { id: 42 };
+            const stub = createStub().yields(obj, "Crazy");
+            const callback = createStub().throws();
 
             assert.exception(function () {
                 stub(callback);
@@ -1673,8 +1673,8 @@ describe("stub", function () {
         });
 
         it("throws takes precedent over yielded return value", function () {
-            var stub = createStub().throws().yields();
-            var callback = createStub().returns("return value");
+            const stub = createStub().throws().yields();
+            const callback = createStub().returns("return value");
 
             assert.exception(function () {
                 stub(callback);
@@ -1683,43 +1683,43 @@ describe("stub", function () {
         });
 
         it("returns takes precedent over yielded return value", function () {
-            var obj = {};
-            var stub = createStub().returns(obj).yields();
-            var callback = createStub().returns("return value");
+            const obj = {};
+            const stub = createStub().returns(obj).yields();
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), obj);
             assert(callback.calledOnce);
         });
 
         it("returnsArg takes precedent over yielded return value", function () {
-            var stub = createStub().returnsArg(0).yields();
-            var callback = createStub().returns("return value");
+            const stub = createStub().returnsArg(0).yields();
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), callback);
             assert(callback.calledOnce);
         });
 
         it("returnsThis takes precedent over yielded return value", function () {
-            var obj = {};
-            var stub = createStub().returnsThis().yields();
-            var callback = createStub().returns("return value");
+            const obj = {};
+            const stub = createStub().returnsThis().yields();
+            const callback = createStub().returns("return value");
 
             assert.same(stub.call(obj, callback), obj);
             assert(callback.calledOnce);
         });
 
         it("returns the result of the yielded callback", function () {
-            var stub = createStub().yields();
-            var callback = createStub().returns("return value");
+            const stub = createStub().yields();
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), "return value");
             assert(callback.calledOnce);
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub().yields(1);
-            var stub = createStub().callsFake(fakeFn).yields(2);
-            var spy = createSpy();
+            const fakeFn = createStub().yields(1);
+            const stub = createStub().callsFake(fakeFn).yields(2);
+            const spy = createSpy();
             stub(spy);
 
             assert(spy.calledWith, 2);
@@ -1729,8 +1729,8 @@ describe("stub", function () {
 
     describe(".yieldsRight", function () {
         it("invokes only argument as callback", function () {
-            var stub = createStub().yieldsRight();
-            var spy = createSpy();
+            const stub = createStub().yieldsRight();
+            const spy = createSpy();
             stub(spy);
 
             assert(spy.calledOnce);
@@ -1738,7 +1738,7 @@ describe("stub", function () {
         });
 
         it("throws understandable error if no callback is passed", function () {
-            var stub = createStub().yieldsRight();
+            const stub = createStub().yieldsRight();
 
             assert.exception(stub, {
                 message: "stub expected to yield, but no callback was passed.",
@@ -1746,12 +1746,12 @@ describe("stub", function () {
         });
 
         it("includes stub name and actual arguments in error", function () {
-            var myObj = {
+            const myObj = {
                 somethingAwesome: function () {
                     return;
                 },
             };
-            var stub = createStub(myObj, "somethingAwesome").yieldsRight();
+            const stub = createStub(myObj, "somethingAwesome").yieldsRight();
 
             assert.exception(
                 function () {
@@ -1765,8 +1765,8 @@ describe("stub", function () {
         });
 
         it("invokes last argument as callback", function () {
-            var stub = createStub().yieldsRight();
-            var spy = createSpy();
+            const stub = createStub().yieldsRight();
+            const spy = createSpy();
             stub(24, {}, spy);
 
             assert(spy.calledOnce);
@@ -1774,9 +1774,9 @@ describe("stub", function () {
         });
 
         it("invokes the last of two callbacks", function () {
-            var stub = createStub().yieldsRight();
-            var spy = createSpy();
-            var spy2 = createSpy();
+            const stub = createStub().yieldsRight();
+            const spy = createSpy();
+            const spy2 = createSpy();
             stub(24, {}, spy, spy2);
 
             assert(!spy.called);
@@ -1784,18 +1784,18 @@ describe("stub", function () {
         });
 
         it("invokes callback with arguments", function () {
-            var obj = { id: 42 };
-            var stub = createStub().yieldsRight(obj, "Crazy");
-            var spy = createSpy();
+            const obj = { id: 42 };
+            const stub = createStub().yieldsRight(obj, "Crazy");
+            const spy = createSpy();
             stub(spy);
 
             assert(spy.calledWith(obj, "Crazy"));
         });
 
         it("throws if callback throws", function () {
-            var obj = { id: 42 };
-            var stub = createStub().yieldsRight(obj, "Crazy");
-            var callback = createStub().throws();
+            const obj = { id: 42 };
+            const stub = createStub().yieldsRight(obj, "Crazy");
+            const callback = createStub().throws();
 
             assert.exception(function () {
                 stub(callback);
@@ -1803,8 +1803,8 @@ describe("stub", function () {
         });
 
         it("throws takes precedent over yielded return value", function () {
-            var stub = createStub().yieldsRight().throws();
-            var callback = createStub().returns("return value");
+            const stub = createStub().yieldsRight().throws();
+            const callback = createStub().returns("return value");
 
             assert.exception(function () {
                 stub(callback);
@@ -1813,43 +1813,43 @@ describe("stub", function () {
         });
 
         it("returns takes precedent over yielded return value", function () {
-            var obj = {};
-            var stub = createStub().returns(obj).yieldsRight();
-            var callback = createStub().returns("return value");
+            const obj = {};
+            const stub = createStub().returns(obj).yieldsRight();
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), obj);
             assert(callback.calledOnce);
         });
 
         it("returnsArg takes precedent over yielded return value", function () {
-            var stub = createStub().returnsArg(0).yieldsRight();
-            var callback = createStub().returns("return value");
+            const stub = createStub().returnsArg(0).yieldsRight();
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), callback);
             assert(callback.calledOnce);
         });
 
         it("returnsThis takes precedent over yielded return value", function () {
-            var obj = {};
-            var stub = createStub().returnsThis().yieldsRight();
-            var callback = createStub().returns("return value");
+            const obj = {};
+            const stub = createStub().returnsThis().yieldsRight();
+            const callback = createStub().returns("return value");
 
             assert.same(stub.call(obj, callback), obj);
             assert(callback.calledOnce);
         });
 
         it("returns the result of the yielded callback", function () {
-            var stub = createStub().yields();
-            var callback = createStub().returns("return value");
+            const stub = createStub().yields();
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), "return value");
             assert(callback.calledOnce);
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub().yieldsRight(1);
-            var stub = createStub().callsFake(fakeFn).yieldsRight(2);
-            var spy = createSpy();
+            const fakeFn = createStub().yieldsRight(1);
+            const stub = createStub().callsFake(fakeFn).yieldsRight(2);
+            const spy = createSpy();
             stub(spy);
 
             assert(spy.calledWith, 2);
@@ -1864,7 +1864,7 @@ describe("stub", function () {
         });
 
         it("invokes only argument as callback", function () {
-            var spy = createSpy();
+            const spy = createSpy();
 
             this.stub.yieldsOn(this.fakeContext);
             this.stub(spy);
@@ -1892,12 +1892,12 @@ describe("stub", function () {
         });
 
         it("includes stub name and actual arguments in error", function () {
-            var myObj = {
+            const myObj = {
                 somethingAwesome: function () {
                     return;
                 },
             };
-            var stub = createStub(myObj, "somethingAwesome").yieldsOn(
+            const stub = createStub(myObj, "somethingAwesome").yieldsOn(
                 this.fakeContext
             );
 
@@ -1913,7 +1913,7 @@ describe("stub", function () {
         });
 
         it("invokes last argument as callback", function () {
-            var spy = createSpy();
+            const spy = createSpy();
             this.stub.yieldsOn(this.fakeContext);
 
             this.stub(24, {}, spy);
@@ -1924,8 +1924,8 @@ describe("stub", function () {
         });
 
         it("invokes first of two callbacks", function () {
-            var spy = createSpy();
-            var spy2 = createSpy();
+            const spy = createSpy();
+            const spy2 = createSpy();
 
             this.stub.yieldsOn(this.fakeContext);
             this.stub(24, {}, spy, spy2);
@@ -1936,8 +1936,8 @@ describe("stub", function () {
         });
 
         it("invokes callback with arguments", function () {
-            var obj = { id: 42 };
-            var spy = createSpy();
+            const obj = { id: 42 };
+            const spy = createSpy();
 
             this.stub.yieldsOn(this.fakeContext, obj, "Crazy");
             this.stub(spy);
@@ -1947,8 +1947,8 @@ describe("stub", function () {
         });
 
         it("throws if callback throws", function () {
-            var obj = { id: 42 };
-            var callback = createStub().throws();
+            const obj = { id: 42 };
+            const callback = createStub().throws();
 
             this.stub.yieldsOn(this.fakeContext, obj, "Crazy");
 
@@ -1958,8 +1958,8 @@ describe("stub", function () {
         });
 
         it("throws takes precedent over yielded return value", function () {
-            var stub = this.stub.throws().yieldsOn(this.fakeContext);
-            var callback = createStub().returns("return value");
+            const stub = this.stub.throws().yieldsOn(this.fakeContext);
+            const callback = createStub().returns("return value");
 
             assert.exception(function () {
                 stub(callback);
@@ -1968,45 +1968,45 @@ describe("stub", function () {
         });
 
         it("returns takes precedent over yielded return value", function () {
-            var obj = {};
-            var stub = this.stub.returns(obj).yieldsOn(this.fakeContext);
-            var callback = createStub().returns("return value");
+            const obj = {};
+            const stub = this.stub.returns(obj).yieldsOn(this.fakeContext);
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), obj);
             assert(callback.calledOnce);
         });
 
         it("returnsArg takes precedent over yielded return value", function () {
-            var stub = this.stub.returnsArg(0).yieldsOn();
-            var callback = createStub().returns("return value");
+            const stub = this.stub.returnsArg(0).yieldsOn();
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), callback);
             assert(callback.calledOnce);
         });
 
         it("returnsThis takes precedent over yielded return value", function () {
-            var obj = {};
-            var stub = this.stub.returnsThis().yieldsOn(this.fakeContext);
-            var callback = createStub().returns("return value");
+            const obj = {};
+            const stub = this.stub.returnsThis().yieldsOn(this.fakeContext);
+            const callback = createStub().returns("return value");
 
             assert.same(stub.call(obj, callback), obj);
             assert(callback.calledOnce);
         });
 
         it("returns the result of the yielded callback", function () {
-            var stub = this.stub.yieldsOn(this.fakeContext);
-            var callback = createStub().returns("return value");
+            const stub = this.stub.yieldsOn(this.fakeContext);
+            const callback = createStub().returns("return value");
 
             assert.same(stub(callback), "return value");
             assert(callback.calledOnce);
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub().yieldsOn(this.fakeContext, 1);
-            var stub = createStub()
+            const fakeFn = createStub().yieldsOn(this.fakeContext, 1);
+            const stub = createStub()
                 .callsFake(fakeFn)
                 .yieldsOn(this.fakeContext, 2);
-            var spy = createSpy();
+            const spy = createSpy();
             stub(spy);
 
             assert(spy.calledWith, 2);
@@ -2016,8 +2016,8 @@ describe("stub", function () {
 
     describe(".yieldsTo", function () {
         it("yields to property of object argument", function () {
-            var stub = createStub().yieldsTo("success");
-            var callback = createSpy();
+            const stub = createStub().yieldsTo("success");
+            const callback = createSpy();
 
             stub({ success: callback });
 
@@ -2026,7 +2026,7 @@ describe("stub", function () {
         });
 
         it("throws understandable error if no object with callback is passed", function () {
-            var stub = createStub().yieldsTo("success");
+            const stub = createStub().yieldsTo("success");
 
             assert.exception(stub, {
                 message:
@@ -2039,9 +2039,9 @@ describe("stub", function () {
                 this.skip();
             }
 
-            var symbol = Symbol("apple pie");
+            const symbol = Symbol("apple pie");
 
-            var stub = createStub().yieldsTo(symbol);
+            const stub = createStub().yieldsTo(symbol);
 
             assert.exception(stub, {
                 message:
@@ -2050,12 +2050,12 @@ describe("stub", function () {
         });
 
         it("includes stub name and actual arguments in error", function () {
-            var myObj = {
+            const myObj = {
                 somethingAwesome: function () {
                     return;
                 },
             };
-            var stub = createStub(myObj, "somethingAwesome").yieldsTo(
+            const stub = createStub(myObj, "somethingAwesome").yieldsTo(
                 "success"
             );
 
@@ -2073,8 +2073,8 @@ describe("stub", function () {
         });
 
         it("invokes property on last argument as callback", function () {
-            var stub = createStub().yieldsTo("success");
-            var callback = createSpy();
+            const stub = createStub().yieldsTo("success");
+            const callback = createSpy();
             stub(24, {}, { success: callback });
 
             assert(callback.calledOnce);
@@ -2082,9 +2082,9 @@ describe("stub", function () {
         });
 
         it("invokes first of two possible callbacks", function () {
-            var stub = createStub().yieldsTo("error");
-            var callback = createSpy();
-            var callback2 = createSpy();
+            const stub = createStub().yieldsTo("error");
+            const callback = createSpy();
+            const callback2 = createSpy();
             stub(24, {}, { error: callback }, { error: callback2 });
 
             assert(callback.calledOnce);
@@ -2092,18 +2092,18 @@ describe("stub", function () {
         });
 
         it("invokes callback with arguments", function () {
-            var obj = { id: 42 };
-            var stub = createStub().yieldsTo("success", obj, "Crazy");
-            var callback = createSpy();
+            const obj = { id: 42 };
+            const stub = createStub().yieldsTo("success", obj, "Crazy");
+            const callback = createSpy();
             stub({ success: callback });
 
             assert(callback.calledWith(obj, "Crazy"));
         });
 
         it("throws if callback throws", function () {
-            var obj = { id: 42 };
-            var stub = createStub().yieldsTo("error", obj, "Crazy");
-            var callback = createStub().throws();
+            const obj = { id: 42 };
+            const stub = createStub().yieldsTo("error", obj, "Crazy");
+            const callback = createStub().throws();
 
             assert.exception(function () {
                 stub({ error: callback });
@@ -2111,8 +2111,8 @@ describe("stub", function () {
         });
 
         it("throws takes precedent over yielded return value", function () {
-            var stub = createStub().throws().yieldsTo("success");
-            var callback = createStub().returns("return value");
+            const stub = createStub().throws().yieldsTo("success");
+            const callback = createStub().returns("return value");
 
             assert.exception(function () {
                 stub({ success: callback });
@@ -2121,43 +2121,43 @@ describe("stub", function () {
         });
 
         it("returns takes precedent over yielded return value", function () {
-            var obj = {};
-            var stub = createStub().returns(obj).yieldsTo("success");
-            var callback = createStub().returns("return value");
+            const obj = {};
+            const stub = createStub().returns(obj).yieldsTo("success");
+            const callback = createStub().returns("return value");
 
             assert.same(stub({ success: callback }), obj);
             assert(callback.calledOnce);
         });
 
         it("returnsArg takes precedent over yielded return value", function () {
-            var stub = createStub().returnsArg(0).yieldsTo("success");
-            var callback = createStub().returns("return value");
+            const stub = createStub().returnsArg(0).yieldsTo("success");
+            const callback = createStub().returns("return value");
 
             assert.equals(stub({ success: callback }), { success: callback });
             assert(callback.calledOnce);
         });
 
         it("returnsThis takes precedent over yielded return value", function () {
-            var obj = {};
-            var stub = createStub().returnsThis().yieldsTo("success");
-            var callback = createStub().returns("return value");
+            const obj = {};
+            const stub = createStub().returnsThis().yieldsTo("success");
+            const callback = createStub().returns("return value");
 
             assert.same(stub.call(obj, { success: callback }), obj);
             assert(callback.calledOnce);
         });
 
         it("returns the result of the yielded callback", function () {
-            var stub = createStub().yieldsTo("success");
-            var callback = createStub().returns("return value");
+            const stub = createStub().yieldsTo("success");
+            const callback = createStub().returns("return value");
 
             assert.same(stub({ success: callback }), "return value");
             assert(callback.calledOnce);
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub().yieldsTo("success", 1);
-            var stub = createStub().callsFake(fakeFn).yieldsTo("success", 2);
-            var callback = createSpy();
+            const fakeFn = createStub().yieldsTo("success", 1);
+            const stub = createStub().callsFake(fakeFn).yieldsTo("success", 2);
+            const callback = createSpy();
             stub({ success: callback });
 
             assert(callback.calledWith(2));
@@ -2173,7 +2173,7 @@ describe("stub", function () {
 
         it("yields to property of object argument", function () {
             this.stub.yieldsToOn("success", this.fakeContext);
-            var callback = createSpy();
+            const callback = createSpy();
 
             this.stub({ success: callback });
 
@@ -2184,7 +2184,7 @@ describe("stub", function () {
 
         it("yields to property of object argument with undefined context", function () {
             this.stub.yieldsToOn("success", undefined);
-            var callback = createSpy();
+            const callback = createSpy();
 
             this.stub({ success: callback });
 
@@ -2195,7 +2195,7 @@ describe("stub", function () {
 
         it("yields to property of object argument with number context", function () {
             this.stub.yieldsToOn("success", 5);
-            var callback = createSpy();
+            const callback = createSpy();
 
             this.stub({ success: callback });
 
@@ -2214,12 +2214,12 @@ describe("stub", function () {
         });
 
         it("includes stub name and actual arguments in error", function () {
-            var myObj = {
+            const myObj = {
                 somethingAwesome: function () {
                     return;
                 },
             };
-            var stub = createStub(myObj, "somethingAwesome").yieldsToOn(
+            const stub = createStub(myObj, "somethingAwesome").yieldsToOn(
                 "success",
                 this.fakeContext
             );
@@ -2238,7 +2238,7 @@ describe("stub", function () {
         });
 
         it("invokes property on last argument as callback", function () {
-            var callback = createSpy();
+            const callback = createSpy();
 
             this.stub.yieldsToOn("success", this.fakeContext);
             this.stub(24, {}, { success: callback });
@@ -2249,8 +2249,8 @@ describe("stub", function () {
         });
 
         it("invokes first of two possible callbacks", function () {
-            var callback = createSpy();
-            var callback2 = createSpy();
+            const callback = createSpy();
+            const callback2 = createSpy();
 
             this.stub.yieldsToOn("error", this.fakeContext);
             this.stub(24, {}, { error: callback }, { error: callback2 });
@@ -2261,8 +2261,8 @@ describe("stub", function () {
         });
 
         it("invokes callback with arguments", function () {
-            var obj = { id: 42 };
-            var callback = createSpy();
+            const obj = { id: 42 };
+            const callback = createSpy();
 
             this.stub.yieldsToOn("success", this.fakeContext, obj, "Crazy");
             this.stub({ success: callback });
@@ -2272,8 +2272,8 @@ describe("stub", function () {
         });
 
         it("throws if callback throws", function () {
-            var obj = { id: 42 };
-            var callback = createStub().throws();
+            const obj = { id: 42 };
+            const callback = createStub().throws();
 
             this.stub.yieldsToOn("error", this.fakeContext, obj, "Crazy");
 
@@ -2283,10 +2283,10 @@ describe("stub", function () {
         });
 
         it("throws takes precedent over yielded return value", function () {
-            var stub = this.stub
+            const stub = this.stub
                 .throws()
                 .yieldsToOn("success", this.fakeContext);
-            var callback = createStub().returns("return value");
+            const callback = createStub().returns("return value");
 
             assert.exception(function () {
                 stub({ success: callback });
@@ -2295,55 +2295,55 @@ describe("stub", function () {
         });
 
         it("returns takes precedent over yielded return value", function () {
-            var obj = {};
-            var stub = this.stub
+            const obj = {};
+            const stub = this.stub
                 .returns(obj)
                 .yieldsToOn("success", this.fakeContext);
-            var callback = createStub().returns("return value");
+            const callback = createStub().returns("return value");
 
             assert.same(stub({ success: callback }), obj);
             assert(callback.calledOnce);
         });
 
         it("returnsArg takes precedent over yielded return value", function () {
-            var stub = this.stub
+            const stub = this.stub
                 .returnsArg(0)
                 .yieldsToOn("success", this.fakeContext);
-            var callback = createStub().returns("return value");
+            const callback = createStub().returns("return value");
 
             assert.equals(stub({ success: callback }), { success: callback });
             assert(callback.calledOnce);
         });
 
         it("returnsThis takes precedent over yielded return value", function () {
-            var obj = {};
-            var stub = this.stub
+            const obj = {};
+            const stub = this.stub
                 .returnsThis()
                 .yieldsToOn("success", this.fakeContext);
-            var callback = createStub().returns("return value");
+            const callback = createStub().returns("return value");
 
             assert.same(stub.call(obj, { success: callback }), obj);
             assert(callback.calledOnce);
         });
 
         it("returns the result of the yielded callback", function () {
-            var stub = this.stub.yieldsToOn("success", this.fakeContext);
-            var callback = createStub().returns("return value");
+            const stub = this.stub.yieldsToOn("success", this.fakeContext);
+            const callback = createStub().returns("return value");
 
             assert.same(stub({ success: callback }), "return value");
             assert(callback.calledOnce);
         });
 
         it("supersedes previous callsFake", function () {
-            var fakeFn = createStub().yieldsToOn(
+            const fakeFn = createStub().yieldsToOn(
                 "success",
                 this.fakeContext,
                 1
             );
-            var stub = createStub()
+            const stub = createStub()
                 .callsFake(fakeFn)
                 .yieldsToOn("success", this.fakeContext, 2);
-            var callback = createSpy();
+            const callback = createSpy();
             stub({ success: callback });
 
             assert(callback.calledWith(2));
@@ -2353,14 +2353,14 @@ describe("stub", function () {
 
     describe(".withArgs", function () {
         it("defines withArgs method", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.isFunction(stub.withArgs);
         });
 
         it("creates filtered stub", function () {
-            var stub = createStub();
-            var other = stub.withArgs(23);
+            const stub = createStub();
+            const other = stub.withArgs(23);
 
             refute.same(other, stub);
             assert.isFunction(stub.returns);
@@ -2368,7 +2368,7 @@ describe("stub", function () {
         });
 
         it("filters return values based on arguments", function () {
-            var stub = createStub().returns(23);
+            const stub = createStub().returns(23);
             stub.withArgs(42).returns(99);
 
             assert.equals(stub(), 23);
@@ -2376,7 +2376,7 @@ describe("stub", function () {
         });
 
         it("filters exceptions based on arguments", function () {
-            var stub = createStub().returns(23);
+            const stub = createStub().returns(23);
             stub.withArgs(42).throws();
 
             refute.exception(stub);
@@ -2386,7 +2386,7 @@ describe("stub", function () {
         });
 
         it("ensure stub recognizes samsam match fuzzy arguments", function () {
-            var stub = createStub().returns(23);
+            const stub = createStub().returns(23);
             stub.withArgs(match({ foo: "bar" })).returns(99);
 
             assert.equals(stub(), 23);
@@ -2394,12 +2394,12 @@ describe("stub", function () {
         });
 
         it("ensure stub uses last matching arguments", function () {
-            var unmatchedValue = "d3ada6a0-8dac-4136-956d-033b5f23eadf";
-            var firstMatchedValue = "68128619-a639-4b32-a4a0-6519165bf301";
-            var secondMatchedValue = "4ac2dc8f-3f3f-4648-9838-a2825fd94c9a";
-            var expectedArgument = "3e1ed1ec-c377-4432-a33e-3c937f1406d1";
+            const unmatchedValue = "d3ada6a0-8dac-4136-956d-033b5f23eadf";
+            const firstMatchedValue = "68128619-a639-4b32-a4a0-6519165bf301";
+            const secondMatchedValue = "4ac2dc8f-3f3f-4648-9838-a2825fd94c9a";
+            const expectedArgument = "3e1ed1ec-c377-4432-a33e-3c937f1406d1";
 
-            var stub = createStub().returns(unmatchedValue);
+            const stub = createStub().returns(unmatchedValue);
 
             stub.withArgs(expectedArgument).returns(firstMatchedValue);
             stub.withArgs(expectedArgument).returns(secondMatchedValue);
@@ -2409,12 +2409,12 @@ describe("stub", function () {
         });
 
         it("ensure stub uses last matching samsam match arguments", function () {
-            var unmatchedValue = "0aa66a7d-3c50-49ef-8365-bdcab637b2dd";
-            var firstMatchedValue = "1ab2c601-7602-4658-9377-3346f6814caa";
-            var secondMatchedValue = "e2e31518-c4c4-4012-a61f-31942f603ffa";
-            var expectedArgument = "90dc4a22-ef53-4c62-8e05-4cf4b4bf42fa";
+            const unmatchedValue = "0aa66a7d-3c50-49ef-8365-bdcab637b2dd";
+            const firstMatchedValue = "1ab2c601-7602-4658-9377-3346f6814caa";
+            const secondMatchedValue = "e2e31518-c4c4-4012-a61f-31942f603ffa";
+            const expectedArgument = "90dc4a22-ef53-4c62-8e05-4cf4b4bf42fa";
 
-            var stub = createStub().returns(unmatchedValue);
+            const stub = createStub().returns(unmatchedValue);
             stub.withArgs(expectedArgument).returns(firstMatchedValue);
             stub.withArgs(match(expectedArgument)).returns(secondMatchedValue);
 
@@ -2430,7 +2430,7 @@ describe("stub", function () {
 
         it("asynchronously calls argument at specified index", function (done) {
             this.stub.callsArgAsync(2);
-            var callback = createSpy(done);
+            const callback = createSpy(done);
 
             this.stub(1, 2, callback);
 
@@ -2444,11 +2444,11 @@ describe("stub", function () {
         });
 
         it("asynchronously calls callback at specified index with multiple args", function (done) {
-            var object = {};
-            var array = [];
+            const object = {};
+            const array = [];
             this.stub.callsArgWithAsync(1, object, array);
 
-            var callback = createSpy(function () {
+            const callback = createSpy(function () {
                 assert(callback.calledWith(object, array));
                 done();
             });
@@ -2468,10 +2468,10 @@ describe("stub", function () {
         });
 
         it("asynchronously calls argument at specified index with specified context", function (done) {
-            var context = this.fakeContext;
+            const context = this.fakeContext;
             this.stub.callsArgOnAsync(2, context);
 
-            var callback = createSpy(function () {
+            const callback = createSpy(function () {
                 assert(callback.calledOn(context));
                 done();
             });
@@ -2489,11 +2489,11 @@ describe("stub", function () {
         });
 
         it("asynchronously calls argument at specified index with provided context and args", function (done) {
-            var object = {};
-            var context = this.fakeContext;
+            const object = {};
+            const context = this.fakeContext;
             this.stub.callsArgOnWithAsync(1, context, object);
 
-            var callback = createSpy(function () {
+            const callback = createSpy(function () {
                 assert(callback.calledOn(context));
                 assert(callback.calledWith(object));
                 done();
@@ -2507,9 +2507,9 @@ describe("stub", function () {
 
     describe(".yieldsAsync", function () {
         it("asynchronously invokes only argument as callback", function (done) {
-            var stub = createStub().yieldsAsync();
+            const stub = createStub().yieldsAsync();
 
-            var spy = createSpy(done);
+            const spy = createSpy(done);
 
             stub(spy);
 
@@ -2524,10 +2524,10 @@ describe("stub", function () {
         });
 
         it("asynchronously invokes only argument as callback with given context", function (done) {
-            var context = this.fakeContext;
+            const context = this.fakeContext;
             this.stub.yieldsOnAsync(context);
 
-            var spy = createSpy(function () {
+            const spy = createSpy(function () {
                 assert(spy.calledOnce);
                 assert(spy.calledOn(context));
                 assert.equals(spy.args[0].length, 0);
@@ -2542,9 +2542,9 @@ describe("stub", function () {
 
     describe(".yieldsToAsync", function () {
         it("asynchronously yields to property of object argument", function (done) {
-            var stub = createStub().yieldsToAsync("success");
+            const stub = createStub().yieldsToAsync("success");
 
-            var callback = createSpy(function () {
+            const callback = createSpy(function () {
                 assert(callback.calledOnce);
                 assert.equals(callback.args[0].length, 0);
                 done();
@@ -2563,10 +2563,10 @@ describe("stub", function () {
         });
 
         it("asynchronously yields to property of object argument with given context", function (done) {
-            var context = this.fakeContext;
+            const context = this.fakeContext;
             this.stub.yieldsToOnAsync("success", context);
 
-            var callback = createSpy(function () {
+            const callback = createSpy(function () {
                 assert(callback.calledOnce);
                 assert(callback.calledOn(context));
                 assert.equals(callback.args[0].length, 0);
@@ -2580,7 +2580,7 @@ describe("stub", function () {
 
     describe(".onCall", function () {
         it("can be used with returns to produce sequence", function () {
-            var stub = createStub().returns(3);
+            const stub = createStub().returns(3);
             stub.onFirstCall().returns(1).onCall(2).returns(2);
 
             assert.same(stub(), 1);
@@ -2590,7 +2590,7 @@ describe("stub", function () {
         });
 
         it("can be used with returnsArg to produce sequence", function () {
-            var stub = createStub().returns("default");
+            const stub = createStub().returns("default");
             stub.onSecondCall().returnsArg(0);
 
             assert.same(stub(1), "default");
@@ -2599,7 +2599,7 @@ describe("stub", function () {
         });
 
         it("can be used with returnsThis to produce sequence", function () {
-            var instance = {};
+            const instance = {};
             instance.stub = createStub().returns("default");
             instance.stub.onSecondCall().returnsThis();
 
@@ -2609,8 +2609,8 @@ describe("stub", function () {
         });
 
         it("can be used with throwsException to produce sequence", function () {
-            var stub = createStub();
-            var error = new Error();
+            const stub = createStub();
+            const error = new Error();
             stub.onSecondCall().throwsException(error);
 
             stub();
@@ -2621,7 +2621,7 @@ describe("stub", function () {
         });
 
         it("supports chained declaration of behavior", function () {
-            var stub = createStub()
+            const stub = createStub()
                 .onCall(0)
                 .returns(1)
                 .onCall(1)
@@ -2636,7 +2636,7 @@ describe("stub", function () {
 
         describe("in combination with withArgs", function () {
             it("can produce a sequence for a fake", function () {
-                var stub = createStub().returns(0);
+                const stub = createStub().returns(0);
                 stub.withArgs(5)
                     .returns(-1)
                     .onFirstCall()
@@ -2652,7 +2652,7 @@ describe("stub", function () {
             });
 
             it("falls back to stub default behaviour if fake does not have its own default behaviour", function () {
-                var stub = createStub().returns(0);
+                const stub = createStub().returns(0);
                 stub.withArgs(5).onFirstCall().returns(1);
 
                 assert.same(stub(5), 1);
@@ -2660,7 +2660,7 @@ describe("stub", function () {
             });
 
             it("falls back to stub behaviour for call if fake does not have its own behaviour for call", function () {
-                var stub = createStub().returns(0);
+                const stub = createStub().returns(0);
                 stub.withArgs(5).onFirstCall().returns(1);
                 stub.onSecondCall().returns(2);
 
@@ -2670,7 +2670,7 @@ describe("stub", function () {
             });
 
             it("defaults to undefined behaviour once no more calls have been defined", function () {
-                var stub = createStub();
+                const stub = createStub();
                 stub.withArgs(5)
                     .onFirstCall()
                     .returns(1)
@@ -2683,14 +2683,14 @@ describe("stub", function () {
             });
 
             it("does not create undefined behaviour just by calling onCall", function () {
-                var stub = createStub().returns(2);
+                const stub = createStub().returns(2);
                 stub.onFirstCall();
 
                 assert.same(stub(6), 2);
             });
 
             it("works with fakes and reset", function () {
-                var stub = createStub();
+                const stub = createStub();
                 stub.withArgs(5).onFirstCall().returns(1);
                 stub.withArgs(5).onSecondCall().returns(2);
 
@@ -2718,10 +2718,10 @@ describe("stub", function () {
         });
 
         it("can be used with yields* to produce a sequence", function () {
-            var context = { foo: "bar" };
-            var obj = { method1: createSpy(), method2: createSpy() };
-            var obj2 = { method2: createSpy() };
-            var stub = createStub().yieldsToOn("method2", context, 7, 8);
+            const context = { foo: "bar" };
+            const obj = { method1: createSpy(), method2: createSpy() };
+            const obj2 = { method2: createSpy() };
+            const stub = createStub().yieldsToOn("method2", context, 7, 8);
             stub.onFirstCall()
                 .yields(1, 2)
                 .onSecondCall()
@@ -2731,8 +2731,8 @@ describe("stub", function () {
                 .onCall(3)
                 .yieldsToOn("method2", context, 7, 8);
 
-            var spy1 = createSpy();
-            var spy2 = createSpy();
+            const spy1 = createSpy();
+            const spy2 = createSpy();
 
             stub(spy1);
             stub(spy2);
@@ -2764,15 +2764,15 @@ describe("stub", function () {
         });
 
         it("can be used with callsArg* to produce a sequence", function () {
-            var spy1 = createSpy();
-            var spy2 = createSpy();
-            var spy3 = createSpy();
-            var spy4 = createSpy();
-            var spy5 = createSpy();
-            var decoy = createSpy();
-            var context = { foo: "bar" };
+            const spy1 = createSpy();
+            const spy2 = createSpy();
+            const spy3 = createSpy();
+            const spy4 = createSpy();
+            const spy5 = createSpy();
+            const decoy = createSpy();
+            const context = { foo: "bar" };
 
-            var stub = createStub().callsArgOnWith(3, context, "c", "d");
+            const stub = createStub().callsArgOnWith(3, context, "c", "d");
             stub.onFirstCall()
                 .callsArg(0)
                 .onSecondCall()
@@ -2812,7 +2812,7 @@ describe("stub", function () {
         });
 
         it("can be used with yields* and callsArg* in combination to produce a sequence", function () {
-            var stub = createStub().yields(1, 2);
+            const stub = createStub().yields(1, 2);
             stub.onSecondCall()
                 .callsArg(1)
                 .onThirdCall()
@@ -2820,11 +2820,11 @@ describe("stub", function () {
                 .onCall(3)
                 .callsArgWith(2, "a", "b");
 
-            var obj = { method: createSpy() };
-            var spy1 = createSpy();
-            var spy2 = createSpy();
-            var spy3 = createSpy();
-            var decoy = createSpy();
+            const obj = { method: createSpy() };
+            const spy1 = createSpy();
+            const spy2 = createSpy();
+            const spy3 = createSpy();
+            const decoy = createSpy();
 
             stub(spy1);
             stub(decoy, spy2);
@@ -2847,8 +2847,8 @@ describe("stub", function () {
         });
 
         it("should interact correctly with assertions (GH-231)", function () {
-            var stub = createStub();
-            var spy = createSpy();
+            const stub = createStub();
+            const spy = createSpy();
 
             stub.callsArgWith(0, "a");
 
@@ -2867,12 +2867,12 @@ describe("stub", function () {
 
     describe(".reset", function () {
         it("resets behavior", function () {
-            var obj = {
+            const obj = {
                 a: function () {
                     return;
                 },
             };
-            var spy = createSpy();
+            const spy = createSpy();
             createStub(obj, "a").callsArg(1);
 
             obj.a(null, spy);
@@ -2883,7 +2883,7 @@ describe("stub", function () {
         });
 
         it("resets call history", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             stub(1);
             stub.reset();
@@ -2896,7 +2896,7 @@ describe("stub", function () {
 
     describe(".resetHistory", function () {
         it("resets history", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             stub(1);
             stub.reset();
@@ -2907,7 +2907,7 @@ describe("stub", function () {
         });
 
         it("doesn't reset behavior defined using withArgs", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.withArgs("test").returns(10);
 
             stub.resetHistory();
@@ -2916,7 +2916,7 @@ describe("stub", function () {
         });
 
         it("doesn't reset behavior", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.returns(10);
 
             stub.resetHistory();
@@ -2927,12 +2927,12 @@ describe("stub", function () {
 
     describe(".resetBehavior", function () {
         it("clears yields* and callsArg* sequence", function () {
-            var stub = createStub().yields(1);
+            const stub = createStub().yields(1);
             stub.onFirstCall().callsArg(1);
             stub.resetBehavior();
             stub.yields(3);
-            var spyWanted = createSpy();
-            var spyNotWanted = createSpy();
+            const spyWanted = createSpy();
+            const spyNotWanted = createSpy();
 
             stub(spyWanted, spyNotWanted);
 
@@ -2942,7 +2942,7 @@ describe("stub", function () {
         });
 
         it("cleans 'returns' behavior", function () {
-            var stub = createStub().returns(1);
+            const stub = createStub().returns(1);
 
             stub.resetBehavior();
 
@@ -2950,7 +2950,7 @@ describe("stub", function () {
         });
 
         it("cleans behavior of fakes returned by withArgs", function () {
-            var stub = createStub();
+            const stub = createStub();
             stub.withArgs("lolz").returns(2);
 
             stub.resetBehavior();
@@ -2959,8 +2959,8 @@ describe("stub", function () {
         });
 
         it("does not clean parents' behavior when called on a fake returned by withArgs", function () {
-            var parentStub = createStub().returns(false);
-            var childStub = parentStub.withArgs("lolz").returns(true);
+            const parentStub = createStub().returns(false);
+            const childStub = parentStub.withArgs("lolz").returns(true);
 
             childStub.resetBehavior();
 
@@ -2969,7 +2969,7 @@ describe("stub", function () {
         });
 
         it("cleans 'returnsArg' behavior", function () {
-            var stub = createStub().returnsArg(0);
+            const stub = createStub().returnsArg(0);
 
             stub.resetBehavior();
 
@@ -2977,7 +2977,7 @@ describe("stub", function () {
         });
 
         it("cleans 'returnsThis' behavior", function () {
-            var instance = {};
+            const instance = {};
             instance.stub = createStub();
             instance.stub.returnsThis();
 
@@ -2987,7 +2987,7 @@ describe("stub", function () {
         });
 
         it("cleans 'resolvesThis' behavior, so the stub does not resolve nor returns anything", function () {
-            var instance = {};
+            const instance = {};
             instance.stub = createStub();
             instance.stub.resolvesThis();
 
@@ -2998,7 +2998,7 @@ describe("stub", function () {
 
         describe("does not touch properties that are reset by 'reset'", function () {
             it(".calledOnce", function () {
-                var stub = createStub();
+                const stub = createStub();
                 stub(1);
 
                 stub.resetBehavior();
@@ -3007,7 +3007,7 @@ describe("stub", function () {
             });
 
             it("called multiple times", function () {
-                var stub = createStub();
+                const stub = createStub();
                 stub(1);
                 stub(2);
                 stub(3);
@@ -3026,7 +3026,7 @@ describe("stub", function () {
             });
 
             it("call order state", function () {
-                var stubs = [createStub(), createStub()];
+                const stubs = [createStub(), createStub()];
                 stubs[0]();
                 stubs[1]();
 
@@ -3036,13 +3036,13 @@ describe("stub", function () {
             });
 
             it("fakes returned by withArgs", function () {
-                var stub = createStub();
-                var fakeA = stub.withArgs("a");
-                var fakeB = stub.withArgs("b");
+                const stub = createStub();
+                const fakeA = stub.withArgs("a");
+                const fakeB = stub.withArgs("b");
                 stub("a");
                 stub("b");
                 stub("c");
-                var fakeC = stub.withArgs("c");
+                const fakeC = stub.withArgs("c");
 
                 stub.resetBehavior();
 
@@ -3055,85 +3055,85 @@ describe("stub", function () {
 
     describe(".length", function () {
         it("is zero by default", function () {
-            var stub = createStub();
+            const stub = createStub();
 
             assert.equals(stub.length, 0);
         });
 
         it("retains function length 0", function () {
-            var object = {
+            const object = {
                 test: function () {
                     return;
                 },
             };
 
-            var stub = createStub(object, "test");
+            const stub = createStub(object, "test");
 
             assert.equals(stub.length, 0);
         });
 
         it("retains function length 1", function () {
-            var object = {
+            const object = {
                 // eslint-disable-next-line no-unused-vars
                 test: function (a) {
                     return;
                 },
             };
 
-            var stub = createStub(object, "test");
+            const stub = createStub(object, "test");
 
             assert.equals(stub.length, 1);
         });
 
         it("retains function length 2", function () {
-            var object = {
+            const object = {
                 // eslint-disable-next-line no-unused-vars
                 test: function (a, b) {
                     return;
                 },
             };
 
-            var stub = createStub(object, "test");
+            const stub = createStub(object, "test");
 
             assert.equals(stub.length, 2);
         });
 
         it("retains function length 3", function () {
-            var object = {
+            const object = {
                 // eslint-disable-next-line no-unused-vars
                 test: function (a, b, c) {
                     return;
                 },
             };
 
-            var stub = createStub(object, "test");
+            const stub = createStub(object, "test");
 
             assert.equals(stub.length, 3);
         });
 
         it("retains function length 4", function () {
-            var object = {
+            const object = {
                 // eslint-disable-next-line no-unused-vars
                 test: function (a, b, c, d) {
                     return;
                 },
             };
 
-            var stub = createStub(object, "test");
+            const stub = createStub(object, "test");
 
             assert.equals(stub.length, 4);
         });
 
         it("retains function length 12", function () {
             // eslint-disable-next-line no-unused-vars
-            var func12Args = function (a, b, c, d, e, f, g, h, i, j, k, l) {
+            const func12Args = function (a, b, c, d, e, f, g, h, i, j, k, l) {
                 return;
             };
-            var object = {
+            const object = {
                 test: func12Args,
             };
 
-            var stub = createStub(object, "test");
+            const stub = createStub(object, "test");
 
             assert.equals(stub.length, 12);
         });
@@ -3142,20 +3142,20 @@ describe("stub", function () {
     describe(".callThrough", function () {
         it("does not call original function when arguments match conditional stub", function () {
             // We need a function here because we can't wrap properties that are already stubs
-            var callCount = 0;
-            var originalFunc = function increaseCallCount() {
+            let callCount = 0;
+            const originalFunc = function increaseCallCount() {
                 callCount++;
             };
 
-            var myObj = {
+            const myObj = {
                 prop: originalFunc,
             };
 
-            var propStub = createStub(myObj, "prop");
+            const propStub = createStub(myObj, "prop");
             propStub.withArgs("foo").returns("bar");
             propStub.callThrough();
 
-            var result = myObj.prop("foo");
+            const result = myObj.prop("foo");
 
             assert.equals(result, "bar");
             assert.equals(callCount, 0);
@@ -3163,22 +3163,22 @@ describe("stub", function () {
 
         it("calls original function when arguments do not match conditional stub", function () {
             // We need a function here because we can't wrap properties that are already stubs
-            var callCount = 0;
+            let callCount = 0;
 
-            var originalFunc = function increaseCallCount() {
+            const originalFunc = function increaseCallCount() {
                 callCount++;
                 return 1337;
             };
 
-            var myObj = {
+            const myObj = {
                 prop: originalFunc,
             };
 
-            var propStub = createStub(myObj, "prop");
+            const propStub = createStub(myObj, "prop");
             propStub.withArgs("foo").returns("bar");
             propStub.callThrough(propStub);
 
-            var result = myObj.prop("not foo");
+            const result = myObj.prop("not foo");
 
             assert.equals(result, 1337);
             assert.equals(callCount, 1);
@@ -3186,17 +3186,17 @@ describe("stub", function () {
 
         it("calls original function with same arguments when call does not match conditional stub", function () {
             // We need a function here because we can't wrap properties that are already stubs
-            var callArgs = [];
+            let callArgs = [];
 
-            var originalFunc = function increaseCallCount() {
+            const originalFunc = function increaseCallCount() {
                 callArgs = arguments;
             };
 
-            var myObj = {
+            const myObj = {
                 prop: originalFunc,
             };
 
-            var propStub = createStub(myObj, "prop");
+            const propStub = createStub(myObj, "prop");
             propStub.withArgs("foo").returns("bar");
             propStub.callThrough();
 
@@ -3208,17 +3208,17 @@ describe("stub", function () {
 
         it("calls original function with same `this` reference when call does not match conditional stub", function () {
             // We need a function here because we can't wrap properties that are already stubs
-            var reference = {};
+            let reference = {};
 
-            var originalFunc = function increaseCallCount() {
+            const originalFunc = function increaseCallCount() {
                 reference = this;
             };
 
-            var myObj = {
+            const myObj = {
                 prop: originalFunc,
             };
 
-            var propStub = createStub(myObj, "prop");
+            const propStub = createStub(myObj, "prop");
             propStub.withArgs("foo").returns("bar");
             propStub.callThrough();
 
@@ -3231,21 +3231,21 @@ describe("stub", function () {
     describe(".callThroughWithNew", function () {
         it("does not call original function with new when arguments match conditional stub", function () {
             // We need a function here because we can't wrap properties that are already stubs
-            var callCount = 0;
-            var OriginalClass = function SomeClass() {
+            let callCount = 0;
+            const OriginalClass = function SomeClass() {
                 this.foo = "bar";
                 callCount++;
             };
 
-            var myObj = {
+            const myObj = {
                 MyClass: OriginalClass,
             };
 
-            var propStub = createStub(myObj, "MyClass");
+            const propStub = createStub(myObj, "MyClass");
             propStub.withArgs("foo").returns({ foo: "bar" });
             propStub.callThroughWithNew(propStub);
 
-            var result = new myObj.MyClass("foo");
+            const result = new myObj.MyClass("foo");
 
             assert.equals(result.foo, "bar");
             assert.equals(callCount, 0);
@@ -3254,22 +3254,22 @@ describe("stub", function () {
         context("when call does not match conditional stub", function () {
             it("calls original function with new with same arguments", function () {
                 // We need a function here because we can't wrap properties that are already stubs
-                var callArgs = [];
+                let callArgs = [];
 
                 function OriginalClass() {
                     callArgs = arguments;
                     this.foo = "baz";
                 }
 
-                var myObj = {
+                const myObj = {
                     MyClass: OriginalClass,
                 };
 
-                var propStub = createStub(myObj, "MyClass");
+                const propStub = createStub(myObj, "MyClass");
                 propStub.withArgs("foo").returns({ foo: "bar" });
                 propStub.callThroughWithNew(propStub);
 
-                var result = new myObj.MyClass("not foo", [
+                const result = new myObj.MyClass("not foo", [
                     "definitely",
                     "not",
                     "foo",
@@ -3283,7 +3283,7 @@ describe("stub", function () {
 
     describe(".get", function () {
         it("allows users to stub getter functions for properties", function () {
-            var myObj = {
+            const myObj = {
                 prop: "foo",
             };
 
@@ -3295,7 +3295,7 @@ describe("stub", function () {
         });
 
         it("allows users to stub getter functions for functions", function () {
-            var myObj = {
+            const myObj = {
                 prop: function propGetter() {
                     return "foo";
                 },
@@ -3309,7 +3309,7 @@ describe("stub", function () {
         });
 
         it("replaces old getters", function () {
-            var myObj = {
+            const myObj = {
                 get prop() {
                     fail("should not call the old getter");
                     return;
@@ -3324,15 +3324,15 @@ describe("stub", function () {
         });
 
         it("can restore stubbed setters for functions", function () {
-            var propFn = function propFn() {
+            const propFn = function propFn() {
                 return "bar";
             };
 
-            var myObj = {
+            const myObj = {
                 prop: propFn,
             };
 
-            var stub = createStub(myObj, "prop");
+            const stub = createStub(myObj, "prop");
 
             stub.get(function getterFn() {
                 return "baz";
@@ -3344,13 +3344,13 @@ describe("stub", function () {
         });
 
         it("can restore stubbed getters for properties", function () {
-            var myObj = {
+            const myObj = {
                 get prop() {
                     return "bar";
                 },
             };
 
-            var stub = createStub(myObj, "prop");
+            const stub = createStub(myObj, "prop");
 
             stub.get(function getterFn() {
                 return "baz";
@@ -3364,7 +3364,7 @@ describe("stub", function () {
 
     describe(".set", function () {
         it("allows users to stub setter functions for properties", function () {
-            var myObj = {
+            const myObj = {
                 prop: "foo",
             };
 
@@ -3378,7 +3378,7 @@ describe("stub", function () {
         });
 
         it("allows users to stub setter functions for functions", function () {
-            var myObj = {
+            const myObj = {
                 prop: function propSetter() {
                     return "foo";
                 },
@@ -3394,7 +3394,7 @@ describe("stub", function () {
         });
 
         it("replaces old setters", function () {
-            var myObj = {
+            const myObj = {
                 // eslint-disable-next-line accessor-pairs
                 set prop(val) {
                     fail("should not call the old setter");
@@ -3411,15 +3411,15 @@ describe("stub", function () {
         });
 
         it("can restore stubbed setters for functions", function () {
-            var propFn = function propFn() {
+            const propFn = function propFn() {
                 return "bar";
             };
 
-            var myObj = {
+            const myObj = {
                 prop: propFn,
             };
 
-            var stub = createStub(myObj, "prop");
+            const stub = createStub(myObj, "prop");
 
             stub.set(function setterFn() {
                 myObj.otherProp = "baz";
@@ -3431,14 +3431,14 @@ describe("stub", function () {
         });
 
         it("can restore stubbed setters for properties", function () {
-            var myObj = {
+            const myObj = {
                 // eslint-disable-next-line accessor-pairs
                 set prop(val) {
                     this.otherProp = "bar";
                 },
             };
 
-            var stub = createStub(myObj, "prop");
+            const stub = createStub(myObj, "prop");
 
             stub.set(function setterFn() {
                 myObj.otherProp = "baz";
@@ -3453,7 +3453,7 @@ describe("stub", function () {
 
     describe(".value", function () {
         it("allows stubbing property descriptor values", function () {
-            var myObj = {
+            const myObj = {
                 prop: "rawString",
             };
 
@@ -3462,18 +3462,18 @@ describe("stub", function () {
         });
 
         it("allows restoring stubbed property descriptor values", function () {
-            var myObj = {
+            const myObj = {
                 prop: "rawString",
             };
 
-            var stub = createStub(myObj, "prop").value("newString");
+            const stub = createStub(myObj, "prop").value("newString");
             stub.restore();
 
             assert.equals(myObj.prop, "rawString");
         });
 
         it("allows stubbing function static properties", function () {
-            var myFunc = function () {
+            const myFunc = function () {
                 return;
             };
             myFunc.prop = "rawString";
@@ -3483,19 +3483,19 @@ describe("stub", function () {
         });
 
         it("allows restoring function static properties", function () {
-            var myFunc = function () {
+            const myFunc = function () {
                 return;
             };
             myFunc.prop = "rawString";
 
-            var stub = createStub(myFunc, "prop").value("newString");
+            const stub = createStub(myFunc, "prop").value("newString");
             stub.restore();
 
             assert.equals(myFunc.prop, "rawString");
         });
 
         it("allows stubbing object props with configurable false", function () {
-            var myObj = {};
+            const myObj = {};
             Object.defineProperty(myObj, "prop", {
                 configurable: false,
                 enumerable: true,
@@ -3510,7 +3510,7 @@ describe("stub", function () {
 
     describe(".id", function () {
         it("should start with 'stub#'", function () {
-            for (var i = 0; i < 10; i++) {
+            for (let i = 0; i < 10; i++) {
                 assert.isTrue(createStub().id.indexOf("stub#") === 0);
             }
         });
@@ -3518,12 +3518,12 @@ describe("stub", function () {
 
     describe(".printf", function () {
         it("is delegated to proxy", function () {
-            var f = function () {
+            const f = function () {
                 throw new Error("aError");
             };
 
-            var stub = createStub();
-            var proxy = createProxy(f, f);
+            const stub = createStub();
+            const proxy = createProxy(f, f);
 
             assert.same(stub.printf, proxy.printf);
         });
@@ -3531,10 +3531,10 @@ describe("stub", function () {
 
     describe(".wrappedMethod", function () {
         it("should return the original method being stubbed", function () {
-            var myFn = function () {
+            const myFn = function () {
                 return "foo";
             };
-            var myObj = {
+            const myObj = {
                 fn: myFn,
             };
             createStub(myObj, "fn");
@@ -3542,7 +3542,7 @@ describe("stub", function () {
         });
 
         it("should not exist for accessors", function () {
-            var myObj = {
+            const myObj = {
                 get prop() {
                     return "foo";
                 },

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
+const referee = require("@sinonjs/referee");
 
 referee.add("spy", {
     assert: function (obj) {

--- a/test/util/core/color-test.js
+++ b/test/util/core/color-test.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var assert = require("@sinonjs/referee").assert;
-var proxyquire = require("proxyquire");
+const assert = require("@sinonjs/referee").assert;
+const proxyquire = require("proxyquire");
 
-var colors = [
+const colors = [
     { name: "bold", code: 1 },
     { name: "cyan", code: 96 },
     { name: "green", code: 32 },
@@ -13,7 +13,7 @@ var colors = [
 
 describe("color", function () {
     describe("when environment supports color", function () {
-        var color;
+        let color;
 
         beforeEach(function () {
             color = proxyquire("../../../lib/sinon/color", {
@@ -28,8 +28,8 @@ describe("color", function () {
             // eslint-disable-next-line mocha/no-setup-in-describe
             describe(method.name, function () {
                 it("should return a colored string", function () {
-                    var string = "lorem ipsum";
-                    var actual = color[method.name](string);
+                    const string = "lorem ipsum";
+                    const actual = color[method.name](string);
 
                     assert.contains(actual, `${method.code}m${string}`);
                 });
@@ -38,7 +38,7 @@ describe("color", function () {
     });
 
     describe("when environment does not support color", function () {
-        var color;
+        let color;
 
         beforeEach(function () {
             color = proxyquire("../../../lib/sinon/color", {
@@ -53,8 +53,8 @@ describe("color", function () {
             // eslint-disable-next-line mocha/no-setup-in-describe
             describe(method.name, function () {
                 it("should return a regular string", function () {
-                    var string = "lorem ipsum";
-                    var actual = color[method.name](string);
+                    const string = "lorem ipsum";
+                    const actual = color[method.name](string);
 
                     assert.equals(actual, string);
                 });

--- a/test/util/core/export-async-behaviors-test.js
+++ b/test/util/core/export-async-behaviors-test.js
@@ -1,13 +1,13 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var assert = referee.assert;
-var exportAsyncBehaviors = require("../../../lib/sinon/util/core/export-async-behaviors");
+const referee = require("@sinonjs/referee");
+const assert = referee.assert;
+const exportAsyncBehaviors = require("../../../lib/sinon/util/core/export-async-behaviors");
 
 describe("util/core/exportAsyncBehaviors", function () {
     describe("for methods with names starting with 'callsArg' or 'yields'", function () {
         it("should create an async version", function () {
-            var methods = {
+            const methods = {
                 yieldsOn: function yieldsOn() {
                     return "2";
                 },
@@ -24,7 +24,7 @@ describe("util/core/exportAsyncBehaviors", function () {
 
     describe("for methods with names not starting with 'callsArg' or 'yields'", function () {
         it("should not add any new methods", function () {
-            var methods = {
+            const methods = {
                 callsFake: function callsFake() {
                     return "1";
                 },

--- a/test/util/core/function-to-string-test.js
+++ b/test/util/core/function-to-string-test.js
@@ -1,13 +1,13 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var createSpy = require("../../../lib/sinon/spy");
-var functionToString = require("../../../lib/sinon/util/core/function-to-string");
-var assert = referee.assert;
+const referee = require("@sinonjs/referee");
+const createSpy = require("../../../lib/sinon/spy");
+const functionToString = require("../../../lib/sinon/util/core/function-to-string");
+const assert = referee.assert;
 
 describe("util/core/functionToString", function () {
     it("returns function's displayName property", function () {
-        var fn = function () {
+        const fn = function () {
             return;
         };
         fn.displayName = "Larry";
@@ -16,7 +16,7 @@ describe("util/core/functionToString", function () {
     });
 
     it("guesses name from last call's this object", function () {
-        var obj = {};
+        const obj = {};
         obj.doStuff = createSpy();
         obj.doStuff.call({});
         obj.doStuff();
@@ -25,8 +25,8 @@ describe("util/core/functionToString", function () {
     });
 
     it("guesses name from any call where property can be located", function () {
-        var obj = {};
-        var otherObj = { id: 42 };
+        const obj = {};
+        const otherObj = { id: 42 };
 
         obj.doStuff = createSpy();
         obj.doStuff.call({});
@@ -38,7 +38,7 @@ describe("util/core/functionToString", function () {
 
     // https://github.com/sinonjs/sinon/issues/2215
     it("ignores errors thrown by property accessors on thisValue", function () {
-        var obj = {};
+        const obj = {};
 
         Object.defineProperty(obj, "foo", {
             enumerable: true,
@@ -53,11 +53,11 @@ describe("util/core/functionToString", function () {
         };
 
         // validate that the keys are in the expected order that will cause the bug
-        var keys = Object.keys(obj);
+        const keys = Object.keys(obj);
         assert.equals(keys[0], "foo");
         assert.equals(keys[1], "fn");
 
-        var spy = createSpy(obj, "fn");
+        const spy = createSpy(obj, "fn");
 
         obj.fn();
 

--- a/test/util/core/get-config-test.js
+++ b/test/util/core/get-config-test.js
@@ -1,15 +1,15 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var getConfig = require("../../get-config");
-var defaultConfig = require("../../../lib/sinon/util/core/default-config");
-var assert = referee.assert;
-var refute = referee.refute;
+const referee = require("@sinonjs/referee");
+const getConfig = require("../../get-config");
+const defaultConfig = require("../../../lib/sinon/util/core/default-config");
+const assert = referee.assert;
+const refute = referee.refute;
 
 describe("core/util/getConfig", function () {
     describe(".getConfig", function () {
         it("gets copy of default config", function () {
-            var config = getConfig();
+            const config = getConfig();
 
             refute.same(config, defaultConfig);
             assert.equals(config.injectInto, defaultConfig.injectInto);
@@ -19,7 +19,7 @@ describe("core/util/getConfig", function () {
         });
 
         it("should override specified properties", function () {
-            var config = getConfig({
+            const config = getConfig({
                 properties: ["stub", "mock"],
                 useFakeServer: false,
             });

--- a/test/util/core/get-next-tick-test.js
+++ b/test/util/core/get-next-tick-test.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var getNextTick = require("../../../lib/sinon/util/core/get-next-tick");
-var assert = referee.assert;
+const referee = require("@sinonjs/referee");
+const getNextTick = require("../../../lib/sinon/util/core/get-next-tick");
+const assert = referee.assert;
 
 describe("util/core/get-next-tick", function () {
     it("should use process.nextTick when available", function () {
-        var mockProcess = {
+        const mockProcess = {
             nextTick: function () {
                 return;
             },
@@ -24,7 +24,7 @@ describe("util/core/get-next-tick", function () {
     });
 
     it("should fallback to setTimeout", function () {
-        var nextTick = getNextTick(undefined, undefined);
+        const nextTick = getNextTick(undefined, undefined);
 
         assert.isFunction(nextTick);
         assert.contains(String(nextTick), "setTimeout(");

--- a/test/util/core/next-tick-test.js
+++ b/test/util/core/next-tick-test.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var nextTick = require("../../../lib/sinon/util/core/next-tick");
-var assert = referee.assert;
+const referee = require("@sinonjs/referee");
+const nextTick = require("../../../lib/sinon/util/core/next-tick");
+const assert = referee.assert;
 
-var hasNextTick =
+const hasNextTick =
     typeof process === "object" && typeof process.nextTick === "function";
-var hasSetImmediate = typeof setImmediate === "function";
+const hasSetImmediate = typeof setImmediate === "function";
 
 describe("util/core/next-tick", function () {
     describe("browser environment", function () {

--- a/test/util/core/times-in-words-test.js
+++ b/test/util/core/times-in-words-test.js
@@ -1,27 +1,27 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var timesInWords = require("../../../lib/sinon/util/core/times-in-words");
-var assert = referee.assert;
+const referee = require("@sinonjs/referee");
+const timesInWords = require("../../../lib/sinon/util/core/times-in-words");
+const assert = referee.assert;
 
 describe("util/core/timesInWords", function () {
     it('should return "once" for input of 1', function () {
-        var result = timesInWords(1);
+        const result = timesInWords(1);
         assert.equals(result, "once");
     });
 
     it('should return "twice" for input of 2', function () {
-        var result = timesInWords(2);
+        const result = timesInWords(2);
         assert.equals(result, "twice");
     });
 
     it('should return "thrice" for input of 3', function () {
-        var result = timesInWords(3);
+        const result = timesInWords(3);
         assert.equals(result, "thrice");
     });
 
     it('should return "n times" for n larger than 3', function () {
-        var result, i;
+        let result, i;
 
         for (i = 4; i < 100; i++) {
             result = timesInWords(i);
@@ -30,8 +30,8 @@ describe("util/core/timesInWords", function () {
     });
 
     it('should return "0 times" for falsy input', function () {
-        var falsies = [0, NaN, null, false, undefined, ""];
-        var result, i;
+        const falsies = [0, NaN, null, false, undefined, ""];
+        let result, i;
 
         for (i = 0; i < falsies.length; i++) {
             result = timesInWords(falsies[i]);

--- a/test/util/core/walk-object-test.js
+++ b/test/util/core/walk-object-test.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
+const referee = require("@sinonjs/referee");
 
-var walkObject = require("../../../lib/sinon/util/core/walk-object");
+const walkObject = require("../../../lib/sinon/util/core/walk-object");
 
-var assert = referee.assert;
+const assert = referee.assert;
 
 describe("util/core/walk-object", function () {
     // IE11
@@ -12,7 +12,7 @@ describe("util/core/walk-object", function () {
         function fnWithNoName() {
             return;
         }
-        var anonymousFn = function () {
+        const anonymousFn = function () {
             return;
         };
 
@@ -26,7 +26,7 @@ describe("util/core/walk-object", function () {
                 this.skip();
             }
 
-            var descriptor = { value: undefined };
+            const descriptor = { value: undefined };
 
             Object.defineProperty(anonymousFn, "name", descriptor);
             Object.defineProperty(fnWithNoName, "name", descriptor);

--- a/test/util/core/walk-test.js
+++ b/test/util/core/walk-test.js
@@ -1,15 +1,15 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var walk = require("../../../lib/sinon/util/core/walk");
-var createSpy = require("../../../lib/sinon/spy");
-var assert = referee.assert;
+const referee = require("@sinonjs/referee");
+const walk = require("../../../lib/sinon/util/core/walk");
+const createSpy = require("../../../lib/sinon/spy");
+const assert = referee.assert;
 
 describe("util/core/walk", function () {
     it("should call iterator with value, key, and obj, with context as the receiver", function () {
-        var target = Object.create(null);
-        var rcvr = {};
-        var iterator = createSpy();
+        const target = Object.create(null);
+        const rcvr = {};
+        const iterator = createSpy();
 
         target.hello = "world";
         target.foo = 15;
@@ -23,8 +23,8 @@ describe("util/core/walk", function () {
     });
 
     it("should work with non-enumerable properties", function () {
-        var target = Object.create(null);
-        var iterator = createSpy();
+        const target = Object.create(null);
+        const iterator = createSpy();
 
         target.hello = "world";
         Object.defineProperty(target, "foo", {
@@ -39,9 +39,7 @@ describe("util/core/walk", function () {
     });
 
     it("should walk the prototype chain of an object", function () {
-        var parentProto, proto, target, iterator;
-
-        parentProto = Object.create(null, {
+        const parentProto = Object.create(null, {
             nonEnumerableParentProp: {
                 value: "non-enumerable parent prop",
             },
@@ -51,7 +49,7 @@ describe("util/core/walk", function () {
             },
         });
 
-        proto = Object.create(parentProto, {
+        const proto = Object.create(parentProto, {
             nonEnumerableProp: {
                 value: "non-enumerable prop",
             },
@@ -61,7 +59,7 @@ describe("util/core/walk", function () {
             },
         });
 
-        target = Object.create(proto, {
+        const target = Object.create(proto, {
             nonEnumerableOwnProp: {
                 value: "non-enumerable own prop",
             },
@@ -71,7 +69,7 @@ describe("util/core/walk", function () {
             },
         });
 
-        iterator = createSpy();
+        const iterator = createSpy();
 
         walk(target, iterator);
 
@@ -85,16 +83,16 @@ describe("util/core/walk", function () {
     });
 
     it("should not invoke getters on the original receiving object", function () {
-        var Target = function Target() {
+        const Target = function Target() {
             return;
         };
-        var getter = createSpy();
+        const getter = createSpy();
         Object.defineProperty(Target.prototype, "computedFoo", {
             enumerable: true,
             get: getter,
         });
-        var target = new Target();
-        var iterator = createSpy();
+        const target = new Target();
+        const iterator = createSpy();
 
         walk(target, iterator);
 
@@ -103,16 +101,16 @@ describe("util/core/walk", function () {
     });
 
     it("should fall back to for..in if getOwnPropertyNames is not available", function () {
-        var getOwnPropertyNames = Object.getOwnPropertyNames;
-        var Target = function Target() {
+        const getOwnPropertyNames = Object.getOwnPropertyNames;
+        const Target = function Target() {
             this.hello = "world";
         };
-        var target = new Target();
-        var rcvr = {};
-        var iterator = createSpy();
-        var err = null;
-        var numCalls = 0;
-        var placeholder;
+        const target = new Target();
+        const rcvr = {};
+        const iterator = createSpy();
+        let err = null;
+        let numCalls = 0;
+        let placeholder;
 
         Target.prototype.foo = 15;
         Object.getOwnPropertyNames = null;
@@ -146,20 +144,20 @@ describe("util/core/walk", function () {
     });
 
     it("does not walk the same property twice", function () {
-        var parent = {
+        const parent = {
             func: function parentFunc() {
                 return;
             },
         };
-        var child = Object.create(parent);
+        const child = Object.create(parent);
         child.func = function childFunc() {
             return;
         };
-        var iterator = createSpy();
+        const iterator = createSpy();
 
         walk(child, iterator);
 
-        var propertyNames = iterator.args.map(function (call) {
+        const propertyNames = iterator.args.map(function (call) {
             return call[0];
         });
 

--- a/test/util/core/wrap-method-test.js
+++ b/test/util/core/wrap-method-test.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var wrapMethod = require("../../../lib/sinon/util/core/wrap-method");
-var createSpy = require("../../../lib/sinon/spy");
-var createStub = require("../../../lib/sinon/stub");
-var assert = referee.assert;
-var refute = referee.refute;
+const referee = require("@sinonjs/referee");
+const wrapMethod = require("../../../lib/sinon/util/core/wrap-method");
+const createSpy = require("../../../lib/sinon/spy");
+const createStub = require("../../../lib/sinon/stub");
+const assert = referee.assert;
+const refute = referee.refute;
 
 describe("util/core/wrapMethod", function () {
     beforeEach(function () {
@@ -41,7 +41,7 @@ describe("util/core/wrapMethod", function () {
 
     it("throws if object defines property but is not function", function () {
         this.object.prop = 42;
-        var object = this.object;
+        const object = this.object;
 
         assert.exception(
             function () {
@@ -58,8 +58,8 @@ describe("util/core/wrapMethod", function () {
             this.skip();
         }
 
-        var symbol = Symbol("apple pie");
-        var object = {};
+        const symbol = Symbol("apple pie");
+        const object = {};
         object[symbol] = 42;
 
         assert.exception(
@@ -78,7 +78,7 @@ describe("util/core/wrapMethod", function () {
     });
 
     it("throws if object does not define property", function () {
-        var object = this.object;
+        const object = this.object;
 
         assert.exception(function () {
             wrapMethod(object, "prop", function () {
@@ -99,7 +99,7 @@ describe("util/core/wrapMethod", function () {
     });
 
     it("throws if third argument is missing", function () {
-        var object = this.object;
+        const object = this.object;
 
         assert.exception(
             function () {
@@ -110,7 +110,7 @@ describe("util/core/wrapMethod", function () {
     });
 
     it("throws if third argument is not a function or a property descriptor", function () {
-        var object = this.object;
+        const object = this.object;
 
         assert.exception(
             function () {
@@ -182,8 +182,8 @@ describe("util/core/wrapMethod", function () {
             this.skip();
         }
 
-        var symbol = Symbol("apple pie");
-        var object = {};
+        const symbol = Symbol("apple pie");
+        const object = {};
         object[symbol] = function () {
             return;
         };
@@ -226,7 +226,7 @@ describe("util/core/wrapMethod", function () {
     });
 
     it("throws if method is already a spy", function () {
-        var object = { method: createSpy() };
+        const object = { method: createSpy() };
 
         assert.exception(
             function () {
@@ -243,8 +243,8 @@ describe("util/core/wrapMethod", function () {
             this.skip();
         }
 
-        var symbol = Symbol("apple pie");
-        var object = {};
+        const symbol = Symbol("apple pie");
+        const object = {};
         object[symbol] = createSpy();
 
         assert.exception(
@@ -267,7 +267,7 @@ describe("util/core/wrapMethod", function () {
             this.oldError = Error;
             this.oldTypeError = TypeError;
 
-            var i = 0;
+            let i = 0;
 
             // eslint-disable-next-line no-global-assign, no-native-reassign
             Error = TypeError = function () {
@@ -283,7 +283,7 @@ describe("util/core/wrapMethod", function () {
         });
 
         it("throws with stack trace showing original wrapMethod call", function () {
-            var object = {
+            const object = {
                 method: function () {
                     return;
                 },
@@ -325,7 +325,7 @@ describe("util/core/wrapMethod", function () {
     });
 
     it("mirrors function properties", function () {
-        var object = {
+        const object = {
             method: function () {
                 return;
             },
@@ -340,7 +340,7 @@ describe("util/core/wrapMethod", function () {
     });
 
     it("does not mirror and overwrite existing properties", function () {
-        var object = {
+        const object = {
             method: function () {
                 return;
             },
@@ -369,7 +369,7 @@ describe("util/core/wrapMethod", function () {
         });
 
         it("returns wrapper", function () {
-            var wrapper = wrapMethod(this.object, "method", function () {
+            const wrapper = wrapMethod(this.object, "method", function () {
                 return;
             });
 
@@ -399,7 +399,7 @@ describe("util/core/wrapMethod", function () {
         });
 
         it("wrap adds owned property", function () {
-            var wrapper = wrapMethod(this.object, "method", function () {
+            const wrapper = wrapMethod(this.object, "method", function () {
                 return;
             });
 

--- a/test/util/fake-timers-test.js
+++ b/test/util/fake-timers-test.js
@@ -1,14 +1,14 @@
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var fakeTimers = require("../../lib/sinon/util/fake-timers");
-var sinonStub = require("../../lib/sinon/stub");
-var sinonSpy = require("../../lib/sinon/spy");
+const referee = require("@sinonjs/referee");
+const fakeTimers = require("../../lib/sinon/util/fake-timers");
+const sinonStub = require("../../lib/sinon/stub");
+const sinonSpy = require("../../lib/sinon/spy");
 
-var assert = referee.assert;
-var refute = referee.refute;
-var GlobalDate = Date;
-var setImmediatePresent = typeof setImmediate === "function";
+const assert = referee.assert;
+const refute = referee.refute;
+const GlobalDate = Date;
+const setImmediatePresent = typeof setImmediate === "function";
 
 // `setTimeout` supports a string as the first argument, which we currently
 // support for historical reasons
@@ -20,7 +20,7 @@ var setImmediatePresent = typeof setImmediate === "function";
 function supportsCodeInSettimeout() {
     try {
         // eslint-disable-next-line no-implied-eval
-        var id = setTimeout("console.log('hello');", 100);
+        const id = setTimeout("console.log('hello');", 100);
         clearTimeout(id);
         return true;
     } catch (error) {
@@ -28,7 +28,7 @@ function supportsCodeInSettimeout() {
     }
 }
 
-var usesEvalInSettimeout = supportsCodeInSettimeout();
+const usesEvalInSettimeout = supportsCodeInSettimeout();
 
 describe("fakeTimers.clock", function () {
     beforeEach(function () {
@@ -46,7 +46,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("throws if no arguments", function () {
-            var clock = this.clock;
+            const clock = this.clock;
 
             assert.exception(function () {
                 clock.setTimeout();
@@ -55,25 +55,25 @@ describe("fakeTimers.clock", function () {
 
         it("returns a timer id whose primitive representation is a number", function () {
             // eslint-disable-next-line no-empty-function
-            var noop = function () {};
-            var result = this.clock.setTimeout(noop);
+            const noop = function () {};
+            const result = this.clock.setTimeout(noop);
 
             assert.isNumber(Number(result));
         });
 
         it("returns unique id", function () {
             // eslint-disable-next-line no-empty-function
-            var noop = function () {};
-            var id1 = this.clock.setTimeout(noop);
-            var id2 = this.clock.setTimeout(noop);
+            const noop = function () {};
+            const id1 = this.clock.setTimeout(noop);
+            const id2 = this.clock.setTimeout(noop);
 
             refute.equals(id2, id1);
         });
 
         it("sets timers on instance", function () {
-            var clock1 = fakeTimers.clock.create();
-            var clock2 = fakeTimers.clock.create();
-            var stubs = [sinonStub(), sinonStub()];
+            const clock1 = fakeTimers.clock.create();
+            const clock2 = fakeTimers.clock.create();
+            const stubs = [sinonStub(), sinonStub()];
 
             clock1.setTimeout(stubs[0], 100);
             clock2.setTimeout(stubs[1], 100);
@@ -85,7 +85,7 @@ describe("fakeTimers.clock", function () {
 
         if (!usesEvalInSettimeout) {
             it("throws on non-function callbacks", function () {
-                var string = "apple pie";
+                const string = "apple pie";
 
                 assert.exception(
                     function () {
@@ -100,8 +100,8 @@ describe("fakeTimers.clock", function () {
         }
 
         it("passes setTimeout parameters", function () {
-            var clock = fakeTimers.clock.create();
-            var stub = sinonStub();
+            const clock = fakeTimers.clock.create();
+            const stub = sinonStub();
 
             clock.setTimeout(stub, 2, "the first", "the second");
 
@@ -111,9 +111,9 @@ describe("fakeTimers.clock", function () {
         });
 
         it("calls correct timeout on recursive tick", function () {
-            var clock = fakeTimers.clock.create();
-            var stub = sinonStub();
-            var recurseCallback = function () {
+            const clock = fakeTimers.clock.create();
+            const stub = sinonStub();
+            const recurseCallback = function () {
                 clock.tick(100);
             };
 
@@ -132,7 +132,7 @@ describe("fakeTimers.clock", function () {
 
         if (typeof setImmediate === "function") {
             it("returns a timer whose primitive representation is a number", function () {
-                var result = this.clock.setImmediate(function () {
+                const result = this.clock.setImmediate(function () {
                     return;
                 });
 
@@ -140,7 +140,7 @@ describe("fakeTimers.clock", function () {
             });
 
             it("calls the given callback immediately", function () {
-                var stub = sinonStub();
+                const stub = sinonStub();
 
                 this.clock.setImmediate(stub);
                 this.clock.tick(0);
@@ -149,7 +149,7 @@ describe("fakeTimers.clock", function () {
             });
 
             it("throws if no arguments", function () {
-                var clock = this.clock;
+                const clock = this.clock;
 
                 assert.exception(function () {
                     clock.setImmediate();
@@ -157,9 +157,9 @@ describe("fakeTimers.clock", function () {
             });
 
             it("manages separate timers per clock instance", function () {
-                var clock1 = fakeTimers.clock.create();
-                var clock2 = fakeTimers.clock.create();
-                var stubs = [sinonStub(), sinonStub()];
+                const clock1 = fakeTimers.clock.create();
+                const clock2 = fakeTimers.clock.create();
+                const stubs = [sinonStub(), sinonStub()];
 
                 clock1.setImmediate(stubs[0]);
                 clock2.setImmediate(stubs[1]);
@@ -170,7 +170,7 @@ describe("fakeTimers.clock", function () {
             });
 
             it("passes extra parameters through to the callback", function () {
-                var stub = sinonStub();
+                const stub = sinonStub();
 
                 this.clock.setImmediate(stub, "value1", 2);
                 this.clock.tick(1);
@@ -191,9 +191,9 @@ describe("fakeTimers.clock", function () {
 
         if (typeof clearImmediate === "function") {
             it("removes immediate callbacks", function () {
-                var callback = sinonStub();
+                const callback = sinonStub();
 
-                var id = this.clock.setImmediate(callback);
+                const id = this.clock.setImmediate(callback);
                 this.clock.clearImmediate(id);
                 this.clock.tick(1);
 
@@ -216,7 +216,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("triggers immediately without specified delay", function () {
-            var stub = sinonStub();
+            const stub = sinonStub();
             this.clock.setTimeout(stub);
 
             this.clock.tick(0);
@@ -225,7 +225,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("does not trigger without sufficient delay", function () {
-            var stub = sinonStub();
+            const stub = sinonStub();
             this.clock.setTimeout(stub, 100);
             this.clock.tick(10);
 
@@ -233,7 +233,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("triggers after sufficient delay", function () {
-            var stub = sinonStub();
+            const stub = sinonStub();
             this.clock.setTimeout(stub, 100);
             this.clock.tick(100);
 
@@ -241,7 +241,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("triggers simultaneous timers", function () {
-            var spies = [sinonSpy(), sinonSpy()];
+            const spies = [sinonSpy(), sinonSpy()];
             this.clock.setTimeout(spies[0], 100);
             this.clock.setTimeout(spies[1], 100);
 
@@ -252,7 +252,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("triggers multiple simultaneous timers", function () {
-            var spies = [sinonSpy(), sinonSpy(), sinonSpy(), sinonSpy()];
+            const spies = [sinonSpy(), sinonSpy(), sinonSpy(), sinonSpy()];
             this.clock.setTimeout(spies[0], 100);
             this.clock.setTimeout(spies[1], 100);
             this.clock.setTimeout(spies[2], 99);
@@ -267,8 +267,8 @@ describe("fakeTimers.clock", function () {
         });
 
         it("triggers multiple simultaneous timers with zero callAt", function () {
-            var test = this;
-            var spies = [
+            const test = this;
+            const spies = [
                 sinonSpy(function () {
                     test.clock.setTimeout(spies[1], 0);
                 }),
@@ -289,7 +289,7 @@ describe("fakeTimers.clock", function () {
 
         it("waits after setTimeout was called", function () {
             this.clock.tick(100);
-            var stub = sinonStub();
+            const stub = sinonStub();
             this.clock.setTimeout(stub, 150);
             this.clock.tick(50);
 
@@ -299,7 +299,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("mini integration test", function () {
-            var stubs = [sinonStub(), sinonStub(), sinonStub()];
+            const stubs = [sinonStub(), sinonStub(), sinonStub()];
             this.clock.setTimeout(stubs[0], 100);
             this.clock.setTimeout(stubs[1], 120);
             this.clock.tick(10);
@@ -319,8 +319,8 @@ describe("fakeTimers.clock", function () {
         });
 
         it("triggers even when some throw", function () {
-            var clock = this.clock;
-            var stubs = [sinonStub().throws(), sinonStub()];
+            const clock = this.clock;
+            const stubs = [sinonStub().throws(), sinonStub()];
 
             clock.setTimeout(stubs[0], 100);
             clock.setTimeout(stubs[1], 120);
@@ -334,8 +334,8 @@ describe("fakeTimers.clock", function () {
         });
 
         it("calls function with global object or null (strict mode) as this", function () {
-            var clock = this.clock;
-            var stub = sinonStub().throws();
+            const clock = this.clock;
+            const stub = sinonStub().throws();
             clock.setTimeout(stub, 100);
 
             assert.exception(function () {
@@ -346,7 +346,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("triggers in the order scheduled", function () {
-            var spies = [sinonSpy(), sinonSpy()];
+            const spies = [sinonSpy(), sinonSpy()];
             this.clock.setTimeout(spies[0], 13);
             this.clock.setTimeout(spies[1], 11);
 
@@ -356,7 +356,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("creates updated Date while ticking", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
 
             this.clock.setInterval(function () {
                 spy(new Date().getTime());
@@ -378,7 +378,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("fires timer in intervals of 13", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             this.clock.setInterval(spy, 13);
 
             this.clock.tick(500);
@@ -389,8 +389,8 @@ describe("fakeTimers.clock", function () {
         it("fires timers in correct order", function () {
             this.timeout(5000);
 
-            var spy13 = sinonSpy();
-            var spy10 = sinonSpy();
+            const spy13 = sinonSpy();
+            const spy10 = sinonSpy();
 
             this.clock.setInterval(function () {
                 spy13(new Date().getTime());
@@ -413,7 +413,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("triggers timeouts and intervals in the order scheduled", function () {
-            var spies = [sinonSpy(), sinonSpy()];
+            const spies = [sinonSpy(), sinonSpy()];
             this.clock.setInterval(spies[0], 10);
             this.clock.setTimeout(spies[1], 50);
 
@@ -425,8 +425,9 @@ describe("fakeTimers.clock", function () {
         });
 
         it("does not fire canceled intervals", function () {
-            var id;
-            var callback = sinonSpy(function () {
+            // eslint-disable-next-line prefer-const
+            let id;
+            const callback = sinonSpy(function () {
                 if (callback.callCount === 3) {
                     clearInterval(id);
                 }
@@ -439,7 +440,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("passes 6 seconds", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             this.clock.setInterval(spy, 4000);
 
             this.clock.tick("08");
@@ -448,7 +449,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("passes 1 minute", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             this.clock.setInterval(spy, 6000);
 
             this.clock.tick("01:00");
@@ -459,7 +460,7 @@ describe("fakeTimers.clock", function () {
         it("passes 2 hours, 34 minutes and 12 seconds", function () {
             this.timeout(50000);
 
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             this.clock.setInterval(spy, 10000);
 
             this.clock.tick("02:34:10");
@@ -468,9 +469,9 @@ describe("fakeTimers.clock", function () {
         });
 
         it("throws for invalid format", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             this.clock.setInterval(spy, 10000);
-            var test = this;
+            const test = this;
 
             assert.exception(function () {
                 test.clock.tick("12:02:34:10");
@@ -480,9 +481,9 @@ describe("fakeTimers.clock", function () {
         });
 
         it("throws for invalid minutes", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             this.clock.setInterval(spy, 10000);
-            var test = this;
+            const test = this;
 
             assert.exception(function () {
                 test.clock.tick("67:10");
@@ -492,9 +493,9 @@ describe("fakeTimers.clock", function () {
         });
 
         it("throws for negative minutes", function () {
-            var spy = sinonSpy();
+            const spy = sinonSpy();
             this.clock.setInterval(spy, 10000);
-            var test = this;
+            const test = this;
 
             assert.exception(function () {
                 test.clock.tick("-7:10");
@@ -510,10 +511,10 @@ describe("fakeTimers.clock", function () {
         });
 
         it("fires nested setTimeout calls properly", function () {
-            var i = 0;
-            var clock = this.clock;
+            let i = 0;
+            const clock = this.clock;
 
-            var callback = function () {
+            const callback = function () {
                 ++i;
                 clock.setTimeout(function () {
                     callback();
@@ -528,7 +529,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("does not silently catch exceptions", function () {
-            var clock = this.clock;
+            const clock = this.clock;
 
             clock.setTimeout(function () {
                 throw new Error("oh no!");
@@ -540,8 +541,8 @@ describe("fakeTimers.clock", function () {
         });
 
         it("returns the current now value", function () {
-            var clock = this.clock;
-            var value = clock.tick(200);
+            const clock = this.clock;
+            const value = clock.tick(200);
             assert.equals(clock.now, value);
         });
     });
@@ -552,8 +553,8 @@ describe("fakeTimers.clock", function () {
         });
 
         it("removes timeout", function () {
-            var stub = sinonStub();
-            var id = this.clock.setTimeout(stub, 50);
+            const stub = sinonStub();
+            const id = this.clock.setTimeout(stub, 50);
             this.clock.clearTimeout(id);
             this.clock.tick(50);
 
@@ -572,7 +573,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("empties timeouts queue", function () {
-            var stub = sinonStub();
+            const stub = sinonStub();
             this.clock.setTimeout(stub);
             this.clock.reset();
             this.clock.tick(0);
@@ -587,7 +588,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("throws if no arguments", function () {
-            var clock = this.clock;
+            const clock = this.clock;
 
             assert.exception(function () {
                 clock.setInterval();
@@ -596,23 +597,23 @@ describe("fakeTimers.clock", function () {
 
         it("returns a timer whose primitive representation is a number", function () {
             // eslint-disable-next-line no-empty-function
-            var noop = function () {};
-            var result = this.clock.setInterval(noop);
+            const noop = function () {};
+            const result = this.clock.setInterval(noop);
 
             assert.isNumber(Number(result));
         });
 
         it("returns unique id", function () {
             // eslint-disable-next-line no-empty-function
-            var noop = function () {};
-            var id1 = this.clock.setInterval(noop);
-            var id2 = this.clock.setInterval(noop);
+            const noop = function () {};
+            const id1 = this.clock.setInterval(noop);
+            const id2 = this.clock.setInterval(noop);
 
             refute.equals(id2, id1);
         });
 
         it("schedules recurring timeout", function () {
-            var stub = sinonStub();
+            const stub = sinonStub();
             this.clock.setInterval(stub, 10);
             this.clock.tick(99);
 
@@ -620,9 +621,10 @@ describe("fakeTimers.clock", function () {
         });
 
         it("does not schedule recurring timeout when cleared", function () {
-            var clock = this.clock;
-            var id;
-            var stub = sinonSpy(function () {
+            const clock = this.clock;
+            // eslint-disable-next-line
+            let id;
+            const stub = sinonSpy(function () {
                 if (stub.callCount === 3) {
                     clock.clearInterval(id);
                 }
@@ -635,8 +637,8 @@ describe("fakeTimers.clock", function () {
         });
 
         it("passes setTimeout parameters", function () {
-            var clock = fakeTimers.clock.create();
-            var stub = sinonStub();
+            const clock = fakeTimers.clock.create();
+            const stub = sinonStub();
 
             clock.setInterval(stub, 2, "the first", "the second");
 
@@ -662,19 +664,19 @@ describe("fakeTimers.clock", function () {
         });
 
         it("creates real Date objects", function () {
-            var date = new this.clock.Date();
+            const date = new this.clock.Date();
 
             assert(Date.prototype.isPrototypeOf(date));
         });
 
         it("creates date strings when called as function", function () {
-            var date = this.clock.Date();
+            const date = this.clock.Date();
 
             assert.isString(date);
         });
 
         it("creates real Date objects when Date constructor is gone", function () {
-            var realDate = new Date();
+            const realDate = new Date();
 
             // eslint-disable-next-line no-global-assign, no-native-reassign
             Date = function () {
@@ -684,7 +686,7 @@ describe("fakeTimers.clock", function () {
                 return;
             };
 
-            var date = new this.clock.Date();
+            const date = new this.clock.Date();
 
             // restore directly after use, because tearDown is async in buster-next and
             // the overridden Date is used in node 0.x native code
@@ -697,64 +699,64 @@ describe("fakeTimers.clock", function () {
         });
 
         it("creates Date objects representing clock time", function () {
-            var date = new this.clock.Date();
+            const date = new this.clock.Date();
 
             assert.equals(date.getTime(), new Date(this.now).getTime());
         });
 
         it("listens to ticking clock", function () {
-            var date1 = new this.clock.Date();
+            const date1 = new this.clock.Date();
             this.clock.tick(3);
-            var date2 = new this.clock.Date();
+            const date2 = new this.clock.Date();
 
             assert.equals(date2.getTime() - date1.getTime(), 3);
         });
 
         it("creates regular date when passing timestamp", function () {
-            var date = new Date();
-            var fakeDate = new this.clock.Date(date.getTime());
+            const date = new Date();
+            const fakeDate = new this.clock.Date(date.getTime());
 
             assert.equals(fakeDate.getTime(), date.getTime());
         });
 
         it("creates regular date when passing year, month", function () {
-            var date = new Date(2010, 4);
-            var fakeDate = new this.clock.Date(2010, 4);
+            const date = new Date(2010, 4);
+            const fakeDate = new this.clock.Date(2010, 4);
 
             assert.equals(fakeDate.getTime(), date.getTime());
         });
 
         it("creates regular date when passing y, m, d", function () {
-            var date = new Date(2010, 4, 2);
-            var fakeDate = new this.clock.Date(2010, 4, 2);
+            const date = new Date(2010, 4, 2);
+            const fakeDate = new this.clock.Date(2010, 4, 2);
 
             assert.equals(fakeDate.getTime(), date.getTime());
         });
 
         it("creates regular date when passing y, m, d, h", function () {
-            var date = new Date(2010, 4, 2, 12);
-            var fakeDate = new this.clock.Date(2010, 4, 2, 12);
+            const date = new Date(2010, 4, 2, 12);
+            const fakeDate = new this.clock.Date(2010, 4, 2, 12);
 
             assert.equals(fakeDate.getTime(), date.getTime());
         });
 
         it("creates regular date when passing y, m, d, h, m", function () {
-            var date = new Date(2010, 4, 2, 12, 42);
-            var fakeDate = new this.clock.Date(2010, 4, 2, 12, 42);
+            const date = new Date(2010, 4, 2, 12, 42);
+            const fakeDate = new this.clock.Date(2010, 4, 2, 12, 42);
 
             assert.equals(fakeDate.getTime(), date.getTime());
         });
 
         it("creates regular date when passing y, m, d, h, m, s", function () {
-            var date = new Date(2010, 4, 2, 12, 42, 53);
-            var fakeDate = new this.clock.Date(2010, 4, 2, 12, 42, 53);
+            const date = new Date(2010, 4, 2, 12, 42, 53);
+            const fakeDate = new this.clock.Date(2010, 4, 2, 12, 42, 53);
 
             assert.equals(fakeDate.getTime(), date.getTime());
         });
 
         it("creates regular date when passing y, m, d, h, m, s, ms", function () {
-            var date = new Date(2010, 4, 2, 12, 42, 53, 498);
-            var fakeDate = new this.clock.Date(2010, 4, 2, 12, 42, 53, 498);
+            const date = new Date(2010, 4, 2, 12, 42, 53, 498);
+            const fakeDate = new this.clock.Date(2010, 4, 2, 12, 42, 53, 498);
 
             assert.equals(fakeDate.getTime(), date.getTime());
         });
@@ -891,7 +893,7 @@ describe("fakeTimers.clock", function () {
 
         it("replaces global setTimeout", function () {
             this.clock = fakeTimers.useFakeTimers();
-            var stub = sinonStub();
+            const stub = sinonStub();
 
             setTimeout(stub, 1000);
             this.clock.tick(1000);
@@ -909,7 +911,7 @@ describe("fakeTimers.clock", function () {
 
         it("replaces global clearTimeout", function () {
             this.clock = fakeTimers.useFakeTimers();
-            var stub = sinonStub();
+            const stub = sinonStub();
 
             clearTimeout(setTimeout(stub, 1000));
             this.clock.tick(1000);
@@ -919,7 +921,7 @@ describe("fakeTimers.clock", function () {
 
         it("restores global setTimeout", function () {
             this.clock = fakeTimers.useFakeTimers();
-            var stub = sinonStub();
+            const stub = sinonStub();
             this.clock.restore();
 
             this.timer = setTimeout(stub, 1000);
@@ -939,7 +941,7 @@ describe("fakeTimers.clock", function () {
 
         it("replaces global setInterval", function () {
             this.clock = fakeTimers.useFakeTimers();
-            var stub = sinonStub();
+            const stub = sinonStub();
 
             setInterval(stub, 500);
             this.clock.tick(1000);
@@ -949,7 +951,7 @@ describe("fakeTimers.clock", function () {
 
         it("replaces global clearInterval", function () {
             this.clock = fakeTimers.useFakeTimers();
-            var stub = sinonStub();
+            const stub = sinonStub();
 
             clearInterval(setInterval(stub, 500));
             this.clock.tick(1000);
@@ -959,7 +961,7 @@ describe("fakeTimers.clock", function () {
 
         it("restores global setInterval", function () {
             this.clock = fakeTimers.useFakeTimers();
-            var stub = sinonStub();
+            const stub = sinonStub();
             this.clock.restore();
 
             this.timer = setInterval(stub, 1000);
@@ -983,7 +985,7 @@ describe("fakeTimers.clock", function () {
             }
 
             this.clock = fakeTimers.useFakeTimers();
-            var stub = sinonStub();
+            const stub = sinonStub();
             this.clock.restore();
 
             this.timer = setImmediate(stub);
@@ -1067,7 +1069,7 @@ describe("fakeTimers.clock", function () {
 
         it("fakes Date constructor", function () {
             this.clock = fakeTimers.useFakeTimers(0);
-            var now = new Date();
+            const now = new Date();
 
             refute.same(Date, fakeTimers.timers.Date);
             assert.equals(now.getTime(), 0);
@@ -1097,7 +1099,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("mirrors custom Date properties", function () {
-            var f = function () {
+            const f = function () {
                 return;
             };
             this.global.Date.format = f;
@@ -1154,7 +1156,7 @@ describe("fakeTimers.clock", function () {
 
             it("installs by default without nextTick", function () {
                 this.clock = fakeTimers.useFakeTimers();
-                var called = false;
+                let called = false;
                 process.nextTick(function () {
                     called = true;
                 });
@@ -1165,7 +1167,7 @@ describe("fakeTimers.clock", function () {
 
             it("installs with nextTick", function () {
                 this.clock = fakeTimers.useFakeTimers({ toFake: ["nextTick"] });
-                var called = false;
+                let called = false;
                 process.nextTick(function () {
                     called = true;
                 });
@@ -1188,9 +1190,9 @@ describe("fakeTimers.clock", function () {
 
         it("installs clock in advancing mode and triggers setInterval", function (done) {
             this.clock = fakeTimers.useFakeTimers({ shouldAdvanceTime: true });
-            var counter = 0;
-            var iterations = 3;
-            var id = this.clock.setInterval(
+            let counter = 0;
+            const iterations = 3;
+            const id = this.clock.setInterval(
                 function () {
                     if (counter++ < iterations) {
                         return;
@@ -1218,7 +1220,7 @@ describe("fakeTimers.clock", function () {
         });
 
         it("throws on old useFakeTimers signatures", function () {
-            var expectedError =
+            const expectedError =
                 "useFakeTimers expected epoch or config object. See https://github.com/sinonjs/sinon";
 
             assert.exception(
@@ -1255,8 +1257,8 @@ describe("fakeTimers.clock", function () {
         });
 
         it("supports a way to pass the global context", function () {
-            var stub = sinonStub();
-            var globalCtx = {
+            const stub = sinonStub();
+            const globalCtx = {
                 Date: sinonStub(),
                 setTimeout: stub,
                 clearTimeout: sinonStub(),

--- a/test/webworker/webworker-script.js
+++ b/test/webworker/webworker-script.js
@@ -6,7 +6,7 @@
 if (typeof importScripts !== "undefined") {
     importScripts("/pkg/sinon.js");
 
-    var mySpy = sinon.spy(function (msg) {
+    const mySpy = sinon.spy(function (msg) {
         return `worker received:${msg}`;
     });
 

--- a/test/webworker/webworker-support-assessment.js
+++ b/test/webworker/webworker-support-assessment.js
@@ -2,14 +2,14 @@
 /* eslint-disable jsdoc/require-jsdoc */
 "use strict";
 
-var referee = require("@sinonjs/referee");
-var assert = referee.assert;
+const referee = require("@sinonjs/referee");
+const assert = referee.assert;
 
 if (typeof Worker !== "undefined") {
     describe("WebWorker support", function () {
-        var sentMessage = "whatever";
+        const sentMessage = "whatever";
         it("should not crash", function (done) {
-            var worker = new Worker("/test/webworker/webworker-script.js");
+            const worker = new Worker("/test/webworker/webworker-script.js");
 
             worker.onmessage = function (msg) {
                 // eslint-disable-next-line no-restricted-syntax
@@ -26,8 +26,8 @@ if (typeof Worker !== "undefined") {
              * @see https://html.spec.whatwg.org/multipage/webappapis.html#errorevent
              */
             function onError(ev) {
-                var error = ev.error;
-                var msg = `An error happened at line ${[
+                const error = ev.error;
+                const msg = `An error happened at line ${[
                     ev.lineno,
                     ev.colno,
                 ].join(":")} in file ${ev.filename}:  ${ev.message}`;

--- a/test/webworker/webworker-support-assessment.js
+++ b/test/webworker/webworker-support-assessment.js
@@ -26,7 +26,7 @@ if (typeof Worker !== "undefined") {
              * @see https://html.spec.whatwg.org/multipage/webappapis.html#errorevent
              */
             function onError(ev) {
-                const error = ev.error;
+                let error = ev.error;
                 const msg = `An error happened at line ${[
                     ev.lineno,
                     ev.colno,


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This simply updates our codebase to consistenly use `const` and `let` everywhere.

Modified the 5to6codemod in doing so. The ES Module codemod involves quite a bit more, so I will let that hang for a while ... 