### PR TITLE
ci: fix browser-test workflow by setting PUPPETEER_EXECUTABLE_PATH

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Integration
         run: |
           export SINON_CHROME_BIN=$(which google-chrome-stable)
+          export PUPPETEER_EXECUTABLE_PATH="$SINON_CHROME_BIN"
 
           # test-coverage runs test-headless in Chrome
           npm run test-coverage  -- --chrome "$SINON_CHROME_BIN" --allow-chrome-as-root


### PR DESCRIPTION
## Problem

The `browser-test` job started failing with:

```
Error: Could not find Chrome (ver. 147.0.7727.57). This can occur if either
 1. you did not perform an installation before running the script (e.g. `npx puppeteer browsers install chrome`) or
 2. your cache path is incorrectly configured (which is: /home/runner/.cache/puppeteer).
```

[Failed run](https://github.com/sinonjs/sinon/actions/runs/26820537088/job/79073653261)

## Cause

Puppeteer v24 (installed via `puppeteer@^24.42.0`) no longer falls back to the system-installed `google-chrome-stable` when the cached browser is missing. The workflow sets `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 1`, so nothing is downloaded during `npm ci`, and Puppeteer exits immediately.

## Fix

Set `PUPPETEER_EXECUTABLE_PATH` to the system Chrome binary so Puppeteer uses it instead of looking in its cache. This env var is read by Puppeteer's `getConfiguration()` and is picked up by both `@mochify/driver-puppeteer` (used in `test-coverage`) and direct `puppeteer.launch()` calls (used in `test-headless` / `test-webworker`).
