### PR TITLE
chore: deprecate usingPromise

### DIFF
--- a/lib/sinon/default-behaviors.js
+++ b/lib/sinon/default-behaviors.js
@@ -10,6 +10,9 @@ const slice = arrayProto.slice;
 const useLeftMostCallback = -1;
 const useRightMostCallback = -2;
 
+const logger = require("@sinonjs/commons").deprecated;
+const wrap = logger.wrap;
+
 function throwsException(fake, error, message) {
     if (typeof error === "function") {
         fake.exceptionCreator = error;
@@ -90,9 +93,9 @@ const defaultBehaviors = {
         fake.callsThrough = false;
     },
 
-    usingPromise: function usingPromise(fake, promiseLibrary) {
+    usingPromise: wrap(function usingPromise(fake, promiseLibrary) {
         fake.promiseLibrary = promiseLibrary;
-    },
+    }, "usingPromise has been deprecated, and will be removed in the next major version"),
 
     yields: function (fake) {
         fake.callArgAt = useLeftMostCallback;

--- a/lib/sinon/fake.js
+++ b/lib/sinon/fake.js
@@ -3,6 +3,8 @@
 const arrayProto = require("@sinonjs/commons").prototypes.array;
 const createProxy = require("./proxy");
 const nextTick = require("./util/core/next-tick");
+const logger = require("@sinonjs/commons").deprecated;
+const wrap = logger.wrap;
 
 const slice = arrayProto.slice;
 let promiseLib = Promise;
@@ -165,10 +167,10 @@ fake.rejects = function rejects(value) {
  * @param {*} promiseLibrary
  * @returns {Function}
  */
-fake.usingPromise = function usingPromise(promiseLibrary) {
+fake.usingPromise = wrap(function usingPromise(promiseLibrary) {
     promiseLib = promiseLibrary;
     return fake;
-};
+}, "usingPromise has been deprecated, and will be removed in the next major version");
 
 /**
  * Returns a `fake` that calls the callback with the defined arguments.

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -17,6 +17,9 @@ const push = arrayProto.push;
 const slice = arrayProto.slice;
 const unshift = arrayProto.unshift;
 
+const logger = require("@sinonjs/commons").deprecated;
+const wrap = logger.wrap;
+
 function mock(object) {
     if (!object || typeof object === "string") {
         return mockExpectation.create(object ? object : "Anonymous mock");
@@ -119,11 +122,11 @@ extend(mock, {
         return true;
     },
 
-    usingPromise: function usingPromise(promiseLibrary) {
+    usingPromise: wrap(function usingPromise(promiseLibrary) {
         this.promiseLibrary = promiseLibrary;
 
         return this;
-    },
+    }, "usingPromise has been deprecated, and will be removed in the next major version"),
 
     invokeMethod: function invokeMethod(method, thisValue, args) {
         /* if we cannot find any matching files we will explicitly call mockExpection#fail with error messages */

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -536,12 +536,17 @@ function Sandbox(opts = {}) {
         "useFakeXMLHttpRequest has been deprecated, and will be removed in the next major version",
     );
 
-    sandbox.usingPromise = function usingPromise(promiseLibrary) {
+    function usingPromise(promiseLibrary) {
         promiseLib = promiseLibrary;
         collection.promiseLibrary = promiseLibrary;
 
         return sandbox;
-    };
+    }
+
+    sandbox.usingPromise = wrap(
+        usingPromise,
+        "usingPromise has been deprecated, and will be removed in the next major version",
+    );
 }
 
 Sandbox.prototype.match = match;


### PR DESCRIPTION
This PR deprecates `usingPromise` in preparation of merging #2644.
