### PR TITLE
Fix Mocha watch task by delegating to Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "test-node": "mocha --recursive -R dot \"test/**/*-test.js\"",
-    "test-dev": "npm run test-node -- --watch -R min",
+    "test-dev": "npm run test-node --  -n watch -n  watch-path=test --node-option watch-path=lib -R min",
     "test-headless": "mochify --no-detect-globals --recursive -R dot --grep WebWorker --invert  \"test/**/*-test.js\"",
     "test-coverage": "nyc npm run test-headless -- --transform [ babelify --ignore [ test ] --plugins [ babel-plugin-istanbul ] ]",
     "test-cloud": "npm run test-headless -- --wd",


### PR DESCRIPTION
Since Node 18 there is a built-in watch mode. Mocha's watch
mode is really buggy and this fix is much snappier and
bug-free AFAIK.

#### Purpose (TL;DR) - mandatory

<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. <your-steps-here>

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
