### PR TITLE
fix: stop sinon.restore() cascading into sub-sandboxes

### DIFF
--- a/src/create-sinon-api.js
+++ b/src/create-sinon-api.js
@@ -20,11 +20,12 @@ export default function createApi() {
     const sandbox = new Sandbox();
 
     const apiMethods = {
-        createSandbox: function createSandbox(config) {
-            const s = createConfiguredSandbox(config);
-            sandbox.getFakes().push(s);
-            return s;
-        },
+        // `createSandbox` returns an isolated sandbox: its fakes are tracked
+        // on its own collection so consumers can rely on `subSandbox.restore()`
+        // (and only that) for cleanup. Don't push it into the global sandbox's
+        // collection — doing so caused `sinon.restore()` to cascade-restore
+        // sub-sandboxes (regression in 21.1.0, see #2701).
+        createSandbox: createConfiguredSandbox,
         match: samsam.createMatcher,
         restoreObject: restoreObject,
         expectation: expectation,

--- a/test/src/create-sinon-api-test.js
+++ b/test/src/create-sinon-api-test.js
@@ -17,12 +17,26 @@ describe("create-sinon-api", function () {
         assert.isFunction(sinon.expectation.create);
     });
 
-    it("tracks created sandboxes in the root sandbox collection", function () {
+    it("does not track created sandboxes in the root sandbox collection", function () {
+        // Sub-sandboxes are isolated by design: pushing them into the root
+        // sandbox's collection caused `sinon.restore()` to cascade-restore
+        // sub-sandbox stubs (regression in 21.1.0, see #2701).
         const sinon = createApi();
         const fakes = sinon.getFakes();
         const sandbox = sinon.createSandbox();
 
-        assert.equals(fakes.indexOf(sandbox) !== -1, true);
+        assert.equals(fakes.indexOf(sandbox), -1);
+    });
+
+    it("does not restore sub-sandboxes when the root sandbox is restored", function () {
+        const sinon = createApi();
+        const sandbox = sinon.createSandbox();
+        const target = { method: () => "original" };
+        sandbox.stub(target, "method").returns("stubbed");
+
+        sinon.restore();
+
+        assert.equals(target.method(), "stubbed");
     });
 
     it("tracks stub instance methods in the root sandbox collection", function () {

--- a/test/src/sandbox-test.js
+++ b/test/src/sandbox-test.js
@@ -2048,7 +2048,11 @@ describe("Sandbox", function () {
     });
 
     describe("nested sandboxes", function () {
-        it("should restore nested sandboxes when the parent is restored", function () {
+        // Sub-sandboxes returned by `parent.createSandbox()` are isolated:
+        // the parent's `restore()` / `resetHistory()` / `verifyAndRestore()`
+        // must not touch the child's fakes or timers. Cascading was a
+        // regression in 21.1.0 (see #2701) and is now reverted.
+        it("should not restore nested sandboxes when the parent is restored", function () {
             const parent = createApi(); // parent is a "sinon-like" sandbox
             const child = parent.createSandbox();
 
@@ -2059,10 +2063,13 @@ describe("Sandbox", function () {
 
             parent.restore();
 
+            assert.equals(myObj.method(), "stubbed");
+
+            child.restore();
             assert.equals(myObj.method(), "original");
         });
 
-        it("should reset history of nested sandboxes when the parent resetHistory is called", function () {
+        it("should not reset history of nested sandboxes when the parent resetHistory is called", function () {
             const parent = createApi();
             const child = parent.createSandbox();
 
@@ -2073,10 +2080,10 @@ describe("Sandbox", function () {
 
             parent.resetHistory();
 
-            assert.isFalse(spy.called);
+            assert.isTrue(spy.calledOnce);
         });
 
-        it("should restore nested sandboxes when the parent verifyAndRestore is called", function () {
+        it("should not restore nested sandboxes when the parent verifyAndRestore is called", function () {
             const parent = createApi();
             const child = parent.createSandbox();
 
@@ -2087,10 +2094,13 @@ describe("Sandbox", function () {
 
             parent.verifyAndRestore();
 
+            assert.equals(myObj.method(), "stubbed");
+
+            child.restore();
             assert.equals(myObj.method(), "original");
         });
 
-        it("should restore fake timers when the parent sandbox is restored", function () {
+        it("should not restore fake timers when the parent sandbox is restored", function () {
             const parent = createApi();
             const child = parent.createSandbox();
 
@@ -2101,6 +2111,9 @@ describe("Sandbox", function () {
 
             parent.restore();
 
+            refute.same(globalContext.Date, originalDate);
+
+            child.restore();
             assert.same(globalContext.Date, originalDate);
         });
     });


### PR DESCRIPTION
fixes #2701

## Summary

Sub-sandboxes returned by `sinon.createSandbox()` used to be **isolated**: only `subSandbox.restore()` cleaned them up. The ESM port of \`createApi\` (#2683 / 21.1.0) changed that without anyone noticing — it now pushes every newly-created sandbox into the root sandbox's fake collection:

```javascript
createSandbox: function createSandbox(config) {
    const s = createConfiguredSandbox(config);
    sandbox.getFakes().push(s);   // <- new in 21.1.0
    return s;
},
```

\`Sandbox#restore()\` then iterates that collection and calls \`.restore()\` on every entry, so any top-level \`sinon.restore()\` cascades into every sub-sandbox and undoes its stubs/timers/etc. Same goes for \`resetHistory()\` and \`verifyAndRestore()\` (and fake timers — \`Date\` etc. installed via \`subSandbox.useFakeTimers()\` get torn down too).

The repro from #2701 fails on `main`:

```javascript
const sandbox = Sinon.createSandbox();
const foor = { bar: () => "baz" };
sandbox.stub(foor, "bar").returns("qux");

Sinon.restore();              // <-- 21.1.0 wipes \`sandbox\`'s stub here
foor.bar();                   // expected: "qux"  actual: "baz"
```

## Fix

Drop the wrapper and expose \`createConfiguredSandbox\` directly, matching pre-21.1 behaviour. Sub-sandboxes go back to being isolated.

## Tests

\`test/src/create-sinon-api-test.js\` had a test that locked in the buggy cascade (\`tracks created sandboxes in the root sandbox collection\`). Inverted it, plus added a positive regression test that mirrors the issue's repro.

\`test/src/sandbox-test.js\` had four \"nested sandboxes\" tests doing the same — they each asserted that parent \`restore\`/\`resetHistory\`/\`verifyAndRestore\` reaches into the child. Inverted those four to assert the parent does **not** touch the child, with an explicit \`child.restore()\` at the end so each test still cleans up after itself.

\`mocha 'test/src/*-test.js'\` → 1426 passing.
\`mocha test/issues/issues-test.js\` → 41 passing.

(I couldn't run the full \`npm run test\` script end-to-end because the browser/distribution build runs OOM in this environment; the affected logic is purely in the Node-side \`createApi\` so the targeted runs above cover it.)

## Notes

- 21.0.x had \`createSandbox: createSandbox\` (no nesting), which is the behaviour this PR returns to.
- \`createStubInstance\` still pushes its synthesized methods into the root collection — that's intentional because there's no per-stub-instance handle to restore them with, and was true pre-21.1 as well. Untouched here.