### PR TITLE
chore!: remove fakeXMLHttpRequest and fakeServer

### DIFF
--- a/lib/create-sinon-api.js
+++ b/lib/create-sinon-api.js
@@ -7,18 +7,11 @@ const fakeTimers = require("./sinon/util/fake-timers");
 const Sandbox = require("./sinon/sandbox");
 const stub = require("./sinon/stub");
 const promise = require("./sinon/promise");
-const nise = require("nise");
-const assert = require("assert");
 
 /**
- * @param {object} opts injection point to override the default XHR lib in testing
- * @param {object} opts.sinonXhrLib
  * @returns {object} a configured sandbox
  */
-module.exports = function createApi(opts = { sinonXhrLib: nise }) {
-    assert(opts?.sinonXhrLib, "No XHR lib passed in");
-    const { sinonXhrLib } = opts;
-
+module.exports = function createApi() {
     const apiMethods = {
         createSandbox: createSandbox,
         match: require("@sinonjs/samsam").createMatcher,
@@ -28,20 +21,6 @@ module.exports = function createApi(opts = { sinonXhrLib: nise }) {
 
         // fake timers
         timers: fakeTimers.timers,
-
-        // fake XHR
-        xhr: sinonXhrLib.fakeXhr.xhr,
-        FakeXMLHttpRequest: sinonXhrLib.fakeXhr.FakeXMLHttpRequest,
-
-        // fake server
-        fakeServer: sinonXhrLib.fakeServer,
-        fakeServerWithClock: sinonXhrLib.fakeServerWithClock,
-        createFakeServer: sinonXhrLib.fakeServer.create.bind(
-            sinonXhrLib.fakeServer,
-        ),
-        createFakeServerWithClock: sinonXhrLib.fakeServerWithClock.create.bind(
-            sinonXhrLib.fakeServerWithClock,
-        ),
 
         addBehavior: function (name, fn) {
             behavior.addBehavior(stub, name, fn);

--- a/lib/sinon/create-sandbox.js
+++ b/lib/sinon/create-sandbox.js
@@ -9,14 +9,6 @@ const push = arrayProto.push;
 function prepareSandboxFromConfig(config) {
     const sandbox = new Sandbox({ assertOptions: config.assertOptions });
 
-    if (config.useFakeServer) {
-        if (typeof config.useFakeServer === "object") {
-            sandbox.serverPrototype = config.useFakeServer;
-        }
-
-        sandbox.useFakeServer();
-    }
-
     if (config.useFakeTimers) {
         if (typeof config.useFakeTimers === "object") {
             sandbox.useFakeTimers(config.useFakeTimers);
@@ -52,7 +44,6 @@ function exposeValue(sandbox, config, key, value) {
  * @property {string[]} properties The properties of the API to expose on the sandbox. Examples: ['spy', 'fake', 'restore']
  * @property {object} injectInto an object in which to inject properties from the sandbox (a facade). This is mostly an integration feature (sinon-test being one).
  * @property {boolean} useFakeTimers  whether timers are faked by default
- * @property {boolean|object} useFakeServer  whether XHR's are faked and the server feature enabled by default. It could also be a different default fake server implementation to use
  * @property {object} [assertOptions] see CreateAssertOptions in ./assert
  *
  * This type def is really suffering from JSDoc not having standardized

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -14,8 +14,6 @@ const sinonStub = require("./stub");
 const sinonCreateStubInstance = require("./create-stub-instance");
 const sinonFake = require("./fake");
 const valueToString = require("@sinonjs/commons").valueToString;
-const fakeServer = require("nise").fakeServer;
-const fakeXhr = require("nise").fakeXhr;
 const usePromiseLibrary = require("./util/core/use-promise-library");
 
 const DEFAULT_LEAK_THRESHOLD = 10000;
@@ -101,8 +99,6 @@ function Sandbox(opts = {}) {
 
     sandbox.assert = sinonAssert.createAssertObject(assertOptions);
 
-    sandbox.serverPrototype = fakeServer;
-
     // this is for testing only
     sandbox.getFakes = function getFakes() {
         return collection;
@@ -161,11 +157,6 @@ function Sandbox(opts = {}) {
 
         if (sandbox.clock) {
             obj.clock = sandbox.clock;
-        }
-
-        if (sandbox.server) {
-            obj.server = sandbox.server;
-            obj.requests = sandbox.server.requests;
         }
 
         obj.match = match;
@@ -504,25 +495,6 @@ function Sandbox(opts = {}) {
         if (exception) {
             throw exception;
         }
-    };
-
-    sandbox.useFakeServer = function useFakeServer() {
-        const proto = sandbox.serverPrototype || fakeServer;
-
-        if (!proto || !proto.create) {
-            return null;
-        }
-
-        sandbox.server = proto.create();
-        addToCollection(sandbox.server);
-
-        return sandbox.server;
-    };
-
-    sandbox.useFakeXMLHttpRequest = function useFakeXMLHttpRequest() {
-        const xhr = fakeXhr.useFakeXMLHttpRequest();
-        addToCollection(xhr);
-        return xhr;
     };
 
     sandbox.usingPromise = function usingPromise(promiseLibrary) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@sinonjs/fake-timers": "^13.0.5",
         "@sinonjs/samsam": "^8.0.1",
         "diff": "^7.0.0",
-        "nise": "^6.1.1",
         "supports-color": "^7.2.0"
       },
       "devDependencies": {
@@ -1296,11 +1295,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
-      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA=="
     },
     "node_modules/@studio/changes": {
       "version": "3.0.0",
@@ -6203,11 +6197,6 @@
         "node": "*"
       }
     },
-    "node_modules/just-extend": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
-      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw=="
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7214,18 +7203,6 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
-    "node_modules/nise": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
-      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^13.0.1",
-        "@sinonjs/text-encoding": "^0.7.3",
-        "just-extend": "^6.2.0",
-        "path-to-regexp": "^8.1.0"
-      }
-    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -7875,14 +7852,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "@sinonjs/fake-timers": "^13.0.5",
     "@sinonjs/samsam": "^8.0.1",
     "diff": "^7.0.0",
-    "nise": "^6.1.1",
     "supports-color": "^7.2.0"
   },
   "devDependencies": {

--- a/scripts/preversion.sh
+++ b/scripts/preversion.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for package in $(npm outdated --parseable nise @sinonjs/fake-timers @sinonjs/samsam)
+for package in $(npm outdated --parseable @sinonjs/fake-timers @sinonjs/samsam)
 do
     wanted="$(cut -d: -f2 <<< "$package")"
     current="$(cut -d: -f3 <<< "$package")"

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -6,8 +6,6 @@ const createStub = require("../../lib/sinon/stub");
 const assert = referee.assert;
 const refute = referee.refute;
 const globalContext = typeof global !== "undefined" ? global : window;
-const globalXHR = globalContext.XMLHttpRequest;
-const globalAXO = globalContext.ActiveXObject;
 
 describe("issues", function () {
     beforeEach(function () {
@@ -423,20 +421,6 @@ describe("issues", function () {
         });
     });
 
-    describe("#1531 - some copied functions on root sinon module throw", function () {
-        it("should create a fake server without throwing", function () {
-            refute.exception(function () {
-                sinon.createFakeServer();
-            });
-        });
-
-        it("should create a fake server with clock without throwing", function () {
-            refute.exception(function () {
-                sinon.createFakeServerWithClock();
-            });
-        });
-    });
-
     describe("#1442 - callThrough with a mock expectation", function () {
         it("should call original method", function () {
             const foo = {
@@ -546,16 +530,6 @@ describe("issues", function () {
                 globalContext.setTimeout,
                 "fakeTimers restored",
             );
-        });
-    });
-
-    describe("#1840 - sinon.restore useFakeXMLHttpRequest", function () {
-        it("should restore XMLHttpRequest and ActiveXObject", function () {
-            sinon.useFakeXMLHttpRequest();
-            sinon.restore();
-
-            assert.same(globalContext.XMLHttpRequest, globalXHR);
-            assert.same(globalContext.ActiveXObject, globalAXO);
         });
     });
 

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1,13 +1,9 @@
 "use strict";
 
 const referee = require("@sinonjs/referee");
-const samsam = require("@sinonjs/samsam");
 const assert = referee.assert;
 const deprecated = require("@sinonjs/commons").deprecated;
 const refute = referee.refute;
-const fakeXhr = require("nise").fakeXhr;
-const fakeServerWithClock = require("nise").fakeServerWithClock;
-const fakeServer = require("nise").fakeServer;
 const match = require("@sinonjs/samsam").createMatcher;
 const Sandbox = require("../lib/sinon/sandbox");
 const createSandbox = require("../lib/sinon/create-sandbox");
@@ -16,28 +12,12 @@ const sinonSpy = require("../lib/sinon/spy");
 const sinonStub = require("../lib/sinon/stub");
 const sinonClock = require("../lib/sinon/util/fake-timers");
 
-const supportsAjax =
-    typeof XMLHttpRequest !== "undefined" ||
-    typeof ActiveXObject !== "undefined";
 const supportPromise = typeof Promise !== "undefined";
 const globalContext = typeof global !== "undefined" ? global : window;
-const globalXHR = globalContext.XMLHttpRequest;
-const globalAXO = globalContext.ActiveXObject;
 
 if (!assert.stub) {
     require("./test-helper");
 }
-
-referee.add("fakeServerWithClock", {
-    assert: function (obj, expected) {
-        return (
-            samsam.deepEqual(obj, expected) &&
-            fakeServer.create.calledOn(fakeServerWithClock)
-        );
-    },
-    assertMessage: "Expected object ${0} to be a fake server with clock",
-    refuteMessage: "Expected object ${0} not to be a fake server with clock",
-});
 
 describe("Sandbox", function () {
     function noop() {
@@ -48,21 +28,6 @@ describe("Sandbox", function () {
         const sandbox = new Sandbox();
 
         assert.same(sandbox.match, match);
-    });
-
-    it("can be reset without failing when pre-configured to use a fake server", function () {
-        const sandbox = createSandbox({ useFakeServer: true });
-        refute.exception(function () {
-            sandbox.reset();
-        });
-    });
-
-    it("can be reset without failing when configured to use a fake server", function () {
-        const sandbox = new Sandbox();
-        sandbox.useFakeServer();
-        refute.exception(function () {
-            sandbox.reset();
-        });
     });
 
     describe(".mock", function () {
@@ -1755,119 +1720,6 @@ describe("Sandbox", function () {
         });
     });
 
-    // These were not run in browsers before, as we were only testing in node
-    if (typeof window !== "undefined") {
-        describe("fake XHR/server", function () {
-            describe(".useFakeXMLHttpRequest", function () {
-                beforeEach(function () {
-                    this.sandbox = new Sandbox();
-                });
-
-                afterEach(function () {
-                    this.sandbox.restore();
-                });
-
-                it("calls sinon.useFakeXMLHttpRequest", function () {
-                    const stubXhr = {
-                        restore: function () {
-                            return;
-                        },
-                    };
-
-                    this.sandbox
-                        .stub(fakeXhr, "useFakeXMLHttpRequest")
-                        .returns(stubXhr);
-                    const returnedXhr = this.sandbox.useFakeXMLHttpRequest();
-
-                    assert(fakeXhr.useFakeXMLHttpRequest.called);
-                    assert.equals(stubXhr, returnedXhr);
-                });
-
-                it("returns fake xhr object created by nise", function () {
-                    this.sandbox
-                        .stub(fakeXhr, "useFakeXMLHttpRequest")
-                        .returns({
-                            restore: function () {
-                                return;
-                            },
-                        });
-                    this.sandbox.useFakeXMLHttpRequest();
-
-                    assert(fakeXhr.useFakeXMLHttpRequest.called);
-                });
-
-                it("doesn't secretly use useFakeServer", function () {
-                    this.sandbox.stub(fakeServer, "create").returns({
-                        restore: function () {
-                            return;
-                        },
-                    });
-                    this.sandbox.useFakeXMLHttpRequest();
-
-                    assert(fakeServer.create.notCalled);
-                });
-
-                it("adds fake xhr to fake collection", function () {
-                    this.sandbox.useFakeXMLHttpRequest();
-                    this.sandbox.restore();
-
-                    assert.same(globalContext.XMLHttpRequest, globalXHR);
-                    assert.same(globalContext.ActiveXObject, globalAXO);
-                });
-            });
-
-            describe(".useFakeServer", function () {
-                beforeEach(function () {
-                    this.sandbox = new Sandbox();
-                });
-
-                afterEach(function () {
-                    this.sandbox.restore();
-                });
-
-                it("returns server", function () {
-                    const server = this.sandbox.useFakeServer();
-
-                    assert.isObject(server);
-                    assert.isFunction(server.restore);
-                });
-
-                it("exposes server property", function () {
-                    const server = this.sandbox.useFakeServer();
-
-                    assert.same(this.sandbox.server, server);
-                });
-
-                it("creates server", function () {
-                    const server = this.sandbox.useFakeServer();
-
-                    assert(fakeServer.isPrototypeOf(server));
-                });
-
-                it("creates server without clock by default", function () {
-                    const server = this.sandbox.useFakeServer();
-
-                    refute(fakeServerWithClock.isPrototypeOf(server));
-                });
-
-                it("creates server with clock", function () {
-                    this.sandbox.serverPrototype = fakeServerWithClock;
-                    const server = this.sandbox.useFakeServer();
-
-                    assert(fakeServerWithClock.isPrototypeOf(server));
-                });
-
-                it("adds server to fake collection", function () {
-                    this.sandbox.useFakeServer();
-                    this.sandbox.restore();
-
-                    assert.same(globalContext.XMLHttpRequest, globalXHR);
-                    assert.same(globalContext.ActiveXObject, globalAXO);
-                });
-            });
-        });
-    }
-
     describe(".inject", function () {
         beforeEach(function () {
             this.obj = {};
@@ -1950,44 +1802,6 @@ describe("Sandbox", function () {
             assert.isObject(injected);
             assert.isFunction(injected.spy);
         });
-
-        if (supportsAjax) {
-            describe("ajax options", function () {
-                it("defines server and requests when using fake time", function () {
-                    this.sandbox.useFakeServer();
-                    this.sandbox.inject(this.obj);
-
-                    assert.isFunction(this.obj.spy);
-                    assert.isFunction(this.obj.stub);
-                    assert.isFunction(this.obj.mock);
-                    assert.isFalse("clock" in this.obj);
-                    assert.isObject(this.obj.server);
-                    assert.equals(this.obj.requests, []);
-                });
-
-                it("should define all possible fakes", function () {
-                    this.sandbox.useFakeServer();
-                    this.sandbox.useFakeTimers();
-                    this.sandbox.inject(this.obj);
-
-                    const spy = sinonSpy();
-                    setTimeout(spy, 10);
-
-                    this.sandbox.clock.tick(10);
-
-                    const xhr = window.XMLHttpRequest
-                        ? new XMLHttpRequest()
-                        : new ActiveXObject("Microsoft.XMLHTTP"); //eslint-disable-line no-undef
-
-                    assert.isFunction(this.obj.spy);
-                    assert.isFunction(this.obj.stub);
-                    assert.isFunction(this.obj.mock);
-                    assert(spy.called);
-                    assert.isObject(this.obj.server);
-                    assert.equals(this.obj.requests, [xhr]);
-                });
-            });
-        }
     });
 
     describe(".verify", function () {
@@ -2053,16 +1867,11 @@ describe("Sandbox", function () {
 
     describe("configurable sandbox", function () {
         beforeEach(function () {
-            this.requests = [];
-            this.fakeServer = { requests: this.requests };
-
             this.useFakeTimersSpy = sinonSpy(sinonClock, "useFakeTimers");
-            sinonStub(fakeServer, "create").returns(this.fakeServer);
         });
 
         afterEach(function () {
             this.useFakeTimersSpy.restore();
-            fakeServer.create.restore();
         });
 
         it("yields stub, mock as arguments", function () {
@@ -2089,19 +1898,6 @@ describe("Sandbox", function () {
             sandbox.restore();
         });
 
-        it("does not yield server when not faking xhr", function () {
-            const sandbox = createSandbox({
-                properties: ["server", "stub", "mock"],
-                useFakeServer: false,
-            });
-
-            assert.equals(sandbox.args.length, 2);
-            assert.stub(sandbox.args[0]());
-            assert.mock(sandbox.args[1]({}));
-
-            sandbox.restore();
-        });
-
         it("does not inject properties if they are already present", function () {
             const server = function () {
                 return;
@@ -2120,100 +1916,6 @@ describe("Sandbox", function () {
 
             sandbox.restore();
         });
-
-        if (supportsAjax) {
-            describe("ajax options", function () {
-                it("yields server when faking xhr", function () {
-                    const sandbox = createSandbox({
-                        useFakeServer: true,
-                        properties: ["server", "stub", "mock"],
-                    });
-
-                    assert.equals(sandbox.args.length, 3);
-                    assert.equals(sandbox.args[0], this.fakeServer);
-                    assert.stub(sandbox.args[1]());
-                    assert.mock(sandbox.args[2]({}));
-
-                    sandbox.restore();
-                });
-
-                it("uses serverWithClock when faking xhr", function () {
-                    const sandbox = createSandbox({
-                        properties: ["server"],
-                        useFakeServer: fakeServerWithClock,
-                    });
-
-                    assert.fakeServerWithClock(
-                        sandbox.args[0],
-                        this.fakeServer,
-                    );
-
-                    sandbox.restore();
-                });
-
-                it("uses fakeServer as the serverPrototype by default", function () {
-                    const sandbox = createSandbox();
-
-                    assert.same(sandbox.serverPrototype, fakeServer);
-                });
-
-                it("uses configured implementation as the serverPrototype", function () {
-                    const sandbox = createSandbox({
-                        useFakeServer: fakeServerWithClock,
-                    });
-
-                    assert.same(sandbox.serverPrototype, fakeServerWithClock);
-                });
-
-                it("yields clock when faking timers", function () {
-                    const sandbox = createSandbox({
-                        properties: ["server", "clock"],
-                        useFakeServer: true,
-                        useFakeTimers: true,
-                    });
-
-                    assert.same(sandbox.args[0], this.fakeServer);
-                    assert.clock(sandbox.args[1]);
-
-                    sandbox.restore();
-                });
-
-                it("should inject server and clock when enabling them", function () {
-                    const object = {};
-
-                    const sandbox = createSandbox({
-                        injectInto: object,
-                        properties: ["clock", "server", "requests"],
-                        useFakeTimers: true,
-                        useFakeServer: true,
-                    });
-
-                    assert.equals(sandbox.args.length, 0);
-                    assert.equals(object.server, this.fakeServer);
-                    assert.clock(object.clock);
-                    assert.isArray(object.requests);
-
-                    sandbox.restore();
-                });
-
-                it("should not inject server and clock if not enabled, even if the props are whitelisted", function () {
-                    const object = {};
-
-                    const sandbox = createSandbox({
-                        injectInto: object,
-                        properties: ["clock", "server", "requests"],
-                        useFakeTimers: false,
-                        useFakeServer: false,
-                    });
-
-                    assert.isUndefined(object.requests);
-                    assert.isUndefined(object.sandbox);
-                    assert.isUndefined(object.clock);
-
-                    sandbox.restore();
-                });
-            });
-        }
 
         // This is currently testing the internals of useFakeTimers, we could possibly change it to be based on
         // behavior.

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -5,35 +5,12 @@ const functionName = require("@sinonjs/commons").functionName;
 const Sandbox = require("../lib/sinon/sandbox");
 
 describe("sinon module", function () {
-    let sinon, fakeNise;
+    let sinon;
 
     before(function () {
         if (typeof Promise !== "function") {
             this.skip();
         }
-    });
-
-    beforeEach(function () {
-        fakeNise = {
-            fakeServer: {
-                create: function () {
-                    return "47c86a4c-6b48-4748-bb8c-d853f999720c";
-                },
-            },
-            fakeServerWithClock: {
-                create: function () {
-                    return "e69974f8-4568-48d1-a5e9-2b511a59c14b";
-                },
-            },
-            fakeXhr: {
-                xhr: "958e8996-0cc3-4136-8a0e-6a120f5311bc",
-                FakeXMLHttpRequest: "6adbf569-f6d7-4b86-be22-38340ae0f8c8",
-                useFakeXMLHttpRequest: "ba8bd609-c921-4a62-a1b9-49336bd426a4",
-            },
-        };
-        sinon = require("../lib/create-sinon-api")({
-            sinonXhrLib: fakeNise,
-        });
     });
 
     describe("exports", function () {
@@ -54,73 +31,6 @@ describe("sinon module", function () {
                     functionName(sinon.createSandbox),
                     "createSandbox",
                 );
-            });
-        });
-
-        describe("fakeServer", function () {
-            it("should be the fakeServer export from nise", function () {
-                assert.same(sinon.fakeServer, fakeNise.fakeServer);
-            });
-        });
-
-        describe("createFakeServer", function () {
-            it("should be fakeServer.create from nise", function () {
-                assert.equals(
-                    sinon.createFakeServer(),
-                    fakeNise.fakeServer.create(),
-                );
-            });
-        });
-
-        describe("fakeServerWithClock", function () {
-            it("should be the fakeServerWithClock export from nise", function () {
-                assert.same(
-                    sinon.fakeServerWithClock,
-                    fakeNise.fakeServerWithClock,
-                );
-            });
-        });
-
-        describe("createFakeServerWithClock", function () {
-            it("should be fakeServerWithClock.create from nise", function () {
-                assert.equals(
-                    sinon.createFakeServerWithClock(),
-                    fakeNise.fakeServerWithClock.create(),
-                );
-            });
-        });
-
-        describe("xhr", function () {
-            it("should be the fakeXhr.xhr export from nise", function () {
-                assert.equals(sinon.xhr, fakeNise.fakeXhr.xhr);
-            });
-        });
-
-        describe("FakeXMLHttpRequest", function () {
-            it("should be the fakeXhr.FakeXMLHttpRequest export from nise", function () {
-                assert.equals(
-                    sinon.FakeXMLHttpRequest,
-                    fakeNise.fakeXhr.FakeXMLHttpRequest,
-                );
-            });
-        });
-
-        describe("useFakeXMLHttpRequest", function () {
-            let nise;
-
-            beforeEach(function () {
-                sinon = require("../lib/sinon");
-                nise = require("nise");
-            });
-
-            afterEach(function () {
-                nise.fakeXhr.useFakeXMLHttpRequest.restore();
-            });
-
-            it("should be the fakeXhr.useFakeXMLHttpRequest export from nise", function () {
-                sinon.spy(nise.fakeXhr, "useFakeXMLHttpRequest");
-                sinon.useFakeXMLHttpRequest();
-                assert.isTrue(nise.fakeXhr.useFakeXMLHttpRequest.called);
             });
         });
     });

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -36,18 +36,6 @@ referee.add("mock", {
     refuteMessage: "Expected object ${0} not to be a mock",
 });
 
-referee.add("fakeServer", {
-    assert: function (obj) {
-        return (
-            obj !== null &&
-            Object.prototype.toString.call(obj.requests) === "[object Array]" &&
-            typeof obj.respondWith === "function"
-        );
-    },
-    assertMessage: "Expected object ${0} to be a fake server",
-    refuteMessage: "Expected object ${0} not to be a fake server",
-});
-
 referee.add("clock", {
     assert: function (obj) {
         return (


### PR DESCRIPTION
BREAKING CHANGE: remove fakeXMLHttpRequest and fakeServer from the API

Times have changed, and people shouldn't be using these anymore, but prefer better options for testing their remote requests.


#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
