### PR TITLE
Quality: Potential false negative when color support object lacks `stdout`

### DIFF
--- a/lib/sinon/colorizer.js
+++ b/lib/sinon/colorizer.js
@@ -12,7 +12,7 @@ module.exports = class Colorizer {
      * @private
      */
     colorize(str, color) {
-        if (this.supportsColor.stdout === false) {
+        if (!this.supportsColor || !this.supportsColor.stdout) {
             return str;
         }
 


### PR DESCRIPTION
## Problem

`Colorizer.colorize` only disables ANSI codes when `this.supportsColor.stdout === false`. If `supportsColor` is missing, malformed, or has `stdout` undefined, the function still emits ANSI escapes, which can pollute logs in non-TTY environments.

**Severity**: `medium`
**File**: `lib/sinon/colorizer.js`

## Solution

Use a stricter capability check, e.g. `if (!this.supportsColor || !this.supportsColor.stdout) return str;` and consider guarding constructor input shape.

## Changes

- `lib/sinon/colorizer.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
