### PR TITLE
Fix some typos at code comments

### DIFF
--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -134,7 +134,7 @@ fake.resolves = function resolves(value) {
  * var f1 = sinon.fake.rejects(":(");
  *
  * try {
- *   await ft();
+ *   await f1();
  * } catch (error) {
  *   console.log(error);
  *   // ":("

--- a/lib/sinon/util/core/extend.js
+++ b/lib/sinon/util/core/extend.js
@@ -114,7 +114,7 @@ module.exports = function extend(target, ...sources) {
                 enumerable: sourceOwnPropertyDescriptor.enumerable,
             };
             /*
-                if the sorce has an Accessor property copy over the accessor functions (get and set)
+                if the source has an Accessor property copy over the accessor functions (get and set)
                 data properties has writable attribute where as accessor property don't
                 REF: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#properties
             */


### PR DESCRIPTION
Fix some typos found at code comments

- [V] `npm run lint` passes
- [V] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
