### PR TITLE
Fix issue 2534: spies are not restored

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -218,6 +218,7 @@ function Sandbox() {
                 delete object[property];
             }
         }
+
         restorer.object = object;
         restorer.property = property;
         return restorer;
@@ -263,7 +264,7 @@ function Sandbox() {
             throw new TypeError(
                 `Cannot replace ${typeof object[
                     property
-                ]} with ${typeof replacement}`
+                    ]} with ${typeof replacement}`
             );
         }
 
@@ -355,8 +356,7 @@ function Sandbox() {
     };
 
     function commonPostInitSetup(args, spy) {
-        const object = args[0];
-        const property = args[1];
+        const [object, property, types] = args;
 
         const isSpyingOnEntireObject =
             typeof property === "undefined" && typeof object === "object";
@@ -369,6 +369,11 @@ function Sandbox() {
             });
 
             usePromiseLibrary(promiseLib, ownMethods);
+        } else if (Array.isArray(types)) {
+            for(const accessorType of types) {
+                addToCollection(spy[accessorType])
+                usePromiseLibrary(promiseLib, spy[accessorType]);
+            }
         } else {
             addToCollection(spy);
             usePromiseLibrary(promiseLib, spy);

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -264,7 +264,7 @@ function Sandbox() {
             throw new TypeError(
                 `Cannot replace ${typeof object[
                     property
-                    ]} with ${typeof replacement}`
+                ]} with ${typeof replacement}`
             );
         }
 
@@ -370,8 +370,8 @@ function Sandbox() {
 
             usePromiseLibrary(promiseLib, ownMethods);
         } else if (Array.isArray(types)) {
-            for(const accessorType of types) {
-                addToCollection(spy[accessorType])
+            for (const accessorType of types) {
+                addToCollection(spy[accessorType]);
                 usePromiseLibrary(promiseLib, spy[accessorType]);
             }
         } else {

--- a/lib/sinon/util/core/get-property-descriptor.js
+++ b/lib/sinon/util/core/get-property-descriptor.js
@@ -8,7 +8,6 @@
  * days for that reason (and the fact that JSDoc is essentially unmaintained)
  */
 
-
 /**
  * @typedef {{isOwn: boolean} & PropertyDescriptor} SinonPropertyDescriptor
  * a slightly enriched property descriptor
@@ -33,7 +32,7 @@ function getPropertyDescriptor(object, property) {
     while (
         proto &&
         !(descriptor = Object.getOwnPropertyDescriptor(proto, property))
-        ) {
+    ) {
         proto = Object.getPrototypeOf(proto);
     }
 

--- a/lib/sinon/util/core/get-property-descriptor.js
+++ b/lib/sinon/util/core/get-property-descriptor.js
@@ -1,6 +1,29 @@
 "use strict";
 
-module.exports = function getPropertyDescriptor(object, property) {
+/* eslint-disable jsdoc/valid-types */
+/*
+ * The following type def is strictly an illegal JSDoc, but the expression forms a
+ * legal Typescript union type and is understood by Visual Studio and the IntelliJ
+ * family of editors. The "TS" flavor of JSDoc is becoming the de-facto standard these
+ * days for that reason (and the fact that JSDoc is essentially unmaintained)
+ */
+
+
+/**
+ * @typedef {{isOwn: boolean} & PropertyDescriptor} SinonPropertyDescriptor
+ * a slightly enriched property descriptor
+ * @property {boolean} isOwn true if the descriptor is owned by this object, false if it comes from the prototype
+ */
+/* eslint-enable jsdoc/valid-types */
+
+/**
+ * Returns a slightly modified property descriptor that one can tell is from the object or the prototype
+ *
+ * @param {*} object
+ * @param {string} property
+ * @returns {SinonPropertyDescriptor}
+ */
+function getPropertyDescriptor(object, property) {
     let proto = object;
     let descriptor;
     const isOwn = Boolean(
@@ -10,7 +33,7 @@ module.exports = function getPropertyDescriptor(object, property) {
     while (
         proto &&
         !(descriptor = Object.getOwnPropertyDescriptor(proto, property))
-    ) {
+        ) {
         proto = Object.getPrototypeOf(proto);
     }
 
@@ -19,4 +42,6 @@ module.exports = function getPropertyDescriptor(object, property) {
     }
 
     return descriptor;
-};
+}
+
+module.exports = getPropertyDescriptor;

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -899,4 +899,17 @@ describe("issues", function () {
             this.sandbox.restore();
         });
     });
+
+    it("#2534 - spies on accessors are not being cleaned up", function() {
+        const object = {
+            get prop(){ return "bar"},
+        };
+        const spy = sinon.spy(object, "prop", ["get"]);
+        /* eslint-disable no-unused-expressions */
+        object.prop;
+        assert.equals(spy.get.callCount,1);
+        sinon.restore();
+        object.prop;
+        assert.equals(spy.get.callCount,1); // should remain unchanged
+    })
 });

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -900,16 +900,18 @@ describe("issues", function () {
         });
     });
 
-    it("#2534 - spies on accessors are not being cleaned up", function() {
+    it("#2534 - spies on accessors are not being cleaned up", function () {
         const object = {
-            get prop(){ return "bar"},
+            get prop() {
+                return "bar";
+            },
         };
         const spy = sinon.spy(object, "prop", ["get"]);
         /* eslint-disable no-unused-expressions */
         object.prop;
-        assert.equals(spy.get.callCount,1);
+        assert.equals(spy.get.callCount, 1);
         sinon.restore();
         object.prop;
-        assert.equals(spy.get.callCount,1); // should remain unchanged
-    })
+        assert.equals(spy.get.callCount, 1); // should remain unchanged
+    });
 });

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -2205,7 +2205,7 @@ describe("Sandbox", function () {
             assert.equals(object.prop, "blabla");
         });
 
-        it("allows restoring setters", function () {
+        it("allows putting setters on fields and subsequently restoring them", function () {
             const object = {
                 prop: "bar",
             };
@@ -2220,6 +2220,34 @@ describe("Sandbox", function () {
             object.prop = "bla";
 
             assert.equals(object.prop, "bla");
+        })
+
+        it("allows replacing setters on fields and subsequently restoring them", function () {
+            const object = {
+                get prop(){ return "bar"},
+            };
+
+            const sandbox = new Sandbox();
+            const getter = sandbox.spy(() => "foobar");
+            sandbox.stub(object, "prop").get(getter);
+            assert.equals(object.prop, "foobar");
+            assert.equals(getter.callCount,1);
+
+
+            sandbox.restore();
+            assert.equals(object.prop, "bar");
+        });
+
+        it("allows spying on accessors and subsequently restoring them", function () {
+            const object = {
+                get prop(){ return "bar"},
+            };
+            const sandbox = new Sandbox();
+            const spy = sandbox.spy(object, "prop", ["get"]);
+            sandbox.restore();
+            const descriptor = Object.getOwnPropertyDescriptor(object, "prop");
+            const getter = descriptor.get
+            refute.equals(getter,spy.get);
         });
     });
 

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -2220,19 +2220,20 @@ describe("Sandbox", function () {
             object.prop = "bla";
 
             assert.equals(object.prop, "bla");
-        })
+        });
 
         it("allows replacing setters on fields and subsequently restoring them", function () {
             const object = {
-                get prop(){ return "bar"},
+                get prop() {
+                    return "bar";
+                },
             };
 
             const sandbox = new Sandbox();
             const getter = sandbox.spy(() => "foobar");
             sandbox.stub(object, "prop").get(getter);
             assert.equals(object.prop, "foobar");
-            assert.equals(getter.callCount,1);
-
+            assert.equals(getter.callCount, 1);
 
             sandbox.restore();
             assert.equals(object.prop, "bar");
@@ -2240,14 +2241,16 @@ describe("Sandbox", function () {
 
         it("allows spying on accessors and subsequently restoring them", function () {
             const object = {
-                get prop(){ return "bar"},
+                get prop() {
+                    return "bar";
+                },
             };
             const sandbox = new Sandbox();
             const spy = sandbox.spy(object, "prop", ["get"]);
             sandbox.restore();
             const descriptor = Object.getOwnPropertyDescriptor(object, "prop");
-            const getter = descriptor.get
-            refute.equals(getter,spy.get);
+            const getter = descriptor.get;
+            refute.equals(getter, spy.get);
         });
     });
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix issue #2534 by ensuring spies on accessors are explicitly added to the sandbox collection

 #### Background (Problem in detail)  - optional
See #2534

#### How to verify - mandatory

Run the tests

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
