### PR TITLE
docs: add guides section with migration, FAQ, how-tos, and external resources

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -106,5 +106,7 @@ jobs:
             --exclude "opencollective"
             --exclude "llms"
             --exclude "node-tap.org"
+            --exclude "reqres.in"
+            --exclude "somepage"
             --accept '200..=299,403'
           fail: true

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -28,6 +28,15 @@ export default defineConfig({
     nav: [
       { text: "Getting Started", link: "/getting-started" },
       {
+        text: "Guides",
+        items: [
+          { text: "How-to articles", link: "/guides/how-to/" },
+          { text: "FAQ", link: "/guides/faq" },
+          { text: "Migration", link: "/guides/migration" },
+          { text: "External resources", link: "/guides/external-resources" }
+        ]
+      },
+      {
         text: "Concepts",
         activeMatch: "/concepts/",
         items: [

--- a/docs/.vitepress/sidebar.mjs
+++ b/docs/.vitepress/sidebar.mjs
@@ -1002,6 +1002,55 @@ export default {
       ]
     }
   ],
+  "/guides/": [
+    {
+      "text": "Guides",
+      "items": [
+        {
+          "text": "How-to articles",
+          "collapsed": false,
+          "items": [
+            {
+              "text": "Overview",
+              "link": "/guides/how-to/"
+            },
+            {
+              "text": "Async functions with fake timers",
+              "link": "/guides/how-to/fake-timers-async"
+            },
+            {
+              "text": "Link seams (CommonJS)",
+              "link": "/guides/how-to/link-seams-commonjs"
+            },
+            {
+              "text": "Stub a dependency",
+              "link": "/guides/how-to/stub-dependency"
+            },
+            {
+              "text": "Stub ES module imports",
+              "link": "/guides/how-to/stub-esm"
+            },
+            {
+              "text": "TypeScript and SWC",
+              "link": "/guides/how-to/typescript-swc"
+            }
+          ]
+        },
+        {
+          "text": "FAQ",
+          "link": "/guides/faq"
+        },
+        {
+          "text": "Migration",
+          "link": "/guides/migration"
+        },
+        {
+          "text": "External resources",
+          "link": "/guides/external-resources"
+        }
+      ]
+    }
+  ],
   "/concepts/utils/": [
     {
       "text": "Utils",

--- a/docs/guides/external-resources.md
+++ b/docs/guides/external-resources.md
@@ -7,7 +7,6 @@ description: Curated list of external articles and related libraries for Sinon.J
 
 ## Articles elsewhere on the web
 
-- [How to Test NodeJS Apps using Mocha, Chai and SinonJS](https://scotch.io/tutorials/how-to-test-nodejs-apps-using-mocha-chai-and-sinonjs)
 - [How to stub or mock complex objects, such as DOM objects](https://codeutopia.net/blog/2016/05/23/sinon-js-quick-tip-how-to-stubmock-complex-objects-such-as-dom-objects/)
 - [Using Sinon.js with Promises](https://www.sitepoint.com/promises-in-javascript-unit-tests-the-definitive-guide/)
 - [Best practices for spies, stubs and mocks](https://semaphoreci.com/community/tutorials/best-practices-for-spies-stubs-and-mocks-in-sinon-js)

--- a/docs/guides/external-resources.md
+++ b/docs/guides/external-resources.md
@@ -1,0 +1,26 @@
+---
+title: External resources
+description: Curated list of external articles and related libraries for Sinon.JS.
+---
+
+# External resources
+
+## Articles elsewhere on the web
+
+- [How to Test NodeJS Apps using Mocha, Chai and SinonJS](https://scotch.io/tutorials/how-to-test-nodejs-apps-using-mocha-chai-and-sinonjs)
+- [How to stub or mock complex objects, such as DOM objects](https://codeutopia.net/blog/2016/05/23/sinon-js-quick-tip-how-to-stubmock-complex-objects-such-as-dom-objects/)
+- [Using Sinon.js with Promises](https://www.sitepoint.com/promises-in-javascript-unit-tests-the-definitive-guide/)
+- [Best practices for spies, stubs and mocks](https://semaphoreci.com/community/tutorials/best-practices-for-spies-stubs-and-mocks-in-sinon-js)
+- [Using Sinon.js to help test Mongoose models](https://codeutopia.net/blog/2016/06/10/mongoose-models-and-unit-tests-the-definitive-guide/)
+- [Stubbing HTTP Requests With Sinon](http://mherman.org/blog/2017/11/06/stubbing-http-requests-with-sinon/)
+- [Stubbing Node Authentication Middleware with Sinon](http://mherman.org/blog/2018/01/22/stubbing-node-authentication-middleware-with-sinon)
+- [Testing ImmutableJS with Sinon custom matchers](https://www.scraggo.com/testing-immutable-js-with-sinon-custom-matchers/)
+- [SinonJS Fundamentals](https://www.pluralsight.com/courses/sinonjs-fundamentals) (Pluralsight course)
+
+## Related libraries
+
+- [proxyquire](https://github.com/thlorenz/proxyquire) — Proxies Node.js require to override dependencies during testing
+- [inject-loader](https://github.com/plasticine/inject-loader) — Webpack loader that allows overriding dependencies during testing
+- [fetch-mock](http://www.wheresrhys.co.uk/fetch-mock/) — Mock HTTP requests made using fetch
+- [mock-socket](https://github.com/thoov/mock-socket) — Mocking library for WebSockets and socket.io
+- [testdouble.js](https://github.com/testdouble/testdouble.js) — Minimal test double library for TDD with JavaScript

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -1,0 +1,68 @@
+---
+title: Frequently Asked Questions
+---
+
+# Frequently Asked Questions
+
+## Property Descriptor Errors
+
+### "Descriptor for property X is non-configurable and non-writable"
+
+If you encounter an error like this:
+
+```
+TypeError: Descriptor for property toBeMocked is non-configurable and non-writable
+```
+
+This error occurs when Sinon tries to stub or spy on a property that has been defined as immutable by JavaScript's property descriptor system. This is not a bug in Sinon, but rather a limitation imposed by the JavaScript engine itself.
+
+#### Common Causes
+
+1. **ES Module transpilation**: When ES modules are transpiled to CommonJS (e.g., by TypeScript, Babel, or SWC), the exported properties often become non-configurable and non-writable.
+
+2. **`Object.freeze()` or `Object.seal()`**: Objects that have been frozen or sealed have immutable properties.
+
+3. **Native browser/Node.js APIs**: Some built-in objects and their properties are inherently immutable.
+
+4. **Third-party libraries**: Some libraries define their exports with non-configurable descriptors.
+
+#### Solutions
+
+1. **Use dependency injection**: Instead of stubbing the import directly, pass the dependency as a parameter:
+
+   ```javascript
+   // Instead of this:
+   import { toBeMocked } from "./module";
+   sinon.stub(module, "toBeMocked"); // This might fail
+
+   // Do this:
+   function myFunction(dependency = toBeMocked) {
+     return dependency();
+   }
+
+   // In tests:
+   const stub = sinon.stub();
+   myFunction(stub);
+   ```
+
+2. **Stub at the module level**: For ES modules, consider using a tool like `proxyquire` or `testdouble.js` for module-level mocking.
+
+3. **Use dynamic imports**: Dynamic imports can sometimes work around transpilation issues:
+
+   ```javascript
+   // In your test
+   const module = await import("./module");
+   sinon.stub(module, "toBeMocked");
+   ```
+
+4. **Restructure your code**: Consider whether the code under test can be refactored to be more testable.
+
+#### For TypeScript Users
+
+When using TypeScript with SWC or similar transpilers, see our [TypeScript with SWC guide](./how-to/typescript-swc) for specific solutions.
+
+#### Further Reading
+
+- [MDN: Object.getOwnPropertyDescriptor()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor)
+- [MDN: Property descriptors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Description)
+- [How-to: Stub dependencies in CommonJS](./how-to/stub-dependency)

--- a/docs/guides/how-to/fake-timers-async.md
+++ b/docs/guides/how-to/fake-timers-async.md
@@ -1,0 +1,93 @@
+---
+title: How to test async functions with fake timers
+---
+
+# How to test async functions with fake timers
+
+With fake timers, testing code that depends on timers is easier, as it sometimes
+becomes possible to skip the waiting part and trigger scheduled callbacks
+synchronously. Consider the following function of a maker module:
+
+```js
+// maker.js
+module.exports.callAfterOneSecond = (callback) => {
+  setTimeout(callback, 1000);
+};
+```
+
+We can use a test runner with Sinon's fake timers to verify that `callAfterOneSecond` works as expected, but
+skipping that part where the test takes one second:
+
+```js
+// test.js
+before(function () {
+  this.clock = sinon.useFakeTimers();
+});
+
+after(function () {
+  this.clock.restore();
+});
+
+it("should call after one second", function () {
+  const spy = sinon.spy();
+  maker.callAfterOneSecond(spy);
+
+  // callback is not called immediately
+  assert.ok(!spy.called);
+
+  // but it is called synchronously after the clock is fast forwarded
+  this.clock.tick(1000);
+  assert.ok(spy.called); // PASS
+});
+```
+
+The same approach can be used to test a function returning a promise:
+
+```js
+module.exports.fulfillAfterOneSecond = () => {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(42), 1000);
+  });
+};
+```
+
+The following test uses a test runner's support for promises:
+
+```js
+it("should be fulfilled after one second", function () {
+  const promise = maker.fulfillAfterOneSecond();
+  this.clock.tick(1000);
+  return promise.then((result) => assert.equal(result, 42)); // PASS
+});
+```
+
+While returning a promise from the test, we can still progress the timers
+using fake timers, so the test passes almost instantly, and not in 1 second.
+
+Since `async` functions behave the same way as functions that return promises
+explicitly, the following code can be tested using the same approach:
+
+```js
+// maker.js
+module.exports.asyncReturnAfterOneSecond = async () => {
+  const setTimeoutPromise = (timeout) => {
+    return new Promise((resolve) => setTimeout(resolve, timeout));
+  };
+  await setTimeoutPromise(1000);
+  return 42;
+};
+```
+
+```js
+it("should return 42 after 1000ms", async function () {
+  const promise = maker.asyncReturnAfterOneSecond();
+  this.clock.tick(1000);
+  const result = await promise;
+  assert.equal(result, 42); // PASS
+});
+```
+
+Although these tests pass almost instantly, they are still asynchronous. Note
+that they return promises instead of running the assertions right after the
+`clock.tick(1000)` call, like in the first example. **Promises' `then()`
+function always runs asynchronously**, but we can still speed up the tests.

--- a/docs/guides/how-to/index.md
+++ b/docs/guides/how-to/index.md
@@ -1,0 +1,14 @@
+---
+title: How-to articles
+description: Practical how-to guides for common Sinon.JS scenarios — stubbing dependencies, fake timers with async, TypeScript + SWC, and more.
+---
+
+# How-to articles
+
+Practical guides for common testing scenarios.
+
+- [Async functions with fake timers](./fake-timers-async) — Speed up tests that depend on timers
+- [Link seams (CommonJS)](./link-seams-commonjs) — Isolate your system under test with proxyquire
+- [Stub a dependency](./stub-dependency) — Stub a dependency of a CommonJS module
+- [Stub ES module imports](./stub-esm) — Make ES module namespaces mutable for stubbing
+- [TypeScript and SWC](./typescript-swc) — A detailed case study on real world dependency stubbing

--- a/docs/guides/how-to/link-seams-commonjs.md
+++ b/docs/guides/how-to/link-seams-commonjs.md
@@ -1,0 +1,83 @@
+---
+title: How to stub out CommonJS modules
+---
+
+# How to stub out CommonJS modules
+
+This page describes how to isolate your system under test, by targeting the [link seams](http://www.informit.com/articles/article.aspx?p=359417); replacing your dependencies with stubs you control.
+
+> If you want a better understanding of the example and get a good description of what _seams_ are, we recommend that you read the [seams (all 3 web pages)](http://www.informit.com/articles/article.aspx?p=359417) excerpt from the classic [Working Effectively with Legacy Code](https://www.goodreads.com/book/show/44919.Working_Effectively_with_Legacy_Code), though it is not strictly necessary.
+
+This guide targets the CommonJS module system, made popular by Node.js. There are other module systems, but until recent years this was the de-facto module system and even when the actual EcmaScript Module standard arrived in 2015, transpilers and bundlers can still _output_ code as CJS modules. For instance, TypeScript outputs CJS modules per default as of 2023, so it is still relevant, as your `import foo from './foo'` might still end up being transpiled into `const foo = require('./foo')` in the end.
+
+For ES Modules (ESM) see [How to stub ES module imports](./stub-esm).
+
+## Hooking into `require`
+
+For us to replace the underlying calls done by `require` we need a tool to hook into the process. There are many tools that can do this: rewire, proxyquire, [Quibble](https://www.npmjs.com/package/quibble), etc. This example will be using [proxyquire](https://github.com/thlorenz/proxyquire) to construct our _seams_ (i.e. replace the modules), but the actual mechanics will be very similar for the other tools.
+
+## Example
+
+The folder structure in our example looks like this:
+
+```
+.
+├── lib
+│   └── does-file-exist.js
+└── test
+    └── does-file-exist.test.js
+```
+
+[Source and runnable demo of the example code](https://github.com/sinonjs/demo-proxyquire).
+
+### Source file: `lib/does-file-exist.js`
+
+This is the source file of the module `doesFileExist`, it only has one dependency: `fs`.
+
+```javascript
+var fs = require("fs");
+
+function doesFileExist(path) {
+  return fs.existsSync(path);
+}
+
+module.exports = doesFileExist;
+```
+
+### Test file: `test/does-file-exist.test.js`
+
+In order to isolate our `doesFileExist` module for testing, we will stub out `fs` and provide a fake implementation of `fs.existsSync`, where we have complete control of the behaviour.
+
+```javascript
+var proxyquire = require("proxyquire");
+var sinon = require("sinon");
+var assert = require("referee").assert;
+
+var doesFileExist; // the module to test
+var existsSyncStub; // the fake method on the dependency
+
+describe("example", function () {
+  beforeEach(function () {
+    existsSyncStub = sinon.stub(); // create a stub for every test
+
+    // import the module to test, using a fake dependency
+    doesFileExist = proxyquire("../lib/does-file-exist", {
+      fs: {
+        existsSync: existsSyncStub,
+      },
+    });
+  });
+
+  describe("when a path exists", function () {
+    beforeEach(function () {
+      existsSyncStub.returns(true); // set the return value that we want
+    });
+
+    it("should return `true`", function () {
+      var actual = doesFileExist("9d7af804-4719-4578-ba1d-5dd8a4dae89f");
+
+      assert.isTrue(actual);
+    });
+  });
+});
+```

--- a/docs/guides/how-to/stub-dependency.md
+++ b/docs/guides/how-to/stub-dependency.md
@@ -1,0 +1,182 @@
+---
+title: How to stub a dependency of a module
+---
+
+# How to stub a dependency of a module
+
+Sinon is a stubbing library, not a module interception library. Stubbing dependencies is highly dependent on your environment and the implementation. For Node environments, we usually recommend solutions targeting [link seams](./link-seams-commonjs) or explicit dependency injection. Though in some more basic cases, you can get away with only using Sinon by modifying the module exports of the dependency.
+
+To stub a dependency (imported module) of a module under test you have to import it explicitly in your test and stub the desired method. For the stubbing to work, the stubbed method cannot be [destructured](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment), neither in the module under test nor in the test.
+
+## An example
+
+### Source file: `dependencyModule.js`
+
+```javascript
+function getSecretNumber() {
+  return 44;
+}
+
+module.exports = {
+  getSecretNumber,
+};
+```
+
+### Source file: `moduleUnderTest.js`
+
+```javascript
+const dependencyModule = require("./dependencyModule");
+
+function getTheSecret() {
+  return `The secret was: ${dependencyModule.getSecretNumber()}`;
+}
+
+module.exports = {
+  getTheSecret,
+};
+```
+
+### Test file: `test.js`
+
+```javascript
+const assert = require("assert");
+const sinon = require("sinon");
+
+const dependencyModule = require("./dependencyModule");
+const { getTheSecret } = require("./moduleUnderTest");
+
+describe("moduleUnderTest", function () {
+  describe("when the secret is 3", function () {
+    it("should be returned with a string prefix", function () {
+      sinon.stub(dependencyModule, "getSecretNumber").returns(3);
+      const result = getTheSecret();
+      assert.equal(result, "The secret was: 3");
+    });
+  });
+});
+```
+
+## A complex example with asynchronous code
+
+In some cases you might need to stub a dependency that returns a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). To test it you can add the [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) keyword to the test method and call the method being tested with the [await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) keyword.
+
+### Source file: `userApi.js`
+
+```javascript
+const axios = require("axios");
+
+async function getPageOfUsers(page) {
+  const result = await axios({
+    method: "GET",
+    url: `https://reqres.in/api/users?page=${page}`,
+  });
+  return result.data;
+}
+
+module.exports = {
+  getPageOfUsers,
+};
+```
+
+### Source file: `userUtils.js`
+
+```javascript
+const userApi = require("./userApi");
+
+async function getAllUsers() {
+  const users = [];
+
+  let page = 0,
+    usersPage = null;
+
+  do {
+    page += 1;
+    usersPage = await userApi.getPageOfUsers(page);
+
+    users.push(...usersPage.data);
+  } while (usersPage.total_pages > page);
+
+  return users;
+}
+
+module.exports = {
+  getAllUsers,
+};
+```
+
+### Test file: `UserUtils-test.js`
+
+```javascript
+const assert = require("assert");
+const sinon = require("sinon");
+const userUtils = require("./userUtils");
+const userApi = require("./userApi");
+
+function aUser(id) {
+  return {
+    id,
+    email: `someemail@user${id}.com`,
+    first_name: `firstName${id}`,
+    last_name: `lastName${id}`,
+    avatar: `https://www.somepage${id}.com`,
+  };
+}
+
+describe("userUtils", function () {
+  let getPageOfUsersStub;
+
+  beforeEach(function () {
+    getPageOfUsersStub = sinon.stub(userApi, "getPageOfUsers");
+  });
+
+  afterEach(function () {
+    getPageOfUsersStub.restore();
+  });
+
+  describe("when a single page of users exists", function () {
+    it("should return users from that page", async function () {
+      // Arrange
+      const pageOfUsers = {
+        page: 1,
+        total_pages: 1,
+        data: [aUser(1), aUser(2), aUser(3)],
+      };
+
+      getPageOfUsersStub.returns(Promise.resolve(pageOfUsers));
+
+      // Act
+      const result = await userUtils.getAllUsers();
+
+      // Assert
+      assert.equal(result.length, 3);
+      assert.equal(getPageOfUsersStub.calledOnce, true);
+    });
+  });
+
+  describe("when multiple pages of users exists", function () {
+    it("should return a combined list of all users", async function () {
+      // Arrange
+      const pageOfUsers1 = {
+        page: 1,
+        total_pages: 2,
+        data: [aUser(1), aUser(2), aUser(3)],
+      };
+      const pageOfUsers2 = {
+        page: 2,
+        total_pages: 2,
+        data: [aUser(4), aUser(5)],
+      };
+
+      getPageOfUsersStub.withArgs(1).returns(Promise.resolve(pageOfUsers1));
+      getPageOfUsersStub.withArgs(2).returns(Promise.resolve(pageOfUsers2));
+
+      // Act
+      const result = await userUtils.getAllUsers();
+
+      // Assert
+      assert.equal(result.length, 5);
+      assert.equal(getPageOfUsersStub.callCount, 2);
+    });
+  });
+});
+```

--- a/docs/guides/how-to/stub-esm.md
+++ b/docs/guides/how-to/stub-esm.md
@@ -1,0 +1,219 @@
+---
+title: How to stub ES module imports
+---
+
+# How to stub ES module imports
+
+ES Modules (ESM) are statically analyzed and their bindings are **live and immutable** by the [ECMAScript specification](https://tc39.es/ecma262/#sec-module-namespace-objects). This means that attempting to stub a named export of an ES module with Sinon will throw a `TypeError` like:
+
+```
+TypeError: ES Modules cannot be stubbed
+```
+
+This article shows how to configure Node.js to allow mutable ES module namespaces, enabling Sinon stubs to work in an ESM context.
+
+## The problem
+
+Consider an ES module source file and a consumer that imports from it:
+
+### Source file: `src/math.mjs`
+
+```javascript
+export function add(a, b) {
+  return a + b;
+}
+```
+
+### Module under test: `src/calculator.mjs`
+
+```javascript
+import { add } from "./math.mjs";
+
+export function calculate(a, b) {
+  return add(a, b);
+}
+```
+
+### Test file: `test/calculator.test.mjs`
+
+```javascript
+import sinon from "sinon";
+import * as mathModule from "../src/math.mjs";
+import { calculate } from "../src/calculator.mjs";
+
+describe("calculator", () => {
+  it("should use the add function", () => {
+    // This will throw: TypeError: ES Modules cannot be stubbed
+    sinon.stub(mathModule, "add").returns(99);
+  });
+});
+```
+
+Sinon correctly raises an error here because, per the ES module spec, namespace object properties are non-writable, non-configurable, and non-deletable.
+
+## The solution: use the `esm` package with `mutableNamespace`
+
+The [`esm`](https://github.com/standard-things/esm) package is a fast, production-ready ES module loader for Node.js. It offers a `mutableNamespace` option that makes module namespace objects writable, which is what Sinon needs to install stubs.
+
+### Step 1: Install the `esm` package
+
+```bash
+npm install --save-dev esm
+```
+
+### Step 2: Create a loader / setup file
+
+Create a file at the root of your project (e.g., `esm-loader.cjs`) that enables the `mutableNamespace` option:
+
+```javascript
+// esm-loader.cjs
+require = require("esm")(module, {
+  cjs: true,
+  mutableNamespace: true,
+});
+```
+
+> **Note:** The `.cjs` extension (or `"type": "module"` absent in `package.json`) ensures this file is treated as CommonJS, which is required to call `require('esm')`.
+
+### Step 3: Register the loader when running tests
+
+Update your `package.json` test script to use `--require` to load the setup file before your test runner:
+
+```json
+{
+  "scripts": {
+    "test": "mocha --require ./esm-loader.cjs 'test/**/*.test.mjs'"
+  }
+}
+```
+
+### Step 4: Write the test
+
+Now your test can use `sinon.stub()` normally against ES module exports:
+
+```javascript
+// test/calculator.test.mjs
+import sinon from "sinon";
+import * as mathModule from "../src/math.mjs";
+import { calculate } from "../src/calculator.mjs";
+import assert from "assert";
+
+describe("calculator", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should delegate to the add function", () => {
+    sinon.stub(mathModule, "add").returns(99);
+
+    const result = calculate(1, 2);
+
+    assert.equal(result, 99);
+    assert.ok(mathModule.add.calledOnce);
+  });
+});
+```
+
+## Complete example: project layout
+
+```
+.
+├── src
+│   ├── math.mjs
+│   └── calculator.mjs
+├── test
+│   └── calculator.test.mjs
+├── esm-loader.cjs
+└── package.json
+```
+
+### `package.json`
+
+```json
+{
+  "name": "esm-sinon-example",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "mocha --require ./esm-loader.cjs 'test/**/*.test.mjs'"
+  },
+  "devDependencies": {
+    "esm": "^3.2.25",
+    "mocha": "^10.0.0",
+    "sinon": "*"
+  }
+}
+```
+
+### `esm-loader.cjs`
+
+```javascript
+require = require("esm")(module, {
+  cjs: true,
+  mutableNamespace: true,
+});
+```
+
+### `src/math.mjs`
+
+```javascript
+export function add(a, b) {
+  return a + b;
+}
+```
+
+### `src/calculator.mjs`
+
+```javascript
+import { add } from "./math.mjs";
+
+export function calculate(a, b) {
+  return add(a, b);
+}
+```
+
+### `test/calculator.test.mjs`
+
+```javascript
+import sinon from "sinon";
+import * as mathModule from "../src/math.mjs";
+import { calculate } from "../src/calculator.mjs";
+import assert from "assert";
+
+describe("calculator", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should use stubbed add function", () => {
+    sinon.stub(mathModule, "add").returns(42);
+
+    const result = calculate(10, 20);
+
+    assert.equal(result, 42);
+    assert.ok(mathModule.add.calledOnceWith(10, 20));
+  });
+
+  it("should call the real add function when not stubbed", () => {
+    const result = calculate(3, 4);
+
+    assert.equal(result, 7);
+  });
+});
+```
+
+## Why does this work?
+
+The `esm` package hooks into Node.js's module loading system. When `mutableNamespace: true` is set, it wraps ES module namespace objects with a `Proxy` that allows property assignment. Sinon's `stub()` function replaces the property on the namespace object; with the proxy in place, this assignment succeeds instead of throwing.
+
+## Limitations and caveats
+
+- **Only works with the `esm` package.** Native `--experimental-vm-modules` or other loaders do not support `mutableNamespace` out of the box.
+- **Transpiled output**: If you are using TypeScript or Babel that already compiles your ESM to CommonJS, this approach is not needed. [Stub the CommonJS dependency](./stub-dependency) instead.
+- **Destructured imports cannot be stubbed.** If the module under test does `import { add } from './math.mjs'` and uses `add` as a local binding, the stub on the namespace will **not** affect the already-captured binding. The consumer must access the export through the module namespace object for stubs to take effect.
+- **`mutableNamespace` is non-standard.** It deviates from the ESM specification. Consider it a testing convenience rather than a production technique.
+
+## Related articles
+
+- [How to stub a dependency of a module (CommonJS)](./stub-dependency)
+- [How to stub out CommonJS modules using link seams](./link-seams-commonjs)
+- [Real world dependency stubbing](./typescript-swc) (using TypeScript and SWC)

--- a/docs/guides/how-to/typescript-swc.md
+++ b/docs/guides/how-to/typescript-swc.md
@@ -1,0 +1,276 @@
+---
+title: "Case study: real world dependency stubbing"
+---
+
+# Case study: real world dependency stubbing
+
+Sinon is a simple tool that only tries to do a few things and do them well: creating and injecting test doubles (spies, fakes, stubs) into objects. Unfortunately, in today's world of build pipelines, complex tooling, transpilers and different module systems, doing the simple thing quickly becomes difficult.
+
+This article is a detailed step-by-step guide on how one can approach the typical issues that arise and various approaches for debugging and solving them. The real-world case chosen is using Sinon along with [SWC](https://swc.rs/), running tests written in TypeScript in the [Mocha test runner](https://mochajs.org/) and wanting to replace dependencies in this system under test. The essence is that there are always _many_ approaches for achieving what you want. Some require tooling, some can get away with almost no tooling, some are general in nature (not specific to SWC for instance) and some are a blend. This means you can usually make some of these approaches work for other combinations of tooling as well, once you understand what is going on. Draw inspiration from the approach and figure out what works for you!
+
+## On TypeScript
+
+The Sinon project does not explicitly list TypeScript as a supported target environment. That does not mean Sinon will not run, just that there are so many complications that we cannot come up with guides on figuring out the details for you on every system.
+
+TypeScript is a super-set of JavaScript and can be transpiled in a wide variety of ways into JavaScript, both by targeting different runtimes (ES5, ES2015, ES2023, etc) and module systems (CommonJS, ESM, AMD, ...). Some transpilers are closer to what the standard TypeScript compiler produces, some are laxer in various ways and additionally they have all kinds of options to tweak the result. This is indeed complex, so before you dig yourself down in this matter, it is essential that you try to figure out what the resulting code _actually_ looks like.
+
+As you will see in this guide, adding a few sprinkles of `console.log` with the output of [`Object.getOwnPropertyDescriptor(object, propname)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor) is usually sufficient to understand what is going on!
+
+All code and working setups described in this guide are on [GitHub](https://github.com/fatso83/sinon-swc-bug) and links to the correct branch can be found in each section.
+
+## Scenario
+
+### Tech
+
+- Mocha: drives the tests
+- SWC: very fast Rust-based transpiler able to target different module systems (CJS, ESM, ...) and target runtimes (ES5, ES2020, ...)
+- TypeScript: Type-safe JavaScript superset
+- Sinon: library for creating and injecting test doubles (stubs, mocks, spies and fakes)
+- Module system: CommonJS
+
+### Desired outcome
+
+Being able to replace exports on the dependency `./other` with a Sinon created test double in `main.ts` when running tests (see code below).
+
+### Problem
+
+Running tests with `ts-node` works fine, but changing the setup to using SWC instead results in the tests failing with the following output from Mocha:
+
+```
+1) main
+       should mock:
+     TypeError: Descriptor for property toBeMocked is non-configurable and non-writable
+```
+
+### Original code
+
+**`main.ts`**
+
+```typescript
+import { toBeMocked } from "./other";
+
+export function main() {
+  const out = toBeMocked();
+  console.log(out);
+}
+```
+
+**`other.ts`**
+
+```typescript
+export function toBeMocked() {
+  return "I am the original function";
+}
+```
+
+**`main.spec.ts`**
+
+```typescript
+import sinon from "sinon";
+import "./init";
+import * as Other from "./other";
+import { main } from "./main";
+import { expect } from "chai";
+
+const sandbox = sinon.createSandbox();
+
+describe("main", () => {
+  let mocked;
+  it("should mock", () => {
+    mocked = sandbox.stub(Other, "toBeMocked").returns("mocked");
+    main();
+    expect(mocked.called).to.be.true;
+  });
+});
+```
+
+Additionally, both the `.swcrc` file used by SWC and the `tsconfig.json` file used by `ts-node` is configured to produce modules of the CommonJS form, not ES Modules.
+
+### Brief Analysis
+
+The error message indicates the resulting output of transpilation is different from that of `ts-node`, as this is Sinon telling us that it is unable to do anything with the property of an object, when the [property descriptor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) is essentially immutable.
+
+Let us sprinkle some debugging statements to figure out what the differences between the two tools are. First we will add some debugging output to the beginning of the test:
+
+```javascript
+console.log("Other", Other);
+console.log(
+  "Other property descriptors",
+  Object.getOwnPropertyDescriptors(Other),
+);
+```
+
+#### Output of a SWC configured run
+
+```
+Other { toBeMocked: [Getter] }
+Other property descriptors {
+  __esModule: {
+    value: true,
+    writable: false,
+    enumerable: false,
+    configurable: false
+  },
+  toBeMocked: {
+    get: [Function: get],
+    set: undefined,
+    enumerable: true,
+    configurable: false
+  }
+}
+    1) should mock
+```
+
+#### Output of a `ts-node` configured run
+
+```
+Other { toBeMocked: [Function: toBeMocked] }
+Other property descriptors {
+  __esModule: {
+    value: true,
+    writable: false,
+    enumerable: false,
+    configurable: false
+  },
+  toBeMocked: {
+    value: [Function: toBeMocked],
+    writable: true,
+    enumerable: true,
+    configurable: true
+  }
+}
+mocked
+    ✔ should mock
+```
+
+The important difference is that the property `toBeMocked` is a simple writable _value_ in the case of `ts-node` and a non-configurable _getter_ in the case of SWC. It being a getter is not a problem for Sinon, as we have a multitude of options for replacing those, but if `configurable` is set to `false` Sinon cannot really do anything about it.
+
+#### Conclusion of analysis
+
+SWC transforms imports on the form `import * as Other from './other'` into objects where the individual exports are exposed through immutable accessors (_getters_).
+
+We can address this issue in mainly 3 ways:
+
+1. reconfigure SWC to produce different output when running tests, either making writable values or configurable getters
+2. use pure dependency injection, opening up `./other.ts` to be changed from the inside
+3. address how modules are loaded, injecting an additional `require` hook
+
+## Solutions
+
+### Mutating the output from the transpiler
+
+If we can just flip the `configurable` flag to `true` during transpilation, Sinon could be instructed to replace the getter. It turns out, there is a SWC _plugin_ that does just that: [`swc_mut_cjs_exports`](https://www.npmjs.com/package/swc_mut_cjs_exports). By installing that and adding the following under the `jsc` key in `.swcrc`, you now get a configurable property descriptor.
+
+```json
+"experimental": {
+  "plugins": [[ "swc_mut_cjs_exports", {} ]]
+},
+```
+
+A getter _is_ different from a value, so you need to change your test code slightly to replace the getter:
+
+```js
+const stub = sandbox.fake.returns("mocked");
+sandbox.replaceGetter(Other, "toBeMocked", () => stub);
+```
+
+### Use pure dependency injection
+
+#### Version 1: full manual mode
+
+This technique works regardless of language, module systems, bundlers and tool chains, but requires slight modifications of the system under test to allow modifying it. Sinon does not help in resetting state automatically in this scenario.
+
+**`other.ts`**
+
+```typescript
+function _toBeMocked() {
+  return "I am the original function";
+}
+
+export let toBeMocked = _toBeMocked;
+
+export function _setToBeMocked(mockImplementation) {
+  toBeMocked = mockImplementation;
+}
+```
+
+**`main.spec.ts`**
+
+```typescript
+describe("main", () => {
+  let mocked;
+  let original = Other.toBeMocked;
+
+  after(() => Other._setToBeMocked(original));
+
+  it("should mock", () => {
+    mocked = sandbox.stub().returns("mocked");
+    Other._setToBeMocked(mocked);
+    main();
+    expect(mocked.called).to.be.true;
+  });
+});
+```
+
+#### Version 2: using Sinon's auto-cleanup
+
+This is a slight variation of the fully manual dependency injection version, but with a twist to make it nicer. Sinon 16.1 gained the ability to assign and restore values that were defined using _accessors_. That means, that if you expose an object with setters and getters for props you would like to replace, you can get Sinon to clean up after you.
+
+**`other.ts`**
+
+```typescript
+function _toBeMocked() {
+  return "I am the original function";
+}
+
+export let toBeMocked = _toBeMocked;
+
+export const myMocks = {
+  set toBeMocked(mockImplementation) {
+    toBeMocked = mockImplementation;
+  },
+  get toBeMocked() {
+    return _toBeMocked;
+  },
+};
+```
+
+**`main.spec.ts`**
+
+```typescript
+describe("main", () => {
+  after(() => sandbox.restore());
+
+  it("should mock", () => {
+    mocked = sandbox.fake.returns("mocked");
+    sandbox.replace.usingAccessor(Other.myMocks, 'toBeMocked', mocked);
+    main();
+    expect(mocked.called).to.be.true;
+  });
+});
+```
+
+### Hooking into Node's module loading
+
+This is what [the article on targeting the link seams](./link-seams-commonjs) is about. The only difference here is using Quibble instead of Proxyquire. Quibble is slightly terser and also supports being used as an ESM _loader_, making it a bit more modern and useful. The end result looks like this:
+
+```typescript
+describe("main module", () => {
+  let mocked, main;
+
+  before(() => {
+    mocked = sandbox.stub().returns("mocked");
+    quibble("./other", { toBeMocked: mocked });
+    ({ main } = require("./main"));
+  });
+
+  it("should mock", () => {
+    main();
+    expect(mocked.called).to.be.true;
+  });
+});
+```
+
+## Final remarks
+
+As can be seen, there are lots of different paths to walk in order to achieve the same basic goal. Find the one that works for your case.

--- a/docs/guides/migration.md
+++ b/docs/guides/migration.md
@@ -1,0 +1,302 @@
+---
+title: Migrating between versions
+---
+
+# Migrating between versions
+
+## Sinon 19
+
+### All timers are stubbed by default
+
+A breaking change is that Fake Timers 13 now fake all timers by default. Previously
+Node's `nextTick()` and `Window#queueMicroTask()` were explicitly skipped, which
+was quite confusing to some. This typically might affect `async` tests where
+you rely on some Node function that invokes `nextTick` under the hood. See
+[issue #2619](https://github.com/sinonjs/sinon/issues/2619) for such an example
+and [a suggestion on how one could employ `clock#runToLastAsync()`](https://github.com/fatso83/usefaketimers-bug-reproduction/commit/54c812d)
+in asynchronous tests that stopped resolving in Sinon 19.
+
+_If you want the old behavior, specify the timers you want to fake in the `toFake`
+option and leave out the name of the timers giving you trouble_.
+
+### New implementation of the fake Date class
+
+The new version of fake-timers also no longer creating dates using the original Date
+class, but a _subclass_ (proxy). This should not matter _unless_ you are doing some kind
+of identity checks on the constructor: functionally they are the same.
+See ([fake-timers#504](https://github.com/sinonjs/fake-timers/issues/504)) for an
+example (which we ended up pushing a small fix for to make `instanceof` work as before).
+
+### Removal of `useFakeServer({legacyRoutes: true})`
+
+The `legacyRoutes` option that was enabled in a previous version has been removed.
+An underlying library, `path-to-regexp`, had a fundamental change to its parsing that
+made the option a no-op. This should not affect most users of Sinon.
+
+## Sinon 18
+
+Mostly removal of some deprecated exports related to `sinon-test`, such as
+`sinon.defaultConfig` and related modules.
+
+## Sinon 17
+
+Drops support for Node 16.
+
+## Sinon 15
+
+Removes option to pass a custom formatter.
+
+## Sinon 7
+
+For users upgrading to Sinon 7 the only known breaking API change is that
+**negative ticks** are not allowed in `sinon@7` due to updating to lolex 3
+internally. This means you cannot use negative values in
+`sinon.useFakeTimers().tick()`.
+
+If you experience any issues moving from Sinon 6 to Sinon 7, please
+[let us know](https://github.com/sinonjs/sinon/issues/new?template=Bug_report.md).
+
+## Sinon 6
+
+There should be no reason for any code changes with the new Sinon 6.
+Usually, `MAJOR` releases should come with breaking changes, but there are
+no known breaking changes in `sinon@6` at the time of this writing. We chose
+to release a new major version as a [pragmatic solution to some noise related to releasing Sinon 5.1](https://github.com/sinonjs/sinon/pull/1829#issue-193284761),
+which featured some breaking changes related to ESM (which since
+has been resolved).
+
+If you should experience any issues moving from Sinon 5 to Sinon 6, please
+[let us know](https://github.com/sinonjs/sinon/issues/new?template=Bug_report.md).
+
+## Sinon 5
+
+As with all `MAJOR` releases in [semver](http://semver.org/), there are breaking changes in `sinon@5`.
+This guide will walk you through those changes.
+
+### `spy.reset()` is removed, use `spy.resetHistory()`
+
+In a previous version we deprecated and aliased `spy.reset` in favour of
+using `spy.resetHistory`. `spy.reset` has now been removed, you should use
+`spy.resetHistory`.
+
+### `sinon` is now a (default) sandbox
+
+Since `sinon@5.0.0`, the `sinon` object is a default sandbox. Unless you
+have a very advanced setup or need a special configuration, you probably
+want to only use that one.
+
+The old sandbox API is still available, so you don't **have** to do
+anything.
+
+However, switching to using the default sandbox can help make your code more
+concise.
+
+**Before (`sinon@4`)**:
+
+```js
+describe("myFunction", function () {
+  var sandbox = sinon.sandbox.create();
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("should make pie");
+});
+```
+
+**After (`sinon@5`)**:
+
+```js
+describe("myFunction", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("should make pie");
+});
+```
+
+## Sinon 4
+
+As with all `MAJOR` releases in [semver](http://semver.org/), there are breaking changes in `sinon@4`.
+This guide will walk you through those changes.
+
+### `sinon.stub(obj, 'nonExistingProperty')` — Throws
+
+Trying to stub a non-existing property will now fail, to ensure you are creating
+[less error-prone tests](https://github.com/sinonjs/sinon/pull/1557).
+
+## Sinon 3
+
+As with all `MAJOR` releases in [semver](http://semver.org/), there are
+breaking changes in `sinon@3`.
+This guide will walk you through those changes.
+
+### `sinon.stub(object, "method", func)` — Removed
+
+Please use `sinon.stub(obj, "method").callsFake(func)` instead.
+
+```js
+var stub = sinon.stub(obj, "stubbedMethod").callsFake(function () {
+  return 42;
+});
+```
+
+A [codemod is available](https://github.com/hurrymaplelad/sinon-codemod) to
+upgrade your code.
+
+### `sinon.stub(object, property, value)` — Removed
+
+Calling `sinon.stub` with three arguments will throw an Error. This was
+deprecated with `sinon@2` and has been removed with `sinon@3`.
+
+### `sinon.useFakeTimers([now, ]prop1, prop2, ...)` — Removed
+
+`sinon.useFakeTimers()` signature has changed.
+To define which methods to fake,
+please use `config.toFake`. Other options are now available when configuring
+`useFakeTimers`. Please consult the documentation for more information.
+
+### `sinon.sandbox.create(config)` — Config changes
+
+The changes in configuration for fake timers implicitly affect sandbox creation.
+If your config used to look
+like `{ useFaketimers: ["setTimeout", "setInterval"]}`, you
+will now need to change it to `{ useFaketimers: { toFake: ["setTimeout", "setInterval"] }}`.
+
+### `sandbox.stub(obj, 'nonExistingProperty')` — Throws
+
+Trying to stub a non-existing property will now fail to ensure you are
+creating
+[less error-prone tests](https://github.com/sinonjs/sinon/issues/1537#issuecomment-323948482).
+
+### Removal of internal helpers
+
+The following internal functions were deprecated as of `sinon@1.x` and have
+been removed in `sinon@3`:
+
+- `sinon.calledInOrder`
+- `sinon.create`
+- `sinon.deepEqual`
+- `sinon.format`
+- `sinon.functionName`
+- `sinon.functionToString`
+- `sinon.getConfig`
+- `sinon.getPropertyDescriptor`
+- `sinon.objectKeys`
+- `sinon.orderByFirstCall`
+- `sinon.restore`
+- `sinon.timesInWorlds`
+- `sinon.valueToString`
+- `sinon.walk`
+- `sinon.wrapMethod`
+- `sinon.Event`
+- `sinon.CustomEvent`
+- `sinon.EventTarget`
+- `sinon.ProgressEvent`
+- `sinon.typeOf`
+- `sinon.extend`
+
+## Sinon 2
+
+Sinon v2.0 is the second major release, we have made several breaking
+changes in this release as a result of modernising the internals of Sinon.
+This guide is intended to walk you through the changes.
+
+### `sinon.log` and `sinon.logError` Removed
+
+`sinon.log` and `sinon.logError` were used in Sinon v1.x to globally
+configure `FakeServer`, `FakeXMLHttpRequest` and `FakeXDomainRequest`; these
+three functions now allow the logger to be configured on a per-use basis. In
+v1.x you may have written:
+
+```js
+sinon.log = function (msg) { /* your logging impl */ };
+```
+
+You would now individually import and configure the utility upon creation:
+
+```js
+var sinon = require("sinon");
+
+var myFakeServer = sinon.fakeServer.create({
+  logger: function (msg) { /* your logging impl */ }
+});
+```
+
+### `sinon.test`, `sinon.testCase` and `sinon.config` Removed
+
+`sinon.test` and `sinon.testCase` have been extracted from the Sinon API and
+moved into their own node module, [sinon-test](https://www.npmjs.com/package/sinon-test).
+Please refer to the [sinon-test README](https://github.com/sinonjs/sinon-test/blob/master/README.md) for migration examples.
+
+### `stub.callsFake` replaces `stub(obj, 'meth', fn)`
+
+`sinon.stub(obj, 'meth', fn)` return a spy, not a full stub. Behavior could
+not be redefined. `stub.callsFake`
+now returns a full stub. Here's a [codemod script](https://github.com/hurrymaplelad/sinon-codemod) to help you migrate.
+See [discussion](https://github.com/sinonjs/sinon/pull/823).
+
+```js
+// Old
+sinon.stub(obj, "meth", fn);
+// New
+sinon.stub(obj, "meth").callsFake(fn);
+```
+
+### `stub.resetHistory` replaces `stub.reset`
+
+`stub.reset()` now resets the history and the behaviour of the stub.
+Previously `stub.reset()` only reset the history of the stub. Stubs now have
+separate methods for resetting the history and the behaviour. To mimic the
+old behaviour replace all `stub.reset()` calls with `stub.resetHistory()`.
+
+```js
+// Old
+stub.reset();
+// New
+stub.resetHistory();
+```
+
+### Deprecation of internal helpers
+
+The following utility functions are being marked as deprecated and are
+planned for removal in Sinon v3.0; please check your codebase for usage to
+ease future migrations:
+
+- `sinon.calledInOrder`
+- `sinon.create`
+- `sinon.deepEqual`
+- `sinon.format`
+- `sinon.functionName`
+- `sinon.functionToString`
+- `sinon.getConfig`
+- `sinon.getPropertyDescriptor`
+- `sinon.objectKeys`
+- `sinon.orderByFirstCall`
+- `sinon.restore`
+- `sinon.timesInWorlds`
+- `sinon.valueToString`
+- `sinon.walk`
+- `sinon.wrapMethod`
+- `sinon.Event`
+- `sinon.CustomEvent`
+- `sinon.EventTarget`
+- `sinon.ProgressEvent`
+- `sinon.typeOf`
+- `sinon.extend`
+
+### `sandbox.useFakeXMLHttpRequest` no longer returns a "server"
+
+In Sinon 1.x, the sandbox' `useFakeXMLHttpRequest` was the same as its
+`useFakeServer`. In 2.x, it maps directly to `sinon.useFakeXMLHttpRequest`
+(but with sandboxing). If you use `sandbox.useFakeXMLHttpRequest`, replace
+it with `sandbox.useFakeServer`, and your tests should behave as they always
+did.
+
+### `sinon.behavior` is gone
+
+The `sinon.behavior` object is no longer exposed for random modification.
+However, there is a new mechanism in place aided to add new behavior to
+stubs, `sinon.addBehavior(name, fn)`, see the stub docs.

--- a/docs/scripts/generate-sidebar.mjs
+++ b/docs/scripts/generate-sidebar.mjs
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 
 const API_DIR = "concepts";
+const GUIDES_DIR = "guides";
 
 const SECTIONS = [
   "spies",
@@ -266,6 +267,69 @@ function generateSidebar() {
           },
           ...sectionItems
         ]
+      }
+    ];
+  }
+
+  // Guides sidebar
+  if (fs.existsSync(GUIDES_DIR)) {
+    const guideItems = [];
+
+    // How-to sub-directory (first)
+    const howToDir = path.join(GUIDES_DIR, "how-to");
+    if (fs.existsSync(howToDir)) {
+      const howToFiles = fs
+        .readdirSync(howToDir)
+        .filter((f) => f.endsWith(".md") && f !== "index.md")
+        .sort();
+
+      const howToDisplayNames = {
+        "stub-dependency": "Stub a dependency",
+        "link-seams-commonjs": "Link seams (CommonJS)",
+        "stub-esm": "Stub ES module imports",
+        "fake-timers-async": "Async functions with fake timers",
+        "typescript-swc": "TypeScript and SWC",
+      };
+
+      const howToItems = howToFiles.map((f) => {
+        const name = f.replace(".md", "");
+        return {
+          text: howToDisplayNames[name] || name.charAt(0).toUpperCase() + name.slice(1).replace(/-/g, " "),
+          link: `/guides/how-to/${name}`
+        };
+      });
+
+      guideItems.push({
+        text: "How-to articles",
+        collapsed: false,
+        items: [
+          { text: "Overview", link: "/guides/how-to/" },
+          ...howToItems
+        ]
+      });
+    }
+
+    // Top-level guide pages in specified order
+    const topLevelOrder = ["faq", "migration", "external-resources"];
+    const topLevelDisplayNames = {
+      faq: "FAQ",
+      migration: "Migration",
+      "external-resources": "External resources",
+    };
+
+    for (const name of topLevelOrder) {
+      if (fs.existsSync(path.join(GUIDES_DIR, `${name}.md`))) {
+        guideItems.push({
+          text: topLevelDisplayNames[name],
+          link: `/guides/${name}`
+        });
+      }
+    }
+
+    sidebar["/guides/"] = [
+      {
+        text: "Guides",
+        items: guideItems
       }
     ];
   }


### PR DESCRIPTION
Brings back non-API documentation from the old Jekyll site (removed in the VitePress migration, #2720) that was never ported.

**Nav:** New "Guides" dropdown sits between "Getting Started" and "Concepts":

> Guides → How-to articles | FAQ | Migration | External resources

**Sidebar** (auto-generated from filesystem): shows the guides hierarchy when browsing under `/guides/` paths.

<img width="1212" height="563" alt="image" src="https://github.com/user-attachments/assets/9c293b55-a7f6-4f56-a686-553efaf0cac6" />

### Content added

- **How-to articles** (`/guides/how-to/`)
  - Async functions with fake timers
  - Link seams (CommonJS) — isolating modules with proxyquire
  - Stub a dependency of a CommonJS module
  - Stub ES module imports using `esm` with `mutableNamespace`
  - TypeScript + SWC — real-world dependency stubbing case study

- **FAQ** (`/guides/faq`) — Property descriptor errors ("non-configurable and non-writable"), causes, and solutions

- **Migration guide** (`/guides/migration`) — Breaking changes from v2 through v19

- **External resources** (`/guides/external-resources`) — Curated links to articles and related libraries

### Infrastructure

- Updated `scripts/generate-sidebar.mjs` to scan the `guides/` directory

### How to review locally

```sh
gh pr checkout 2741
cd docs
npm install
npx vitepress dev .
```

Then open http://localhost:5173 and look for the "Guides" nav item between "Getting Started" and "Concepts".
