### PR TITLE
docs(sandbox): fix example that defines a non-function property

### DIFF
--- a/docs/release-source/release/sandbox.md
+++ b/docs/release-source/release/sandbox.md
@@ -190,9 +190,7 @@ Defines the `property` on `object` with the value `value`. Attempts to define an
 ```js
 var myObject = {};
 
-sandbox.define(myObject, "myValue", function () {
-  return "blackberry";
-});
+sandbox.define(myObject, "myValue", "blackberry");
 
 sandbox.define(myObject, "myMethod", function () {
   return "strawberry";


### PR DESCRIPTION
#### Purpose (TL;DR)

<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

This PR follows #2539 and fixes the example that defines a non-function property when using `.define()`.

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->


 #### Solution
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

This fixes works by following the tests of `.define()`:
https://github.com/sinonjs/sinon/blob/baa1aee9e5766ff1bfcbc62d81ddaf3138174c54/test/sandbox-test.js#L819-L833

#### How to verify

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
