### PR TITLE
chore: deprecate useFakeXMLHttpRequest and useFakeServer

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -2,6 +2,7 @@
 
 const arrayProto = require("@sinonjs/commons").prototypes.array;
 const logger = require("@sinonjs/commons").deprecated;
+const wrap = logger.wrap;
 const collectOwnMethods = require("./collect-own-methods");
 const getPropertyDescriptor = require("./util/core/get-property-descriptor");
 const isPropertyConfigurable = require("./util/core/is-property-configurable");
@@ -506,7 +507,7 @@ function Sandbox(opts = {}) {
         }
     };
 
-    sandbox.useFakeServer = function useFakeServer() {
+    function useFakeServer() {
         const proto = sandbox.serverPrototype || fakeServer;
 
         if (!proto || !proto.create) {
@@ -517,13 +518,23 @@ function Sandbox(opts = {}) {
         addToCollection(sandbox.server);
 
         return sandbox.server;
-    };
+    }
 
-    sandbox.useFakeXMLHttpRequest = function useFakeXMLHttpRequest() {
+    sandbox.useFakeServer = wrap(
+        useFakeServer,
+        "useFakeServer has been deprecated, and will be removed in the next major version",
+    );
+
+    function useFakeXMLHttpRequest() {
         const xhr = fakeXhr.useFakeXMLHttpRequest();
         addToCollection(xhr);
         return xhr;
-    };
+    }
+
+    sandbox.useFakeXMLHttpRequest = wrap(
+        useFakeXMLHttpRequest,
+        "useFakeXMLHttpRequest has been deprecated, and will be removed in the next major version",
+    );
 
     sandbox.usingPromise = function usingPromise(promiseLibrary) {
         promiseLib = promiseLibrary;


### PR DESCRIPTION
This PR deprecates `useFakeXMLHttpRequest` and `useFakeServer`, which will be both be removed in #2642.