### PR TITLE
Fix typo in mocks documentation

### DIFF
--- a/docs/release-source/release/mocks.md
+++ b/docs/release-source/release/mocks.md
@@ -148,7 +148,7 @@ An `expectation` instance only holds onto a single set of arguments specified wi
 
 #### `expectation.on(obj);`
 
-Expect the method to be called with `obj` as `this`."}
+Expect the method to be called with `obj` as `this`.
 
 #### `expectation.verify();`
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Improve documentation.

Page changed: https://sinonjs.org/releases/v17/mocks/.

Typo is under _expectation.on(obj);_ header:
![sinonjs-docs-mocks-typo](https://github.com/sinonjs/sinon/assets/52535457/99e4d350-d5bf-4665-bd30-c46973ca6a3b)

#### How to verify - mandatory

1. Open docs/release-source/release/mocks.md file with a markdown viewer.
2. Check typo has been removed.

#### Checklist for author

- [ ] ”} typo is not present any more.
