### PR TITLE
Improved empty error handling incase error string not provided

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -16,7 +16,7 @@ function throwsException(fake, error, message) {
     } else if (typeof error === "string") {
         fake.exceptionCreator = function () {
             const newException = new Error(
-                message || `Sinon-provided ${error}`,
+                message || `Sinon-provided Error:${error}`,
             );
             newException.name = error;
             return newException;


### PR DESCRIPTION
Updated the error message in throwsException to prepend "Error :" after "Sinon-provided" for better clarity. The issue was already resolved but not marked, and I was unaware of it. This change improves error message consistency and readability, ensuring better debugging clarity for developers.