### PR TITLE
docs: Remove threw(obj) from docs

### DIFF
--- a/docs/release-source/release/spies.md
+++ b/docs/release-source/release/spies.md
@@ -282,10 +282,6 @@ Returns `true` if spy threw an exception at least once.
 
 Returns `true` if spy threw an exception of the provided type at least once.
 
-#### `spy.threw(obj);`
-
-Returns `true` if spy threw the provided exception object at least once.
-
 #### `spy.alwaysThrew();`
 
 Returns `true` if spy always threw an exception.
@@ -293,10 +289,6 @@ Returns `true` if spy always threw an exception.
 #### `spy.alwaysThrew("TypeError");`
 
 Returns `true` if spy always threw an exception of the provided type.
-
-#### `spy.alwaysThrew(obj);`
-
-Returns `true` if spy always threw the provided exception object.
 
 #### `spy.returned(obj);`
 


### PR DESCRIPTION
Since the introduction of threw in 0feec9ffba0da6bc2996cefa0c6e71872e8bedb2, no one have reported that `threw(obj)` doesn't work as the documentation states.

```js
const sinon = require("sinon");
const o = { pie: "apple" };
const f = sinon.fake.throws(o);

f();
// this is supposed to return true
f.threw(o);
// => false
```

Since it has been 12+ years without an error report, it's safe to assume that no one uses the `threw` method in this way. Let's remove it from the documentation.