### PR TITLE
feat: replace unimported with knip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint": "^10.2.0",
         "get-stdin": "^10.0.0",
         "js-yaml": "^4.1.1",
-        "knip": "^6.4.0",
+        "knip": "^6.4.1",
         "lint-staged": "^16.4.0",
         "mocha": "^11.7.5",
         "npm-run-all": "^4.1.5",
@@ -80,6 +80,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -319,31 +320,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -351,7 +327,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1213,6 +1188,7 @@
       "integrity": "sha512-R41I1mwsdBMHF7aV6xQFNb14MxfCNiVZBpSZ3EGe2WV+zCRdZuPZ48cqrnwWEuk9YzEhb/TL3Gu9mtSUBkwKTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "convert-source-map": "^2.0.0",
         "deepmerge": "^4.3.1",
@@ -3110,6 +3086,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3543,6 +3520,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4152,7 +4130,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "8.0.4",
@@ -5021,6 +5000,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7178,9 +7158,9 @@
       }
     },
     "node_modules/knip": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-6.4.0.tgz",
-      "integrity": "sha512-SAEeggehgkPdoLZWVEcFKzPw+vNlnrUBDqcX8cOcHGydRInSn5pnn9LN3dDJ8SkDHKXR7xYzNq3HtRJaYmxOHg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.4.1.tgz",
+      "integrity": "sha512-Ry+ywmDFSZvKp/jx7LxMgsZWRTs931alV84e60lh0Stf6kSRYqSIUTkviyyDFRcSO3yY1Kpbi83OirN+4lA2Xw==",
       "dev": true,
       "funding": [
         {
@@ -9130,6 +9110,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9690,6 +9671,7 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "prettier:write": "prettier --write '**/*.{js,css,md}'",
     "preversion": "./scripts/preversion.sh",
     "version": "./scripts/version.sh",
-    "postversion": "./scripts/postversion.sh"
+    "postversion": "./scripts/postversion.sh",
+    "check:unused": "knip"
   },
   "nyc": {
     "instrument": false,
@@ -143,16 +144,16 @@
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@sinonjs/eslint-config": "^7.0.3",
     "@sinonjs/eslint-plugin-no-prototype-methods": "^0.1.1",
-    "eslint": "^10.2.0",
     "@sinonjs/referee": "^11.0.2",
     "@studio/changes": "^3.0.0",
     "debug": "^4.4.3",
     "esbuild": "^0.28.0",
     "esbuild-plugin-istanbul": "^0.3.0",
     "esbuild-plugin-umd-wrapper": "^3.0.0",
+    "eslint": "^10.2.0",
     "get-stdin": "^10.0.0",
     "js-yaml": "^4.1.1",
-    "knip": "^6.4.0",
+    "knip": "^6.4.1",
     "lint-staged": "^16.4.0",
     "mocha": "^11.7.5",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Picks up where #2636 left off. unimported was archived and removed, but nothing replaced it. This adds knip as the replacement with a check:unused npm script.

knip runs clean and finds some configuration hints (stale entries in ignoreFiles and ignoreDependencies) which can be addressed in a follow-up.

1531/1531 tests pass.

Fixes #2637