### PR TITLE
fix: let returns override returnsArg

### DIFF
--- a/src/sinon/default-behaviors.js
+++ b/src/sinon/default-behaviors.js
@@ -145,6 +145,7 @@ const defaultBehaviors = {
     returns: function returns(fake, value) {
         fake.callsThrough = false;
         fake.returnValue = value;
+        fake.returnArgAt = undefined;
         fake.resolve = false;
         fake.reject = false;
         fake.returnValueDefined = true;

--- a/test/src/stub-test.js
+++ b/test/src/stub-test.js
@@ -721,6 +721,15 @@ describe("stub", function () {
             assert.equals(obj.fn("myarg"), "myarg");
         });
 
+        it("is superseded by returns", function () {
+            const stub = createStub();
+
+            stub.returnsArg(0);
+            stub.returns(42);
+
+            assert.equals(stub("myarg"), 42);
+        });
+
         it("throws if no index is specified", function () {
             const stub = createStub();
 


### PR DESCRIPTION
Fixes #2656.

This clears the previous `returnsArg()` behavior when `returns()` is configured afterwards. Without clearing `returnArgAt`, the behavior invocation path still prioritizes `returnsArg` over the explicit return value, so `stub.returnsArg(0).returns(42)` returns the first argument instead of `42`.

The added regression test covers that chaining order directly.

Verification:

- `npm run test-node -- test/src/stub-test.js --grep "is superseded by returns"`
- `npm run test-node -- test/src/stub-test.js --grep "returnsArg"`
- `npm run test-node -- test/src/stub-test.js`
- `npm run test-node`
- `npx eslint src/sinon/default-behaviors.js test/src/stub-test.js --max-warnings 0`
- `npx prettier --check src/sinon/default-behaviors.js test/src/stub-test.js`