### PR TITLE
Also mirror the calledOnceWith assertion

### DIFF
--- a/docs/release-source/release/assertions.md
+++ b/docs/release-source/release/assertions.md
@@ -87,6 +87,12 @@ Passes if `spy` was called with the provided arguments.
 
 It's possible to assert on a dedicated spy call: `sinon.assert.calledWith(spy.firstCall, arg1, arg2, ...);`.
 
+#### `sinon.assert.calledOnceWith(spyOrSpyCall, arg1, arg2, ...);`
+
+Passes if `spy` was called once and only once with the provided arguments.
+
+It's possible to assert on a dedicated spy call: `sinon.assert.calledOnceWith(spy.firstCall, arg1, arg2, ...);`.
+
 #### `sinon.assert.alwaysCalledWith(spy, arg1, arg2, ...);`
 
 Passes if `spy` was always called with the provided arguments.

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -305,6 +305,10 @@ function createAssertObject(opts) {
         "expected %n to be called with exact arguments %D",
     );
     mirrorPropAsAssertion(
+        "calledOnceWith",
+        "expected %n to be called once and with arguments %D",
+    );
+    mirrorPropAsAssertion(
         "calledOnceWithExactly",
         "expected %n to be called once and with exact arguments %D",
     );

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -841,6 +841,109 @@ describe("assert", function () {
             });
         });
 
+        describe(".calledOnceWith", function () {
+            // eslint-disable-next-line mocha/no-setup-in-describe
+            requiresValidFake("calledOnceWith");
+
+            it("fails when method fails", function () {
+                const object = {};
+                sinonStub(this.stub, "calledOnceWith").returns(false);
+                const stub = this.stub;
+
+                assert.exception(function () {
+                    sinonAssert.calledOnceWith(stub, object, 1);
+                });
+
+                assert(
+                    this.stub.calledOnceWith.calledOnceWithExactly(object, 1),
+                );
+                assert(sinonAssert.fail.called);
+            });
+
+            it("passes when method doesn't fail", function () {
+                const object = {};
+                sinonStub(this.stub, "calledOnceWith").returns(true);
+                const stub = this.stub;
+
+                refute.exception(function () {
+                    sinonAssert.calledOnceWith(stub, object, 1);
+                });
+
+                assert(
+                    this.stub.calledOnceWith.calledOnceWithExactly(object, 1),
+                );
+                assert.isFalse(sinonAssert.fail.called);
+            });
+
+            it("calls pass callback", function () {
+                this.stub("yeah");
+                sinonAssert.calledOnceWith(this.stub, "yeah");
+
+                assert(sinonAssert.pass.calledOnce);
+                assert(sinonAssert.pass.calledWith("calledOnceWith"));
+            });
+
+            it("fails when method does not exist", function () {
+                assert.exception(function () {
+                    sinonAssert.calledOnceWith();
+                });
+
+                assert(sinonAssert.fail.called);
+            });
+
+            it("fails when method is not stub", function () {
+                assert.exception(function () {
+                    sinonAssert.calledOnceWith(function () {
+                        return;
+                    });
+                });
+
+                assert(sinonAssert.fail.called);
+            });
+
+            it("fails when method was not called", function () {
+                const stub = this.stub;
+
+                assert.exception(function () {
+                    sinonAssert.calledOnceWith(stub);
+                });
+
+                assert(sinonAssert.fail.called);
+            });
+
+            it("fails when called with more than one argument", function () {
+                const stub = this.stub;
+                stub();
+
+                assert.exception(function () {
+                    sinonAssert.calledOnceWith(stub, 1);
+                });
+            });
+
+            it("passes when method was called", function () {
+                const stub = this.stub;
+                stub();
+
+                refute.exception(function () {
+                    sinonAssert.calledOnceWith(stub);
+                });
+
+                assert.isFalse(sinonAssert.fail.called);
+            });
+
+            it("fails when method was called more than once", function () {
+                const stub = this.stub;
+                stub();
+                stub();
+
+                assert.exception(function () {
+                    sinonAssert.calledOnceWith(stub);
+                });
+
+                assert(sinonAssert.fail.called);
+            });
+        });
+
         describe(".calledOnceWithExactly", function () {
             // eslint-disable-next-line mocha/no-setup-in-describe
             requiresValidFake("calledOnceWithExactly");


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

For Chrome DevTools front-end testing we generally prefer the `sinon.assert.foo(spy, ...)` form over `assert.isTrue(spy.foo(...))`, and `calledOnceWith` is missing from the `sinon.assert` object currently.

 #### Solution  - optional

It's pretty straight-forward to also expose the `calledOnceWith` on the `sinon.assert` object.

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test` (specifically the `test/assert-test.js` file checks that the method is properly exposed)

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
