### PR TITLE
fix(2525): ensure non empty message when error of type string is passed, but no message

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -15,7 +15,9 @@ function throwsException(fake, error, message) {
         fake.exceptionCreator = error;
     } else if (typeof error === "string") {
         fake.exceptionCreator = function () {
-            const newException = new Error(message || `Sinon-provided ${error}` || "");
+            const newException = new Error(
+                message || `Sinon-provided ${error}` || ""
+            );
             newException.name = error;
             return newException;
         };

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -16,7 +16,7 @@ function throwsException(fake, error, message) {
     } else if (typeof error === "string") {
         fake.exceptionCreator = function () {
             const newException = new Error(
-                message || `Sinon-provided ${error}` || ""
+                message || `Sinon-provided ${error}`
             );
             newException.name = error;
             return newException;

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -15,7 +15,7 @@ function throwsException(fake, error, message) {
         fake.exceptionCreator = error;
     } else if (typeof error === "string") {
         fake.exceptionCreator = function () {
-            const newException = new Error(message || "");
+            const newException = new Error(message || error || "");
             newException.name = error;
             return newException;
         };

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -15,7 +15,7 @@ function throwsException(fake, error, message) {
         fake.exceptionCreator = error;
     } else if (typeof error === "string") {
         fake.exceptionCreator = function () {
-            const newException = new Error(message || error || "");
+            const newException = new Error(message || `Sinon-provided ${error}` || "");
             newException.name = error;
             return newException;
         };

--- a/test/proxy-call-test.js
+++ b/test/proxy-call-test.js
@@ -1134,7 +1134,7 @@ describe("sinonSpy.call", function () {
 
             assert.equals(
                 object.doIt.getCall(0).toString().replace(/ at.*/g, ""),
-                "doIt() !TypeError"
+                "doIt() !TypeError(Sinon-provided TypeError)"
             );
         });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -941,16 +941,19 @@ describe("stub", function () {
         });
 
         it("creates a non empty error message when error is a string and no message is passed", function () {
-            const stub = createStub()
+            const stub = createStub();
 
-            stub.withArgs(1).throws("TypeError")
+            stub.withArgs(1).throws("TypeError");
 
-            assert.exception(function () {
-                stub(1)
-            }, {
-                message: "Sinon-provided TypeError"
-            })
-        })
+            assert.exception(
+                function () {
+                    stub(1);
+                },
+                {
+                    message: "Sinon-provided TypeError",
+                }
+            );
+        });
 
         describe("lazy instantiation of exceptions", function () {
             let errorSpy;

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -940,6 +940,18 @@ describe("stub", function () {
             assert.contains(stub.firstCall.toString(), "not implemented");
         });
 
+        it("creates a non empty error message when error is a string and no message is passed", function () {
+            const stub = createStub()
+
+            stub.withArgs(1).throws("apple pie")
+
+            assert.exception(function () {
+                stub(1)
+            }, {
+                message: "apple pie"
+            })
+        })
+
         describe("lazy instantiation of exceptions", function () {
             let errorSpy;
             beforeEach(function () {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -943,12 +943,12 @@ describe("stub", function () {
         it("creates a non empty error message when error is a string and no message is passed", function () {
             const stub = createStub()
 
-            stub.withArgs(1).throws("apple pie")
+            stub.withArgs(1).throws("TypeError")
 
             assert.exception(function () {
                 stub(1)
             }, {
-                message: "Sinon-provided apple pie"
+                message: "Sinon-provided TypeError"
             })
         })
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -948,7 +948,7 @@ describe("stub", function () {
             assert.exception(function () {
                 stub(1)
             }, {
-                message: "apple pie"
+                message: "Sinon-provided apple pie"
             })
         })
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

When an error of type String and an undefined message are passed to `throwsException`, ensure a non-empty error.message

See issue: #2525 

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

Note: The branch currently causes [this test](https://github.com/sinonjs/sinon/blob/main/test/proxy-call-test.js#L1128) to fail, so I'd appreciate guidance on whether expectations change, given this will result in a major semver change.
