### PR TITLE
Support callable instances

### DIFF
--- a/lib/sinon/proxy-invoke.js
+++ b/lib/sinon/proxy-invoke.js
@@ -43,7 +43,7 @@ module.exports = function invoke(func, thisValue, args) {
                 concat([thisValue], args)
             ))();
 
-            if (typeof returnValue !== "object") {
+            if (typeof returnValue !== "object" && typeof returnValue !== "function") {
                 returnValue = thisValue;
             }
         } else {

--- a/test/proxy-call-test.js
+++ b/test/proxy-call-test.js
@@ -1246,6 +1246,44 @@ describe("sinonSpy.call", function () {
         });
     });
 
+    describe("constructor return", function () {
+        it("preserves returned object", function () {
+            const customReturn = {}
+            function CustomConstructor () { return customReturn }
+            const SpiedCustomConstructor = sinonSpy(CustomConstructor)
+            const myInstance = new SpiedCustomConstructor()
+
+            assert(myInstance === customReturn)
+        })
+
+        it("allows explicit returned object", function () {
+            const StubConstructor = sinonStub()
+            const customReturn = {}
+            StubConstructor.returns(customReturn)
+            const myInstance = new StubConstructor()
+
+            assert(myInstance === customReturn)
+        })
+
+        it("preserves returned function", function () {
+            function customReturn () {} // eslint-disable-line no-empty-function
+            function CustomConstructor () { return customReturn }
+            const SpiedCustomConstructor = sinonSpy(CustomConstructor)
+            const myInstance = new SpiedCustomConstructor()
+
+            assert(myInstance === customReturn)
+        })
+
+        it("allows explicit returned function", function () {
+            const StubConstructor = sinonStub()
+            function customReturn () {} // eslint-disable-line no-empty-function
+            StubConstructor.returns(customReturn)
+            const myInstance = new StubConstructor()
+
+            assert(myInstance === customReturn)
+        })
+    })
+
     describe("functions", function () {
         it("throws if spying on non-existent property", function () {
             const myObj = {};


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Support callable instances
Closes #2516

#### Background (Problem in detail)

Enables testing constructors that return functions. #2516 has further description.

#### Solution  - optional

The constructor return value seems to be checked in `proxy-invoke.js`. This expands the `typeof` check to include functions.

```js
if (typeof returnValue !== "object" && typeof returnValue !== "function") {
  returnValue = thisValue;
}
```

This works for my code in a local patched version. Tests are included to verify.

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

You can verify manually by running this code from the checkout root. Output should be `true`.

```js
import sinon from './pkg/sinon-esm.js'
function CallableInstance () { return () => {} }
const SpiedCallableInstance = sinon.spy(CallableInstance)
const callable = new SpiedCallableInstance()
console.log(typeof callable === 'function')
```

```
$ nano test.js
true
```

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
