### PR TITLE
Make sandbox concurrency safe

### DIFF
--- a/lib/sinon/proxy-invoke.js
+++ b/lib/sinon/proxy-invoke.js
@@ -12,6 +12,9 @@ const bind = Function.prototype.bind;
 
 module.exports = function invoke(func, thisValue, args, ctx = globalContext) {
     const matchings = this.matchingFakes(args);
+    if (ctx.callId == null) {
+        ctx.callId = 0;
+    }
     const currentCallId = ctx.callId++;
     let exception, returnValue;
 

--- a/lib/sinon/proxy-invoke.js
+++ b/lib/sinon/proxy-invoke.js
@@ -2,6 +2,7 @@
 
 const arrayProto = require("@sinonjs/commons").prototypes.array;
 const proxyCallUtil = require("./proxy-call-util");
+const globalContext = require("./util/core/global-context");
 
 const push = arrayProto.push;
 const forEach = arrayProto.forEach;
@@ -9,11 +10,9 @@ const concat = arrayProto.concat;
 const ErrorConstructor = Error.prototype.constructor;
 const bind = Function.prototype.bind;
 
-let callId = 0;
-
-module.exports = function invoke(func, thisValue, args) {
+module.exports = function invoke(func, thisValue, args, ctx = globalContext) {
     const matchings = this.matchingFakes(args);
-    const currentCallId = callId++;
+    const currentCallId = ctx.callId++;
     let exception, returnValue;
 
     proxyCallUtil.incrementCallCount(this);

--- a/lib/sinon/proxy.js
+++ b/lib/sinon/proxy.js
@@ -254,7 +254,7 @@ function createProxy(func, originalFunc, ctx = globalContext) {
     return proxy;
 }
 
-function wrapFunction(func, originalFunc, ctx) {
+function wrapFunction(func, originalFunc, ctx = globalContext) {
     const arity = originalFunc.length;
     let p;
     // Do not change this to use an eval. Projects that depend on sinon block the use of eval.

--- a/lib/sinon/proxy.js
+++ b/lib/sinon/proxy.js
@@ -2,6 +2,7 @@
 
 const arrayProto = require("@sinonjs/commons").prototypes.array;
 const extend = require("./util/core/extend");
+const globalContext = require("./util/core/global-context");
 const functionToString = require("./util/core/function-to-string");
 const proxyCall = require("./proxy-call");
 const proxyCallUtil = require("./proxy-call-util");
@@ -240,8 +241,8 @@ delegateToCalls(proxyApi, "alwaysReturned", false, "returned");
 delegateToCalls(proxyApi, "calledWithNew", true);
 delegateToCalls(proxyApi, "alwaysCalledWithNew", false, "calledWithNew");
 
-function createProxy(func, originalFunc) {
-    const proxy = wrapFunction(func, originalFunc);
+function createProxy(func, originalFunc, ctx = globalContext) {
+    const proxy = wrapFunction(func, originalFunc, ctx);
 
     // Inherit function properties:
     extend(proxy, func);
@@ -253,7 +254,7 @@ function createProxy(func, originalFunc) {
     return proxy;
 }
 
-function wrapFunction(func, originalFunc) {
+function wrapFunction(func, originalFunc, ctx) {
     const arity = originalFunc.length;
     let p;
     // Do not change this to use an eval. Projects that depend on sinon block the use of eval.
@@ -262,72 +263,72 @@ function wrapFunction(func, originalFunc) {
         /*eslint-disable no-unused-vars, max-len*/
         case 0:
             p = function proxy() {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 1:
             p = function proxy(a) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 2:
             p = function proxy(a, b) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 3:
             p = function proxy(a, b, c) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 4:
             p = function proxy(a, b, c, d) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 5:
             p = function proxy(a, b, c, d, e) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 6:
             p = function proxy(a, b, c, d, e, f) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 7:
             p = function proxy(a, b, c, d, e, f, g) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 8:
             p = function proxy(a, b, c, d, e, f, g, h) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 9:
             p = function proxy(a, b, c, d, e, f, g, h, i) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 10:
             p = function proxy(a, b, c, d, e, f, g, h, i, j) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 11:
             p = function proxy(a, b, c, d, e, f, g, h, i, j, k) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         case 12:
             p = function proxy(a, b, c, d, e, f, g, h, i, j, k, l) {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         default:
             p = function proxy() {
-                return p.invoke(func, this, slice(arguments));
+                return p.invoke(func, this, slice(arguments), ctx);
             };
             break;
         /*eslint-enable*/

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -78,6 +78,7 @@ function checkForValidArguments(descriptor, property, replacement) {
  */
 function Sandbox(opts = {}) {
     const sandbox = this;
+    sandbox.callId = 0;
     const assertOptions = opts.assertOptions || {};
     let fakeRestorers = [];
     let promiseLib;

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -445,8 +445,13 @@ function Sandbox(opts = {}) {
         return spy;
     }
 
-    sandbox.spy = function spy() {
-        const createdSpy = sinonSpy.apply(sinonSpy, arguments);
+    sandbox.spy = function spy(object, property, types) {
+        const createdSpy = sinonSpy.apply(sinonSpy, [
+            object,
+            property,
+            types,
+            sandbox,
+        ]);
         return commonPostInitSetup(arguments, createdSpy);
     };
 

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -11,6 +11,7 @@ const proxyCallUtil = require("./proxy-call-util");
 const walkObject = require("./util/core/walk-object");
 const wrapMethod = require("./util/core/wrap-method");
 const valueToString = require("@sinonjs/commons").valueToString;
+const globalContext = require("./util/core/global-context");
 
 /* cache references to library methods so that they also can be stubbed without problems */
 const forEach = arrayProto.forEach;
@@ -130,7 +131,7 @@ delegateToCalls(
     },
 );
 
-function createSpy(func) {
+function createSpy(func, context = globalContext) {
     let name;
     let funk = func;
 
@@ -142,7 +143,7 @@ function createSpy(func) {
         name = functionName(funk);
     }
 
-    const proxy = createProxy(funk, funk);
+    const proxy = createProxy(funk, funk, context);
 
     // Inherit spy API:
     extend.nonEnum(proxy, spyApi);
@@ -155,13 +156,13 @@ function createSpy(func) {
     return proxy;
 }
 
-function spy(object, property, types) {
+function spy(object, property, types, context = globalContext) {
     if (isEsModule(object)) {
         throw new TypeError("ES Modules cannot be spied");
     }
 
     if (!property && typeof object === "function") {
-        return createSpy(object);
+        return createSpy(object, context);
     }
 
     if (!property && typeof object === "object") {
@@ -171,18 +172,22 @@ function spy(object, property, types) {
     if (!object && !property) {
         return createSpy(function () {
             return;
-        });
+        }, context);
     }
 
     if (!types) {
-        return wrapMethod(object, property, createSpy(object[property]));
+        return wrapMethod(
+            object,
+            property,
+            createSpy(object[property], context),
+        );
     }
 
     const descriptor = {};
     const methodDesc = getPropertyDescriptor(object, property);
 
     forEach(types, function (type) {
-        descriptor[type] = createSpy(methodDesc[type]);
+        descriptor[type] = createSpy(methodDesc[type], context);
     });
 
     return wrapMethod(object, property, descriptor);

--- a/lib/sinon/util/core/global-context.js
+++ b/lib/sinon/util/core/global-context.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+    callId: 0,
+};

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -2401,7 +2401,7 @@ describe("Sandbox", function () {
             }
 
             const fn = async () => {
-                const sinonSandbox = sinon.createSandbox();
+                const sinonSandbox = createSandbox();
 
                 const f = new F();
 
@@ -2422,7 +2422,7 @@ describe("Sandbox", function () {
                 assert(b.calledImmediatelyBefore(c));
             };
 
-            await Promise.all([fn, fn, fn]);
+            await Promise.all([fn(), fn(), fn(), fn()]);
         });
     });
 });


### PR DESCRIPTION
#### Make sandbox concurrency safe

Fix #2472, sandbox not working when running tests concurrently because of global callId variable
<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

 #### Solution

Store callId in a context passed with an optional argument, which is the sandbox object when using sandbox


<!--

-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

Added a test with the #2472 reproduction

1. Check out this branch
2. `npm install`
3. npm test

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
