### PR TITLE
use random port for test:webworker

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test-headless": "mochify --no-detect-globals --recursive -R dot --grep WebWorker --invert  \"test/**/*-test.js\"",
     "test-coverage": "nyc npm run test-headless -- --transform [ babelify --ignore [ test ] --plugins [ babel-plugin-istanbul ] ]",
     "test-cloud": "npm run test-headless -- --wd",
-    "test-webworker": "mochify --no-detect-globals --https-server 8080 --no-request-interception test/webworker/webworker-support-assessment.js",
+    "test-webworker": "mochify --no-detect-globals --https-server 0 --no-request-interception test/webworker/webworker-support-assessment.js",
     "test-esm-support": "mocha test/es2015/module-support-assessment-test.mjs",
     "check-esm-bundle-runs-in-browser": "node test/es2015/check-esm-bundle-is-runnable.js",
     "test-docker-image": "docker-compose up",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Dev machine may already have port 8080 taken, which will fail the test, so listening to a random port instead

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
