### PR TITLE
chore: fix codecov upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,8 @@ jobs:
           npm run test-webworker -- --chrome $SINON_CHROME_BIN --allow-chrome-as-root
           npm run test-esm-browser-build
       - name: Upload coverage report
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
 
   saucelabs-test:


### PR DESCRIPTION
We are seeing errors uploading coverage reports to codecov:

```
Rate limit reached. Please upload with the Codecov repository upload token to resolve issue
```

I've added a repository token, as instructed in https://docs.codecov.com/docs/adding-the-codecov-token.

This changeset should fix the upload issue.
