### PR TITLE
Fix sandbox restore not handling stubbed functions

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -408,7 +408,8 @@ function Sandbox(opts = {}) {
         const [object, property, types] = args;
 
         const isSpyingOnEntireObject =
-            typeof property === "undefined" && typeof object === "object";
+            typeof property === "undefined" &&
+            (typeof object === "object" || typeof object === "function");
 
         if (isSpyingOnEntireObject) {
             const ownMethods = collectOwnMethods(spy);

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1766,6 +1766,17 @@ describe("Sandbox", function () {
 
             assert.isUndefined(o.foo.callCount);
         });
+
+        it("restores all fields of a stubbed function", function () {
+            const sandbox = new Sandbox();
+            const o = function () {};
+            o.foo = function () {};
+
+            sandbox.stub(o);
+            sandbox.restore();
+
+            assert.isUndefined(o.foo.callCount);
+        });
     });
 
     describe("configurable sandbox", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Sandbox restore is not restoring functions stubbed by `stub(func)`. This PR aligns the behaviour of `stub`and `restore`.

 #### Background (Problem in detail)  - optional

This is an issue when stubbing, for example, axios instances. Those are build in a way that looses their original object prototype. `stub(axios)` will work fine and stub all methods as expected, but `restore` wont work.

 #### Solution  - optional

The issue can be fixed by aligning the sandbox code

https://github.com/sinonjs/sinon/blob/26055043212a03afeb2914e16ea32cb7f0a3ac44/lib/sinon/sandbox.js#L410-L411

with the stub code

https://github.com/sinonjs/sinon/blob/26055043212a03afeb2914e16ea32cb7f0a3ac44/lib/sinon/stub.js#L91-L94

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm run test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
