### PR TITLE
Add log limit to assert.fake 

### DIFF
--- a/.unimportedrc.json
+++ b/.unimportedrc.json
@@ -1,8 +1,23 @@
 {
-  "entry": ["lib/sinon.js", "lib/sinon-esm.js"],
-  "extensions": [".js"],
-  "ignorePatterns": ["**/node_modules/**"],
+  "entry": [
+    "lib/sinon.js",
+    "lib/sinon-esm.js",
+    "test/**/*-test.js",
+    "test/webworker/webworker-script.js",
+    "test/webworker/webworker-support-assessment.js"
+  ],
+  "extensions": [
+    ".js"
+  ],
+  "ignorePatterns": [
+    "**/node_modules/**"
+  ],
   "ignoreUnresolved": [],
-  "ignoreUnimported": ["docs/**", "pkg/**", "test/**"],
+  "ignoreUnimported": [
+    "docs/**/*",
+    "pkg/**/*",
+    "vendor/**/*",
+    "test/es2015/check-esm-bundle-is-runnable.js"
+  ],
   "ignoreUnused": []
 }

--- a/lib/create-sinon-api.js
+++ b/lib/create-sinon-api.js
@@ -21,7 +21,6 @@ module.exports = function createApi(opts = { sinonXhrLib: nise }) {
 
     const apiMethods = {
         createSandbox: createSandbox,
-        assert: require("./sinon/assert"),
         match: require("@sinonjs/samsam").createMatcher,
         restoreObject: require("./sinon/restore-object"),
 

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -15,12 +15,40 @@ const forEach = arrayProto.forEach;
 const join = arrayProto.join;
 const splice = arrayProto.splice;
 
-function createAssertObject() {
+function applyDefaults(obj, defaults) {
+    for (const key of Object.keys(defaults)) {
+        const val = obj[key];
+        if (val === null || typeof val === "undefined") {
+            obj[key] = defaults[key];
+        }
+    }
+}
+
+/**
+ * @param {object}  [opts] options bag
+ * @param {boolean} [opts.shouldLimitAssertionLogs] default is false
+ * @param {number}  [opts.assertionLogLimit] default is 10K
+ * @returns {object} object with multiple assertion methods
+ */
+function createAssertObject(opts) {
+    const cleanedAssertOptions = opts || {};
+    applyDefaults(cleanedAssertOptions, {
+        shouldLimitAssertionLogs: false,
+        assertionLogLimit: 1e4,
+    });
+
     const assert = {
         failException: "AssertError",
 
         fail: function fail(message) {
-            const error = new Error(message);
+            let msg = message;
+            if (cleanedAssertOptions.shouldLimitAssertionLogs) {
+                msg = message.substring(
+                    0,
+                    cleanedAssertOptions.assertionLogLimit,
+                );
+            }
+            const error = new Error(msg);
             error.name = this.failException || assert.failException;
 
             throw error;

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -1,4 +1,5 @@
 "use strict";
+/** @module */
 
 const arrayProto = require("@sinonjs/commons").prototypes.array;
 const calledInOrder = require("@sinonjs/commons").calledInOrder;
@@ -25,9 +26,17 @@ function applyDefaults(obj, defaults) {
 }
 
 /**
- * @param {object}  [opts] options bag
- * @param {boolean} [opts.shouldLimitAssertionLogs] default is false
- * @param {number}  [opts.assertionLogLimit] default is 10K
+ * @typedef {object} CreateAssertOptions
+ * @global
+ *
+ * @property {boolean} [shouldLimitAssertionLogs] default is false
+ * @property {number}  [assertionLogLimit] default is 10K
+ */
+
+/**
+ * Create an assertion object that exposes several methods to invoke
+ *
+ * @param {CreateAssertOptions}  [opts] options bag
  * @returns {object} object with multiple assertion methods
  */
 function createAssertObject(opts) {

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -333,4 +333,20 @@ function createAssertObject(opts) {
 }
 
 module.exports = createAssertObject();
-module.exports.createAssertObject = createAssertObject;
+Object.defineProperty(module.exports, "createAssertObject", {
+    get() {
+        return createAssertObject;
+    },
+});
+
+// allow for easy mocking
+module.exports.mock = {};
+Object.defineProperty(module.exports.mock, "createAssertObject", {
+    get() {
+        return createAssertObject;
+    },
+    set(newImpl) {
+        // eslint-disable-next-line no-func-assign
+        createAssertObject = newImpl;
+    },
+});

--- a/lib/sinon/create-sandbox.js
+++ b/lib/sinon/create-sandbox.js
@@ -7,7 +7,7 @@ const forEach = arrayProto.forEach;
 const push = arrayProto.push;
 
 function prepareSandboxFromConfig(config) {
-    const sandbox = new Sandbox();
+    const sandbox = new Sandbox({ assertOptions: config.assertOptions });
 
     if (config.useFakeServer) {
         if (typeof config.useFakeServer === "object") {
@@ -50,7 +50,10 @@ function exposeValue(sandbox, config, key, value) {
  * @property {(object|null)} injectInto TBD
  * @property {boolean} useFakeTimers  whether timers are faked by default
  * @property {boolean} useFakeServer  whether XHR's are faked and the server feature enabled by default
+ * @property {object} [assertOptions] see CreateAssertOptions in ./assert
  */
+// This type def is really suffering from JSDoc not being
+// able to reference types in other modules
 
 /**
  * A configured sinon sandbox.

--- a/lib/sinon/create-sandbox.js
+++ b/lib/sinon/create-sandbox.js
@@ -41,6 +41,31 @@ function exposeValue(sandbox, config, key, value) {
     }
 }
 
+/**
+ * Customize the sandbox.
+ * This is mostly an integration feature most users will not need
+ *
+ * @typedef {object} SandboxConfig
+ * @property {string[]} properties The properties of the API to expose on the sandbox. Examples: ['spy', 'fake', 'restore']
+ * @property {(object|null)} injectInto TBD
+ * @property {boolean} useFakeTimers  whether timers are faked by default
+ * @property {boolean} useFakeServer  whether XHR's are faked and the server feature enabled by default
+ */
+
+/**
+ * A configured sinon sandbox.
+ *
+ * @typedef {object} ConfiguredSinonSandboxType
+ * @augments Sandbox
+ * @property {string[]} injectedKeys the keys that have been injected (from config.injectInto)
+ * @property {*} injectInto TBD
+ * @property {*[]} args the arguments for the sandbox
+ */
+
+/**
+ * @param config {SandboxConfig}
+ * @returns {Sandbox}
+ */
 function createSandbox(config) {
     if (!config) {
         return new Sandbox();

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -72,10 +72,13 @@ function checkForValidArguments(descriptor, property, replacement) {
 /**
  * A sinon sandbox
  *
+ * @param opts
+ * @param {object} [opts.assertOptions] see the CreateAssertOptions in ./assert
  * @class
  */
-function Sandbox() {
+function Sandbox(opts = {}) {
     const sandbox = this;
+    const assertOptions = opts.assertOptions || {};
     let fakeRestorers = [];
     let promiseLib;
 
@@ -96,7 +99,7 @@ function Sandbox() {
         }
     }
 
-    sandbox.assert = sinonAssert.createAssertObject();
+    sandbox.assert = sinonAssert.createAssertObject(assertOptions);
 
     sandbox.serverPrototype = fakeServer;
 

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -69,6 +69,11 @@ function checkForValidArguments(descriptor, property, replacement) {
     }
 }
 
+/**
+ * A sinon sandbox
+ *
+ * @class
+ */
 function Sandbox() {
     const sandbox = this;
     let fakeRestorers = [];

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -65,6 +65,18 @@ describe("assert", function () {
             sinonAssert.failException = this.exceptionName;
         });
 
+        it("can be configured to limit the error message length", function () {
+            const customAssert = sinonAssert.createAssertObject({
+                shouldLimitAssertionLogs: true,
+                assertionLogLimit: 10,
+            });
+
+            assert.exception(
+                () => customAssert.fail("1234567890--THIS SHOULD NOT SHOW--"),
+                { message: "1234567890" },
+            );
+        });
+
         it("throws exception", function () {
             assert.exception(
                 function () {

--- a/test/create-sandbox-test.js
+++ b/test/create-sandbox-test.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const sinonAssert = require("../lib/sinon/assert");
+const createSandbox = require("../lib/sinon/create-sandbox");
+
+describe("create-sandbox", function () {
+    it("passes on options to the creation of the assert object", function () {
+        // Arrange
+        const sb = createSandbox();
+        const spy = sb.spy();
+        sb.replace.usingAccessor(sinonAssert.mock, "createAssertObject", spy);
+
+        // Act
+        createSandbox({
+            assertOptions: {
+                shouldLimitAssertionLogs: true,
+                assertionLogLimit: 1234,
+            },
+        });
+
+        // Assert
+        sb.assert.calledWith(
+            spy,
+            sb.match({
+                shouldLimitAssertionLogs: true,
+                assertionLogLimit: 1234,
+            }),
+        );
+        sb.restore();
+    });
+});


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This basically re-implements #2485 (which fixes #2484), addressing the concerns raised there, adding tests and fixes a few other nuisances while at it.


#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
