### PR TITLE
Quality: Global mutable call id can grow unbounded across long-lived processes

### DIFF
--- a/src/sinon/proxy-invoke.js
+++ b/src/sinon/proxy-invoke.js
@@ -27,7 +27,7 @@ const maxSafeInteger = Number.MAX_SAFE_INTEGER;
 export default function invoke(func, thisValue, args) {
     const matchings = this.matchingFakes(args);
     const currentCallId = callId;
-    callId = callId === maxSafeInteger ? 0 : callId + 1;
+    callId = callId >= maxSafeInteger ? 0 : callId + 1;
     let exception, returnValue;
 
     proxyCallUtil.incrementCallCount(this);

--- a/src/sinon/proxy-invoke.js
+++ b/src/sinon/proxy-invoke.js
@@ -8,6 +8,7 @@ const ErrorConstructor = Error.prototype.constructor;
 const { bind } = Function.prototype;
 
 let callId = 0;
+const maxSafeInteger = Number.MAX_SAFE_INTEGER;
 
 /**
  * @callback SinonFunction
@@ -25,7 +26,8 @@ let callId = 0;
  */
 export default function invoke(func, thisValue, args) {
     const matchings = this.matchingFakes(args);
-    const currentCallId = callId++;
+    const currentCallId = callId;
+    callId = callId === maxSafeInteger ? 0 : callId + 1;
     let exception, returnValue;
 
     proxyCallUtil.incrementCallCount(this);


### PR DESCRIPTION
## Problem

`callId` is module-scoped and incremented on every invocation. In long-running test runners or embedded usage, this can grow indefinitely and eventually lose integer precision semantics for strict ordering comparisons.

**Severity**: `low`
**File**: `lib/sinon/proxy-invoke.js`

## Solution

Reset or wrap `callId` safely (e.g., modulo `Number.MAX_SAFE_INTEGER`) and document ordering guarantees when rollover occurs.

## Changes

- `lib/sinon/proxy-invoke.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
