### PR TITLE
docs: add CarbonAds to right sidebar

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -65,7 +65,11 @@ export default defineConfig({
     ],
     sidebar: sidebarConfig,
     search: { provider: "local" },
-    socialLinks: [{ icon: "github", link: "https://github.com/sinonjs/sinon" }]
+    socialLinks: [{ icon: "github", link: "https://github.com/sinonjs/sinon" }],
+    carbonAds: {
+      code: "CE7D453M",
+      placement: "sinonjsorg"
+    }
   },
   editLink: {
     pattern: "https://github.com/sinonjs/sinon/edit/main/docs/:path",


### PR DESCRIPTION
Add CarbonAds to the right sidebar of the VitePress documentation site
using VitePress's built-in support — no plugins or custom components needed.

- VitePress renders the ad below the outline, pushed to the bottom of
  the aside by a flex spacer
- The Carbon script loads lazily only at desktop widths (hidden on mobile)
- Auto-refreshes on page navigation via `_carbonads.refresh()`
- Uses the same `CE7D453M` serve ID and `sinonjsorg` placement as the
  old Jekyll site

The old Jekyll site had CarbonAds via `_includes/carbonads.html`, but
this was never ported to the new VitePress site.