### PR TITLE
fix: bundling compatibility with webpack@5

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "LICENSE",
     "README.md"
   ],
-  "browser": "./pkg/sinon-esm.js",
+  "browser": "./lib/sinon.js",
   "main": "./lib/sinon.js",
   "module": "./pkg/sinon-esm.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -116,11 +116,12 @@
     "LICENSE",
     "README.md"
   ],
-  "browser": "./lib/sinon.js",
+  "browser": "./pkg/sinon-esm.js",
   "main": "./lib/sinon.js",
   "module": "./pkg/sinon-esm.js",
   "exports": {
     ".": {
+      "browser": "./pkg/sinon-esm.js",
       "require": "./lib/sinon.js",
       "import": "./pkg/sinon-esm.js"
     },


### PR DESCRIPTION
#### Purpose (TL;DR)
Ensure sinon bundles nicely for browsers without any errors or warnings.
https://github.com/sinonjs/sinon/issues/2411 re-fixed (after "exports" were added I think).

#### Background

When using webpack v5 to bundle cjs code that calls `require('sinon')`, it would have defaulted to "exports->require" and fail with multiple node API errors/warnings (util, timers, etc.).

This patch ensures that anyone who bundles sinon with a bundler that respects "exports" gets the (browser-compatible) esm version.

Tested on both webpack v5 and v4. should be noted that v4 worked even without this patch, as it automatically injected polyfills.  webpack@5 no longer does so.

#### Solution

The esm version bundles without any errors/warnings, so make sure bundlers pick that one up.

#### How to verify

Use the same steps to reproduce in https://github.com/sinonjs/sinon/issues/2411
Modify the node_modules with this patch and rerun ` npx webpack --mode development`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
