### PR TITLE
feat(docs): overview of previously supported Node.js

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -50,7 +50,7 @@ The following table serves as an orientation if support for an older unsupported
 |    12    |    12, 14, 16     |
 |    11    |    10, 12, 14     |
 |    10    |    10, 12, 14     |
-|    9     |     8, 10, 12     |
+|    9     |     10, 12     |
 |    8     |     8, 10, 12     |
 
 [es5]: http://www.ecma-international.org/ecma-262/5.1/

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -40,7 +40,7 @@ To see what that means in practice, you can use https://browserslist.dev
 The following table serves as an orientation if support for an older unsupported Node.js version is required.
 
 | Sinon.JS | supported Node.js |
-|:--------:|:-----------------:|
+| :------: | :---------------: |
 |    18    |    18, 20, 22     |
 |    17    |      18, 20       |
 |    16    |    16, 18, 20     |
@@ -48,9 +48,9 @@ The following table serves as an orientation if support for an older unsupported
 |    14    |    14, 16, 18     |
 |    13    |    12, 14, 16     |
 |    12    |    12, 14, 16     |
-|    11    |    12, 14     |
+|    11    |      12, 14       |
 |    10    |    10, 12, 14     |
-|    9     |     10, 12     |
+|    9     |      10, 12       |
 |    8     |     8, 10, 12     |
 
 [es5]: http://www.ecma-international.org/ecma-262/5.1/

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -48,7 +48,7 @@ The following table serves as an orientation if support for an older unsupported
 |    14    |    14, 16, 18     |
 |    13    |    12, 14, 16     |
 |    12    |    12, 14, 16     |
-|    11    |    10, 12, 14     |
+|    11    |    12, 14     |
 |    10    |    10, 12, 14     |
 |    9     |     10, 12     |
 |    8     |     8, 10, 12     |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -35,6 +35,24 @@ To see what that means in practice, you can use https://browserslist.dev
 <a href="https://saucelabs.com/u/sinonjs"><img src="https://saucelabs.com/browser-matrix/sinonjs.svg" alt="Sauce Test Status"></a>
 </p>
 
+## Previous supported Node.js
+
+The following table serves as an orientation if support for an older unsupported Node.js version is required.
+
+| Sinon.JS | supported Node.js |
+|:--------:|:-----------------:|
+|    18    |    18, 20, 22     |
+|    17    |      18, 20       |
+|    16    |    16, 18, 20     |
+|    15    |    14, 16, 18     |
+|    14    |    14, 16, 18     |
+|    13    |    12, 14, 16     |
+|    12    |    12, 14, 16     |
+|    11    |    10, 12, 14     |
+|    10    |    10, 12, 14     |
+|    9     |     8, 10, 12     |
+|    8     |     8, 10, 12     |
+
 [es5]: http://www.ecma-international.org/ecma-262/5.1/
 [es2017]: https://262.ecma-international.org/8.0/
 [shared-config]: https://github.com/sinonjs/eslint-config


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

fixes #2601

#### Background (Problem in detail) 

For projects that are slower to upgrade the node version, it is difficult to find the correct sinon version, as the current LTS version is newer than the old one required by the projects. Currently it is difficult to find out which sinon version supports an old node version.

#### Solution  - optional

Add overview of previously supported Node.js and the according Sinon.js version.

#### How to verify - mandatory

pass

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
