### PR TITLE
feat: make sinon.restoreObject idempotent

### DIFF
--- a/src/sinon/restore-object.js
+++ b/src/sinon/restore-object.js
@@ -1,4 +1,4 @@
-import walkObject from "./util/core/walk-object.js";
+import { walkObject } from "./util/core/walk-object.js";
 
 function filter(object, property) {
     return object[property].restore && object[property].restore.sinon;

--- a/src/sinon/spy.js
+++ b/src/sinon/spy.js
@@ -5,7 +5,7 @@ import extend from "./util/core/extend.js";
 import getPropertyDescriptor from "./util/core/get-property-descriptor.js";
 import isEsModule from "./util/core/is-es-module.js";
 import * as proxyCallUtil from "./proxy-call-util.js";
-import walkObject from "./util/core/walk-object.js";
+import { walkObjectStrict } from "./util/core/walk-object.js";
 import wrapMethod from "./util/core/wrap-method.js";
 
 const { prototypes, functionName, valueToString } = commons;
@@ -185,7 +185,7 @@ function spyImpl(object, property, types, context) {
     }
 
     if (!property && typeof object === "object") {
-        return walkObject(function (obj, prop, propTypes) {
+        return walkObjectStrict(function (obj, prop, propTypes) {
             return spyImpl(obj, prop, propTypes, context);
         }, object);
     }

--- a/src/sinon/stub.js
+++ b/src/sinon/stub.js
@@ -10,7 +10,7 @@ import isEsModule from "./util/core/is-es-module.js";
 import sinonType from "./util/core/sinon-type.js";
 import wrapMethod from "./util/core/wrap-method.js";
 import throwOnFalsyObject from "./throw-on-falsy-object.js";
-import walkObject from "./util/core/walk-object.js";
+import { walkObjectStrict } from "./util/core/walk-object.js";
 
 const { prototypes: commonsPrototypes, functionName, valueToString } = commons;
 const { array: arrayProto, object: objectProto } = commonsPrototypes;
@@ -118,7 +118,7 @@ function stubImpl(object, property, context) {
             typeof actualDescriptor.value !== "function");
 
     if (isStubbingEntireObject) {
-        return walkObject(function (obj, prop) {
+        return walkObjectStrict(function (obj, prop) {
             return stubImpl(obj, prop, context);
         }, object);
     }

--- a/src/sinon/util/core/walk-object.js
+++ b/src/sinon/util/core/walk-object.js
@@ -18,15 +18,7 @@ import walk from "./walk.js";
  * @returns {boolean}
  */
 
-/**
- * A utility that allows traversing an object, applying mutating functions on the properties
- *
- * @param {ObjectMutator} mutator called on each property
- * @param {object} object the object we are walking over
- * @param {ObjectFilter} filter a predicate (boolean function) that will decide whether or not to apply the mutator to the current property
- * @returns {void} nothing
- */
-const walkObject = function (mutator, object, filter) {
+const applyMutations = function (mutator, object, filter) {
     let called = false;
     const name = functionName(mutator);
 
@@ -56,7 +48,33 @@ const walkObject = function (mutator, object, filter) {
         }
     });
 
-    if (!called) {
+    return called;
+};
+
+/**
+ * A utility that allows traversing an object, applying mutating functions on the properties
+ *
+ * @param {ObjectMutator} mutator called on each property
+ * @param {object} object the object we are walking over
+ * @param {ObjectFilter} filter a predicate (boolean function) that will decide whether or not to apply the mutator to the current property
+ * @returns {void} nothing
+ */
+export const walkObject = function (mutator, object, filter) {
+    applyMutations(mutator, object, filter);
+
+    return object;
+};
+
+/**
+ * Like walkObject, but throws if the mutator was never applied to any property
+ *
+ * @param {ObjectMutator} mutator called on each property
+ * @param {object} object the object we are walking over
+ * @param {ObjectFilter} filter a predicate (boolean function) that will decide whether or not to apply the mutator to the current property
+ * @returns {void} nothing
+ */
+export const walkObjectStrict = function (mutator, object, filter) {
+    if (!applyMutations(mutator, object, filter)) {
         throw new Error(
             `Found no methods on object to which we could apply mutations`,
         );
@@ -64,5 +82,3 @@ const walkObject = function (mutator, object, filter) {
 
     return object;
 };
-
-export default walkObject;

--- a/test/src/restore-object-test.js
+++ b/test/src/restore-object-test.js
@@ -35,19 +35,15 @@ describe("restore-object", function () {
         );
     });
 
-    it("throws with no spies or stubs", function () {
-        assert.exception(
-            function () {
-                restoreObject({
-                    catpants: function () {},
-                    meh: "okay",
-                });
-            },
-            {
-                message:
-                    "Found no methods on object to which we could apply mutations",
-            },
-        );
+    it("is a no-op with no spies or stubs", function () {
+        const object = {
+            catpants: function () {},
+            meh: "okay",
+        };
+
+        refute.exception(function () {
+            restoreObject(object);
+        });
     });
 
     it("works with mixed spies and stubs", function () {

--- a/test/src/util/core/walk-object-test.js
+++ b/test/src/util/core/walk-object-test.js
@@ -1,5 +1,5 @@
 import referee from "@sinonjs/referee";
-import walkObject from "../../../../src/sinon/util/core/walk-object.js";
+import { walkObjectStrict } from "../../../../src/sinon/util/core/walk-object.js";
 
 const assert = referee.assert;
 
@@ -32,14 +32,14 @@ describe("util/core/walk-object", function () {
         it("should still identify functions in environments", function () {
             assert.exception(
                 function () {
-                    walkObject(fnWithNoName, false);
+                    walkObjectStrict(fnWithNoName, false);
                 },
                 { message: "Trying to fnWithNoName object but received false" },
             );
 
             assert.exception(
                 function () {
-                    walkObject(fnWithNoName, {});
+                    walkObjectStrict(fnWithNoName, {});
                 },
                 {
                     message:
@@ -51,14 +51,14 @@ describe("util/core/walk-object", function () {
         it("should work with anonymous functions", function () {
             assert.exception(
                 function () {
-                    walkObject(anonymousFn, false);
+                    walkObjectStrict(anonymousFn, false);
                 },
                 { message: "Trying to undefined object but received false" },
             );
 
             assert.exception(
                 function () {
-                    walkObject(anonymousFn, {});
+                    walkObjectStrict(anonymousFn, {});
                 },
                 {
                     message:


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix #2736 by making `sinon.restoreObject` a no-op on empty/stub-less objects.

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
