### PR TITLE
fix: exclude `__proto__` from `walk()`

### DIFF
--- a/src/sinon/util/core/walk.js
+++ b/src/sinon/util/core/walk.js
@@ -28,7 +28,13 @@ function walkInternal(obj, iterator, context, originalObj, seen) {
     }
 
     forEach(Object.getOwnPropertyNames(obj), function (k) {
-        if (seen[k] !== true) {
+        // Skip __proto__ because:
+        // - It's not currently useful in this project.
+        // - It's automatic, problematic, and deprecated.
+        // - Assigning to it has special effects (or no effect for non-object)
+        //   which may not be expected/handled properly by iterator callback.
+        // - Getting it throws Error with node --disable-proto=throw.
+        if (k !== "__proto__" && seen[k] !== true) {
             seen[k] = true;
             const target =
                 typeof Object.getOwnPropertyDescriptor(obj, k).get ===


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix issue #2695 by excluding `__proto__` from `walk()`.

#### Background (Problem in detail)  - optional

[`__proto__`] is a special property to access an object's prototype.  It has many pitfalls:

- Setting it to an object value changes an object's prototype, which is generally discouraged and may be unexpected by the `iterator` callback.
- Setting it to a non-object value does nothing (meaning `seen[k] = true` has no effect).
- When Node.js is run with the [`--disable-proto=throw`] option, getting or setting `__proto__` causes an exception with code `ERR_PROTO_ACCESS` to be thrown, which causes issues like #2695.

#### Solution  - optional

Since `__proto__` (and all properties of `Object.prototype`) are currently unused by consumers of `walk()` in this project, it is both safe and preferable to exclude it from enumeration by `walk()`.

[`__proto__`]: https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.__proto__
[`--disable-proto=throw`]: https://nodejs.org/api/cli.html#disable-protomode

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `NODE_OPTIONS=--disable-proto=throw npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

#### Additional Work

It would be great if `--disable-proto=throw` could be added to the test suite, either by adding [`--node-option disable-proto=throw`](https://mochajs.org/running/cli/#--node-option-name--n-name) to the mocha invocation in `test-node`, or adding a separate run to test under these conditions.  However, this may introduce an additional maintenance burden, so requires additional discussion and is not currently part of this PR.

Thanks for considering,
Kevin