### PR TITLE
Avoid return and callArg* clearing each other's state

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -30,90 +30,64 @@ function throwsException(fake, error, message) {
     }
 }
 
-const SKIP_OPTIONS_FOR_YIELDS = {
-    skipReturn: true,
-    skipThrows: true,
-};
-
-function clear(fake, options) {
-    fake.fakeFn = undefined;
-
-    fake.callsThrough = undefined;
-    fake.callsThroughWithNew = undefined;
-
-    if (!options || !options.skipThrows) {
-        fake.exception = undefined;
-        fake.exceptionCreator = undefined;
-        fake.throwArgAt = undefined;
-    }
-
-    fake.callArgAt = undefined;
-    fake.callbackArguments = undefined;
-    fake.callbackContext = undefined;
-    fake.callArgProp = undefined;
-    fake.callbackAsync = undefined;
-
-    if (!options || !options.skipReturn) {
-        fake.returnValue = undefined;
-        fake.returnValueDefined = undefined;
-        fake.returnArgAt = undefined;
-        fake.returnThis = undefined;
-    }
-
-    fake.resolve = undefined;
-    fake.resolveThis = undefined;
-    fake.resolveArgAt = undefined;
-
-    fake.reject = undefined;
-}
-
 const defaultBehaviors = {
     callsFake: function callsFake(fake, fn) {
-        clear(fake);
-
         fake.fakeFn = fn;
+        fake.exception = undefined;
+        fake.exceptionCreator = undefined;
+        fake.callsThrough = false;
     },
 
     callsArg: function callsArg(fake, index) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
-        clear(fake);
 
         fake.callArgAt = index;
         fake.callbackArguments = [];
+        fake.callbackContext = undefined;
+        fake.callArgProp = undefined;
+        fake.callbackAsync = false;
+        fake.callsThrough = false;
     },
 
     callsArgOn: function callsArgOn(fake, index, context) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
-        clear(fake);
 
         fake.callArgAt = index;
         fake.callbackArguments = [];
         fake.callbackContext = context;
+        fake.callArgProp = undefined;
+        fake.callbackAsync = false;
+        fake.callsThrough = false;
     },
 
     callsArgWith: function callsArgWith(fake, index) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
-        clear(fake);
 
         fake.callArgAt = index;
         fake.callbackArguments = slice(arguments, 2);
+        fake.callbackContext = undefined;
+        fake.callArgProp = undefined;
+        fake.callbackAsync = false;
+        fake.callsThrough = false;
     },
 
     callsArgOnWith: function callsArgWith(fake, index, context) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
-        clear(fake);
 
         fake.callArgAt = index;
         fake.callbackArguments = slice(arguments, 3);
         fake.callbackContext = context;
+        fake.callArgProp = undefined;
+        fake.callbackAsync = false;
+        fake.callsThrough = false;
     },
 
     usingPromise: function usingPromise(fake, promiseLibrary) {
@@ -121,59 +95,73 @@ const defaultBehaviors = {
     },
 
     yields: function (fake) {
-        clear(fake, SKIP_OPTIONS_FOR_YIELDS);
-
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice(arguments, 1);
+        fake.callbackContext = undefined;
+        fake.callArgProp = undefined;
+        fake.callbackAsync = false;
+        fake.fakeFn = undefined;
+        fake.callsThrough = false;
     },
 
     yieldsRight: function (fake) {
-        clear(fake, SKIP_OPTIONS_FOR_YIELDS);
-
         fake.callArgAt = useRightMostCallback;
         fake.callbackArguments = slice(arguments, 1);
+        fake.callbackContext = undefined;
+        fake.callArgProp = undefined;
+        fake.callbackAsync = false;
+        fake.callsThrough = false;
+        fake.fakeFn = undefined;
     },
 
     yieldsOn: function (fake, context) {
-        clear(fake, SKIP_OPTIONS_FOR_YIELDS);
-
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice(arguments, 2);
         fake.callbackContext = context;
+        fake.callArgProp = undefined;
+        fake.callbackAsync = false;
+        fake.callsThrough = false;
+        fake.fakeFn = undefined;
     },
 
     yieldsTo: function (fake, prop) {
-        clear(fake, SKIP_OPTIONS_FOR_YIELDS);
-
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice(arguments, 2);
+        fake.callbackContext = undefined;
         fake.callArgProp = prop;
+        fake.callbackAsync = false;
+        fake.callsThrough = false;
+        fake.fakeFn = undefined;
     },
 
     yieldsToOn: function (fake, prop, context) {
-        clear(fake, SKIP_OPTIONS_FOR_YIELDS);
-
         fake.callArgAt = useLeftMostCallback;
         fake.callbackArguments = slice(arguments, 3);
         fake.callbackContext = context;
         fake.callArgProp = prop;
+        fake.callbackAsync = false;
+        fake.fakeFn = undefined;
     },
 
     throws: throwsException,
     throwsException: throwsException,
 
     returns: function returns(fake, value) {
-        clear(fake);
-
+        fake.callsThrough = false;
         fake.returnValue = value;
+        fake.resolve = false;
+        fake.reject = false;
         fake.returnValueDefined = true;
+        fake.exception = undefined;
+        fake.exceptionCreator = undefined;
+        fake.fakeFn = undefined;
     },
 
     returnsArg: function returnsArg(fake, index) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
-        clear(fake);
+        fake.callsThrough = false;
 
         fake.returnArgAt = index;
     },
@@ -182,33 +170,42 @@ const defaultBehaviors = {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
-        clear(fake);
+        fake.callsThrough = false;
 
         fake.throwArgAt = index;
     },
 
     returnsThis: function returnsThis(fake) {
-        clear(fake);
-
         fake.returnThis = true;
+        fake.callsThrough = false;
     },
 
     resolves: function resolves(fake, value) {
-        clear(fake);
-
         fake.returnValue = value;
         fake.resolve = true;
+        fake.resolveThis = false;
+        fake.reject = false;
         fake.returnValueDefined = true;
+        fake.exception = undefined;
+        fake.exceptionCreator = undefined;
+        fake.fakeFn = undefined;
+        fake.callsThrough = false;
     },
 
     resolvesArg: function resolvesArg(fake, index) {
         if (typeof index !== "number") {
             throw new TypeError("argument index is not number");
         }
-        clear(fake);
-
         fake.resolveArgAt = index;
+        fake.returnValue = undefined;
         fake.resolve = true;
+        fake.resolveThis = false;
+        fake.reject = false;
+        fake.returnValueDefined = false;
+        fake.exception = undefined;
+        fake.exceptionCreator = undefined;
+        fake.fakeFn = undefined;
+        fake.callsThrough = false;
     },
 
     rejects: function rejects(fake, error, message) {
@@ -221,30 +218,36 @@ const defaultBehaviors = {
         } else {
             reason = error;
         }
-        clear(fake);
-
         fake.returnValue = reason;
+        fake.resolve = false;
+        fake.resolveThis = false;
         fake.reject = true;
         fake.returnValueDefined = true;
+        fake.exception = undefined;
+        fake.exceptionCreator = undefined;
+        fake.fakeFn = undefined;
+        fake.callsThrough = false;
 
         return fake;
     },
 
     resolvesThis: function resolvesThis(fake) {
-        clear(fake);
-
+        fake.returnValue = undefined;
+        fake.resolve = false;
         fake.resolveThis = true;
+        fake.reject = false;
+        fake.returnValueDefined = false;
+        fake.exception = undefined;
+        fake.exceptionCreator = undefined;
+        fake.fakeFn = undefined;
+        fake.callsThrough = false;
     },
 
     callThrough: function callThrough(fake) {
-        clear(fake);
-
         fake.callsThrough = true;
     },
 
     callThroughWithNew: function callThroughWithNew(fake) {
-        clear(fake);
-
         fake.callsThroughWithNew = true;
     },
 

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -915,9 +915,21 @@ describe("issues", function () {
         assert.equals(spy.get.callCount, 1); // should remain unchanged
     });
 
-    it("#2572 - returns clear callArgAt", function () {
+    it("#2572 - returns should not clear callsArgWith", function () {
         const stub = sinon.stub();
         stub.callsArgWith(0, "Hello").returns("World");
+
+        const cb = sinon.stub();
+        const ret = stub(cb);
+
+        assert.equals(ret, "World");
+        assert(cb.calledOnce);
+        assert.equals(cb.firstCall.args, ["Hello"]);
+    });
+
+    it("#2572 - callsArgWith should not clear returns", function () {
+        const stub = sinon.stub();
+        stub.returns("World").callsArgWith(0, "Hello");
 
         const cb = sinon.stub();
         const ret = stub(cb);

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -914,4 +914,16 @@ describe("issues", function () {
         object.prop;
         assert.equals(spy.get.callCount, 1); // should remain unchanged
     });
+
+    it("#2572 - returns clear callArgAt", function () {
+        const stub = sinon.stub();
+        stub.callsArgWith(0, "Hello").returns("World");
+
+        const cb = sinon.stub();
+        const ret = stub(cb);
+
+        assert.equals(ret, "World");
+        assert(cb.calledOnce);
+        assert.equals(cb.firstCall.args, ["Hello"]);
+    });
 });


### PR DESCRIPTION

#### Purpose (TL;DR) - mandatory

This partially reverts changes done in #2567, as the clearing of state was a bit too invasive. It is fully possible to have functions that both call callbacks and return values, which was made impossible by this change.

I kept the tests, which proves this fix is not affecting the intent of the original fix, and additionally added a regression test for #2572 to make sure it keeps that way.

<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. <your-steps-here>

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
