### PR TITLE
.define method

### DIFF
--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -4,7 +4,7 @@ title: Sandboxes - Sinon.JS
 breadcrumb: sandbox
 ---
 
-Sandboxes removes the need to keep track of every fake created, which greatly simplifies cleanup.
+Sandboxes remove the need to keep track of every fake created, which greatly simplifies cleanup.
 
 ```javascript
 var sandbox = require("sinon").createSandbox();
@@ -180,6 +180,40 @@ var sandbox = sinon.createSandbox({
 A convenience reference for [`sinon.assert`](./assertions)
 
 _Since `sinon@2.0.0`_
+
+#### `sandbox.define(object, property, value);`
+
+Defines the `property` on `object` with the value `value`. Attempts to define an already defined value cause an exception.
+
+`value` can be any value except `undefined`, including `spies`, `stubs` and `fakes`.
+
+```js
+var myObject = {};
+
+sandbox.define(myObject, "myValue", function () {
+    return "blackberry";
+});
+
+sandbox.define(myObject, "myMethod", function () {
+  return "strawberry";
+});
+
+console.log(myObject.myValue);
+// blackberry
+
+console.log(myObject.myMethod());
+// strawberry
+
+sandbox.restore();
+
+console.log(myObject.myValue);
+// undefined
+
+console.log(myObject.myMethod);
+// undefined
+```
+
+_Since `sinon@15.3.0`_
 
 #### `sandbox.replace(object, property, replacement);`
 

--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -191,7 +191,7 @@ Defines the `property` on `object` with the value `value`. Attempts to define an
 var myObject = {};
 
 sandbox.define(myObject, "myValue", function () {
-    return "blackberry";
+  return "blackberry";
 });
 
 sandbox.define(myObject, "myMethod", function () {

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -296,7 +296,8 @@ function Sandbox() {
             throw new TypeError("Expected value argument to be defined");
         }
 
-        // likely a no-op, but just in case we allow to replace by undefined in the future
+        // check just in case we allow to replace properties by undefined in the future
+        // in the implementation at the moment of writing, this check always succeeds
         verifyNotReplaced(object, property);
 
         // store a function for restoring the defined property

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -213,7 +213,7 @@ function Sandbox() {
 
         function restorer() {
             if (typeof descriptor === 'undefined') {
-                object[property] = undefined;
+                delete object[property];
             }
             else if (descriptor.isOwn) {
                 Object.defineProperty(object, property, descriptor);

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -247,7 +247,7 @@ function Sandbox() {
             throw new TypeError(
                 `Cannot replace non-existent property ${valueToString(
                     property
-                )}`
+                )}. Perhaps you meant sandbox.define()?`
             );
         }
 
@@ -288,7 +288,7 @@ function Sandbox() {
             throw new TypeError(
                 `Cannot define the already existing property ${valueToString(
                     property
-                )}`
+                )}. Perhaps you meant sandbox.replace()?`
             );
         }
 

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -216,10 +216,7 @@ function Sandbox() {
         const descriptor = getPropertyDescriptor(object, property);
 
         function restorer() {
-            if (typeof descriptor === 'undefined') {
-                delete object[property];
-            }
-            else if (descriptor.isOwn) {
+            if (descriptor?.isOwn) {
                 Object.defineProperty(object, property, descriptor);
             } else {
                 delete object[property];
@@ -288,7 +285,7 @@ function Sandbox() {
     sandbox.define = function define(object, property, value) {
         const descriptor = getPropertyDescriptor(object, property);
 
-        if (typeof descriptor !== "undefined") {
+        if (descriptor) {
             throw new TypeError(
                 `Cannot define the already existing property ${valueToString(
                     property
@@ -300,8 +297,6 @@ function Sandbox() {
             throw new TypeError("Expected value argument to be defined");
         }
 
-        // Check just in case we allow to replace properties by undefined in the future.
-        // In the implementation at the moment of writing, this check always succeeds.
         verifyNotReplaced(object, property);
 
         // store a function for restoring the defined property

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -106,6 +106,10 @@ function Sandbox() {
             return sandbox.fake.apply(null, arguments);
         };
 
+        obj.define = function () {
+            return sandbox.define.apply(null, arguments);
+        };
+
         obj.replace = function () {
             return sandbox.replace.apply(null, arguments);
         };
@@ -296,8 +300,8 @@ function Sandbox() {
             throw new TypeError("Expected value argument to be defined");
         }
 
-        // check just in case we allow to replace properties by undefined in the future
-        // in the implementation at the moment of writing, this check always succeeds
+        // Check just in case we allow to replace properties by undefined in the future.
+        // In the implementation at the moment of writing, this check always succeeds.
         verifyNotReplaced(object, property);
 
         // store a function for restoring the defined property

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -212,7 +212,10 @@ function Sandbox() {
         const descriptor = getPropertyDescriptor(object, property);
 
         function restorer() {
-            if (descriptor.isOwn) {
+            if (typeof descriptor === 'undefined') {
+                object[property] = undefined;
+            }
+            else if (descriptor.isOwn) {
                 Object.defineProperty(object, property, descriptor);
             } else {
                 delete object[property];
@@ -276,6 +279,32 @@ function Sandbox() {
         object[property] = replacement;
 
         return replacement;
+    };
+
+    sandbox.define = function define(object, property, value) {
+        const descriptor = getPropertyDescriptor(object, property);
+
+        if (typeof descriptor !== "undefined") {
+            throw new TypeError(
+                `Cannot define the already existing property ${valueToString(
+                    property
+                )}`
+            );
+        }
+
+        if (typeof value === "undefined") {
+            throw new TypeError("Expected value argument to be defined");
+        }
+
+        // likely a no-op, but just in case we allow to replace by undefined in the future
+        verifyNotReplaced(object, property);
+
+        // store a function for restoring the defined property
+        push(fakeRestorers, getFakeRestorer(object, property));
+
+        object[property] = value;
+
+        return value;
     };
 
     sandbox.replaceGetter = function replaceGetter(

--- a/lib/sinon/util/core/default-config.js
+++ b/lib/sinon/util/core/default-config.js
@@ -10,6 +10,7 @@ module.exports = {
         "server",
         "requests",
         "fake",
+        "define",
         "replace",
         "replaceSetter",
         "replaceGetter",

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -812,6 +812,10 @@ describe("Sandbox", function () {
             this.sandbox = createSandbox();
         });
 
+        afterEach(function () {
+            this.sandbox.restore();
+        });
+
         it("should replace a function property", function () {
             const replacement = function replacement() {
                 return;

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -862,7 +862,7 @@ describe("Sandbox", function () {
                 },
                 {
                     message:
-                        "Cannot define the already existing property existingValue",
+                        "Cannot define the already existing property existingValue. Perhaps you meant sandbox.replace()?",
                     name: "TypeError",
                 }
             );
@@ -873,7 +873,7 @@ describe("Sandbox", function () {
                 },
                 {
                     message:
-                        "Cannot define the already existing property existingFunction",
+                        "Cannot define the already existing property existingFunction. Perhaps you meant sandbox.replace()?",
                     name: "TypeError",
                 }
             );

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -807,6 +807,83 @@ describe("Sandbox", function () {
         });
     });
 
+    describe(".define", function () {
+        beforeEach(function () {
+            this.sandbox = createSandbox();
+        });
+
+        afterEach(function () {
+            this.sandbox.restore();
+        });
+
+        it("should define a function property", function () {
+            function newFunction() {
+                return;
+            }
+
+            const object = {};
+
+            this.sandbox.define(object, "property", newFunction);
+
+            assert.equals(object.property, newFunction);
+
+            this.sandbox.restore();
+
+            assert.isUndefined(object.property);
+        });
+
+        it("should define a non-function property", function () {
+            const newValue = "some-new-value";
+            const object = {};
+
+            this.sandbox.define(object, "property", newValue);
+
+            assert.equals(object.property, newValue);
+
+            this.sandbox.restore();
+
+            assert.isUndefined(object.property);
+        });
+
+        it("should error on existing descriptor", function () {
+            const sandbox = this.sandbox;
+
+            const existingValue = "123";
+            const existingFunction = () => "abcd";
+
+            const object = {
+                existingValue: existingValue,
+                existingFunction: existingFunction
+            };
+
+            assert.exception(
+                function () {
+                    sandbox.define(object, "existingValue", "new value");
+                },
+                {
+                    message:
+                        "Cannot define the already existing property existingValue",
+                    name: "TypeError",
+                }
+            );
+
+            assert.exception(
+                function () {
+                    sandbox.define(object, "existingFunction", () => "new function");
+                },
+                {
+                    message:
+                        "Cannot define the already existing property existingFunction",
+                    name: "TypeError",
+                }
+            );
+
+            // Verify that the methods above, even though they failed, did not replace the values
+            assert.equals(object.existingValue, existingValue);
+            assert.equals(object.existingFunction, existingFunction);
+        });
+    });
+
     describe(".replace", function () {
         beforeEach(function () {
             this.sandbox = createSandbox();

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -853,7 +853,7 @@ describe("Sandbox", function () {
 
             const object = {
                 existingValue: existingValue,
-                existingFunction: existingFunction
+                existingFunction: existingFunction,
             };
 
             assert.exception(
@@ -869,7 +869,11 @@ describe("Sandbox", function () {
 
             assert.exception(
                 function () {
-                    sandbox.define(object, "existingFunction", () => "new function");
+                    sandbox.define(
+                        object,
+                        "existingFunction",
+                        () => "new function"
+                    );
                 },
                 {
                     message:

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -954,7 +954,7 @@ describe("Sandbox", function () {
                 },
                 {
                     message:
-                        "Cannot replace non-existent property i-dont-exist",
+                        "Cannot replace non-existent property i-dont-exist. Perhaps you meant sandbox.define()?",
                     name: "TypeError",
                 }
             );


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Add the `.define(obj, property, value)` method to the sandbox to allow temporarily define properties on the objects (i.e. until the sandbox is restored).

Fixes  #2195

#### How to verify - mandatory

Run the tests

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
