### PR TITLE
fix returns does not override call through

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -33,7 +33,7 @@ function throwsException(fake, error, message) {
 const SKIP_OPTIONS_FOR_YIELDS = {
     skipReturn: true,
     skipThrows: true,
-}
+};
 
 function clear(fake, options) {
     fake.fakeFn = undefined;
@@ -41,7 +41,7 @@ function clear(fake, options) {
     fake.callsThrough = undefined;
     fake.callsThroughWithNew = undefined;
 
-    if(!options || !options.skipThrows) {
+    if (!options || !options.skipThrows) {
         fake.exception = undefined;
         fake.exceptionCreator = undefined;
         fake.throwArgAt = undefined;
@@ -53,7 +53,7 @@ function clear(fake, options) {
     fake.callArgProp = undefined;
     fake.callbackAsync = undefined;
 
-    if(!options || !options.skipReturn) {
+    if (!options || !options.skipReturn) {
         fake.returnValue = undefined;
         fake.returnValueDefined = undefined;
         fake.returnArgAt = undefined;

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -30,59 +30,90 @@ function throwsException(fake, error, message) {
     }
 }
 
-const defaultBehaviors = {
-    callsFake: function callsFake(fake, fn) {
-        fake.fakeFn = fn;
+const SKIP_OPTIONS_FOR_YIELDS = {
+    skipReturn: true,
+    skipThrows: true,
+}
+
+function clear(fake, options) {
+    fake.fakeFn = undefined;
+
+    fake.callsThrough = undefined;
+    fake.callsThroughWithNew = undefined;
+
+    if(!options || !options.skipThrows) {
         fake.exception = undefined;
         fake.exceptionCreator = undefined;
+        fake.throwArgAt = undefined;
+    }
+
+    fake.callArgAt = undefined;
+    fake.callbackArguments = undefined;
+    fake.callbackContext = undefined;
+    fake.callArgProp = undefined;
+    fake.callbackAsync = undefined;
+
+    if(!options || !options.skipReturn) {
+        fake.returnValue = undefined;
+        fake.returnValueDefined = undefined;
+        fake.returnArgAt = undefined;
+        fake.returnThis = undefined;
+    }
+
+    fake.resolve = undefined;
+    fake.resolveThis = undefined;
+    fake.resolveArgAt = undefined;
+
+    fake.reject = undefined;
+}
+
+const defaultBehaviors = {
+    callsFake: function callsFake(fake, fn) {
+        clear(fake);
+
+        fake.fakeFn = fn;
     },
 
     callsArg: function callsArg(fake, index) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
+        clear(fake);
 
         fake.callArgAt = index;
         fake.callbackArguments = [];
-        fake.callbackContext = undefined;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
     },
 
     callsArgOn: function callsArgOn(fake, index, context) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
+        clear(fake);
 
         fake.callArgAt = index;
         fake.callbackArguments = [];
         fake.callbackContext = context;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
     },
 
     callsArgWith: function callsArgWith(fake, index) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
+        clear(fake);
 
         fake.callArgAt = index;
         fake.callbackArguments = slice(arguments, 2);
-        fake.callbackContext = undefined;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
     },
 
     callsArgOnWith: function callsArgWith(fake, index, context) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
+        clear(fake);
 
         fake.callArgAt = index;
         fake.callbackArguments = slice(arguments, 3);
         fake.callbackContext = context;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
     },
 
     usingPromise: function usingPromise(fake, promiseLibrary) {
@@ -90,67 +121,59 @@ const defaultBehaviors = {
     },
 
     yields: function (fake) {
+        clear(fake, SKIP_OPTIONS_FOR_YIELDS);
+
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice(arguments, 1);
-        fake.callbackContext = undefined;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
-        fake.fakeFn = undefined;
     },
 
     yieldsRight: function (fake) {
+        clear(fake, SKIP_OPTIONS_FOR_YIELDS);
+
         fake.callArgAt = useRightMostCallback;
         fake.callbackArguments = slice(arguments, 1);
-        fake.callbackContext = undefined;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
-        fake.fakeFn = undefined;
     },
 
     yieldsOn: function (fake, context) {
+        clear(fake, SKIP_OPTIONS_FOR_YIELDS);
+
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice(arguments, 2);
         fake.callbackContext = context;
-        fake.callArgProp = undefined;
-        fake.callbackAsync = false;
-        fake.fakeFn = undefined;
     },
 
     yieldsTo: function (fake, prop) {
+        clear(fake, SKIP_OPTIONS_FOR_YIELDS);
+
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice(arguments, 2);
-        fake.callbackContext = undefined;
         fake.callArgProp = prop;
-        fake.callbackAsync = false;
-        fake.fakeFn = undefined;
     },
 
     yieldsToOn: function (fake, prop, context) {
+        clear(fake, SKIP_OPTIONS_FOR_YIELDS);
+
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice(arguments, 3);
         fake.callbackContext = context;
         fake.callArgProp = prop;
-        fake.callbackAsync = false;
-        fake.fakeFn = undefined;
     },
 
     throws: throwsException,
     throwsException: throwsException,
 
     returns: function returns(fake, value) {
+        clear(fake);
+
         fake.returnValue = value;
-        fake.resolve = false;
-        fake.reject = false;
         fake.returnValueDefined = true;
-        fake.exception = undefined;
-        fake.exceptionCreator = undefined;
-        fake.fakeFn = undefined;
     },
 
     returnsArg: function returnsArg(fake, index) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
+        clear(fake);
 
         fake.returnArgAt = index;
     },
@@ -159,38 +182,33 @@ const defaultBehaviors = {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
+        clear(fake);
 
         fake.throwArgAt = index;
     },
 
     returnsThis: function returnsThis(fake) {
+        clear(fake);
+
         fake.returnThis = true;
     },
 
     resolves: function resolves(fake, value) {
+        clear(fake);
+
         fake.returnValue = value;
         fake.resolve = true;
-        fake.resolveThis = false;
-        fake.reject = false;
         fake.returnValueDefined = true;
-        fake.exception = undefined;
-        fake.exceptionCreator = undefined;
-        fake.fakeFn = undefined;
     },
 
     resolvesArg: function resolvesArg(fake, index) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
+        clear(fake);
+
         fake.resolveArgAt = index;
-        fake.returnValue = undefined;
         fake.resolve = true;
-        fake.resolveThis = false;
-        fake.reject = false;
-        fake.returnValueDefined = false;
-        fake.exception = undefined;
-        fake.exceptionCreator = undefined;
-        fake.fakeFn = undefined;
     },
 
     rejects: function rejects(fake, error, message) {
@@ -203,34 +221,30 @@ const defaultBehaviors = {
         } else {
             reason = error;
         }
+        clear(fake);
+
         fake.returnValue = reason;
-        fake.resolve = false;
-        fake.resolveThis = false;
         fake.reject = true;
         fake.returnValueDefined = true;
-        fake.exception = undefined;
-        fake.exceptionCreator = undefined;
-        fake.fakeFn = undefined;
 
         return fake;
     },
 
     resolvesThis: function resolvesThis(fake) {
-        fake.returnValue = undefined;
-        fake.resolve = false;
+        clear(fake);
+
         fake.resolveThis = true;
-        fake.reject = false;
-        fake.returnValueDefined = false;
-        fake.exception = undefined;
-        fake.exceptionCreator = undefined;
-        fake.fakeFn = undefined;
     },
 
     callThrough: function callThrough(fake) {
+        clear(fake);
+
         fake.callsThrough = true;
     },
 
     callThroughWithNew: function callThroughWithNew(fake) {
+        clear(fake);
+
         fake.callsThroughWithNew = true;
     },
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -229,9 +229,9 @@ describe("stub", function () {
             const obj = {
                 fn() {
                     return 1;
-                }
-            }
-            const stub = createStub(obj, 'fn').callThrough().returns(2);
+                },
+            };
+            const stub = createStub(obj, "fn").callThrough().returns(2);
 
             assert.equals(stub(), 2);
         });
@@ -299,14 +299,13 @@ describe("stub", function () {
             const obj = {
                 fn() {
                     return Promise.resolve(1);
-                }
-            }
-            const stub = createStub(obj, 'fn').callThrough().resolves(2);
+                },
+            };
+            const stub = createStub(obj, "fn").callThrough().resolves(2);
 
-            return stub()
-                .then(function (actual) {
-                    assert.equals(actual, 2);
-                });
+            return stub().then(function (actual) {
+                assert.equals(actual, 2);
+            });
         });
 
         it("supersedes previous callsFake", function () {
@@ -434,10 +433,10 @@ describe("stub", function () {
             const obj = {
                 fn() {
                     return Promise.resolve(1);
-                }
+                },
             };
             const reason = new Error();
-            const stub = createStub(obj, 'fn').callThrough().rejects(reason);
+            const stub = createStub(obj, "fn").callThrough().rejects(reason);
 
             return stub()
                 .then(function () {
@@ -528,14 +527,13 @@ describe("stub", function () {
             const obj = {
                 fn() {
                     return Promise.resolve(1);
-                }
+                },
             };
-            createStub(obj, 'fn').callThrough().resolvesThis();
+            createStub(obj, "fn").callThrough().resolvesThis();
 
-            return obj.fn()
-                .then(function (actual) {
-                    assert.same(actual, obj);
-                });
+            return obj.fn().then(function (actual) {
+                assert.same(actual, obj);
+            });
         });
 
         it("supersedes previous callsFake", function () {
@@ -623,15 +621,14 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return Promise.resolve('nooooo');
-                }
+                    return Promise.resolve("nooooo");
+                },
             };
-            createStub(obj, 'fn').callThrough().resolvesArg(1);
+            createStub(obj, "fn").callThrough().resolvesArg(1);
 
-            return obj.fn('zero', 'one')
-                .then(function (actual) {
-                    assert.same(actual, "one");
-                });
+            return obj.fn("zero", "one").then(function (actual) {
+                assert.same(actual, "one");
+            });
         });
 
         it("does not invoke Promise.resolve when the behavior is added to the stub", function () {
@@ -696,10 +693,10 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return 'nooooo';
-                }
+                    return "nooooo";
+                },
             };
-            createStub(obj, 'fn').callThrough().returnsArg(0);
+            createStub(obj, "fn").callThrough().returnsArg(0);
 
             assert.equals(obj.fn("myarg"), "myarg");
         });
@@ -833,10 +830,10 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return 'nooooo';
-                }
+                    return "nooooo";
+                },
             };
-            createStub(obj, 'fn').callThrough().throwsArg(1);
+            createStub(obj, "fn").callThrough().throwsArg(1);
             const expectedError = new Error("catpants");
 
             assert.exception(
@@ -905,10 +902,10 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return 'nooooo';
-                }
+                    return "nooooo";
+                },
             };
-            createStub(obj, 'fn').callThrough().returnsThis();
+            createStub(obj, "fn").callThrough().returnsThis();
 
             assert.same(obj.fn(), obj);
         });
@@ -1150,11 +1147,11 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return 'nooooo';
-                }
+                    return "nooooo";
+                },
             };
             const expectedError = new Error("catpants");
-            createStub(obj, 'fn').callThrough().throws(expectedError);
+            createStub(obj, "fn").callThrough().throws(expectedError);
 
             assert.exception(obj.fn, {
                 message: expectedError.message,
@@ -1240,10 +1237,10 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return 'nooooo';
-                }
+                    return "nooooo";
+                },
             };
-            const stub = createStub(obj, 'fn').callThrough().callsArg(0);
+            const stub = createStub(obj, "fn").callThrough().callsArg(0);
 
             const callback = createStub().returns("return value");
 
@@ -1326,10 +1323,12 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return 'nooooo';
-                }
+                    return "nooooo";
+                },
             };
-            const stub = createStub(obj, 'fn').callThrough().callsArgWith(0, 'test');
+            const stub = createStub(obj, "fn")
+                .callThrough()
+                .callsArgWith(0, "test");
             const callback = createStub().returns("return value");
 
             assert.same(stub(callback), "return value");
@@ -1426,10 +1425,10 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return 'nooooo';
-                }
+                    return "nooooo";
+                },
             };
-            createStub(obj, 'fn').callThrough().callsArgOn(0, this.fakeContext);
+            createStub(obj, "fn").callThrough().callsArgOn(0, this.fakeContext);
             const callback = createStub().returns("return value");
 
             assert.same(obj.fn(callback), "return value");
@@ -1562,12 +1561,14 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return 'nooooo';
-                }
+                    return "nooooo";
+                },
             };
 
-            const arg = 'hello';
-            createStub(obj, 'fn').callThrough().callsArgOnWith(1, this.fakeContext, arg);
+            const arg = "hello";
+            createStub(obj, "fn")
+                .callThrough()
+                .callsArgOnWith(1, this.fakeContext, arg);
             const callback = createStub();
 
             obj.fn(1, callback);
@@ -1632,13 +1633,15 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return 'nooooo';
-                }
+                    return "nooooo";
+                },
             };
 
-            createStub(obj, 'fn').callThrough().callsFake(() => 'yeees');
+            createStub(obj, "fn")
+                .callThrough()
+                .callsFake(() => "yeees");
 
-            assert.same(obj.fn(), 'yeees');
+            assert.same(obj.fn(), "yeees");
         });
     });
 
@@ -1941,10 +1944,10 @@ describe("stub", function () {
             const obj = {
                 fn() {
                     return 1;
-                }
+                },
             };
 
-            createStub(obj, 'fn').callThrough().yields(2);
+            createStub(obj, "fn").callThrough().yields(2);
             const spy = createSpy();
             obj.fn(spy);
 
@@ -2085,10 +2088,10 @@ describe("stub", function () {
             const obj = {
                 fn() {
                     return 1;
-                }
+                },
             };
 
-            createStub(obj, 'fn').callThrough().yieldsRight(2);
+            createStub(obj, "fn").callThrough().yieldsRight(2);
             const spy = createSpy();
             obj.fn(spy);
 
@@ -2256,10 +2259,10 @@ describe("stub", function () {
             const obj = {
                 fn() {
                     return 1;
-                }
+                },
             };
 
-            createStub(obj, 'fn').callThrough().yieldsOn(this.fakeContext, 2);
+            createStub(obj, "fn").callThrough().yieldsOn(this.fakeContext, 2);
             const spy = createSpy();
             obj.fn(spy);
 
@@ -2421,10 +2424,10 @@ describe("stub", function () {
             const obj = {
                 fn() {
                     return 1;
-                }
+                },
             };
 
-            createStub(obj, 'fn').callThrough().yieldsTo("success", 2);
+            createStub(obj, "fn").callThrough().yieldsTo("success", 2);
             const callback = createSpy();
             obj.fn({ success: callback });
 
@@ -2621,10 +2624,12 @@ describe("stub", function () {
             const obj = {
                 fn() {
                     return 1;
-                }
+                },
             };
 
-            createStub(obj, 'fn').callThrough().yieldsToOn("success", this.fakeContext, 2);
+            createStub(obj, "fn")
+                .callThrough()
+                .yieldsToOn("success", this.fakeContext, 2);
             const callback = createSpy();
             obj.fn({ success: callback });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -905,7 +905,7 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return'nooooo';
+                    return 'nooooo';
                 }
             };
             createStub(obj, 'fn').callThrough().returnsThis();
@@ -1240,7 +1240,7 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return'nooooo';
+                    return 'nooooo';
                 }
             };
             const stub = createStub(obj, 'fn').callThrough().callsArg(0);
@@ -1326,7 +1326,7 @@ describe("stub", function () {
         it("supersedes previous callThrough", function () {
             const obj = {
                 fn() {
-                    return'nooooo';
+                    return 'nooooo';
                 }
             };
             const stub = createStub(obj, 'fn').callThrough().callsArgWith(0, 'test');
@@ -1419,6 +1419,20 @@ describe("stub", function () {
             const callback = createStub().returns("return value");
 
             assert.same(stub(callback), "return value");
+            assert(callback.calledOnce);
+            assert(callback.calledOn(this.fakeContext));
+        });
+
+        it("supersedes previous callThrough", function () {
+            const obj = {
+                fn() {
+                    return 'nooooo';
+                }
+            };
+            createStub(obj, 'fn').callThrough().callsArgOn(0, this.fakeContext);
+            const callback = createStub().returns("return value");
+
+            assert.same(obj.fn(callback), "return value");
             assert(callback.calledOnce);
             assert(callback.calledOn(this.fakeContext));
         });
@@ -1544,6 +1558,23 @@ describe("stub", function () {
             assert(callback.calledOnce);
             assert(callback.calledWith(object));
         });
+
+        it("supersedes previous callThrough", function () {
+            const obj = {
+                fn() {
+                    return 'nooooo';
+                }
+            };
+
+            const arg = 'hello';
+            createStub(obj, 'fn').callThrough().callsArgOnWith(1, this.fakeContext, arg);
+            const callback = createStub();
+
+            obj.fn(1, callback);
+
+            assert(callback.calledWith(arg));
+            assert(callback.calledOn(this.fakeContext));
+        });
     });
 
     describe(".callsFake", function () {
@@ -1596,6 +1627,18 @@ describe("stub", function () {
 
             assert(fakeFn.called);
             assert(returned === 5);
+        });
+
+        it("supersedes previous callThrough", function () {
+            const obj = {
+                fn() {
+                    return 'nooooo';
+                }
+            };
+
+            createStub(obj, 'fn').callThrough().callsFake(() => 'yeees');
+
+            assert.same(obj.fn(), 'yeees');
         });
     });
 
@@ -1893,6 +1936,20 @@ describe("stub", function () {
             assert(spy.calledWith, 2);
             refute(fakeFn.called);
         });
+
+        it("supersedes previous callThrough", function () {
+            const obj = {
+                fn() {
+                    return 1;
+                }
+            };
+
+            createStub(obj, 'fn').callThrough().yields(2);
+            const spy = createSpy();
+            obj.fn(spy);
+
+            assert(spy.calledWith, 2);
+        });
     });
 
     describe(".yieldsRight", function () {
@@ -2022,6 +2079,20 @@ describe("stub", function () {
 
             assert(spy.calledWith, 2);
             refute(fakeFn.called);
+        });
+
+        it("supersedes previous callThrough", function () {
+            const obj = {
+                fn() {
+                    return 1;
+                }
+            };
+
+            createStub(obj, 'fn').callThrough().yieldsRight(2);
+            const spy = createSpy();
+            obj.fn(spy);
+
+            assert(spy.calledWith, 2);
         });
     });
 
@@ -2180,6 +2251,20 @@ describe("stub", function () {
             assert(spy.calledWith, 2);
             refute(fakeFn.called);
         });
+
+        it("supersedes previous callThrough", function () {
+            const obj = {
+                fn() {
+                    return 1;
+                }
+            };
+
+            createStub(obj, 'fn').callThrough().yieldsOn(this.fakeContext, 2);
+            const spy = createSpy();
+            obj.fn(spy);
+
+            assert(spy.calledWith, 2);
+        });
     });
 
     describe(".yieldsTo", function () {
@@ -2330,6 +2415,20 @@ describe("stub", function () {
 
             assert(callback.calledWith(2));
             refute(fakeFn.called);
+        });
+
+        it("supersedes previous callThrough", function () {
+            const obj = {
+                fn() {
+                    return 1;
+                }
+            };
+
+            createStub(obj, 'fn').callThrough().yieldsTo("success", 2);
+            const callback = createSpy();
+            obj.fn({ success: callback });
+
+            assert(callback.calledWith, 2);
         });
     });
 
@@ -2516,6 +2615,20 @@ describe("stub", function () {
 
             assert(callback.calledWith(2));
             refute(fakeFn.called);
+        });
+
+        it("supersedes previous callThrough", function () {
+            const obj = {
+                fn() {
+                    return 1;
+                }
+            };
+
+            createStub(obj, 'fn').callThrough().yieldsToOn("success", this.fakeContext, 2);
+            const callback = createSpy();
+            obj.fn({ success: callback });
+
+            assert(callback.calledWith(2));
         });
     });
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix issue #2566 by clearing the fake current behavior

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
