### PR TITLE
Handling non-configurable object descriptors on the prototype

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -134,7 +134,7 @@ function assertValidPropertyDescriptor(descriptor, property) {
     if (!descriptor || !property) {
         return;
     }
-    if (!descriptor.configurable && !descriptor.writable) {
+    if (descriptor.isOwn && !descriptor.configurable && !descriptor.writable) {
         throw new TypeError(
             `Descriptor for property ${property} is non-configurable and non-writable`
         );

--- a/lib/sinon/util/core/wrap-method.js
+++ b/lib/sinon/util/core/wrap-method.js
@@ -137,6 +137,7 @@ module.exports = function wrapMethod(object, property, method) {
         for (i = 0; i < types.length; i++) {
             mirrorProperties(methodDesc[types[i]], wrappedMethodDesc[types[i]]);
         }
+        methodDesc.configurable = true;
         Object.defineProperty(object, property, methodDesc);
 
         // catch failing assignment

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -825,9 +825,7 @@ describe("issues", function () {
 
     describe("#2491 - unable to restore spies on an instance where the prototype has an unconfigurable property descriptor", function () {
         function createInstanceFromClassWithReadOnlyPropertyDescriptor() {
-            class BaseClass {
-                instanceProperty = 1;
-            }
+            class BaseClass {}
             Object.defineProperty(BaseClass.prototype, "aMethod", {
                 value: function () {
                     return 42;

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -822,4 +822,25 @@ describe("issues", function () {
             assert.isTrue(fooStubInstance.wasCalled);
         });
     });
+
+    describe("#2491 - unable to restore stubs on an instance where the prototype has an unconfigurable property descriptor", function () {
+        it("should ensure object descriptors are always configurable", function () {
+            class BaseClass {}
+            Object.defineProperty(BaseClass.prototype, "aMethod", {
+                value: function () {
+                    return 42;
+                },
+            });
+
+            // anchor
+            const instance = new BaseClass();
+            assert.isFunction(instance.aMethod);
+            assert.equals(instance.aMethod(), 42);
+            this.sandbox.spy(instance, "aMethod")
+
+            refute.exception(() => {
+                this.sandbox.restore(); // #2491: this throws "TypeError: Cannot assign to read only property 'myMethod' of object '#<BaseClass>'"
+           });
+        });
+    });
 });

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -874,17 +874,5 @@ describe("issues", function () {
                 mock.expects("aMethod").once();
             });
         });
-
-        it("should not throw if the unconfigurable object descriptor to be used for a Fake is on the prototype", function () {
-            const instance =
-                createInstanceFromClassWithReadOnlyPropertyDescriptor();
-
-            // per #2491 this throws "TypeError: Cannot assign to read only property 'aMethod' of object '#<BaseClass>'"
-            // that makes sense for descriptors taken from the object, but not its prototype, as we are free to change
-            // the latter when setting it
-            refute.exception(() => {
-                this.sandbox.replace(instance, "aMethod", sinon.fake());
-            });
-        });
     });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix for #2491 where it seems that we fail to restore spies set on instances if their prototypes have unconfigurable property descriptors.

 #### Background (Problem in detail)  - optional
A property descriptor must have `configurable: true` set for us to be able to restore it. If we get the property descriptor from a prototype we should be free to modify this to whatever we want.

_This is work in progress, as I hit issues when trying to achieve consistency for spies, stubs, mocks and fakes._

Fixing this in `wrap-method.js` only fixes the issue for _spies_ as we deal with the issues in four different ways:

**stubs**
Even though this module is also imported by the `stubs` module it fails for stubs _before_ getting to the `wrapMethod` call, as it has checks of their own on the object descriptors: `Descriptor for property aMethod is non-configurable and non-writable`

**mocks**
`wrap-method` is also used by the `mock` module, but it also fails before getting to it: `Attempted to wrap undefined property myMethod as function`

**fakes / sandbox.replace()**
Fakes do not implement anything to do with replacing properties themselves and leave that to `Sandbox#replace`, which fails with `Cannot assign to read only property 'aMethod' of object '#<BaseClass>'`. ~The "weird" thing here is that we do not use any of the old `wrap-method` logic and instead have resorted to build new functionality for restoring. I am not sure why.~ 
EDIT: by intent. See discussion in #2195

![image](https://user-images.githubusercontent.com/618076/233308924-51feb430-9bca-4c7e-aa7a-bd1178c7c632.png)

 #### Solution  - optional
Setting `configurable: true` in wrap-method was only helpful for spies. 

These are my thoughts for further work in this PR
- The `Descriptor for property aMethod is non-configurable and non-writable` check is good and could be re-used elsewhere, but it needs to _only apply to cases where the descriptor comes from the object,_ not its prototype. We can use the `isOwn` property from `get-property-descriptor.js` to do this.
- Could the also perhaps be moved to `wrap-method` so that it would also be used for spies?
- I am not sure why the mocks logic is not using any of the above (wrap-method) for spies and stubs. Probably should
- `Sandbox#replace` _probably_ should not use `wrap-method`, as it seems to have simplified the use-cases. Not sure though

#### How to verify - mandatory

1. Check out this branch
2. `npm i; npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

**`isOwn` and `shadowsPropOnPrototype` is relevant**
![image](https://user-images.githubusercontent.com/618076/233317897-eed3c899-9bbd-493d-ad59-69b541660b49.png)

