### PR TITLE
fix(docs): convert fake-timers sidebar names to camelCase

### DIFF
--- a/docs/scripts/generate-sidebar.mjs
+++ b/docs/scripts/generate-sidebar.mjs
@@ -116,6 +116,10 @@ function getConceptDisplayName(section) {
   );
 }
 
+function kebabToCamel(str) {
+  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
 function generateSidebar() {
   const sidebar = {};
 
@@ -226,7 +230,7 @@ function generateSidebar() {
     // Add use-fake-timers as first item after Introduction
     if (rootFiles.includes("use-fake-timers.md")) {
       sectionItems.push({
-        text: "use fake timers",
+        text: "useFakeTimers",
         link: "/concepts/fake-timers/use-fake-timers",
         collapsed: false
       });
@@ -240,7 +244,7 @@ function generateSidebar() {
       const apiItems = remainingItems.map((f) => {
         const name = f.replace(".md", "");
         return {
-          text: name.replace(/-/g, " "),
+          text: kebabToCamel(name),
           link: `/concepts/fake-timers/${name}`
         };
       });


### PR DESCRIPTION

#### Purpose (TL;DR) - mandatory
The sidebar generator was using name.replace(/-\/g, " ") to convert kebab-case filenames to display text, producing lowercase spaced names like "run all" and "set system time". The predocs:build hook runs the generator before every production build, so production always showed the wrong casing while local dev (which skips the hook) showed the manually-committed camelCase names.

<!--
 #### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
 #### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
