### PR TITLE
Add a notice that the Fake Timers API doc is incomplete

### DIFF
--- a/docs/release-source/release/fake-timers.md
+++ b/docs/release-source/release/fake-timers.md
@@ -6,10 +6,12 @@ breadcrumb: fake timers
 
 Fake timers are synchronous implementations of `setTimeout` and friends that
 Sinon.JS can overwrite the global functions with to allow you to more easily
-test code using them.
+test code using them. It also has utilities for working with `async`/Promise code.
 
 Fake timers provide a `clock` object to pass time, which can also be used to control `Date` objects created through either `new Date();`
 or `Date.now();` (if supported by the browser).
+
+> The separate Fake Timers project is constantly being added to and updated, and we have a hard time keeping these docs in sync! Therefore it might be better to just refer directly to the [fake-timer API reference][api reference], as that shows all it has to offer. The `clock` object is not wrapped, so everything `fake-timers` has to offer can be used through it.
 
 For standalone usage of fake timers it is recommended to use [fake-timers](https://github.com/sinonjs/fake-timers) package instead. It provides the same
 set of features (Sinon uses it under the hood) and was previously extracted from Sinon.JS.
@@ -38,6 +40,8 @@ set of features (Sinon uses it under the hood) and was previously extracted from
 ```
 
 ## Fake timers API
+
+> This is just the most important subset of the available methods. Refer to the [Fake Timers API reference][api reference] for the full _smørgåsbord_ of available methods.
 
 #### `var clock = sinon.useFakeTimers();`
 
@@ -176,3 +180,5 @@ The `runAllAsync()` will also break the event loop, allowing any scheduled promi
 Restore the faked methods.
 
 Call in e.g. `tearDown`.
+
+[api reference]: https://github.com/sinonjs/fake-timers#api-reference


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This is basically linking to the original Fake Timers
project as an excuse for not keeping the documented API
in sync. 

This is a case where the community TypeScript effort at 
DefinitelyTyped is doing a much better job than us, as
they simply import the fake-timers types in the Sinon definitions.

<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. <your-steps-here>

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
