### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "author": "Christian Johansen",
   "repository": {
     "type": "git",
-    "url": "http://github.com/sinonjs/sinon.git"
+    "url": "git+https://github.com/sinonjs/sinon.git"
   },
   "bugs": {
-    "url": "http://github.com/sinonjs/sinon/issues"
+    "url": "https://github.com/sinonjs/sinon/issues"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
Change repository and bugs URLs from legacy http format to modern git+https and https formats respectively.

Before:
```
repository: {
  type: git,
  url: http://github.com/sinonjs/sinon.git
},
bugs: {
  url: http://github.com/sinonjs/sinon/issues
}
```

After:
```
repository: {
  type: git,
  url: git+https://github.com/sinonjs/sinon.git
},
bugs: {
  url: https://github.com/sinonjs/sinon/issues
}
```

This is metadata-only. There are no runtime code, dependency, or lockfile changes.