### PR TITLE
feat: throw when trying to use .value() on a method

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -4,6 +4,7 @@ const arrayProto = require("@sinonjs/commons").prototypes.array;
 const isPropertyConfigurable = require("./util/core/is-property-configurable");
 const exportAsyncBehaviors = require("./util/core/export-async-behaviors");
 const extend = require("./util/core/extend");
+const getPropertyDescriptor = require("./util/core/get-property-descriptor");
 
 const slice = arrayProto.slice;
 
@@ -286,6 +287,20 @@ const defaultBehaviors = {
 
     value: function value(fake, newVal) {
         const rootStub = fake.stub || fake;
+        const propertyDescriptor = getPropertyDescriptor(
+            rootStub.rootObj,
+            rootStub.propName,
+        );
+        const propertyIsGetter = propertyDescriptor.get !== undefined;
+        const propertyIsMethod =
+            !propertyIsGetter &&
+            typeof rootStub.rootObj[rootStub.propName] === "function";
+
+        if (propertyIsMethod) {
+            throw new Error(
+                `${rootStub.propName} is a function, not a getter or value. Use .returns() instead of .value()`,
+            );
+        }
 
         Object.defineProperty(rootStub.rootObj, rootStub.propName, {
             value: newVal,

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -3781,6 +3781,29 @@ describe("stub", function () {
             assert.equals(myFunc.prop, "rawString");
         });
 
+        it("allows stubbing getters", function () {
+            const y = {
+                get foo() {
+                    return "bar";
+                },
+            };
+            refute.exception(function () {
+                createStub(y, "foo").value("bar");
+            });
+        });
+
+        it("disallows stubbing non-accessor methods", function () {
+            const x = {
+                getFoo: function getFoo() {
+                    return "bar";
+                },
+            };
+
+            assert.exception(function () {
+                createStub(x, "getFoo").value("baz");
+            }, "Error: getFoo is a function, not a getter or value. Use .returns() instead of .value()");
+        });
+
         it("allows stubbing object props with configurable false", function () {
             const myObj = {};
             Object.defineProperty(myObj, "prop", {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This is a solution for #2629

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
