### PR TITLE
Add createStubInstance header in stubs.md

### DIFF
--- a/docs/release-source/release/stubs.md
+++ b/docs/release-source/release/stubs.md
@@ -90,6 +90,8 @@ Note that it's usually better practice to stub individual methods, particularly 
 
 Stubbing individual methods tests intent more precisely and is less susceptible to unexpected behavior as the object's code evolves.
 
+#### `var stubInstance = sinon.createStubInstance(MyConstructor, overrides);`
+
 If you want to create a stub object of `MyConstructor`, but don't want the constructor to be invoked, use this utility function.
 
 ```javascript


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

I kept scrolling past the parts of this page that explain `createStubInstance` so I created a section for it. I think the reason it didn't already exist is because it's considered a part of the utilities API, not the stub API. Even if that's the reasoning, I hope this PR is still a net positive, because personally, it makes it easier to find what I'm looking for.

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. <your-steps-here>

The documentation contribute in guide led me to believe that this doesn't apply to documentation changes. Let me know if I misinterpreted it, though.

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
