### PR TITLE
fix: throw a clear error when throwArg index equals the argument count

### DIFF
--- a/src/sinon/proxy-call.js
+++ b/src/sinon/proxy-call.js
@@ -140,7 +140,7 @@ const callProto = {
     },
 
     throwArg: function (pos) {
-        if (pos > this.args.length) {
+        if (pos >= this.args.length) {
             throw new TypeError(
                 `Not enough arguments: ${pos} required but only ${this.args.length} present`,
             );

--- a/test/src/proxy-call-test.js
+++ b/test/src/proxy-call-test.js
@@ -613,6 +613,53 @@ describe("sinonSpy.call", function () {
         });
     });
 
+    describe("call.throwArg", function () {
+        beforeEach(spyCallCallSetup);
+
+        it("throws argument at specified index", function () {
+            const expectedError = new TypeError("catpants");
+            this.args.push(1, expectedError, 2);
+            const call = this.call;
+
+            assert.exception(
+                function () {
+                    call.throwArg(1);
+                },
+                { message: "catpants" },
+            );
+        });
+
+        it("throws if index equals the number of arguments", function () {
+            this.args.push(1, 2);
+            const call = this.call;
+
+            assert.exception(
+                function () {
+                    call.throwArg(2);
+                },
+                {
+                    name: "TypeError",
+                    message: "Not enough arguments: 2 required but only 2 present",
+                },
+            );
+        });
+
+        it("throws if there aren't enough arguments", function () {
+            this.args.push(1, 2);
+            const call = this.call;
+
+            assert.exception(
+                function () {
+                    call.throwArg(3);
+                },
+                {
+                    name: "TypeError",
+                    message: "Not enough arguments: 3 required but only 2 present",
+                },
+            );
+        });
+    });
+
     describe("call.yieldTest", function () {
         beforeEach(spyCallCallSetup);
 


### PR DESCRIPTION
`spyCall.throwArg(pos)` (and the aggregate `spy.throwArg(pos)`) make a recorded call throw one of its own arguments. The bounds guard is off by one, so calling `throwArg(pos)` with `pos` equal to the number of recorded arguments throws `undefined` instead of the intended `TypeError`.

Valid indices are `0 .. args.length - 1`. The guard `pos > this.args.length` lets `pos === args.length` through to `throw this.args[pos]`, where `this.args[pos]` is `undefined`. The thrown `undefined` cannot be inspected as an Error, and test frameworks report it as "no exception was thrown", which hides the real off-by-one.

The sibling helpers (`callArg`, `callArgOn`, and the rest) and the stub-time `throwsArg` (via `ensureArgs` in `behavior.js`, which uses `>=`) already reject an out-of-range index with a clear error. PR #1848 established that these argument-index helpers should throw a clear `TypeError` rather than yield `undefined`.

## Fix

Change the guard in `src/sinon/proxy-call.js` from `>` to `>=`, matching `ensureArgs`:

    if (pos >= this.args.length) {

Added a `call.throwArg` block to `test/src/proxy-call-test.js`: it throws the argument at a valid index, and throws a clear `TypeError` when the index equals or exceeds the argument count. The equal-to-count case fails before this change; the full `test/src` suite (1497) stays green.
