### PR TITLE
BREAKING CHANGE: remove assert.failException property

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -47,8 +47,6 @@ function createAssertObject(opts) {
     });
 
     const assert = {
-        failException: "AssertError",
-
         fail: function fail(message) {
             let msg = message;
             if (cleanedAssertOptions.shouldLimitAssertionLogs) {
@@ -58,7 +56,7 @@ function createAssertObject(opts) {
                 );
             }
             const error = new Error(msg);
-            error.name = this.failException || assert.failException;
+            error.name = "AssertError";
 
             throw error;
         },

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -57,14 +57,6 @@ describe("assert", function () {
     });
 
     describe(".fail", function () {
-        beforeEach(function () {
-            this.exceptionName = sinonAssert.failException;
-        });
-
-        afterEach(function () {
-            sinonAssert.failException = this.exceptionName;
-        });
-
         it("can be configured to limit the error message length", function () {
             const customAssert = sinonAssert.createAssertObject({
                 shouldLimitAssertionLogs: true,
@@ -85,17 +77,6 @@ describe("assert", function () {
                 {
                     name: "AssertError",
                 },
-            );
-        });
-
-        it("throws configured exception type", function () {
-            sinonAssert.failException = "CustomError";
-
-            assert.exception(
-                function () {
-                    sinonAssert.fail("Some message");
-                },
-                { name: "CustomError" },
             );
         });
     });
@@ -1352,7 +1333,6 @@ describe("assert", function () {
             sinonAssert.expose(test);
 
             assert.isFunction(test.fail);
-            assert.isString(test.failException);
             assert.isFunction(test.assertCalled);
             assert.isFunction(test.assertCalledOn);
             assert.isFunction(test.assertCalledWith);
@@ -1367,7 +1347,6 @@ describe("assert", function () {
                 includeFail: false,
             });
 
-            assert.equals(typeof failException, "undefined");
             /*eslint-disable no-undef*/
             assert.isFunction(assertCalled);
             assert.isFunction(assertCalledOn);
@@ -1401,7 +1380,6 @@ describe("assert", function () {
             sinonAssert.expose(test, { prefix: "" });
 
             assert.isFunction(test.fail);
-            assert.isString(test.failException);
             assert.isFunction(test.called);
             assert.isFunction(test.calledOn);
             assert.isFunction(test.calledWith);

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1965,31 +1965,4 @@ describe("Sandbox", function () {
             refute.equals(getter, spy.get);
         });
     });
-
-    describe(".assert", function () {
-        it("allows rebinding of .fail on a per-sandbox level", function () {
-            const sandboxA = createSandbox();
-            const sandboxB = createSandbox();
-
-            sandboxA.assert.failException = "CustomErrorA";
-            sandboxB.assert.failException = "CustomErrorB";
-
-            assert.exception(
-                function () {
-                    sandboxA.assert.fail("Some message");
-                },
-                { name: "CustomErrorA" },
-            );
-
-            assert.exception(
-                function () {
-                    sandboxB.assert.fail("Some message");
-                },
-                { name: "CustomErrorB" },
-            );
-
-            sandboxA.restore();
-            sandboxB.restore();
-        });
-    });
 });


### PR DESCRIPTION
Fixes #2658 


#### Purpose

Remove `sinon.assert.failException`, which makes `sinon` slightly smaller and makes tests run slightly faster.

#### Background

This was used for allowing customisation of the thrown error between sandboxes and for customisation for integrations (most likely from the days of BusterJS).

To my knowledge and what I've been able to find on GitHub, this has never had any _production_ use by end users.

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
