### PR TITLE
Enable use of assignment in the presence of accessors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,7 @@ docs/releases/
 docs/_releases/
 docs/assets/js/
 docs/vendor
+vendor/
 
 # has linting of its own
 docs/release-source/release/examples

--- a/docs/release-source/release.md
+++ b/docs/release-source/release.md
@@ -36,5 +36,5 @@ If you need to support old runtimes you can try [Sinon 9][compat-doc-v9].
 
 {% include docs/contribute.md %}
 
-[compat-doc]: https://github.com/sinonjs/sinon/COMPATIBILITY.md
+[compat-doc]: https://github.com/sinonjs/sinon/blob/main/COMPATIBILITY.md
 [compat-doc-v9]: https://github.com/sinonjs/sinon/blob/v9.2.4/COMPATIBILITY.md

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -236,7 +236,7 @@ console.log(myObject.myMethod());
 // strawberry
 ```
 
-#### `sandbox.replace.usingAccessor(obj, property, value);`
+#### `sandbox.replace.usingAccessor(object, property, value);`
 
 Usually one intends to _replace_ the value or getter of a field, but there are use cases where one actually wants to _assign_ a value to a property using an existing setter. `#replace.usingAccessor(object, property, value)` will do just that; pass the value into setter function and vice-versa use the getter to get the value used for restoring later on.
 

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -241,6 +241,7 @@ console.log(myObject.myMethod());
 Usually one intends to _replace_ the value or getter of a field, but there are use cases where one actually wants to _assign_ a value to a property using an existing setter. `#replace.usingAccessor(object, property, value)` will do just that; pass the value into setter function and vice-versa use the getter to get the value used for restoring later on.
 
 ##### Use case: no-frills dependency injection in ESM with cleanup
+
 One use case can be to conveniently allow ESM module stubbing using pure dependency injection, having Sinon help you with the cleanup, without resorting to external machinery such as module loaders or require hooks (see [#2403](https://github.com/sinonjs/sinon/issues/2403)). This would then work regardless of bundler, browser or server environment.
 
 #### `sandbox.replaceGetter(object, property, replacementFunction);`

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -181,7 +181,6 @@ A convenience reference for [`sinon.assert`](./assertions)
 
 _Since `sinon@2.0.0`_
 
-<<<<<<< HEAD
 #### `sandbox.define(object, property, value);`
 
 Defines the `property` on `object` with the value `value`. Attempts to define an already defined value cause an exception.
@@ -220,7 +219,7 @@ Replaces `property` on `object` with `replacement` argument. Attempts to replace
 
 `replacement` can be any value, including `spies`, `stubs` and `fakes`.
 
-By default, this method only works on non-accessor properties, for replacing accessors, use `sandbox.replaceGetter()` and `sandbox.replaceSetter()`.
+This method only works on non-accessor properties, for replacing accessors, use `sandbox.replaceGetter()` and `sandbox.replaceSetter()`.
 
 ```js
 var myObject = {
@@ -239,11 +238,14 @@ console.log(myObject.myMethod());
 
 #### `sandbox.replace.usingAccessor(obj, property, value);`
 
-The usual `replace` will throw on encountering a setter, but this will not. Instead, this method allows for the rather special case where we will pass a value to the setter function and vice-versa use the getter to get the value used for restoring later on. One use case is to allow a simple pattern for DI based ESM module stubbing without resorting to external/fancy machinery such as module loaders (see [#2403](https://github.com/sinonjs/sinon/issues/2403) for background).
+Usually one intends to _replace_ the value or getter of a field, but there are use cases where one actually wants to _assign_ a value to a property using an existing setter. `#replace.usingAccessor(object, property, value)` will do just that; pass the value into setter function and vice-versa use the getter to get the value used for restoring later on.
 
-#### `sandbox.replaceGetter(object, property, replacement);`
+##### Use case: no-frills dependency injection in ESM with cleanup
+One use case can be to conveniently allow ESM module stubbing using pure dependency injection, having Sinon help you with the cleanup, without resorting to external machinery such as module loaders or require hooks (see [#2403](https://github.com/sinonjs/sinon/issues/2403)). This would then work regardless of bundler, browser or server environment.
 
-Replaces an existing getter for `property` on `object` with `replacement` argument. Attempts to replace an already replaced getter cause an exception.
+#### `sandbox.replaceGetter(object, property, replacementFunction);`
+
+Replaces an existing getter for `property` on `object` with the `replacementFunction` argument. Attempts to replace an already replaced getter cause an exception.
 
 `replacement` must be a `Function`, and can be instances of `spies`, `stubs` and `fakes`.
 
@@ -262,9 +264,9 @@ console.log(myObject.myProperty);
 // strawberry
 ```
 
-#### `sandbox.replaceSetter(object, property, replacement);`
+#### `sandbox.replaceSetter(object, property, replacementFunction);`
 
-Replaces setter for `property` on `object` with `replacement` argument. Attempts to replace an already replaced setter cause an exception.
+Replaces an existing setter for `property` on `object` with the `replacementFunction` argument. Attempts to replace an already replaced setter cause an exception.
 
 `replacement` must be a `Function`, and can be instances of `spies`, `stubs` and `fakes`.
 

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -181,6 +181,7 @@ A convenience reference for [`sinon.assert`](./assertions)
 
 _Since `sinon@2.0.0`_
 
+<<<<<<< HEAD
 #### `sandbox.define(object, property, value);`
 
 Defines the `property` on `object` with the value `value`. Attempts to define an already defined value cause an exception.
@@ -219,7 +220,7 @@ Replaces `property` on `object` with `replacement` argument. Attempts to replace
 
 `replacement` can be any value, including `spies`, `stubs` and `fakes`.
 
-This method only works on non-accessor properties, for replacing accessors, use `sandbox.replaceGetter()` and `sandbox.replaceSetter()`.
+By default, this method only works on non-accessor properties, for replacing accessors, use `sandbox.replaceGetter()` and `sandbox.replaceSetter()`.
 
 ```js
 var myObject = {
@@ -236,9 +237,13 @@ console.log(myObject.myMethod());
 // strawberry
 ```
 
-#### `sandbox.replaceGetter();`
+#### `sandbox.replace.usingAccessor(obj, property, value);`
 
-Replaces getter for `property` on `object` with `replacement` argument. Attempts to replace an already replaced getter cause an exception.
+The usual `replace` will throw on encountering a setter, but this will not. Instead, this method allows for the rather special case where we will pass a value to the setter function and vice-versa use the getter to get the value used for restoring later on. One use case is to allow a simple pattern for DI based ESM module stubbing without resorting to external/fancy machinery such as module loaders (see [#2403](https://github.com/sinonjs/sinon/issues/2403) for background).
+
+#### `sandbox.replaceGetter(object, property, replacement);`
+
+Replaces an existing getter for `property` on `object` with `replacement` argument. Attempts to replace an already replaced getter cause an exception.
 
 `replacement` must be a `Function`, and can be instances of `spies`, `stubs` and `fakes`.
 
@@ -257,7 +262,7 @@ console.log(myObject.myProperty);
 // strawberry
 ```
 
-#### `sandbox.replaceSetter();`
+#### `sandbox.replaceSetter(object, property, replacement);`
 
 Replaces setter for `property` on `object` with `replacement` argument. Attempts to replace an already replaced setter cause an exception.
 

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -35,6 +35,40 @@ function applyOnEach(fakes, method) {
     });
 }
 
+function throwOnAccessors(descriptor) {
+    if (typeof descriptor.get === "function") {
+        throw new Error("Use sandbox.replaceGetter for replacing getters");
+    }
+
+    if (typeof descriptor.set === "function") {
+        throw new Error("Use sandbox.replaceSetter for replacing setters");
+    }
+}
+
+function verifySameType(object, property, replacement) {
+    if (typeof object[property] !== typeof replacement) {
+        throw new TypeError(
+            `Cannot replace ${typeof object[
+                property
+            ]} with ${typeof replacement}`
+        );
+    }
+}
+
+function checkForValidArguments(descriptor, property, replacement) {
+    if (typeof descriptor === "undefined") {
+        throw new TypeError(
+            `Cannot replace non-existent property ${valueToString(
+                property
+            )}. Perhaps you meant sandbox.define()?`
+        );
+    }
+
+    if (typeof replacement === "undefined") {
+        throw new TypeError("Expected replacement argument to be defined");
+    }
+}
+
 function Sandbox() {
     const sandbox = this;
     let fakeRestorers = [];
@@ -239,59 +273,38 @@ function Sandbox() {
      */
     sandbox.replace = function replace(object, property, replacement) {
         const descriptor = getPropertyDescriptor(object, property);
-
-        if (typeof descriptor === "undefined") {
-            throw new TypeError(
-                `Cannot replace non-existent property ${valueToString(
-                    property
-                )}. Perhaps you meant sandbox.define()?`
-            );
-        }
-
-        if (typeof replacement === "undefined") {
-            throw new TypeError("Expected replacement argument to be defined");
-        }
-
-        if (typeof descriptor.get === "function") {
-            throw new Error("Use sandbox.replaceGetter for replacing getters");
-        }
-
-        if (typeof descriptor.set === "function") {
-            throw new Error("Use sandbox.replaceSetter for replacing setters");
-        }
-
-        if (typeof object[property] !== typeof replacement) {
-            throw new TypeError(
-                `Cannot replace ${typeof object[
-                    property
-                ]} with ${typeof replacement}`
-            );
-        }
+        checkForValidArguments(descriptor, property, replacement);
+        throwOnAccessors(descriptor);
+        verifySameType(object, property, replacement);
 
         verifyNotReplaced(object, property);
 
         // store a function for restoring the replaced property
-        push(
-            fakeRestorers,
-            getFakeRestorer(object, property)
-        );
+        push(fakeRestorers, getFakeRestorer(object, property));
 
         object[property] = replacement;
 
         return replacement;
     };
 
-    sandbox.replace.usingAccessor = function replaceUsingAccessor(object, property, replacement) {
+    sandbox.replace.usingAccessor = function replaceUsingAccessor(
+        object,
+        property,
+        replacement
+    ) {
+        const descriptor = getPropertyDescriptor(object, property);
+        checkForValidArguments(descriptor, property, replacement);
+        verifySameType(object, property, replacement);
+
+        verifyNotReplaced(object, property);
+
         // store a function for restoring the replaced property
-        push(
-            fakeRestorers,
-            getFakeRestorer(object, property, true)
-        );
+        push(fakeRestorers, getFakeRestorer(object, property, true));
 
         object[property] = replacement;
 
         return replacement;
-    }
+    };
 
     sandbox.define = function define(object, property, value) {
         const descriptor = getPropertyDescriptor(object, property);

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -255,11 +255,15 @@ function Sandbox() {
 
         if (!options?.forceAssignment) {
             if (typeof descriptor.get === "function") {
-                throw new Error("Use sandbox.replaceGetter for replacing getters");
+                throw new Error(
+                    "Use sandbox.replaceGetter for replacing getters"
+                );
             }
 
             if (typeof descriptor.set === "function") {
-                throw new Error("Use sandbox.replaceSetter for replacing setters");
+                throw new Error(
+                    "Use sandbox.replaceSetter for replacing setters"
+                );
             }
         }
 
@@ -267,14 +271,17 @@ function Sandbox() {
             throw new TypeError(
                 `Cannot replace ${typeof object[
                     property
-                    ]} with ${typeof replacement}`
+                ]} with ${typeof replacement}`
             );
         }
 
         verifyNotReplaced(object, property);
 
         // store a function for restoring the replaced property
-        push(fakeRestorers, getFakeRestorer(object, property, options?.forceAssignment));
+        push(
+            fakeRestorers,
+            getFakeRestorer(object, property, options?.forceAssignment)
+        );
 
         object[property] = replacement;
 

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -196,11 +196,14 @@ function Sandbox() {
         sandbox.injectedKeys.length = 0;
     };
 
-    function getFakeRestorer(object, property) {
+    function getFakeRestorer(object, property, forceAssignment) {
         const descriptor = getPropertyDescriptor(object, property);
+        const value = object[property];
 
         function restorer() {
-            if (descriptor?.isOwn) {
+            if (forceAssignment) {
+                object[property] = value;
+            } else if (descriptor.isOwn) {
                 Object.defineProperty(object, property, descriptor);
             } else {
                 delete object[property];
@@ -225,7 +228,7 @@ function Sandbox() {
         });
     }
 
-    sandbox.replace = function replace(object, property, replacement) {
+    sandbox.replace = function replace(object, property, replacement, options) {
         const descriptor = getPropertyDescriptor(object, property);
 
         if (typeof descriptor === "undefined") {
@@ -240,26 +243,28 @@ function Sandbox() {
             throw new TypeError("Expected replacement argument to be defined");
         }
 
-        if (typeof descriptor.get === "function") {
-            throw new Error("Use sandbox.replaceGetter for replacing getters");
-        }
+        if (!options?.forceAssignment) {
+            if (typeof descriptor.get === "function") {
+                throw new Error("Use sandbox.replaceGetter for replacing getters");
+            }
 
-        if (typeof descriptor.set === "function") {
-            throw new Error("Use sandbox.replaceSetter for replacing setters");
+            if (typeof descriptor.set === "function") {
+                throw new Error("Use sandbox.replaceSetter for replacing setters");
+            }
         }
 
         if (typeof object[property] !== typeof replacement) {
             throw new TypeError(
                 `Cannot replace ${typeof object[
                     property
-                ]} with ${typeof replacement}`
+                    ]} with ${typeof replacement}`
             );
         }
 
         verifyNotReplaced(object, property);
 
         // store a function for restoring the replaced property
-        push(fakeRestorers, getFakeRestorer(object, property));
+        push(fakeRestorers, getFakeRestorer(object, property, options?.forceAssignment));
 
         object[property] = replacement;
 

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -191,7 +191,13 @@ function Sandbox() {
         sandbox.injectedKeys.length = 0;
     };
 
-    function getFakeRestorer(object, property, forceAssignment) {
+    /**
+     * Creates a restorer function for the property
+     * @param {object|Function} object
+     * @param {string} property
+     * @param {boolean} forceAssignment
+     */
+    function getFakeRestorer(object, property, forceAssignment = false) {
         const descriptor = getPropertyDescriptor(object, property);
         const value = object[property];
 
@@ -229,11 +235,9 @@ function Sandbox() {
      * @param {object|Function} object
      * @param {string} property
      * @param {*} replacement a fake, stub, spy or any other value
-     * @param {object} [options]
-     * @param {boolean} options.forceAssignment allows you to force use of assignment in the presence of a setter
      * @returns {*}
      */
-    sandbox.replace = function replace(object, property, replacement, options) {
+    sandbox.replace = function replace(object, property, replacement) {
         const descriptor = getPropertyDescriptor(object, property);
 
         if (typeof descriptor === "undefined") {
@@ -248,18 +252,12 @@ function Sandbox() {
             throw new TypeError("Expected replacement argument to be defined");
         }
 
-        if (!options?.forceAssignment) {
-            if (typeof descriptor.get === "function") {
-                throw new Error(
-                    "Use sandbox.replaceGetter for replacing getters"
-                );
-            }
+        if (typeof descriptor.get === "function") {
+            throw new Error("Use sandbox.replaceGetter for replacing getters");
+        }
 
-            if (typeof descriptor.set === "function") {
-                throw new Error(
-                    "Use sandbox.replaceSetter for replacing setters"
-                );
-            }
+        if (typeof descriptor.set === "function") {
+            throw new Error("Use sandbox.replaceSetter for replacing setters");
         }
 
         if (typeof object[property] !== typeof replacement) {
@@ -275,13 +273,25 @@ function Sandbox() {
         // store a function for restoring the replaced property
         push(
             fakeRestorers,
-            getFakeRestorer(object, property, options?.forceAssignment)
+            getFakeRestorer(object, property)
         );
 
         object[property] = replacement;
 
         return replacement;
     };
+
+    sandbox.replace.usingAccessor = function replaceUsingAccessor(object, property, replacement) {
+        // store a function for restoring the replaced property
+        push(
+            fakeRestorers,
+            getFakeRestorer(object, property, true)
+        );
+
+        object[property] = replacement;
+
+        return replacement;
+    }
 
     sandbox.define = function define(object, property, value) {
         const descriptor = getPropertyDescriptor(object, property);

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -66,11 +66,6 @@ function Sandbox() {
         return collection;
     };
 
-    // this is for testing only
-    sandbox.getRestorers = function () {
-        return fakeRestorers;
-    };
-
     sandbox.createStubInstance = function createStubInstance() {
         const stubbed = sinonCreateStubInstance.apply(null, arguments);
 

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -198,7 +198,7 @@ function Sandbox() {
         function restorer() {
             if (forceAssignment) {
                 object[property] = value;
-            } else if (descriptor.isOwn) {
+            } else if (descriptor?.isOwn) {
                 Object.defineProperty(object, property, descriptor);
             } else {
                 delete object[property];

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -228,6 +228,16 @@ function Sandbox() {
         });
     }
 
+    /**
+     * Replace an existing property
+     *
+     * @param {object|Function} object
+     * @param {string} property
+     * @param {*} replacement a fake, stub, spy or any other value
+     * @param {object} [options]
+     * @param {boolean} options.forceAssignment allows you to force use of assignment in the presence of a setter
+     * @returns {*}
+     */
     sandbox.replace = function replace(object, property, replacement, options) {
         const descriptor = getPropertyDescriptor(object, property);
 

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -227,9 +227,11 @@ function Sandbox() {
 
     /**
      * Creates a restorer function for the property
+     *
      * @param {object|Function} object
      * @param {string} property
      * @param {boolean} forceAssignment
+     * @returns {Function} restorer function
      */
     function getFakeRestorer(object, property, forceAssignment = false) {
         const descriptor = getPropertyDescriptor(object, property);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "dev-docs": "cd docs; cp -rl release-source releases/dev; npm run serve-docs",
     "build-docs": "cd docs; bundle exec jekyll build",
     "serve-docs": "cd docs; bundle exec jekyll serve --incremental --verbose --livereload",
-    "lint": "eslint --max-warnings 99 '**/*.{js,cjs,mjs}'",
+    "lint": "eslint --max-warnings 101 '**/*.{js,cjs,mjs}'",
     "unimported": "unimported .",
     "pretest-webworker": "npm run build",
     "prebuild": "rimraf pkg && npm run check-dependencies",

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -52,7 +52,7 @@ describe("Sandbox", function () {
     });
 
     it("can be reset without failing when pre-configured to use a fake server", function () {
-        const sandbox = createSandbox({useFakeServer: true});
+        const sandbox = createSandbox({ useFakeServer: true });
         refute.exception(function () {
             sandbox.reset();
         });
@@ -387,7 +387,7 @@ describe("Sandbox", function () {
                         foo: sinonStub().returns(3),
                     });
                 },
-                {message: "Cannot stub foo. Property does not exist!"}
+                { message: "Cannot stub foo. Property does not exist!" }
             );
         });
 
@@ -564,7 +564,7 @@ describe("Sandbox", function () {
 
     describe("stub anything", function () {
         beforeEach(function () {
-            this.object = {property: 42};
+            this.object = { property: 42 };
             this.sandbox = new Sandbox();
         });
 
@@ -996,7 +996,7 @@ describe("Sandbox", function () {
                 function () {
                     sandbox.replace(object, "property", replacement);
                 },
-                {message: "Cannot replace string with function"}
+                { message: "Cannot replace string with function" }
             );
         });
 
@@ -1013,7 +1013,7 @@ describe("Sandbox", function () {
                 function () {
                     sandbox.replace(object, "property", replacement);
                 },
-                {message: "Cannot replace function with string"}
+                { message: "Cannot replace function with string" }
             );
         });
 
@@ -1117,10 +1117,10 @@ describe("Sandbox", function () {
 
             it("should allow forcing assignment", function () {
                 const sandbox = this.sandbox;
-                let hiddenFoo = () => 'original';
+                let hiddenFoo = () => "original";
                 const object = {
                     // eslint-disable-next-line accessor-pairs
-                    get foo(){
+                    get foo() {
                         return hiddenFoo;
                     },
                     set foo(value) {
@@ -1128,12 +1128,14 @@ describe("Sandbox", function () {
                     },
                 };
 
-                assert.equals(object.foo(),'original')
-                sandbox.replace(object, "foo", sinonFake.returns('fake'), {forceAssignment: true});
-                assert.equals(object.foo(),'fake')
-                sandbox.restore()
-                assert.equals(object.foo(),'original');
-            })
+                assert.equals(object.foo(), "original");
+                sandbox.replace(object, "foo", sinonFake.returns("fake"), {
+                    forceAssignment: true,
+                });
+                assert.equals(object.foo(), "fake");
+                sandbox.restore();
+                assert.equals(object.foo(), "original");
+            });
         });
     });
 
@@ -1515,8 +1517,8 @@ describe("Sandbox", function () {
             const sandbox = (this.sandbox = createSandbox());
             const fakes = sandbox.getFakes();
 
-            fakes.push({resetBehavior: sinonSpy()});
-            fakes.push({resetBehavior: sinonSpy()});
+            fakes.push({ resetBehavior: sinonSpy() });
+            fakes.push({ resetBehavior: sinonSpy() });
         });
 
         it("calls resetBehavior on all fakes", function () {
@@ -1602,13 +1604,13 @@ describe("Sandbox", function () {
                 "useFakeTimers"
             ).returns({});
 
-            this.sandbox.useFakeTimers({toFake: ["Date", "setTimeout"]});
+            this.sandbox.useFakeTimers({ toFake: ["Date", "setTimeout"] });
             this.sandbox.useFakeTimers({
                 toFake: ["setTimeout", "clearTimeout", "setInterval"],
             });
 
             assert(
-                useFakeTimersStub.calledWith({toFake: ["Date", "setTimeout"]})
+                useFakeTimersStub.calledWith({ toFake: ["Date", "setTimeout"] })
             );
             assert(
                 useFakeTimersStub.calledWith({
@@ -1879,12 +1881,10 @@ describe("Sandbox", function () {
             this.sandbox.inject(this.obj);
 
             const myObj = {
-                a: function () {
-                }
+                a: function () {},
             };
 
-            function MyClass() {
-            }
+            function MyClass() {}
 
             MyClass.prototype.method1 = noop;
             Object.defineProperty(myObj, "b", {
@@ -1894,8 +1894,7 @@ describe("Sandbox", function () {
                 configurable: true,
             });
             Object.defineProperty(myObj, "c", {
-                set: function () {
-                },
+                set: function () {},
                 configurable: true,
             });
 
@@ -1981,8 +1980,8 @@ describe("Sandbox", function () {
             const sandbox = createSandbox();
             const fakes = sandbox.getFakes();
 
-            fakes.push({verify: sinonSpy()});
-            fakes.push({verify: sinonSpy()});
+            fakes.push({ verify: sinonSpy() });
+            fakes.push({ verify: sinonSpy() });
 
             sandbox.verify();
 
@@ -2040,7 +2039,7 @@ describe("Sandbox", function () {
     describe("configurable sandbox", function () {
         beforeEach(function () {
             this.requests = [];
-            this.fakeServer = {requests: this.requests};
+            this.fakeServer = { requests: this.requests };
 
             this.useFakeTimersSpy = sinonSpy(sinonClock, "useFakeTimers");
             sinonStub(fakeServer, "create").returns(this.fakeServer);
@@ -2100,7 +2099,7 @@ describe("Sandbox", function () {
             };
             const clock = {};
             const spy = false;
-            const object = {server: server, clock: clock, spy: spy};
+            const object = { server: server, clock: clock, spy: spy };
             const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["server", "clock", "spy"],
@@ -2227,7 +2226,7 @@ describe("Sandbox", function () {
             const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["clock"],
-                    useFakeTimers: {toFake: ["Date", "setTimeout"]},
+                    useFakeTimers: { toFake: ["Date", "setTimeout"] },
                 })
             );
 
@@ -2379,14 +2378,14 @@ describe("Sandbox", function () {
                 function () {
                     sandboxA.assert.fail("Some message");
                 },
-                {name: "CustomErrorA"}
+                { name: "CustomErrorA" }
             );
 
             assert.exception(
                 function () {
                     sandboxB.assert.fail("Some message");
                 },
-                {name: "CustomErrorB"}
+                { name: "CustomErrorB" }
             );
 
             sandboxA.restore();

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1114,26 +1114,28 @@ describe("Sandbox", function () {
                     }
                 );
             });
+        });
+    });
 
-            it("should allow using assignment when replacing a value", function () {
-                const sandbox = this.sandbox;
-                let hiddenFoo = () => "original";
-                const object = {
-                    // eslint-disable-next-line accessor-pairs
-                    get foo() {
-                        return hiddenFoo;
-                    },
-                    set foo(value) {
-                        hiddenFoo = value;
-                    },
-                };
+    describe(".replace.usingAccessor", function () {
+        it("should allow using assignment when replacing a value", function () {
+            const sandbox = createSandbox();
+            let quaziPrivateStateOfObject = "original";
+            const object = {
+                // eslint-disable-next-line accessor-pairs
+                get foo() {
+                    return quaziPrivateStateOfObject;
+                },
+                set foo(value) {
+                    quaziPrivateStateOfObject = value;
+                },
+            };
 
-                assert.equals(object.foo(), "original");
-                sandbox.replace.usingAccessor(object, "foo", sinonFake.returns("fake"));
-                assert.equals(object.foo(), "fake");
-                sandbox.restore();
-                assert.equals(object.foo(), "original");
-            });
+            assert.equals(object.foo, "original");
+            sandbox.replace.usingAccessor(object, "foo", "fake");
+            assert.equals(object.foo, "fake");
+            sandbox.restore();
+            assert.equals(object.foo, "original");
         });
     });
 

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -52,7 +52,7 @@ describe("Sandbox", function () {
     });
 
     it("can be reset without failing when pre-configured to use a fake server", function () {
-        const sandbox = createSandbox({ useFakeServer: true });
+        const sandbox = createSandbox({useFakeServer: true});
         refute.exception(function () {
             sandbox.reset();
         });
@@ -387,7 +387,7 @@ describe("Sandbox", function () {
                         foo: sinonStub().returns(3),
                     });
                 },
-                { message: "Cannot stub foo. Property does not exist!" }
+                {message: "Cannot stub foo. Property does not exist!"}
             );
         });
 
@@ -398,6 +398,7 @@ describe("Sandbox", function () {
                 constructor() {
                     this.privateGetter = () => 42;
                 }
+
                 getValue() {
                     return this.privateGetter();
                 }
@@ -563,7 +564,7 @@ describe("Sandbox", function () {
 
     describe("stub anything", function () {
         beforeEach(function () {
-            this.object = { property: 42 };
+            this.object = {property: 42};
             this.sandbox = new Sandbox();
         });
 
@@ -995,7 +996,7 @@ describe("Sandbox", function () {
                 function () {
                     sandbox.replace(object, "property", replacement);
                 },
-                { message: "Cannot replace string with function" }
+                {message: "Cannot replace string with function"}
             );
         });
 
@@ -1012,7 +1013,7 @@ describe("Sandbox", function () {
                 function () {
                     sandbox.replace(object, "property", replacement);
                 },
-                { message: "Cannot replace function with string" }
+                {message: "Cannot replace function with string"}
             );
         });
 
@@ -1072,8 +1073,8 @@ describe("Sandbox", function () {
             assert.equals(actual, replacement);
         });
 
-        describe("when asked to replace a getter", function () {
-            it("should throw an Error", function () {
+        describe("when asked to replace a property with a getter", function () {
+            it("should throw an Error by default that informs of replaceGetter", function () {
                 const sandbox = this.sandbox;
                 const object = {
                     get foo() {
@@ -1093,7 +1094,7 @@ describe("Sandbox", function () {
             });
         });
 
-        describe("when asked to replace a setter", function () {
+        describe("when asked to replace a property with a setter", function () {
             it("should throw an Error", function () {
                 const sandbox = this.sandbox;
                 const object = {
@@ -1113,6 +1114,26 @@ describe("Sandbox", function () {
                     }
                 );
             });
+
+            it("should allow forcing assignment", function () {
+                const sandbox = this.sandbox;
+                let hiddenFoo = () => 'original';
+                const object = {
+                    // eslint-disable-next-line accessor-pairs
+                    get foo(){
+                        return hiddenFoo;
+                    },
+                    set foo(value) {
+                        hiddenFoo = value;
+                    },
+                };
+
+                assert.equals(object.foo(),'original')
+                sandbox.replace(object, "foo", sinonFake.returns('fake'), {forceAssignment: true});
+                assert.equals(object.foo(),'fake')
+                sandbox.restore()
+                assert.equals(object.foo(),'original');
+            })
         });
     });
 
@@ -1494,8 +1515,8 @@ describe("Sandbox", function () {
             const sandbox = (this.sandbox = createSandbox());
             const fakes = sandbox.getFakes();
 
-            fakes.push({ resetBehavior: sinonSpy() });
-            fakes.push({ resetBehavior: sinonSpy() });
+            fakes.push({resetBehavior: sinonSpy()});
+            fakes.push({resetBehavior: sinonSpy()});
         });
 
         it("calls resetBehavior on all fakes", function () {
@@ -1581,13 +1602,13 @@ describe("Sandbox", function () {
                 "useFakeTimers"
             ).returns({});
 
-            this.sandbox.useFakeTimers({ toFake: ["Date", "setTimeout"] });
+            this.sandbox.useFakeTimers({toFake: ["Date", "setTimeout"]});
             this.sandbox.useFakeTimers({
                 toFake: ["setTimeout", "clearTimeout", "setInterval"],
             });
 
             assert(
-                useFakeTimersStub.calledWith({ toFake: ["Date", "setTimeout"] })
+                useFakeTimersStub.calledWith({toFake: ["Date", "setTimeout"]})
             );
             assert(
                 useFakeTimersStub.calledWith({
@@ -1857,8 +1878,14 @@ describe("Sandbox", function () {
             /* eslint-disable no-empty-function, accessor-pairs */
             this.sandbox.inject(this.obj);
 
-            const myObj = { a: function () {} };
-            function MyClass() {}
+            const myObj = {
+                a: function () {
+                }
+            };
+
+            function MyClass() {
+            }
+
             MyClass.prototype.method1 = noop;
             Object.defineProperty(myObj, "b", {
                 get: function () {
@@ -1867,7 +1894,8 @@ describe("Sandbox", function () {
                 configurable: true,
             });
             Object.defineProperty(myObj, "c", {
-                set: function () {},
+                set: function () {
+                },
                 configurable: true,
             });
 
@@ -1953,8 +1981,8 @@ describe("Sandbox", function () {
             const sandbox = createSandbox();
             const fakes = sandbox.getFakes();
 
-            fakes.push({ verify: sinonSpy() });
-            fakes.push({ verify: sinonSpy() });
+            fakes.push({verify: sinonSpy()});
+            fakes.push({verify: sinonSpy()});
 
             sandbox.verify();
 
@@ -2012,7 +2040,7 @@ describe("Sandbox", function () {
     describe("configurable sandbox", function () {
         beforeEach(function () {
             this.requests = [];
-            this.fakeServer = { requests: this.requests };
+            this.fakeServer = {requests: this.requests};
 
             this.useFakeTimersSpy = sinonSpy(sinonClock, "useFakeTimers");
             sinonStub(fakeServer, "create").returns(this.fakeServer);
@@ -2072,7 +2100,7 @@ describe("Sandbox", function () {
             };
             const clock = {};
             const spy = false;
-            const object = { server: server, clock: clock, spy: spy };
+            const object = {server: server, clock: clock, spy: spy};
             const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["server", "clock", "spy"],
@@ -2199,7 +2227,7 @@ describe("Sandbox", function () {
             const sandbox = createSandbox(
                 sinonConfig({
                     properties: ["clock"],
-                    useFakeTimers: { toFake: ["Date", "setTimeout"] },
+                    useFakeTimers: {toFake: ["Date", "setTimeout"]},
                 })
             );
 
@@ -2351,14 +2379,14 @@ describe("Sandbox", function () {
                 function () {
                     sandboxA.assert.fail("Some message");
                 },
-                { name: "CustomErrorA" }
+                {name: "CustomErrorA"}
             );
 
             assert.exception(
                 function () {
                     sandboxB.assert.fail("Some message");
                 },
-                { name: "CustomErrorB" }
+                {name: "CustomErrorB"}
             );
 
             sandboxA.restore();

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1115,7 +1115,7 @@ describe("Sandbox", function () {
                 );
             });
 
-            it("should allow forcing assignment", function () {
+            it("should allow using assignment when replacing a value", function () {
                 const sandbox = this.sandbox;
                 let hiddenFoo = () => "original";
                 const object = {
@@ -1129,9 +1129,7 @@ describe("Sandbox", function () {
                 };
 
                 assert.equals(object.foo(), "original");
-                sandbox.replace(object, "foo", sinonFake.returns("fake"), {
-                    forceAssignment: true,
-                });
+                sandbox.replace.usingAccessor(object, "foo", sinonFake.returns("fake"));
                 assert.equals(object.foo(), "fake");
                 sandbox.restore();
                 assert.equals(object.foo(), "original");


### PR DESCRIPTION
#### Purpose

Allows specifying a fourth argument, an options bag, to `sandbox.replace()` to make it possible to override the default behaviour of throwing when encountering accessor methods (getters/setters). 

This means we will pass the supplied replacement to the setter and vice-versa get the original value from the getter when restoring.

P.S. I am not sold on the options name, so could be something else like "allowUsingAccessor". Was just inspired by the original issue.

#### Background (Problem in detail)  - optional

Issue #2403 made the case for using assignment, instead of defining object descriptors, in injection methods. Enabling this in all existing methods would probably break some projects in unforeseen ways. It would also mean adding yet another argument to most of these, which would make them harder to use, as some of them (spy) already have optional third arguments today.

The discussion in #2403 revealed we already had a "special case" in our `Sandbox#replace` method, as this already uses basic assignment. The only thing preventing it from being used was that it tries to prevent false usage by throwing on encounter accessor methods for the given property. Thus this PR simply opens up for circumenting this.

This opens up for some exotic cases, such as manual setups for stubbing the exports of true ESM modules through the innards of the module, in the way described in that feature:

**my-module.mjs**
```javascript
export function doThing() {
    console.log("Wow, we did the thing!");
}

export function doThingTwice() {
    doThing();
    doThing();
}

export const myModule = {
    get doThing() {
        return doThing;
    },
    set doThing(value) {
        doThing = value;
    },
};
```

**my-module.test.mjs**
```javascript
import { doThingTwice, myModule } from "./my-module.mjs";
import sinon from "./lib/sinon.js";

const stub = sinon.replace(myModule, "doThing", sinon.fake(), {
    forceAssignment: true,
});

doThingTwice();

sinon.assert.calledTwice(stub);
```


Alternatively one could, of course, _not_ do this change, and instead say that this manual stubbing setup is already doable by exposing functions for setting the corresponding exports and manually invoking these. The downside is that this will cause lots of manual restore code, which would otherwise by handled by Sinon.

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

Run tests and alternatively try the copy-pasting the example above into the root of the repo, then run `node *.test.mjs`.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
