### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "author": "Christian Johansen",
   "repository": {
     "type": "git",
-    "url": "http://github.com/sinonjs/sinon.git"
+    "url": "git+https://github.com/sinonjs/sinon.git"
   },
   "bugs": {
-    "url": "http://github.com/sinonjs/sinon/issues"
+    "url": "https://github.com/sinonjs/sinon/issues"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
## Summary
- replace the legacy HTTP repository URL with a public HTTPS Git URL
- update the issue tracker URL to HTTPS
- prevent npm from normalizing repository metadata to an SSH-only URL

## Verification
- Rollup generated 40 CommonJS entries from `src/`
- Mocha: 1,552 tests passed; 12 existing tests pending
- ESLint passed with zero warnings
- direct assertions for repository and bugs metadata
- `git diff --check`

The standard build script is not Windows-safe because `rollup.config.mjs` passes backslash entry paths to Rollup. For validation only, the same config was loaded with entry separators normalized to `/`; no repository source files were changed for that workaround.