### PR TITLE
fix #2589: avoid invoking getter as side-effect

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -243,7 +243,7 @@ function Sandbox(opts = {}) {
      */
     function getFakeRestorer(object, property, forceAssignment = false) {
         const descriptor = getPropertyDescriptor(object, property);
-        const value = object[property];
+        const value = forceAssignment && object[property];
 
         function restorer() {
             if (forceAssignment) {

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1296,6 +1296,20 @@ describe("Sandbox", function () {
                 },
             );
         });
+
+        it("do not call getter whilst replacing getter", function () {
+            const sandbox = this.sandbox;
+            const fake = sandbox.fake.returns("bar");
+            const object = {
+                get foo() {
+                    return fake();
+                },
+            };
+
+            sandbox.replaceGetter(object, "foo", () => "replacement");
+
+            refute(fake.called);
+        });
     });
 
     describe(".replaceSetter", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix the issue in #2589 by checking for the odd case where we actually force setting a value through accessor functions and only look up the value at that time.

The alternative would be more elaborate, check if the descriptor had a `get` or a `value` field, and then decide, but this should do the trick.


<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
