### PR TITLE
Stop wrapping strings in Error

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -213,7 +213,7 @@ const defaultBehaviors = {
 
     rejects: function rejects(fake, error, message) {
         let reason;
-        if (typeof error === "string") {
+        if (typeof error === "string" && typeof message !== "undefined") {
             reason = new Error(message || "");
             reason.name = error;
         } else if (!error) {

--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -13,11 +13,9 @@ const useRightMostCallback = -2;
 function throwsException(fake, error, message) {
     if (typeof error === "function") {
         fake.exceptionCreator = error;
-    } else if (typeof error === "string") {
+    } else if (typeof error === "string" && typeof message !== "undefined") {
         fake.exceptionCreator = function () {
-            const newException = new Error(
-                message || `Sinon-provided ${error}`,
-            );
+            const newException = new Error(message);
             newException.name = error;
             return newException;
         };

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -74,32 +74,26 @@ fake.returns = function returns(value) {
 
 /**
  * Creates a `fake` that throws an Error.
- * If the `value` argument does not have Error in its prototype chain, it will
- * be used for creating a new error.
  *
  * @example
  * var f1 = sinon.fake.throws("hello");
  *
- * f1();
- * // Uncaught Error: hello
- *
+ * try { f1(); } catch (err} { console.log(typeof err, err); }
+ * // string hello
  * @example
  * var f2 = sinon.fake.throws(new TypeError("Invalid argument"));
  *
- * f2();
+ * try { f2(); } catch (err} { console.log(typeof err, err); }
  * // Uncaught TypeError: Invalid argument
  *
  * @memberof fake
- * @param {*|Error} value
+ * @param {*} err
  * @returns {Function}
  */
-fake.throws = function throws(value) {
-    // eslint-disable-next-line jsdoc/require-jsdoc
-    function f() {
-        throw getError(value);
-    }
-
-    return wrapFunc(f);
+fake.throws = function throws(err) {
+    return wrapFunc(() => {
+        throw err;
+    });
 };
 
 /**
@@ -127,8 +121,7 @@ fake.resolves = function resolves(value) {
 
 /**
  * Creates a `fake` that returns a promise that rejects to the passed `value`
- * argument. When `value` does not have Error in its prototype chain, it will be
- * wrapped in an Error.
+ * argument.
  *
  * @example
  * var f1 = sinon.fake.rejects(":(");
@@ -136,18 +129,18 @@ fake.resolves = function resolves(value) {
  * try {
  *   await ft();
  * } catch (error) {
- *   console.log(error);
- *   // ":("
+ *   console.log(typeof error, error);
+ *   // "string :("
  * }
  *
  * @memberof fake
- * @param {*} value
+ * @param {*} reason
  * @returns {Function}
  */
-fake.rejects = function rejects(value) {
+fake.rejects = function rejects(reason) {
     // eslint-disable-next-line jsdoc/require-jsdoc
     function f() {
-        return promiseLib.reject(getError(value));
+        return promiseLib.reject(reason);
     }
 
     return wrapFunc(f);
@@ -272,16 +265,4 @@ function wrapFunc(f) {
     proxy.id = `fake#${uuid++}`;
 
     return proxy;
-}
-
-/**
- * Returns an Error instance from the passed value, if the value is not
- * already an Error instance.
- *
- * @private
- * @param  {*} value [description]
- * @returns {Error}       [description]
- */
-function getError(value) {
-    return value instanceof Error ? value : new Error(value);
 }

--- a/test/fake-test.js
+++ b/test/fake-test.js
@@ -229,7 +229,7 @@ describe("fake", function () {
             try {
                 myFake();
             } catch (error) {
-                assert.equals(error.message, expectedMessage);
+                assert.equals(error, expectedMessage);
             }
             /* eslint-disable no-restricted-syntax */
         });
@@ -248,21 +248,6 @@ describe("fake", function () {
                 assert.isTrue(actual instanceof TypeError);
             }
             /* eslint-disable no-restricted-syntax */
-        });
-
-        describe("when passed a String", function () {
-            it("should throw an Error", function () {
-                const expected = "lorem ipsum";
-                const myFake = fake.throws(expected);
-
-                /* eslint-disable no-restricted-syntax */
-                try {
-                    myFake();
-                } catch (actual) {
-                    assert.isTrue(actual instanceof Error);
-                }
-                /* eslint-disable no-restricted-syntax */
-            });
         });
     });
 
@@ -290,28 +275,19 @@ describe("fake", function () {
             const myFake = fake.rejects(expectedMessage);
 
             return myFake().catch(function (actual) {
-                assert.equals(actual.message, expectedMessage);
+                assert.equals(actual, expectedMessage);
             });
         });
 
         // eslint-disable-next-line mocha/no-setup-in-describe
         verifyProxy(fake.rejects, "42");
 
-        it("should return the same error type as it is passed", function () {
+        it("should return the same reason as it is passed", function () {
             const expected = new TypeError("hello world");
             const myFake = fake.rejects(expected);
 
             return myFake().catch(function (actual) {
                 assert.isTrue(actual instanceof TypeError);
-            });
-        });
-
-        it("should reject with an Error when passed a String", function () {
-            const expected = "lorem ipsum";
-            const myFake = fake.rejects(expected);
-
-            return myFake().catch(function (actual) {
-                assert.isTrue(actual instanceof Error);
             });
         });
     });

--- a/test/proxy-call-test.js
+++ b/test/proxy-call-test.js
@@ -1126,7 +1126,9 @@ describe("sinonSpy.call", function () {
         });
 
         it("includes exception", function () {
-            const object = { doIt: sinonStub().throws("TypeError") };
+            const object = {
+                doIt: sinonStub().throws("TypeError", "some message"),
+            };
 
             assert.exception(function () {
                 object.doIt();
@@ -1134,7 +1136,7 @@ describe("sinonSpy.call", function () {
 
             assert.equals(
                 object.doIt.getCall(0).toString().replace(/ at.*/g, ""),
-                "doIt() !TypeError(Sinon-provided TypeError)",
+                "doIt() !TypeError(some message)",
             );
         });
 

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -986,14 +986,15 @@ describe("stub", function () {
             assert.same(stub.throws({}), stub);
         });
 
-        it("sets type of exception to throw", function () {
+        it("can throw a string", function () {
             const stub = createStub();
-            const exceptionType = "TypeError";
-            stub.throws(exceptionType);
+            stub.throws("a reason");
 
-            assert.exception(function () {
+            try {
                 stub();
-            }, exceptionType);
+            } catch (reason) {
+                assert.equals(reason, "a reason");
+            }
         });
 
         it("specifies exception message", function () {
@@ -1003,15 +1004,6 @@ describe("stub", function () {
 
             assert.exception(stub, {
                 message: message,
-            });
-        });
-
-        it("does not specify exception message if not provided", function () {
-            const stub = createStub();
-            stub.throws("Error");
-
-            assert.exception(stub, {
-                message: "",
             });
         });
 
@@ -1036,19 +1028,16 @@ describe("stub", function () {
             assert.contains(stub.firstCall.toString(), "not implemented");
         });
 
-        it("creates a non empty error message when error is a string and no message is passed", function () {
+        it("throws a string when the error is a string and no message is passed", function () {
             const stub = createStub();
 
-            stub.withArgs(1).throws("TypeError");
+            stub.withArgs(1).throws("something happened");
 
-            assert.exception(
-                function () {
-                    stub(1);
-                },
-                {
-                    message: "Sinon-provided TypeError",
-                },
-            );
+            try {
+                stub(1);
+            } catch (err) {
+                assert.equals(err, "something happened");
+            }
         });
 
         describe("lazy instantiation of exceptions", function () {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -349,7 +349,7 @@ describe("stub", function () {
 
         it("returns a promise which rejects for the specified reason", function () {
             const stub = createStub();
-            const reason = new Error();
+            const reason = "the reason";
             stub.rejects(reason);
 
             return stub()
@@ -367,7 +367,7 @@ describe("stub", function () {
             assert.same(stub.rejects({}), stub);
         });
 
-        it("specifies exception message", function () {
+        it("specifies error type and exception message", function () {
             const stub = createStub();
             const message = "Oh no!";
             stub.rejects("Error", message);
@@ -378,19 +378,6 @@ describe("stub", function () {
                 })
                 .catch(function (reason) {
                     assert.equals(reason.message, message);
-                });
-        });
-
-        it("does not specify exception message if not provided", function () {
-            const stub = createStub();
-            stub.rejects("Error");
-
-            return stub()
-                .then(function () {
-                    referee.fail("Expected stub to reject");
-                })
-                .catch(function (reason) {
-                    assert.equals(reason.message, "");
                 });
         });
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix #1679 by changing the Stub and Fake API to not wrap strings in Error

 #### Background (Problem in detail)  
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

In #1679 it was raised how stub.rejects("error") does not reject the promise with the passed in reason, but chooses to wrap it in an error. Some people found that behavior surprising that and had objections to that API design.

@mantoni chimed in to say that he thought stub.rejects should behave in line with `Promise.reject`.

I made the point that while `stub.rejects(string)` might be surprising to someone comparing it to the `Promise.reject` API _it is totally _consistent_ with the current behavior of `stub.throws(string)` and that we should keep the two aligned.

 #### Solution  

This is _one_ solution to the issue: it changes the `rejects` and `throws` API's of Stub and Fake to not treat the single-argument string in a special matter. This will potentially break a lot of existing code, but at least keeps consistency across the API's for throwing sync and async.

There are other takes, one being to simply keep things as they are and document in the docs how to these are _utility_ methods to achieve the most normal flow (which is throwing an error sync and async), and simply update the docs (both JSDoc and homepage docs) to point to other methods for achieving more specialized cases.

For instance, if you want to throw a string using the API that is today (before this change), you can just create a fake or stub that does that:
```javascript
sinon.stub(() => {throw "foo"; })
// throws a string "foo"
```
Same goes for Promises / throwing async
```javascript
sinon.stub(() => Promise.reject("foo"))
// alternatively
sinon.stub().returns(Promise.reject("foo"))
```

I think this is just as valid an approach: making people aware that 
the basic building blocks are there. That's what I like about the
Fake API: fewer methods in that API to rather create explicit 
behavior that creates less misconceptions about what something is doing.

<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. <your-steps-here>

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
