### PR TITLE
Fix issue 2645 (part 2)

### DIFF
--- a/docs/_releases/latest/spy-call.md
+++ b/docs/_releases/latest/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an individual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v1/fake-xhr-and-server.md
+++ b/docs/_releases/v1/fake-xhr-and-server.md
@@ -195,7 +195,6 @@ When `autoRespond` is `true`, respond to requests after this number of milliseco
 ## Fake server
 High-level API to manipulate `FakeXMLHttpRequest` instances.
 
-For help with handling JSON-P please refer to our [notes below](#json-p)
 
 ```javascript
 {

--- a/docs/_releases/v1/spies.md
+++ b/docs/_releases/v1/spies.md
@@ -374,7 +374,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the *nth* [call](#spycall).
+Returns the *nth* [call](../spy-call).
 
 Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 

--- a/docs/_releases/v1/spy-call.md
+++ b/docs/_releases/v1/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a *spied* functi
 
 ### `var spyCall = spy.getCall(n);`
 
-Returns the *nth* [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the *nth* [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v10/fake-xhr-and-server.md
+++ b/docs/_releases/v10/fake-xhr-and-server.md
@@ -177,7 +177,6 @@ When `autoRespond` is `true`, respond to requests after this number of milliseco
 
 High-level API to manipulate `FakeXMLHttpRequest` instances.
 
-For help with handling JSON-P please refer to our [notes below](#json-p)
 
 ```javascript
 {

--- a/docs/_releases/v10/sandbox.md
+++ b/docs/_releases/v10/sandbox.md
@@ -177,7 +177,7 @@ var sandbox = sinon.createSandbox({
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v10/sandbox.md
+++ b/docs/_releases/v10/sandbox.md
@@ -81,7 +81,7 @@ var sandbox = sinon.createSandbox({
 });
 ```
 
-The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/master/lib/sinon/util/core/default-config.js):
+The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/v17.0.0/lib/sinon/util/core/default-config.js):
 
 ```javascript
 sinon.defaultConfig = {

--- a/docs/_releases/v10/spies.md
+++ b/docs/_releases/v10/spies.md
@@ -310,7 +310,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 If _n_ is negative, the _nth_ call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v10/spy-call.md
+++ b/docs/_releases/v10/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v11.md
+++ b/docs/_releases/v11.md
@@ -36,5 +36,5 @@ If you need to support old runtimes you can try [Sinon 9][compat-doc-v9].
 
 {% include docs/contribute.md %}
 
-[compat-doc]: https://github.com/sinonjs/sinon/COMPATIBILITY.md
+[compat-doc]: https://github.com/sinonjs/sinon/blob/main/COMPATIBILITY.md
 [compat-doc-v9]: https://github.com/sinonjs/sinon/blob/v9.2.4/COMPATIBILITY.md

--- a/docs/_releases/v11/sandbox.md
+++ b/docs/_releases/v11/sandbox.md
@@ -177,7 +177,7 @@ var sandbox = sinon.createSandbox({
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v11/sandbox.md
+++ b/docs/_releases/v11/sandbox.md
@@ -81,7 +81,7 @@ var sandbox = sinon.createSandbox({
 });
 ```
 
-The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/master/lib/sinon/util/core/default-config.js):
+The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/v17.0.0/lib/sinon/util/core/default-config.js):
 
 ```javascript
 sinon.defaultConfig = {

--- a/docs/_releases/v11/spies.md
+++ b/docs/_releases/v11/spies.md
@@ -310,7 +310,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 If _n_ is negative, the _nth_ call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v11/spy-call.md
+++ b/docs/_releases/v11/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v12.md
+++ b/docs/_releases/v12.md
@@ -36,5 +36,5 @@ If you need to support old runtimes you can try [Sinon 9][compat-doc-v9].
 
 {% include docs/contribute.md %}
 
-[compat-doc]: https://github.com/sinonjs/sinon/COMPATIBILITY.md
+[compat-doc]: https://github.com/sinonjs/sinon/blob/main/COMPATIBILITY.md
 [compat-doc-v9]: https://github.com/sinonjs/sinon/blob/v9.2.4/COMPATIBILITY.md

--- a/docs/_releases/v12/sandbox.md
+++ b/docs/_releases/v12/sandbox.md
@@ -177,7 +177,7 @@ var sandbox = sinon.createSandbox({
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v12/sandbox.md
+++ b/docs/_releases/v12/sandbox.md
@@ -81,7 +81,7 @@ var sandbox = sinon.createSandbox({
 });
 ```
 
-The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/master/lib/sinon/util/core/default-config.js):
+The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/v17.0.0/lib/sinon/util/core/default-config.js):
 
 ```javascript
 sinon.defaultConfig = {

--- a/docs/_releases/v12/spies.md
+++ b/docs/_releases/v12/spies.md
@@ -310,7 +310,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 If _n_ is negative, the _nth_ call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v12/spy-call.md
+++ b/docs/_releases/v12/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an individual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v13.md
+++ b/docs/_releases/v13.md
@@ -36,5 +36,5 @@ If you need to support old runtimes you can try [Sinon 9][compat-doc-v9].
 
 {% include docs/contribute.md %}
 
-[compat-doc]: https://github.com/sinonjs/sinon/COMPATIBILITY.md
+[compat-doc]: https://github.com/sinonjs/sinon/blob/main/COMPATIBILITY.md
 [compat-doc-v9]: https://github.com/sinonjs/sinon/blob/v9.2.4/COMPATIBILITY.md

--- a/docs/_releases/v13/sandbox.md
+++ b/docs/_releases/v13/sandbox.md
@@ -177,7 +177,7 @@ var sandbox = sinon.createSandbox({
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v13/sandbox.md
+++ b/docs/_releases/v13/sandbox.md
@@ -81,7 +81,7 @@ var sandbox = sinon.createSandbox({
 });
 ```
 
-The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/master/lib/sinon/util/core/default-config.js):
+The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/v17.0.0/lib/sinon/util/core/default-config.js):
 
 ```javascript
 sinon.defaultConfig = {

--- a/docs/_releases/v13/spies.md
+++ b/docs/_releases/v13/spies.md
@@ -310,7 +310,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 If _n_ is negative, the _nth_ call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v13/spy-call.md
+++ b/docs/_releases/v13/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an individual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v14.md
+++ b/docs/_releases/v14.md
@@ -36,5 +36,5 @@ If you need to support old runtimes you can try [Sinon 9][compat-doc-v9].
 
 {% include docs/contribute.md %}
 
-[compat-doc]: https://github.com/sinonjs/sinon/COMPATIBILITY.md
+[compat-doc]: https://github.com/sinonjs/sinon/blob/main/COMPATIBILITY.md
 [compat-doc-v9]: https://github.com/sinonjs/sinon/blob/v9.2.4/COMPATIBILITY.md

--- a/docs/_releases/v14/sandbox.md
+++ b/docs/_releases/v14/sandbox.md
@@ -177,7 +177,7 @@ var sandbox = sinon.createSandbox({
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v14/sandbox.md
+++ b/docs/_releases/v14/sandbox.md
@@ -81,7 +81,7 @@ var sandbox = sinon.createSandbox({
 });
 ```
 
-The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/master/lib/sinon/util/core/default-config.js):
+The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/v17.0.0/lib/sinon/util/core/default-config.js):
 
 ```javascript
 sinon.defaultConfig = {

--- a/docs/_releases/v14/spies.md
+++ b/docs/_releases/v14/spies.md
@@ -310,7 +310,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 If _n_ is negative, the _nth_ call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v14/spy-call.md
+++ b/docs/_releases/v14/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an individual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v15.md
+++ b/docs/_releases/v15.md
@@ -36,5 +36,5 @@ If you need to support old runtimes you can try [Sinon 9][compat-doc-v9].
 
 {% include docs/contribute.md %}
 
-[compat-doc]: https://github.com/sinonjs/sinon/COMPATIBILITY.md
+[compat-doc]: https://github.com/sinonjs/sinon/blob/main/COMPATIBILITY.md
 [compat-doc-v9]: https://github.com/sinonjs/sinon/blob/v9.2.4/COMPATIBILITY.md

--- a/docs/_releases/v15/sandbox.md
+++ b/docs/_releases/v15/sandbox.md
@@ -177,7 +177,7 @@ var sandbox = sinon.createSandbox({
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v15/sandbox.md
+++ b/docs/_releases/v15/sandbox.md
@@ -81,7 +81,7 @@ var sandbox = sinon.createSandbox({
 });
 ```
 
-The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/master/lib/sinon/util/core/default-config.js):
+The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/v17.0.0/lib/sinon/util/core/default-config.js):
 
 ```javascript
 sinon.defaultConfig = {

--- a/docs/_releases/v15/spies.md
+++ b/docs/_releases/v15/spies.md
@@ -302,7 +302,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 If _n_ is negative, the _nth_ call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v15/spy-call.md
+++ b/docs/_releases/v15/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an individual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v16/sandbox.md
+++ b/docs/_releases/v16/sandbox.md
@@ -177,7 +177,7 @@ var sandbox = sinon.createSandbox({
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v16/sandbox.md
+++ b/docs/_releases/v16/sandbox.md
@@ -81,7 +81,7 @@ var sandbox = sinon.createSandbox({
 });
 ```
 
-The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/master/lib/sinon/util/core/default-config.js):
+The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/v17.0.0/lib/sinon/util/core/default-config.js):
 
 ```javascript
 sinon.defaultConfig = {

--- a/docs/_releases/v16/spies.md
+++ b/docs/_releases/v16/spies.md
@@ -302,7 +302,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 If _n_ is negative, the _nth_ call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v16/spy-call.md
+++ b/docs/_releases/v16/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an individual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v17/sandbox.md
+++ b/docs/_releases/v17/sandbox.md
@@ -170,7 +170,7 @@ const myFacade = sandbox.inject({});
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v17/spies.md
+++ b/docs/_releases/v17/spies.md
@@ -302,7 +302,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 If _n_ is negative, the _nth_ call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v17/spy-call.md
+++ b/docs/_releases/v17/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an individual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v18/sandbox.md
+++ b/docs/_releases/v18/sandbox.md
@@ -170,7 +170,7 @@ const myFacade = sandbox.inject({});
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v18/spies.md
+++ b/docs/_releases/v18/spies.md
@@ -302,7 +302,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 If _n_ is negative, the _nth_ call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v18/spy-call.md
+++ b/docs/_releases/v18/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an individual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v19/spy-call.md
+++ b/docs/_releases/v19/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an individual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v2/fake-xhr-and-server.md
+++ b/docs/_releases/v2/fake-xhr-and-server.md
@@ -196,7 +196,6 @@ When `autoRespond` is `true`, respond to requests after this number of milliseco
 ## Fake server
 High-level API to manipulate `FakeXMLHttpRequest` instances.
 
-For help with handling JSON-P please refer to our [notes below](#json-p)
 
 ```javascript
 {

--- a/docs/_releases/v2/sandbox.md
+++ b/docs/_releases/v2/sandbox.md
@@ -122,7 +122,7 @@ sinon.config = {
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 *Since `sinon@2.0.0`*
 

--- a/docs/_releases/v2/spies.md
+++ b/docs/_releases/v2/spies.md
@@ -384,7 +384,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the *nth* [call](#spycall).
+Returns the *nth* [call](../spy-call).
 
 Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 

--- a/docs/_releases/v2/spy-call.md
+++ b/docs/_releases/v2/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a *spied* functi
 
 ### `var spyCall = spy.getCall(n);`
 
-Returns the *nth* [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the *nth* [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v3/fake-xhr-and-server.md
+++ b/docs/_releases/v3/fake-xhr-and-server.md
@@ -196,7 +196,6 @@ When `autoRespond` is `true`, respond to requests after this number of milliseco
 ## Fake server
 High-level API to manipulate `FakeXMLHttpRequest` instances.
 
-For help with handling JSON-P please refer to our [notes below](#json-p)
 
 ```javascript
 {

--- a/docs/_releases/v3/sandbox.md
+++ b/docs/_releases/v3/sandbox.md
@@ -123,7 +123,7 @@ sinon.config = {
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 *Since `sinon@2.0.0`*
 

--- a/docs/_releases/v3/spies.md
+++ b/docs/_releases/v3/spies.md
@@ -384,7 +384,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the *nth* [call](#spycall).
+Returns the *nth* [call](../spy-call).
 
 Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 

--- a/docs/_releases/v3/spy-call.md
+++ b/docs/_releases/v3/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a *spied* functi
 
 ### `var spyCall = spy.getCall(n);`
 
-Returns the *nth* [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the *nth* [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v4/fake-xhr-and-server.md
+++ b/docs/_releases/v4/fake-xhr-and-server.md
@@ -196,7 +196,6 @@ When `autoRespond` is `true`, respond to requests after this number of milliseco
 ## Fake server
 High-level API to manipulate `FakeXMLHttpRequest` instances.
 
-For help with handling JSON-P please refer to our [notes below](#json-p)
 
 ```javascript
 {

--- a/docs/_releases/v4/sandbox.md
+++ b/docs/_releases/v4/sandbox.md
@@ -123,7 +123,7 @@ sinon.config = {
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 *Since `sinon@2.0.0`*
 

--- a/docs/_releases/v4/spies.md
+++ b/docs/_releases/v4/spies.md
@@ -392,7 +392,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the *nth* [call](#spycall).
+Returns the *nth* [call](../spy-call).
 
 Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 

--- a/docs/_releases/v4/spy-call.md
+++ b/docs/_releases/v4/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a *spied* functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the *nth* [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the *nth* [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v5/fake-xhr-and-server.md
+++ b/docs/_releases/v5/fake-xhr-and-server.md
@@ -196,7 +196,6 @@ When `autoRespond` is `true`, respond to requests after this number of milliseco
 ## Fake server
 High-level API to manipulate `FakeXMLHttpRequest` instances.
 
-For help with handling JSON-P please refer to our [notes below](#json-p)
 
 ```javascript
 {

--- a/docs/_releases/v5/sandbox.md
+++ b/docs/_releases/v5/sandbox.md
@@ -139,7 +139,7 @@ sinon.config = {
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 *Since `sinon@2.0.0`*
 

--- a/docs/_releases/v5/spies.md
+++ b/docs/_releases/v5/spies.md
@@ -392,7 +392,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the *nth* [call](#spycall).
+Returns the *nth* [call](../spy-call).
 
 Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 

--- a/docs/_releases/v5/spy-call.md
+++ b/docs/_releases/v5/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a *spied* functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the *nth* [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the *nth* [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v6/fake-xhr-and-server.md
+++ b/docs/_releases/v6/fake-xhr-and-server.md
@@ -177,7 +177,6 @@ When `autoRespond` is `true`, respond to requests after this number of milliseco
 
 High-level API to manipulate `FakeXMLHttpRequest` instances.
 
-For help with handling JSON-P please refer to our [notes below](#json-p)
 
 ```javascript
 {

--- a/docs/_releases/v6/spies.md
+++ b/docs/_releases/v6/spies.md
@@ -352,7 +352,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 

--- a/docs/_releases/v6/spy-call.md
+++ b/docs/_releases/v6/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v7/fake-xhr-and-server.md
+++ b/docs/_releases/v7/fake-xhr-and-server.md
@@ -177,7 +177,6 @@ When `autoRespond` is `true`, respond to requests after this number of milliseco
 
 High-level API to manipulate `FakeXMLHttpRequest` instances.
 
-For help with handling JSON-P please refer to our [notes below](#json-p)
 
 ```javascript
 {

--- a/docs/_releases/v7/sandbox.md
+++ b/docs/_releases/v7/sandbox.md
@@ -138,7 +138,7 @@ sinon.config = {
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v7/spies.md
+++ b/docs/_releases/v7/spies.md
@@ -350,7 +350,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 

--- a/docs/_releases/v7/spy-call.md
+++ b/docs/_releases/v7/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v8/fake-xhr-and-server.md
+++ b/docs/_releases/v8/fake-xhr-and-server.md
@@ -177,7 +177,6 @@ When `autoRespond` is `true`, respond to requests after this number of milliseco
 
 High-level API to manipulate `FakeXMLHttpRequest` instances.
 
-For help with handling JSON-P please refer to our [notes below](#json-p)
 
 ```javascript
 {

--- a/docs/_releases/v8/sandbox.md
+++ b/docs/_releases/v8/sandbox.md
@@ -177,7 +177,7 @@ var sandbox = sinon.createSandbox({
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 _Since `sinon@2.0.0`_
 

--- a/docs/_releases/v8/sandbox.md
+++ b/docs/_releases/v8/sandbox.md
@@ -81,7 +81,7 @@ var sandbox = sinon.createSandbox({
 });
 ```
 
-The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/master/lib/sinon/util/core/default-config.js):
+The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/v17.0.0/lib/sinon/util/core/default-config.js):
 
 ```javascript
 sinon.defaultConfig = {

--- a/docs/_releases/v8/spies.md
+++ b/docs/_releases/v8/spies.md
@@ -308,7 +308,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the _nth_ [call](#spycall).
+Returns the _nth_ [call](../spy-call).
 
 If _n_ is negative, the _nth_ call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v8/spy-call.md
+++ b/docs/_releases/v8/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a _spied_ functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the _nth_ [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the _nth_ [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/_releases/v9/fake-xhr-and-server.md
+++ b/docs/_releases/v9/fake-xhr-and-server.md
@@ -196,7 +196,6 @@ When `autoRespond` is `true`, respond to requests after this number of milliseco
 ## Fake server
 High-level API to manipulate `FakeXMLHttpRequest` instances.
 
-For help with handling JSON-P please refer to our [notes below](#json-p)
 
 ```javascript
 {

--- a/docs/_releases/v9/sandbox.md
+++ b/docs/_releases/v9/sandbox.md
@@ -83,7 +83,7 @@ var sandbox = sinon.createSandbox({
 });
 ```
 
-The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/master/lib/sinon/util/core/default-config.js):
+The `useFakeTimers` and `useFakeServers` are **false** as opposed to the [defaults in `sinon.defaultConfig`](https://github.com/sinonjs/sinon/blob/v17.0.0/lib/sinon/util/core/default-config.js):
 
 ```javascript
 sinon.defaultConfig = {

--- a/docs/_releases/v9/sandbox.md
+++ b/docs/_releases/v9/sandbox.md
@@ -169,7 +169,7 @@ var sandbox = sinon.createSandbox({
 
 #### `sandbox.assert();`
 
-A convenience reference for [`sinon.assert`](./assertions)
+A convenience reference for [`sinon.assert`](../assertions)
 
 *Since `sinon@2.0.0`*
 

--- a/docs/_releases/v9/spies.md
+++ b/docs/_releases/v9/spies.md
@@ -350,7 +350,7 @@ Returns `true` if spy always returned the provided value.
 
 #### `var spyCall = spy.getCall(n);`
 
-Returns the *nth* [call](#spycall).
+Returns the *nth* [call](../spy-call).
 
 If *n* is negative, the *nth* call from the end is returned. For example, `spy.getCall(-1)` returns the last call, and `spy.getCall(-2)` returns the second to last call.
 

--- a/docs/_releases/v9/spy-call.md
+++ b/docs/_releases/v9/spy-call.md
@@ -10,7 +10,7 @@ A spy call is an object representation of an invididual call to a *spied* functi
 
 ### `var spyCall = spy.getCall(n)`
 
-Returns the *nth* [call](#spycall). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
+Returns the *nth* [call](#spy-call). Accessing individual calls helps with more detailed behavior verification when the spy is called more than once.
 
 ```javascript
 sinon.spy(jQuery, "ajax");

--- a/docs/index.md
+++ b/docs/index.md
@@ -283,11 +283,11 @@ You've seen the most common tasks people tackle with Sinon.JS, yet we've only sc
 - [Testing Backbone applications with Jasmine and Sinon](https://tinnedfruit.com/writing/testing-backbone-apps-with-jasmine-sinon.html)
 - [Sinon.JS fake server live demo](https://github.com/ducin/sinon-backend-less-demo)
 
-Christian Johansen's book [Test-Driven JavaScript Development][tddjs] covers some of the design philosophy and initial sketches for Sinon.JS.
+Sinon's "father", Christian Johansen, wrote the book on [Test-Driven JavaScript Development][tddjs], which covers some of the design philosophy and initial sketches for Sinon.JS.
 
 [fakes]: /releases/v{{current_major}}/fakes
 [fakexhr]: /releases/v{{current_major}}/fake-xhr-and-server
 [fakeserver]: /releases/v{{current_major}}/fake-xhr-and-server#fake-server
 [clock]: /releases/v{{current_major}}/fake-timers
 [api-docs]: /releases/v{{current_major}}
-[tddjs]: http://tddjs.com/
+[tddjs]: https://www.oreilly.com/library/view/test-driven-javascript-development/9780321684097/

--- a/scripts/copy-documentation-for-new-release.sh
+++ b/scripts/copy-documentation-for-new-release.sh
@@ -36,14 +36,14 @@ function copy_source_to(){
 
     # Remove .gitignore'd files from copies
     # Otherwise they will remain on the local filesytem
-    rm -r "$DIR/examples/node_modules"
-    rm "$DIR/examples/package-lock.json"
+    rm -rf "$DIR/examples/node_modules"
+    rm -f "$DIR/examples/package-lock.json"
 
     # replace `release_id: master` with `release_id: $FULL_VERSION` in
     # $FILE_PATH
     sed -i.bak "s/release_id: master/release_id: $FULL_VERSION/g" "$FILE_PATH"
     sed -i.bak "s/sort_id: master/sort_id: $MAJOR_VERSION/g" "$FILE_PATH"
-    rm "$FILE_PATH.bak"
+    rm -f "$FILE_PATH.bak"
 
     git add "$DIR"
     git add "$FILE_PATH"


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Part two of the fix for #2645 (broken links), this bit addressing the `releases` branch. Part 1 is #2646

Some commits are present on both branches, being cherry-picked in. This should sort itself out automatically, but I might rebase this on the `releases` branch first if that gets updated by doing a `npm version patch` first.