### PR TITLE
Fix issue 2668 - Perform additional cleanup on callThrough() to discard any previously defined behavior

### DIFF
--- a/src/sinon/default-behaviors.js
+++ b/src/sinon/default-behaviors.js
@@ -241,10 +241,40 @@ const defaultBehaviors = {
 
     callThrough: function callThrough(fake) {
         fake.callsThrough = true;
+
+        fake.callArgAt = undefined;
+        fake.callsThroughWithNew = false;
+        fake.exception = undefined;
+        fake.exceptionCreator = undefined;
+        fake.fakeFn = undefined;
+        fake.reject = false;
+        fake.resolve = false;
+        fake.resolveArgAt = undefined;
+        fake.resolveThis = false;
+        fake.returnArgAt = undefined;
+        fake.returnThis = false;
+        fake.returnValue = undefined;
+        fake.throwArgAt = undefined;
+
+        fake.callArgProp = undefined;
+        fake.callbackArguments = [];
+        fake.callbackContext = undefined;
+        fake.callbackAsync = false;
+        fake.returnValueDefined = false;
     },
 
     callThroughWithNew: function callThroughWithNew(fake) {
         fake.callsThroughWithNew = true;
+
+        fake.callArgAt = undefined;
+        fake.exception = undefined;
+        fake.exceptionCreator = undefined;
+        fake.throwArgAt = undefined;
+
+        fake.callArgProp = undefined;
+        fake.callbackArguments = [];
+        fake.callbackContext = undefined;
+        fake.callbackAsync = false;
     },
 
     get: function get(fake, getterFunction) {

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -861,6 +861,348 @@ describe("issues", function () {
         assert.equals(cb.firstCall.args, ["Hello"]);
     });
 
+    describe("#2668 - callThrough", function () {
+        describe("callThrough", function () {
+            it("should clear throws(exception)", function () {
+                const instance = {
+                    foo() {
+                        return "ok";
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                const expectedError = new Error("boom");
+                stub.throws(expectedError);
+
+                assert.exception(
+                    () => instance.foo(),
+                    (err) => err === expectedError,
+                );
+
+                stub.callThrough();
+
+                // Issue caused the stub to still apply.
+                assert.equals(instance.foo(), "ok");
+            });
+
+            it("should clear throws(exceptionFactory)", function () {
+                const instance = {
+                    foo() {
+                        return "ok";
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                const expectedError = new Error("boom");
+                stub.throws(function () {
+                    throw expectedError;
+                });
+
+                assert.exception(
+                    () => instance.foo(),
+                    (err) => err === expectedError,
+                );
+
+                stub.callThrough();
+
+                // Issue caused the stub to still apply.
+                assert.equals(instance.foo(), "ok");
+            });
+
+            it("should clear throwsArg", function () {
+                const instance = {
+                    foo() {
+                        return "ok";
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                stub.throwsArg(0);
+
+                const expectedError = new Error("boom");
+                assert.exception(
+                    () => instance.foo(expectedError),
+                    (err) => err === expectedError,
+                );
+
+                stub.callThrough();
+
+                // Issue caused the stub to still apply.
+                assert.equals(
+                    instance.foo(new Error("Should not be thrown")),
+                    "ok",
+                );
+            });
+
+            it("should clear returnsThis", function () {
+                let called = false;
+                const instance = {
+                    foo() {
+                        called = true;
+                        return this;
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                stub.returnsThis();
+
+                assert.equals(instance.foo(), instance);
+                assert.equals(called, false);
+
+                stub.callThrough();
+
+                // Issue caused the stub to still apply.
+                assert.same(instance.foo(), instance);
+                assert.equals(called, true);
+            });
+
+            it("should clear resolves", async function () {
+                const instance = {
+                    foo() {
+                        return Promise.resolve("bar");
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                stub.resolves("baz");
+
+                assert.equals(await instance.foo(), "baz");
+
+                stub.callThrough();
+
+                // Issue caused the stub to still apply.
+                assert.equals(await instance.foo(), "bar");
+            });
+
+            it("should clear resolvesArg", async function () {
+                const instance = {
+                    foo(a) {
+                        return Promise.resolve(a);
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                stub.resolvesArg(1);
+
+                assert.equals(await instance.foo("a", "b"), "b");
+
+                stub.callThrough();
+
+                // Issue caused the stub to still apply.
+                assert.equals(await instance.foo("a", "b"), "a");
+            });
+
+            it("should clear resolvesThis", async function () {
+                const instance = {
+                    callCount: 0,
+                    foo() {
+                        this.callCount += 1;
+                        return Promise.resolve(this);
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                stub.resolvesThis();
+
+                assert.same(await instance.foo(), instance);
+                assert.equals(instance.callCount, 0);
+
+                stub.callThrough();
+
+                // Issue caused the stub to still apply.
+                assert.same(await instance.foo(), instance);
+                assert.equals(instance.callCount, 1);
+            });
+
+            it("should clear rejects", async function () {
+                const instance = {
+                    foo() {
+                        return Promise.resolve("ok");
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                const error = new Error("nope");
+                stub.rejects(error);
+
+                await assert.rejects(instance.foo(), error);
+
+                stub.callThrough();
+
+                // Issue caused the stub to still apply.
+                assert.equals(await instance.foo(), "ok");
+            });
+
+            it("should clear returnsArg", function () {
+                const instance = {
+                    foo(a) {
+                        return `ok ${a}`;
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                stub.returnsArg(0);
+
+                assert.equals(instance.foo("x"), "x");
+
+                stub.callThrough();
+
+                // Issue caused the stub to still apply.
+                assert.equals(instance.foo("z"), "ok z");
+            });
+
+            it("should clear callsFake", function () {
+                const instance = {
+                    foo() {
+                        return "orig";
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                stub.callsFake(function () {
+                    return "fake";
+                });
+
+                assert.equals(instance.foo(), "fake");
+
+                stub.callThrough();
+
+                // Issue caused the stub to still apply.
+                assert.equals(instance.foo(), "orig");
+            });
+
+            it("should clear callsArg/yield stuff", function () {
+                const instance = {
+                    foo(cbk) {
+                        cbk();
+                        return "original";
+                    },
+                };
+
+                const stub = sinon.stub(instance, "foo");
+                stub.callsArg(0);
+                stub.returns("fake");
+
+                const cbkStub = sinon.stub();
+                assert.same(instance.foo(cbkStub), "fake");
+                assert.equals(cbkStub.callCount, 1);
+
+                stub.callThrough();
+
+                const cbkStub2 = sinon.stub();
+                assert.same(instance.foo(cbkStub2), "original");
+                // Issue was causing the callback to be called once by the function, and once by the stub.
+                assert.equals(cbkStub2.callCount, 1);
+            });
+        });
+
+        describe("callThroughWithNew", function () {
+            it("should clear throws(exception)", function () {
+                class OriginalClass {
+                    constructor() {
+                        this.foo = "original";
+                    }
+                }
+
+                const instance = { MyClass: OriginalClass };
+
+                const stub = sinon.stub(instance, "MyClass");
+                const expectedError = new Error("boom");
+                stub.throws(expectedError);
+                assert.exception(
+                    () => new instance.MyClass(),
+                    (err) => err === expectedError,
+                );
+
+                stub.callThroughWithNew();
+
+                // Issue caused the stub to still apply.
+                const obj = new instance.MyClass();
+                assert.equals(obj.foo, "original");
+            });
+
+            it("should clear throws(exceptionFactory)", function () {
+                class OriginalClass {
+                    constructor() {
+                        this.foo = "original";
+                    }
+                }
+
+                const instance = { MyClass: OriginalClass };
+
+                const stub = sinon.stub(instance, "MyClass");
+                const expectedError = new Error("boom");
+                stub.throws(function () {
+                    throw expectedError;
+                });
+                assert.exception(
+                    () => new instance.MyClass(),
+                    (err) => err === expectedError,
+                );
+
+                stub.callThroughWithNew();
+
+                // Issue caused the stub to still apply.
+                const obj = new instance.MyClass();
+                assert.equals(obj.foo, "original");
+            });
+
+            it("should clear throwsArg", function () {
+                class OriginalClass {
+                    constructor() {
+                        this.foo = "original";
+                    }
+                }
+
+                const instance = { MyClass: OriginalClass };
+
+                const stub = sinon.stub(instance, "MyClass");
+                stub.throwsArg(0);
+                const expectedError = new Error("boom");
+                assert.exception(
+                    () => new instance.MyClass(expectedError),
+                    (err) => err === expectedError,
+                );
+
+                stub.callThroughWithNew();
+
+                // Issue caused the stub to still apply.
+                assert.equals(
+                    new instance.MyClass(new Error("Should not be thrown")).foo,
+                    "original",
+                );
+            });
+
+            it("should clear callsArg/yield stuff", function () {
+                class OriginalClass {
+                    constructor(cbk) {
+                        this.foo = "original";
+                        cbk();
+                    }
+                }
+
+                const instance = { MyClass: OriginalClass };
+
+                const stub = sinon.stub(instance, "MyClass");
+
+                stub.callsArg(0);
+                const dummyInstance = { foo: "fake" };
+                stub.returns(dummyInstance);
+
+                const cbkStub = sinon.stub();
+                assert.same(new instance.MyClass(cbkStub), dummyInstance);
+                assert.equals(cbkStub.callCount, 1);
+
+                stub.callThroughWithNew();
+
+                const cbkStub2 = sinon.stub();
+                assert.same(new instance.MyClass(cbkStub2).foo, "original");
+                // Issue was causing the callback to be called once by the constructor, and once by the stub.
+                assert.equals(cbkStub2.callCount, 1);
+            });
+        });
+    });
+
     it("#2702 - stub creation should ignore inherited non-writable Object prototype properties", function () {
         const descriptor = Object.getOwnPropertyDescriptor(
             Object.prototype,


### PR DESCRIPTION
#### Purpose

<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

Fix #2668 by cleanup all other behaviors when calling callThrough()

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm run test`

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
