### PR TITLE
Fix #1741: record calls on stubbed getters/setters

### DIFF
--- a/src/sinon/default-behaviors.js
+++ b/src/sinon/default-behaviors.js
@@ -4,6 +4,7 @@ const { prototypes } = commons;
 import isPropertyConfigurable from "./util/core/is-property-configurable.js";
 import exportAsyncBehaviors from "./util/core/export-async-behaviors.js";
 import extend from "./util/core/extend.js";
+import spy from "./spy.js";
 
 const { slice } = prototypes.array;
 
@@ -280,8 +281,15 @@ const defaultBehaviors = {
     get: function get(fake, getterFunction) {
         const rootStub = fake.stub || fake;
 
+        // Wrap the replacement getter in a spy so that reading the property
+        // records the access (callCount, calledOnce, ...). The spy is exposed
+        // on the stub as `stub.getter`, mirroring the `spy.get` accessor that
+        // `sinon.spy(obj, "prop", ["get"])` produces. See #1741.
+        const getterSpy = spy(getterFunction);
+        rootStub.getter = getterSpy;
+
         Object.defineProperty(rootStub.rootObj, rootStub.propName, {
-            get: getterFunction,
+            get: getterSpy,
             configurable: isPropertyConfigurable(
                 rootStub.rootObj,
                 rootStub.propName,
@@ -294,12 +302,19 @@ const defaultBehaviors = {
     set: function set(fake, setterFunction) {
         const rootStub = fake.stub || fake;
 
+        // Wrap the replacement setter in a spy so that writing the property
+        // records the access (callCount, calledWith, ...). The spy is exposed
+        // on the stub as `stub.setter`, mirroring the `spy.set` accessor that
+        // `sinon.spy(obj, "prop", ["set"])` produces. See #1741.
+        const setterSpy = spy(setterFunction);
+        rootStub.setter = setterSpy;
+
         Object.defineProperty(
             rootStub.rootObj,
             rootStub.propName,
             // eslint-disable-next-line accessor-pairs
             {
-                set: setterFunction,
+                set: setterSpy,
                 configurable: isPropertyConfigurable(
                     rootStub.rootObj,
                     rootStub.propName,

--- a/test/src/stub-test.js
+++ b/test/src/stub-test.js
@@ -3668,6 +3668,25 @@ describe("stub", function () {
 
             assert.equals(myObj.prop, "bar");
         });
+
+        it("records calls to the stubbed getter on stub.getter", function () {
+            const myObj = {
+                prop: "foo",
+            };
+
+            const stub = createStub(myObj, "prop").get(function getterFn() {
+                return "bar";
+            });
+
+            const first = myObj.prop;
+            const second = myObj.prop;
+
+            assert.equals(first, "bar");
+            assert.equals(second, "bar");
+            assert.equals(myObj.prop, "bar");
+            assert.equals(stub.getter.callCount, 3);
+            assert(stub.getter.calledThrice);
+        });
     });
 
     describe(".set", function () {
@@ -3756,6 +3775,24 @@ describe("stub", function () {
 
             myObj.prop = "foo";
             assert.equals(myObj.otherProp, "bar");
+        });
+
+        it("records calls to the stubbed setter on stub.setter", function () {
+            const myObj = {
+                prop: "foo",
+            };
+
+            const stub = createStub(myObj, "prop").set(function setterFn(val) {
+                myObj.example = val;
+            });
+
+            myObj.prop = "bar";
+            myObj.prop = "baz";
+
+            assert.equals(myObj.example, "baz");
+            assert.equals(stub.setter.callCount, 2);
+            assert(stub.setter.calledTwice);
+            assert(stub.setter.calledWith("baz"));
         });
     });
 


### PR DESCRIPTION
## Purpose (TL;DR)

`stub.get(fn)` / `stub.set(fn)` installed the raw replacement function directly as the property accessor, so invoking a stubbed getter/setter ran untracked — `callCount` never incremented (#1741). This wraps the replacement in a spy and exposes it as `stub.getter` / `stub.setter`, so accessor invocations are recorded (mirroring the existing `spy.get` / `spy.set` surface). This is the scoped "tiny PR" @fatso83 green-lit in the issue thread.

## How to verify

```js
const obj = { get prop() { return 1; } };
const s = sinon.stub(obj, "prop").get(() => 42);
obj.prop; obj.prop;
s.getter.callCount; // 2  (previously: not recorded)
```

`npx mocha test/src/stub-test.js --grep "records calls to the stubbed"` → 2 passing.

## Checklist

- [x] Lint passes (`eslint --max-warnings 0`; prettier clean)
- [x] Scoped + non-breaking (+19 lines in `default-behaviors.js`, no API removed); full suite 1554 passing / 0 failing locally.

Fixes #1741
