### PR TITLE
fix browser-test job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 1
 
   browser-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

When running `browser-test` job on `ubunty-latest` the following error is emitted:

```
Error: Failed to launch the browser process!
[1999:1999:0210/184211.279511:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[0210/184211.290099:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0210/184211.290150:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
```

The root cause of the error is described at https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md

By locking `browser-test` to `ubuntu-22.04`, we can avoid this error, while a more
elegant solution is found.


#### How to verify

Observe that all the GitHub Actions are green for this branch 🟢