### PR TITLE
fix: isolate walk state from Object prototype

### DIFF
--- a/build.cjs
+++ b/build.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
- 
+
 const fs = require("node:fs");
 const { execFileSync } = require("node:child_process");
 const esbuild = require("esbuild");
@@ -8,7 +8,8 @@ const pkg = require("./package.json");
 
 // Step 1: Run Rollup to generate lib/ from src/
 console.log("Generating lib/ from src/ using Rollup...");
-execFileSync("npx", ["rollup", "-c", "rollup.config.mjs"], {
+const rollupCli = require.resolve("rollup/dist/bin/rollup");
+execFileSync(process.execPath, [rollupCli, "-c", "rollup.config.mjs"], {
     stdio: "inherit",
 });
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build-artifacts": "node ./build.cjs",
     "pretest-node": "npm run build-artifacts",
-    "test-node": "mocha --recursive -R dot 'test/{src,issues,scripts}/**/*-test.js'",
+    "test-node": "mocha --recursive -R dot \"test/{src,issues,scripts}/**/*-test.js\"",
     "pretest-headless": "npm run build-artifacts",
     "test-dev": "CHOKIDAR_USEPOLLING=1 npm run test-node -- --watch",
     "test-headless": "node ./scripts/run-browser-suite.mjs headless",
@@ -56,7 +56,7 @@
     "build": "npm run build-artifacts",
     "build-docs": "cd docs; make build",
     "serve-docs": "cd docs; make livereload",
-    "lint": "eslint --max-warnings 0 '**/*.{js,cjs,mjs}'",
+    "lint": "eslint --max-warnings 0 \"**/*.{js,cjs,mjs}\"",
     "pretest-webworker": "npm run build-artifacts",
     "prebuild": "rimraf pkg && npm run update-compatibility",
     "postbuild": "run-s test-esm-support test-esm-browser-build test-contract check-dependencies",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,7 +11,7 @@ function getAllFiles(dir, fileList = []) {
         if (fs.statSync(filePath).isDirectory()) {
             getAllFiles(filePath, fileList);
         } else if (filePath.endsWith(".js")) {
-            fileList.push(filePath.split(path.sep).join("/"));
+            fileList.push(path.normalize(filePath));
         }
     }
     return fileList;

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,7 +11,7 @@ function getAllFiles(dir, fileList = []) {
         if (fs.statSync(filePath).isDirectory()) {
             getAllFiles(filePath, fileList);
         } else if (filePath.endsWith(".js")) {
-            fileList.push(filePath);
+            fileList.push(filePath.split(path.sep).join("/"));
         }
     }
     return fileList;

--- a/src/sinon/util/core/walk.js
+++ b/src/sinon/util/core/walk.js
@@ -63,7 +63,7 @@ function walkInternal(obj, iterator, context, originalObj, seen) {
  * @returns {void} nothing
  */
 const walk = function (obj, iterator, context) {
-    return walkInternal(obj, iterator, context, obj, {});
+    return walkInternal(obj, iterator, context, obj, Object.create(null));
 };
 
 export default walk;

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -860,4 +860,29 @@ describe("issues", function () {
         assert(cb.calledOnce);
         assert.equals(cb.firstCall.args, ["Hello"]);
     });
+
+    it("#2702 - stub creation should ignore inherited non-writable Object prototype properties", function () {
+        const descriptor = Object.getOwnPropertyDescriptor(
+            Object.prototype,
+            "someFlag",
+        );
+
+        Object.defineProperty(Object.prototype, "someFlag", {
+            value: "x",
+            writable: false,
+            configurable: true,
+        });
+
+        try {
+            refute.exception(function () {
+                sinon.stub();
+            });
+        } finally {
+            if (descriptor) {
+                Object.defineProperty(Object.prototype, "someFlag", descriptor);
+            } else {
+                delete Object.prototype.someFlag;
+            }
+        }
+    });
 });

--- a/test/src/util/core/walk-test.js
+++ b/test/src/util/core/walk-test.js
@@ -2,6 +2,7 @@ import referee from "@sinonjs/referee";
 import walk from "../../../../src/sinon/util/core/walk.js";
 import createSpy from "../../../../src/sinon/spy.js";
 const assert = referee.assert;
+const refute = referee.refute;
 
 describe("util/core/walk", function () {
     it("should call iterator with value, key, and obj, with context as the receiver", function () {
@@ -162,5 +163,36 @@ describe("util/core/walk", function () {
         propertyNames.forEach(function (name, index) {
             assert.equals(index, propertyNames.lastIndexOf(name));
         });
+    });
+
+    it("tracks visited names without inheriting Object.prototype properties", function () {
+        const target = {};
+        const iterator = createSpy();
+        const descriptor = Object.getOwnPropertyDescriptor(
+            Object.prototype,
+            "someFlag",
+        );
+
+        // eslint-disable-next-line no-extend-native
+        Object.defineProperty(Object.prototype, "someFlag", {
+            value: "x",
+            writable: false,
+            configurable: true,
+        });
+
+        try {
+            refute.exception(function () {
+                walk(target, iterator);
+            });
+
+            assert(iterator.calledWith("someFlag", Object.prototype));
+        } finally {
+            if (descriptor) {
+                // eslint-disable-next-line no-extend-native
+                Object.defineProperty(Object.prototype, "someFlag", descriptor);
+            } else {
+                delete Object.prototype.someFlag;
+            }
+        }
     });
 });


### PR DESCRIPTION
## Summary
- Initialize `walk()`'s visited-name table with a null prototype so inherited `Object.prototype` properties cannot interfere with tracking.
- Add source-level and issue-level regression coverage for `sinon.stub()` when `Object.prototype` has an inherited non-writable property.
- Make the local build, Node test, and lint commands run on Windows by invoking the local Rollup CLI and using cross-platform globs.

## Verification
- `npm run test-node` (1534 passing, 12 pending)
- `npm run lint`
- `npx prettier --check build.cjs rollup.config.mjs package.json src/sinon/util/core/walk.js test/src/util/core/walk-test.js test/issues/issues-test.js`
- Source reproduction script now prints `stub created`

Fixes #2702